### PR TITLE
feat(mcp): expose whisper to desktop clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ One command gets you to a working setup.
 3. Detect supported clients and wire them up automatically:
    - Claude Code: whisper hooks, MCP tools, instructions, maintenance agent, slash command
    - Codex: whisper hooks, MCP tools, instructions, maintenance agent
-   - Claude Desktop (macOS): MCP tools
+   - Claude Desktop (macOS): MCP tools, including whisper
 4. Offer transcript backfill for Claude Code so you can bootstrap memory from earlier sessions
 
 If Claude Code, Codex, or Claude Desktop are already installed, Ormah connects itself to them automatically.
@@ -56,9 +56,10 @@ Before the model sees your prompt, Ormah decides what from your memory graph mat
 
 You usually never see it. Your agent just knows.
 
-Whisper is available three ways:
+Whisper is available four ways:
 
 - Hooks: `ormah setup` wires supported clients to run whisper automatically before each prompt
+- MCP: the `whisper` tool for MCP-only clients such as Claude Desktop
 - CLI: `ormah whisper inject` and `ormah whisper store`
 - HTTP: `POST /agent/whisper`
 
@@ -229,8 +230,8 @@ Ormah is designed to work with both humans and agents through several surfaces.
 
 - Claude Code: hooks, MCP, transcript backfill, session watcher support, maintenance agent
 - Codex: hooks, MCP, maintenance agent
-- Claude Desktop (macOS): MCP
-- Any MCP-compatible client: memory tools
+- Claude Desktop (macOS): MCP, including whisper
+- Any MCP-compatible client: memory tools, including whisper
 - Any local tool that can make HTTP requests: direct API access
 
 ### MCP
@@ -239,6 +240,7 @@ Primary MCP tools:
 
 - `remember`
 - `recall`
+- `whisper`
 - `get_self`
 - `mark_outdated`
 - `submit_feedback`

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 
 import httpx
 from mcp.server import Server
@@ -33,7 +34,11 @@ def _coerce_list(value):
     return value
 
 
-def create_mcp_server(base_url: str, default_space: str | None = None) -> Server:
+def create_mcp_server(
+    base_url: str,
+    default_space: str | None = None,
+    session_id: str | None = None,
+) -> Server:
     """Create an MCP server that delegates to the HTTP API."""
     server = Server("ormah")
 
@@ -51,7 +56,13 @@ def create_mcp_server(base_url: str, default_space: str | None = None) -> Server
     @server.call_tool(validate_input=False)
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
         try:
-            result = await _dispatch(base_url, name, arguments, default_space=default_space)
+            result = await _dispatch(
+                base_url,
+                name,
+                arguments,
+                default_space=default_space,
+                session_id=session_id,
+            )
             return [TextContent(type="text", text=result)]
         except httpx.ConnectError:
             return [
@@ -149,7 +160,11 @@ def _format_maintenance_batches(batches: dict) -> str:
 
 
 async def _dispatch(
-    base_url: str, name: str, args: dict, default_space: str | None = None
+    base_url: str,
+    name: str,
+    args: dict,
+    default_space: str | None = None,
+    session_id: str | None = None,
 ) -> str:
     async with httpx.AsyncClient(base_url=base_url, timeout=30.0) as client:
         if name == "remember":
@@ -226,6 +241,17 @@ async def _dispatch(
             if "weight" in args:
                 body["weight"] = args["weight"]
             resp = await client.post("/agent/connect", json=body)
+            if not resp.is_success:
+                return _handle_error(resp)
+            return resp.json()["text"]
+
+        elif name == "whisper":
+            body = {"prompt": args["prompt"]}
+            if default_space:
+                body["space"] = default_space
+            if session_id:
+                body["session_id"] = session_id
+            resp = await client.post("/agent/whisper", json=body)
             if not resp.is_success:
                 return _handle_error(resp)
             return resp.json()["text"]
@@ -365,10 +391,19 @@ async def _dispatch(
 
 async def run_mcp_stdio():
     """Run the MCP server over stdio transport."""
+    session_id = str(uuid.uuid4())
     default_space = detect_space_from_cwd()
-    logger.info("Detected project space: %s", default_space or "(global)")
+    logger.info(
+        "Detected project space: %s (mcp session %s)",
+        default_space or "(global)",
+        session_id[:8],
+    )
 
-    server = create_mcp_server(_BASE_URL, default_space=default_space)
+    server = create_mcp_server(
+        _BASE_URL,
+        default_space=default_space,
+        session_id=session_id,
+    )
 
     async with stdio_server() as (read_stream, write_stream):
         await server.run(read_stream, write_stream, server.create_initialization_options())

--- a/src/ormah/adapters/tool_schemas.py
+++ b/src/ormah/adapters/tool_schemas.py
@@ -132,6 +132,28 @@ TOOLS = [
         },
     },
     {
+        "name": "whisper",
+        "description": (
+            "Get compact contextual memory relevant to the current user message. "
+            "Pass the latest user prompt verbatim. Returns an empty string when "
+            "nothing relevant should be injected. This is especially useful in "
+            "MCP-only clients that do not support pre-prompt hooks."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": (
+                        "The latest user message or prompt. Pass it verbatim so whisper "
+                        "can retrieve context for this turn."
+                    ),
+                },
+            },
+            "required": ["prompt"],
+        },
+    },
+    {
         "name": "get_self",
         "description": (
             "Get the user's identity profile — preferences, goals, decisions, and key facts. "
@@ -214,7 +236,7 @@ TOOLS = [
             "  - edges: list of {node_a_id, node_b_id, edge_type, reason} — use 'none' to skip\n"
             "  - merges: list of {keep_id, discard_id, merged_content, merged_title}\n"
             "  - consolidations: list of {node_ids, title, content, type}\n\n"
-            "Use when get_context signals unprocessed_memories. "
+            "Use when whisper or another Ormah signal indicates maintenance is due. "
             "No separate API key needed — the calling LLM performs the analysis."
         ),
         "parameters": {

--- a/src/ormah/codex_instructions.md
+++ b/src/ormah/codex_instructions.md
@@ -18,12 +18,12 @@ Ormah is your persistent memory system. It stores, recalls, and surfaces memorie
 
 7. **Use appropriate tiers**: `core` for always-relevant info (user identity, preferences, key architectural decisions), `working` for anything actively relevant now, `archival` for historical/reference data.
 
-8. **Start with context**: Call `get_context` at the beginning of conversations to load core memories. Use `task_hint` when the task is known to get focused context.
+8. **Start with the current turn**: If your client does not already have Ormah whisper hooks, call `whisper` with the latest user message at the start of each new turn. Use `get_self` for explicit identity/profile reads and `recall` for targeted lookups.
 
 9. **Mark outdated info**: When a memory is wrong or outdated, call `mark_outdated` with a reason so it gets demoted in future searches.
 
 10. **Set confidence**: When storing information you're not fully certain about, set `confidence` below 1.0. This affects how prominently the memory appears in search results.
 
-11. **Run maintenance off the critical path**: When `get_context` returns `unprocessed_memories` with a non-zero value, handle maintenance separately from the user-facing turn. If the `ormah-maintenance` custom agent is available, spawn it to run the two-call `run_maintenance` flow instead of doing it inline. Otherwise, defer maintenance to the next safe point rather than interrupting the current response.
+11. **Run maintenance off the critical path**: When whisper surfaces a `maintenance_due` signal, handle maintenance separately from the user-facing turn. If the `ormah-maintenance` custom agent is available, spawn it to run the two-call `run_maintenance` flow instead of doing it inline. Otherwise, defer maintenance to the next safe point rather than interrupting the current response.
 
 12. **Submit implicit feedback on whispered memories**: If a whispered memory is genuinely useful and you actively draw on it in your response, call `submit_feedback(node_id=<id>, signal=1, source="implicit")`. If you explicitly decide a whispered memory is not relevant, call `submit_feedback(node_id=<id>, signal=-1, source="implicit")`. Do not call `submit_feedback` for silence — only call it when you actively use a memory or actively decide it's irrelevant.

--- a/src/ormah/instructions.md
+++ b/src/ormah/instructions.md
@@ -18,12 +18,12 @@ Ormah is your persistent memory system. It stores, recalls, and surfaces memorie
 
 7. **Use appropriate tiers**: `core` for always-relevant info (user identity, preferences, key architectural decisions), `working` for anything actively relevant now, `archival` for historical/reference data.
 
-8. **Start with context**: Call `get_context` at the beginning of conversations to load core memories. Use `task_hint` when the task is known to get focused context.
+8. **Start with the current turn**: If your client does not already have Ormah whisper hooks, call `whisper` with the latest user message at the start of each new turn. Use `get_self` for explicit identity/profile reads and `recall` for targeted lookups.
 
 9. **Mark outdated info**: When a memory is wrong or outdated, call `mark_outdated` with a reason so it gets demoted in future searches.
 
 10. **Set confidence**: When storing information you're not fully certain about, set `confidence` below 1.0. This affects how prominently the memory appears in search results.
 
-11. **Run maintenance in the background**: When `get_context` returns `unprocessed_memories` with a non-zero value, silently spawn `Agent(subagent_type="ormah-maintenance", run_in_background=True)` — do NOT run inline. Continue the conversation normally without mentioning it to the user.
+11. **Run maintenance in the background**: When whisper surfaces a `maintenance_due` signal, silently spawn `Agent(subagent_type="ormah-maintenance", run_in_background=True)` — do NOT run inline. Continue the conversation normally without mentioning it to the user.
 
 12. **Submit implicit feedback on whispered memories**: If a whispered memory is genuinely useful and you actively draw on it in your response, call `submit_feedback(node_id=<id>, signal=1, source="implicit")`. If you explicitly decide a whispered memory is not relevant, call `submit_feedback(node_id=<id>, signal=-1, source="implicit")`. Do not call `submit_feedback` for silence — only call it when you actively use a memory or actively decide it's irrelevant.

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -211,7 +211,7 @@ def configure_claude_desktop(ormah_bin: str) -> bool:
 
     _merge_json_file(config_path, {"mcpServers": mcp_entry})
     ok("Connected to Claude Desktop \u2014 MCP tools available")
-    info("Whisper hooks require Claude Code; Desktop uses MCP tools directly")
+    info("Claude Desktop uses MCP tools directly, including the whisper tool")
     return True
 
 

--- a/tests/test_adapters/test_mcp_adapter.py
+++ b/tests/test_adapters/test_mcp_adapter.py
@@ -1,0 +1,57 @@
+"""Tests for the MCP adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+
+from ormah.adapters.mcp_adapter import _dispatch
+from ormah.adapters.tool_schemas import TOOLS
+
+
+def _mock_response(request: httpx.Request, data: dict, status_code: int = 200) -> httpx.Response:
+    """Create a mock httpx.Response bound to *request*."""
+    return httpx.Response(status_code=status_code, json=data, request=request)
+
+
+def test_whisper_tool_schema_present():
+    whisper = next((tool for tool in TOOLS if tool["name"] == "whisper"), None)
+    assert whisper is not None
+    assert whisper["parameters"]["required"] == ["prompt"]
+
+
+def test_dispatch_whisper_posts_prompt_space_and_session(monkeypatch):
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/agent/whisper"
+        body = json.loads(request.content.decode("utf-8"))
+        assert body == {
+            "prompt": "how does auth work?",
+            "space": "ormah",
+            "session_id": "sess-123",
+        }
+        return _mock_response(request, {"text": "whispered"})
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args, **kwargs):
+        kwargs = dict(kwargs)
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr("ormah.adapters.mcp_adapter.httpx.AsyncClient", fake_async_client)
+
+    result = asyncio.run(
+        _dispatch(
+            "http://test",
+            "whisper",
+            {"prompt": "how does auth work?"},
+            default_space="ormah",
+            session_id="sess-123",
+        )
+    )
+
+    assert result == "whispered"


### PR DESCRIPTION
## Summary
- add a first-class MCP `whisper` tool for clients without pre-prompt hooks
- pass an internal MCP session id through `/agent/whisper` so Claude Desktop gets session-aware whisper behavior
- update docs, setup messaging, and shipped instructions to reflect whisper-first guidance instead of the removed `get_context` path
- add focused adapter coverage for the new MCP whisper flow

## Context
This is a follow-up to #1. The goal is to support the Claude Desktop use case in the current architecture, without reintroducing `get_context`.
