### PR TITLE
feat(improvements): conflict surfacing + gate tuning + decay alerts + versioning + session summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Before each hooked prompt, Ormah:
 4. Reranks candidates for precision
 5. Avoids repeating recently-whispered context when the topic has not shifted
 6. Applies a relevance gate so silence beats noise
+7. Adjusts that gate over time based on your feedback — accepted whispers raise it, rejected ones lower it
 
 The result is a compact block of context added before the model sees your message.
 
@@ -418,6 +419,12 @@ ORMAH_SIMILARITY_THRESHOLD=0.4
 ORMAH_WHISPER_MAX_NODES=6
 ORMAH_WHISPER_INJECTION_GATE=0.50
 ORMAH_WHISPER_RERANKER_ENABLED=true
+
+# Feedback-driven gate tuning (adjusts injection gate based on submit_feedback signals)
+ORMAH_GATE_TUNING_ENABLED=true
+ORMAH_GATE_MIN=0.30
+ORMAH_GATE_MAX=0.80
+ORMAH_GATE_LEARNING_RATE=0.02
 
 # FSRS decay
 ORMAH_FSRS_INITIAL_STABILITY=1.0

--- a/README.md
+++ b/README.md
@@ -193,13 +193,40 @@ Ormah does not just collect memories. It keeps the graph healthy.
 Background jobs:
 
 - link related memories
-- detect contradictions and belief evolution
+- detect contradictions and belief evolution — surfaced as queryable `[observation]` nodes
 - merge near-duplicates
 - score importance from access, centrality, and recency
 - decay stale memories with FSRS-style retrievability
 - consolidate overlapping working memories
 - assign spaces to orphaned memories
 - refresh indexes incrementally
+
+### Conflict surfacing
+
+When the conflict detector finds a genuine **tension** between two beliefs — both simultaneously held and irreconcilable — it no longer just adds a silent `contradicts` edge. It creates a new `[observation]` node that makes the conflict visible and actionable.
+
+The observation node:
+
+- Is tagged `conflict` and `needs-review` so it surfaces in whisper when related topics come up
+- Includes the explanation of why the two memories contradict each other
+- Links directly to both conflicting nodes via `contradicts` edges
+- Stays in the graph until resolved
+
+**To resolve a conflict**, recall it first:
+
+```bash
+ormah recall "conflict needs-review"
+```
+
+Then mark the outdated belief:
+
+```bash
+ormah outdated <node-id> --reason "superseded by newer decision"
+```
+
+Or use the `mark_outdated` MCP tool from within your agent.
+
+**Evolution is handled differently.** When the detector finds that a newer belief superseded an older one — the person's view simply changed over time — it creates an `evolved_from` edge instead. No observation node is created because there is nothing to resolve; the history is just recorded.
 
 ### Agent-in-the-loop maintenance
 

--- a/docs/09 - Affinity and Feedback.md
+++ b/docs/09 - Affinity and Feedback.md
@@ -141,9 +141,44 @@ flowchart LR
     SEARCH[hybrid search] --> RERANK[rerank]
     RERANK --> AFF[affinity boost]
     AFF --> GATE[injection gate]
+    GATE --> TUNE[gate tuning]
 ```
 
 It can rescue a borderline candidate or slightly suppress a noisy one, but it is capped.
+
+## Feedback-driven Gate Tuning
+
+Beyond per-node affinity boosts, each `submit_feedback` call also nudges the **global injection gate** — the minimum blended score required for any memory to be whispered.
+
+The update rule is proportional:
+
+```python
+if signal > 0:
+    new_gate = current + lr * (gate_max - current)   # pull toward gate_max
+else:
+    new_gate = current - lr * (current - gate_min)   # pull toward gate_min
+
+new_gate = clamp(new_gate, gate_min, gate_max)
+```
+
+This means:
+
+- Accepting whispers (`signal=+1`) gradually raises the gate, making future whispers more selective.
+- Rejecting whispers (`signal=-1`) gradually lowers it, widening the window.
+- The gate converges toward the implicit "right level" the user's feedback reveals over time.
+
+The gate value is persisted in the `gate_state` table and survives server restarts. It replaces the static `ORMAH_WHISPER_INJECTION_GATE` config value at runtime.
+
+### Gate tuning config
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `ORMAH_GATE_TUNING_ENABLED` | `true` | Enable/disable gate tuning. `false` falls back to static config. |
+| `ORMAH_GATE_MIN` | `0.30` | Floor — gate never goes below this |
+| `ORMAH_GATE_MAX` | `0.80` | Ceiling — gate never goes above this |
+| `ORMAH_GATE_LEARNING_RATE` | `0.02` | Step size per feedback signal |
+
+The initial gate value is `ORMAH_WHISPER_INJECTION_GATE` (default `0.50`) until the first feedback signal shifts it.
 
 ## Review Loop
 

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -336,6 +336,13 @@ async def _dispatch(
                 )
             return "\n\n".join(lines)
 
+        elif name == "recall_history":
+            node_id = args.get("node_id", "")
+            resp = await client.get(f"/agent/recall/{node_id}/history")
+            if not resp.is_success:
+                return _handle_error(resp)
+            return resp.json().get("text", "")
+
         elif name == "undo_merge":
             resp = await client.post(f"/agent/merges/{args['merge_id']}/undo")
             if not resp.is_success:

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -248,6 +248,13 @@ async def _dispatch(
                 return _handle_error(resp)
             return resp.json()["text"]
 
+        elif name == "promote_memory":
+            body = {"tier": args.get("tier", "core")}
+            resp = await client.post(f"/agent/promote/{args['node_id']}", json=body)
+            if not resp.is_success:
+                return _handle_error(resp)
+            return resp.json()["text"]
+
         elif name == "mark_outdated":
             body = {}
             if args.get("reason"):

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -14,10 +14,12 @@ from mcp.types import TextContent, Tool
 from ormah.adapters.space_detect import detect_space_from_cwd
 from ormah.adapters.tool_schemas import TOOLS
 from ormah.config import settings
+from ormah.store.write_buffer import WriteBuffer, buffer_path_for
 
 logger = logging.getLogger(__name__)
 
 _BASE_URL = f"http://localhost:{settings.port}"
+_write_buffer = WriteBuffer(buffer_path_for(settings.memory_dir))
 
 
 def _coerce_list(value):
@@ -159,6 +161,47 @@ def _format_maintenance_batches(batches: dict) -> str:
     return "\n".join(lines)
 
 
+async def _drain_write_buffer(client: httpx.AsyncClient, base_params: dict) -> str:
+    """Replay any buffered remember calls. Returns a summary string if items were drained."""
+    if _write_buffer.is_empty():
+        return ""
+    pending = _write_buffer.load()
+    if not pending:
+        return ""
+    succeeded, failed = 0, []
+    for entry in pending:
+        buffered_args = entry.get("args", {})
+        buffered_params = entry.get("params", base_params)
+        body = {
+            "content": buffered_args["content"],
+            "type": buffered_args.get("type", "fact"),
+            "tier": buffered_args.get("tier", "working"),
+        }
+        for key in ("title", "space", "about_self", "confidence"):
+            if buffered_args.get(key) is not None:
+                body[key] = buffered_args[key]
+        if buffered_args.get("tags"):
+            body["tags"] = _coerce_list(buffered_args["tags"])
+        if buffered_args.get("links"):
+            body["connections"] = [
+                {"target": nid} for nid in _coerce_list(buffered_args["links"])
+            ]
+        try:
+            resp = await client.post("/agent/remember", json=body, params=buffered_params)
+            if resp.is_success:
+                succeeded += 1
+            else:
+                failed.append(entry)
+        except httpx.ConnectError:
+            failed.append(entry)
+            failed.extend(pending[pending.index(entry) + 1 :])
+            break
+    _write_buffer.rewrite(failed)
+    if succeeded:
+        return f"(Replayed {succeeded} buffered write{'s' if succeeded > 1 else ''} from local queue.)"
+    return ""
+
+
 async def _dispatch(
     base_url: str,
     name: str,
@@ -188,10 +231,24 @@ async def _dispatch(
             params = {}
             if default_space:
                 params["default_space"] = default_space
-            resp = await client.post("/agent/remember", json=body, params=params)
+
+            # Drain buffered writes before sending the current one.
+            drain_msg = await _drain_write_buffer(client, params)
+
+            try:
+                resp = await client.post("/agent/remember", json=body, params=params)
+            except httpx.ConnectError:
+                _write_buffer.append(args=args, params=params)
+                buffered_suffix = (
+                    "\n(Server unreachable — memory queued in local buffer and will be "
+                    "replayed automatically when the server comes back online.)"
+                )
+                return drain_msg + buffered_suffix if drain_msg else buffered_suffix.lstrip()
+
             if not resp.is_success:
                 return _handle_error(resp)
-            return resp.json()["text"]
+            result = resp.json()["text"]
+            return f"{drain_msg}\n{result}" if drain_msg else result
 
         elif name == "recall":
             body = {"query": args["query"]}

--- a/src/ormah/adapters/tool_schemas.py
+++ b/src/ormah/adapters/tool_schemas.py
@@ -442,6 +442,24 @@ ADMIN_TOOLS = [
             },
         },
     },
+    {
+        "name": "recall_history",
+        "description": (
+            "Show the full human-readable edit history for a specific memory node. "
+            "Returns a chronological changelog of all updates, outdating, and deletions, "
+            "with field-by-field diffs showing old → new values for each change."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "string",
+                    "description": "The ID of the memory node to show history for.",
+                },
+            },
+            "required": ["node_id"],
+        },
+    },
 ]
 
 ALL_TOOLS = TOOLS + ADMIN_TOOLS

--- a/src/ormah/adapters/tool_schemas.py
+++ b/src/ormah/adapters/tool_schemas.py
@@ -1,7 +1,7 @@
 """Canonical tool definitions shared across MCP and OpenAI adapters.
 
-TOOLS: The core set of tools exposed via MCP to AI agents (6 tools).
-ADMIN_TOOLS: Tools for human administration via CLI/API only (7 tools).
+TOOLS: The core set of tools exposed via MCP to AI agents (10 tools).
+ADMIN_TOOLS: Tools for human administration via CLI/API only (4 tools).
 ALL_TOOLS: Combined list for adapters that want the full set.
 """
 
@@ -286,16 +286,12 @@ TOOLS = [
             },
         },
     },
-]
-
-# Admin tools — available via CLI and HTTP API but not exposed to AI agents via MCP.
-# These are for human review and administration of the memory system.
-ADMIN_TOOLS = [
     {
         "name": "update_memory",
         "description": (
-            "Update an existing memory's content, type, tier, or tags. "
-            "Use this to correct or enhance stored memories."
+            "Correct or enhance an existing memory. Use this when you find that a stored memory "
+            "has wrong content, an outdated type/tier, or needs better tags. "
+            "Only pass the fields you want to change — omitted fields are left unchanged."
         ),
         "parameters": {
             "type": "object",
@@ -304,16 +300,42 @@ ADMIN_TOOLS = [
                     "type": "string",
                     "description": "The UUID of the memory to update.",
                 },
-                "content": {"type": "string", "description": "New content."},
-                "type": {"type": "string", "description": "New type."},
-                "tier": {"type": "string", "description": "New tier."},
+                "content": {
+                    "type": "string",
+                    "description": "Corrected or updated content.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "New short title.",
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "fact", "decision", "preference", "event", "person",
+                        "project", "concept", "procedure", "goal", "observation",
+                    ],
+                    "description": "New memory type.",
+                },
+                "tier": {
+                    "type": "string",
+                    "enum": ["core", "working", "archival"],
+                    "description": "New importance tier. Use 'core' to pin permanently, 'archival' to deprioritize.",
+                },
+                "confidence": {
+                    "type": "number",
+                    "description": "Updated confidence 0.0–1.0.",
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                },
                 "tags": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "New tags.",
+                    "description": "Replacement tag list (replaces existing tags entirely).",
                 },
-                "title": {"type": "string", "description": "New title."},
-                "space": {"type": "string", "description": "New space/project scope. Use null for global memories."},
+                "space": {
+                    "type": "string",
+                    "description": "New space/project scope. Use null to make the memory global.",
+                },
             },
             "required": ["node_id"],
         },
@@ -321,8 +343,10 @@ ADMIN_TOOLS = [
     {
         "name": "connect_memories",
         "description": (
-            "Create a typed connection between two memories. "
-            "Use this to build relationships in the knowledge graph."
+            "Create a typed edge between two memories. Use this when you recognise a meaningful "
+            "relationship between nodes — e.g. one decision supports another, a fact is part of a "
+            "concept, or two observations contradict each other. "
+            "Background auto-linker runs periodically, but call this for immediate graph updates."
         ),
         "parameters": {
             "type": "object",
@@ -333,20 +357,68 @@ ADMIN_TOOLS = [
                     "type": "string",
                     "enum": [
                         "related_to", "supports", "contradicts", "part_of",
-                        "derived_from", "depends_on", "defines",
+                        "derived_from", "depends_on", "defines", "evolved_from",
                     ],
-                    "description": "The type of connection.",
+                    "description": "The relationship type.",
                     "default": "related_to",
                 },
                 "weight": {
                     "type": "number",
-                    "description": "Connection strength 0.0-1.0.",
+                    "description": "Connection strength 0.0–1.0.",
                     "default": 0.5,
                 },
             },
             "required": ["source_id", "target_id"],
         },
     },
+    {
+        "name": "promote_memory",
+        "description": (
+            "Promote a memory to core tier, marking it as permanently important. "
+            "Use this when you discover a memory that should always be accessible — "
+            "key decisions, identity facts, architectural constants. "
+            "Core memories are never decayed and always surface in whisper context."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "string",
+                    "description": "UUID of the memory to promote.",
+                },
+                "tier": {
+                    "type": "string",
+                    "enum": ["core", "working"],
+                    "description": "Target tier (default: core). Use 'working' to un-archive a demoted memory.",
+                    "default": "core",
+                },
+            },
+            "required": ["node_id"],
+        },
+    },
+    {
+        "name": "recall_history",
+        "description": (
+            "Show the full edit history for a memory. Returns a chronological changelog "
+            "of all updates with field-by-field old→new diffs. "
+            "Use this to understand how a memory has changed over time."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "string",
+                    "description": "The UUID of the memory to show history for.",
+                },
+            },
+            "required": ["node_id"],
+        },
+    },
+]
+
+# Admin tools — available via CLI and HTTP API but not exposed to AI agents via MCP.
+# These are for human review and administration of the memory system.
+ADMIN_TOOLS = [
     {
         "name": "list_proposals",
         "description": (
@@ -440,24 +512,6 @@ ADMIN_TOOLS = [
                     "description": "Filter by operation type.",
                 },
             },
-        },
-    },
-    {
-        "name": "recall_history",
-        "description": (
-            "Show the full human-readable edit history for a specific memory node. "
-            "Returns a chronological changelog of all updates, outdating, and deletions, "
-            "with field-by-field diffs showing old → new values for each change."
-        ),
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "The ID of the memory node to show history for.",
-                },
-            },
-            "required": ["node_id"],
         },
     },
 ]

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -104,6 +104,14 @@ async def delete_node(node_id: str, request: Request):
     return TextResponse(text=text, node_id=node_id)
 
 
+@router.get("/recall/{node_id}/history", response_model=TextResponse)
+async def recall_history(node_id: str, request: Request):
+    """Get the full edit history for a specific memory."""
+    engine = request.app.state.engine
+    text = engine.recall_history(node_id)
+    return TextResponse(text=text, node_id=node_id)
+
+
 @router.post("/connect", response_model=TextResponse)
 async def connect(req: ConnectRequest, request: Request):
     """Create a connection between two memories."""

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -112,6 +112,57 @@ async def recall_history(node_id: str, request: Request):
     return TextResponse(text=text, node_id=node_id)
 
 
+class PromoteRequest(BaseModel):
+    tier: str = "core"
+
+
+@router.post("/promote/{node_id}", response_model=TextResponse)
+async def promote_node(node_id: str, request: Request, body: PromoteRequest | None = None):
+    """Promote a memory to a higher tier (default: core)."""
+    from ormah.models.node import Tier
+
+    target_tier_str = (body.tier if body else None) or "core"
+    try:
+        target_tier = Tier(target_tier_str)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid tier: {target_tier_str!r}")
+
+    engine = request.app.state.engine
+    node = engine.graph.get_node(node_id)
+    if node is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    tier_order = [Tier.archival, Tier.working, Tier.core]
+    current_tier = Tier(node["tier"])
+    current_idx = tier_order.index(current_tier)
+    target_idx = tier_order.index(target_tier)
+
+    if target_idx <= current_idx:
+        return TextResponse(
+            text=f"Memory is already at {current_tier.value} tier — no promotion needed.",
+            node_id=node_id,
+        )
+
+    text = engine.update_node(node_id, UpdateNodeRequest(tier=target_tier))
+    if text is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    # Enforce core cap after promotion
+    if target_tier == Tier.core:
+        protected = {engine.user_node_id} if engine.user_node_id else set()
+        core_nodes = [
+            engine.file_store.load(r["id"])
+            for r in engine.graph.get_nodes_by_tier("core")
+        ]
+        core_nodes = [n for n in core_nodes if n is not None]
+        demoted = engine.tier_manager.enforce_core_cap(core_nodes, protected_ids=protected)
+        for d in demoted:
+            path = engine.file_store.save(d)
+            engine.builder.index_single(path)
+
+    return TextResponse(text=text, node_id=node_id)
+
+
 @router.post("/connect", response_model=TextResponse)
 async def connect(req: ConnectRequest, request: Request):
     """Create a connection between two memories."""

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -7,7 +7,8 @@ import logging
 from datetime import datetime, timezone
 
 from ormah.background.llm import normalize_conflict_type
-from ormah.models.node import Connection, EdgeType
+from ormah.models.node import Connection, EdgeType, NodeType, Tier
+from ormah.models.node import CreateNodeRequest
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +206,38 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
         return []
 
 
+def _store_conflict_node(engine, node_a: dict, node_b: dict, explanation: str) -> None:
+    """Create a queryable observation node surfacing a tension conflict."""
+    try:
+        title_a = (node_a.get("title") or node_a["id"][:8])[:50]
+        title_b = (node_b.get("title") or node_b["id"][:8])[:50]
+        space = node_a.get("space") or None
+
+        content = (
+            f"{explanation}\n\n"
+            f"Node A: {title_a} (id: {node_a['id']})\n"
+            f"Node B: {title_b} (id: {node_b['id']})\n\n"
+            f"Resolve by marking the outdated node with `mark_outdated`."
+        )
+
+        req = CreateNodeRequest(
+            type=NodeType.observation,
+            tier=Tier.working,
+            title=f"Conflict: {title_a} vs {title_b}",
+            content=content,
+            tags=["conflict", "needs-review"],
+            space=space,
+            source="conflict-detector",
+            connections=[
+                Connection(target=node_a["id"], edge=EdgeType.contradicts, weight=0.9),
+                Connection(target=node_b["id"], edge=EdgeType.contradicts, weight=0.9),
+            ],
+        )
+        engine.remember(req, agent_id="conflict-detector")
+    except Exception as e:
+        logger.debug("Failed to store conflict node: %s", e)
+
+
 def run_conflict_detection(engine) -> None:
     """Find potentially contradicting nodes and create edges."""
     try:
@@ -257,6 +290,9 @@ def run_conflict_detection(engine) -> None:
                     )
                     edge_type_str = "contradicts"
                     source_id, target_id = node_a["id"], node_b["id"]
+
+                    # Surface tension conflicts as queryable observation nodes
+                    _store_conflict_node(engine, node_a, node_b, explanation)
 
             md_conn = Connection(
                 target=target_id,

--- a/src/ormah/background/decay_manager.py
+++ b/src/ormah/background/decay_manager.py
@@ -11,11 +11,29 @@ from ormah.models.node import Tier, UpdateNodeRequest
 logger = logging.getLogger(__name__)
 
 
+def _compute_retrievability(row, now: datetime) -> float | None:
+    """Return FSRS retrievability for a node row, or None if uncomputable."""
+    stability = row["stability"] if row["stability"] else 1.0
+    anchor_str = row["last_review"] or row["last_accessed"]
+    try:
+        anchor = datetime.fromisoformat(anchor_str)
+    except (ValueError, TypeError):
+        return None
+    days_since = max((now - anchor).total_seconds() / 86400, 0.001)
+    return math.exp(-days_since / stability)
+
+
 def run_decay(engine) -> None:
-    """Auto-demote working nodes whose FSRS retrievability drops below threshold."""
+    """Auto-demote working nodes whose FSRS retrievability drops below threshold.
+
+    Also writes proactive decay alerts for core and working nodes whose
+    retrievability has dropped below ``decay_alert_threshold`` so that
+    context_builder can whisper a warning before demotion occurs.
+    """
     try:
         settings = engine.settings
         now = datetime.now(timezone.utc)
+        now_iso = now.isoformat()
 
         # One-time cleanup: remove legacy pending decay proposals
         with engine.db.transaction() as conn:
@@ -23,6 +41,51 @@ def run_decay(engine) -> None:
                 "DELETE FROM proposals WHERE type = 'decay' AND status = 'pending'"
             )
 
+        # --- Proactive decay alerts ------------------------------------------
+        if getattr(settings, "decay_alert_enabled", True):
+            alert_threshold = getattr(settings, "decay_alert_threshold", 0.40)
+            refire_days = getattr(settings, "decay_alert_refire_days", 7)
+            user_node_id = getattr(engine, "user_node_id", None)
+
+            alert_rows = engine.db.conn.execute(
+                "SELECT id, tier, importance, stability, last_review, last_accessed "
+                "FROM nodes WHERE tier IN ('core', 'working')"
+            ).fetchall()
+
+            alerted = 0
+            for row in alert_rows:
+                if row["id"] == user_node_id:
+                    continue
+                r = _compute_retrievability(row, now)
+                if r is None or r >= alert_threshold:
+                    continue
+
+                # Suppress if already alerted recently
+                recent = engine.db.conn.execute(
+                    """
+                    SELECT id FROM decay_alert_log
+                    WHERE node_id = ? AND acknowledged = 0
+                      AND alerted_at > datetime(?, '-' || ? || ' days')
+                    LIMIT 1
+                    """,
+                    (row["id"], now_iso, refire_days),
+                ).fetchone()
+                if recent:
+                    continue
+
+                with engine.db.transaction() as conn:
+                    conn.execute(
+                        "INSERT INTO decay_alert_log "
+                        "(node_id, alerted_at, retrievability, tier) "
+                        "VALUES (?, ?, ?, ?)",
+                        (row["id"], now_iso, r, row["tier"]),
+                    )
+                alerted += 1
+
+            if alerted:
+                logger.info("Decay manager created %d proactive alerts", alerted)
+
+        # --- Demotion --------------------------------------------------------
         rows = engine.db.conn.execute(
             "SELECT id, importance, stability, last_review, last_accessed "
             "FROM nodes WHERE tier = 'working'"
@@ -44,17 +107,8 @@ def run_decay(engine) -> None:
             if node_importance >= importance_threshold:
                 continue
 
-            # Compute FSRS retrievability
-            stability = row["stability"] if row["stability"] else 1.0
-            anchor_str = row["last_review"] or row["last_accessed"]
-            try:
-                anchor = datetime.fromisoformat(anchor_str)
-            except (ValueError, TypeError):
-                continue
-            days_since = max((now - anchor).total_seconds() / 86400, 0.001)
-            retrievability = math.exp(-days_since / stability)
-
-            if retrievability >= r_threshold:
+            r = _compute_retrievability(row, now)
+            if r is None or r >= r_threshold:
                 continue
 
             result = engine.update_node(row["id"], UpdateNodeRequest(tier=Tier.archival))

--- a/src/ormah/background/recall_promoter.py
+++ b/src/ormah/background/recall_promoter.py
@@ -1,0 +1,99 @@
+"""Background job: auto-promote working memories that receive positive recall hits
+across multiple distinct sessions.
+
+A ``working`` node is promoted to ``core`` when it has accumulated positive
+affinity signals (signal > 0) from at least ``recall_promotion_sessions``
+distinct sessions. This reflects the intuition that a memory repeatedly useful
+in different contexts has earned long-term prominence.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from ormah.models.node import Tier
+
+logger = logging.getLogger(__name__)
+
+
+def run_recall_promotion(engine) -> None:
+    """Promote working-tier nodes that have positive hits across enough sessions."""
+    settings = engine.settings
+    min_sessions: int = getattr(settings, "recall_promotion_sessions", 3)
+
+    # Find working-tier nodes with sufficient multi-session positive affinity.
+    rows = engine.db.conn.execute(
+        """
+        SELECT a.node_id, COUNT(DISTINCT a.session_id) AS session_count
+          FROM affinity a
+          JOIN nodes n ON n.id = a.node_id
+         WHERE a.signal > 0
+           AND n.tier = 'working'
+         GROUP BY a.node_id
+        HAVING session_count >= ?
+        """,
+        (min_sessions,),
+    ).fetchall()
+
+    if not rows:
+        return
+
+    promoted = 0
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    for row in rows:
+        node_id = row["node_id"]
+        session_count = row["session_count"]
+
+        node = engine.file_store.load(node_id)
+        if node is None:
+            continue
+
+        # Double-check tier — file_store is authoritative.
+        if node.tier != Tier.working:
+            continue
+
+        node.tier = Tier.core
+        node.updated = datetime.now(timezone.utc)
+        path = engine.file_store.save(node)
+        engine.builder.index_single(path)
+
+        with engine.db.transaction() as conn:
+            conn.execute(
+                "UPDATE nodes SET tier = 'core', updated = ? WHERE id = ?",
+                (now_iso, node_id),
+            )
+
+        logger.info(
+            "Auto-promoted node %s to core (positive hits in %d sessions)",
+            node_id[:8],
+            session_count,
+        )
+        promoted += 1
+
+    if promoted:
+        # Enforce core cap after bulk promotion.
+        core_rows = engine.db.conn.execute(
+            "SELECT id, importance FROM nodes WHERE tier = 'core'"
+        ).fetchall()
+        core_nodes = [
+            engine.file_store.load(r["id"])
+            for r in core_rows
+            if engine.file_store.load(r["id"]) is not None
+        ]
+        core_nodes = [n for n in core_nodes if n is not None]
+        demoted = engine.tier_manager.enforce_core_cap(core_nodes)
+        for d in demoted:
+            engine.file_store.save(d)
+            with engine.db.transaction() as conn:
+                conn.execute(
+                    "UPDATE nodes SET tier = 'working', updated = ? WHERE id = ?",
+                    (now_iso, d.id),
+                )
+
+        logger.info(
+            "Recall promoter: promoted %d node(s), demoted %d via cap",
+            promoted,
+            len(demoted),
+        )

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -103,6 +103,17 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
+    from ormah.background.recall_promoter import run_recall_promotion
+
+    scheduler.add_job(
+        tracked(tracker, "recall_promoter", run_recall_promotion, engine),
+        "interval",
+        minutes=s.recall_promotion_interval_minutes,
+        id="recall_promoter",
+        name="Recall promoter",
+        misfire_grace_time=_MISFIRE_GRACE,
+    )
+
     scheduler.add_job(
         tracked(tracker, "index_updater", engine.builder.incremental_update),
         "interval",

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -122,7 +122,85 @@ def _ingest_session(
         "Session watcher ingested %s (%d turns, %d memories extracted)",
         rel, result.user_turn_count, count,
     )
+
+    # Session summary: create an [event] node summarising what was extracted.
+    settings = engine.settings
+    if (
+        getattr(settings, "session_summary_enabled", True)
+        and result.user_turn_count >= getattr(settings, "session_summary_min_turns", 3)
+        and new_node_ids
+    ):
+        _create_session_summary(engine, ingested, result, space)
+
     return True
+
+
+def _create_session_summary(
+    engine: MemoryEngine,
+    ingested: list,
+    result,
+    space: str | None,
+) -> None:
+    """Create a concise [event] memory summarising a completed session.
+
+    Counts extracted nodes by type, picks the top titles, and stores a
+    self-contained summary so the session is searchable and whisper-able
+    without re-reading the full transcript.
+    """
+    from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+    # Count nodes by type
+    type_counts: dict[str, int] = {}
+    titles: list[str] = []
+    for m in ingested:
+        ntype = m.get("type", "fact")
+        type_counts[ntype] = type_counts.get(ntype, 0) + 1
+        title = m.get("title") or m.get("content", "")[:60]
+        if title:
+            titles.append(title)
+
+    type_summary_parts = []
+    for ntype in ("decision", "fact", "event", "preference", "procedure", "observation"):
+        n = type_counts.get(ntype, 0)
+        if n:
+            type_summary_parts.append(f"{n} {ntype}{'s' if n > 1 else ''}")
+    for ntype, n in type_counts.items():
+        if ntype not in ("decision", "fact", "event", "preference", "procedure", "observation") and n:
+            type_summary_parts.append(f"{n} {ntype}{'s' if n > 1 else ''}")
+
+    space_label = space or "global"
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    total = len(ingested)
+
+    body_lines = [
+        f"Session on {date_str} in space '{space_label}': "
+        f"{result.user_turn_count} turns, {total} {'memory' if total == 1 else 'memories'} extracted.",
+    ]
+    if type_summary_parts:
+        body_lines.append("Extracted: " + ", ".join(type_summary_parts) + ".")
+    if titles:
+        preview = titles[:5]
+        body_lines.append("Key memories: " + "; ".join(f'"{t}"' for t in preview) + ".")
+
+    session_id_short = (result.session_id or "")[:8] or "unknown"
+    try:
+        engine.remember(
+            CreateNodeRequest(
+                title=f"Session summary — {date_str} [{space_label}]",
+                content="\n".join(body_lines),
+                type=NodeType.event,
+                tier=Tier.working,
+                space=space,
+                tags=["session-summary", space_label] if space_label != "global" else ["session-summary"],
+            ),
+            agent_id="session-watcher",
+        )
+        logger.info(
+            "Session watcher created summary for session %s (%d memories)",
+            session_id_short, total,
+        )
+    except Exception as e:
+        logger.warning("Session summary creation failed: %s", e)
 
 
 def _scan_sessions(

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -164,6 +164,12 @@ class Settings(BaseSettings):
     # Whisper injection gate (minimum blended score to justify injection)
     whisper_injection_gate: float = 0.50
 
+    # Feedback-driven gate tuning
+    gate_tuning_enabled: bool = True
+    gate_min: float = 0.30
+    gate_max: float = 0.80
+    gate_learning_rate: float = 0.02
+
     # Affinity boost (adaptive feedback loop)
     affinity_similarity_threshold: float = 0.70
     affinity_half_life_days: float = 30.0

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -59,6 +59,8 @@ class Settings(BaseSettings):
     session_watcher_debounce_seconds: float = 60.0
     session_watcher_min_turns: int = 5
     session_watcher_lookback_hours: int = 72
+    session_summary_enabled: bool = True
+    session_summary_min_turns: int = 3  # skip summary for trivial sessions
 
     # Tier limits
     core_memory_cap: int = 50

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -117,6 +117,10 @@ class Settings(BaseSettings):
     # Auto-merge
     auto_merge_threshold: float = 0.85
 
+    # Pre-storage contradiction check (inline, rule-based — no LLM)
+    contradiction_prestorage_enabled: bool = True
+    contradiction_prestorage_threshold: float = 0.88  # cosine similarity to flag
+
     # Importance scoring weights (3 dynamic signals)
     importance_access_weight: float = 0.34
     importance_edge_weight: float = 0.33

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -117,6 +117,10 @@ class Settings(BaseSettings):
     # Auto-merge
     auto_merge_threshold: float = 0.85
 
+    # Auto-promotion: promote working nodes with positive recall hits across N sessions
+    recall_promotion_sessions: int = 3   # min distinct sessions with positive signal
+    recall_promotion_interval_minutes: int = 60
+
     # Importance scoring weights (3 dynamic signals)
     importance_access_weight: float = 0.34
     importance_edge_weight: float = 0.33

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -121,6 +121,10 @@ class Settings(BaseSettings):
     contradiction_prestorage_enabled: bool = True
     contradiction_prestorage_threshold: float = 0.88  # cosine similarity to flag
 
+    # Tag-cascade invalidation: surface siblings when mark_outdated is called
+    tag_cascade_invalidation_enabled: bool = True
+    tag_cascade_max_results: int = 10  # max sibling nodes to surface
+
     # Importance scoring weights (3 dynamic signals)
     importance_access_weight: float = 0.34
     importance_edge_weight: float = 0.33

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -131,6 +131,11 @@ class Settings(BaseSettings):
     # Decay: skip nodes above this importance
     decay_importance_threshold: float = 0.5
 
+    # Proactive decay alerts (warn before demotion)
+    decay_alert_enabled: bool = True
+    decay_alert_threshold: float = 0.40   # alert when R drops below this (above fsrs_decay_threshold)
+    decay_alert_refire_days: int = 7      # suppress repeat alerts for this many days
+
     # Whisper-out (involuntary storage on compaction / session end)
     whisper_out_enabled: bool = True
     whisper_out_min_turns: int = 3

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -194,6 +194,10 @@ class Settings(BaseSettings):
     # Consolidation
     consolidation_interval_minutes: int = 1440
 
+    # Whisper compact mode (token-compressed injection)
+    whisper_compact_mode: bool = False
+    whisper_compact_content_chars: int = 200  # max content chars per full-content node
+
     # Claude-in-the-loop maintenance
     claude_maintenance_enabled: bool = False
     claude_maintenance_interval_hours: int = 24  # hours between maintenance runs

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -19,6 +19,22 @@ _WHISPER_FRAMING = (
     "to get the full content and related memories."
 )
 
+_WHISPER_FRAMING_COMPACT = "# Ormah whispers\nTop memories (full). Rest: titles only. Use recall(node_id) for details."
+
+# Compact mode: abbreviated type labels to reduce token overhead.
+_TYPE_ABBREV: dict[str, str] = {
+    "fact": "F",
+    "concept": "C",
+    "decision": "D",
+    "preference": "P",
+    "observation": "O",
+    "event": "E",
+    "person": "Prs",
+    "project": "Prj",
+    "procedure": "Proc",
+    "goal": "G",
+}
+
 
 _DECAY_ALERT_FRAMING = (
     "\n\n## Ormah: memory fading\n"
@@ -241,6 +257,8 @@ class ContextBuilder:
         topic_shift_threshold: float = 0.75,
         injection_gate: float = 0.55,
         session_id: str | None = None,
+        compact_mode: bool = False,
+        compact_content_chars: int = 200,
         _return_debug: bool = False,
     ) -> str | tuple[str, list[str]]:
         """Build compact whisper context for involuntary recall injection.
@@ -600,14 +618,21 @@ class ContextBuilder:
             node_type = node.get("type", "fact")
             id_suffix = f" (id: {short_id})" if short_id else ""
 
-            lines.append(f"- **[{node_type}]** {title}{id_suffix}")
+            if compact_mode:
+                type_label = _TYPE_ABBREV.get(node_type, node_type[:1].upper())
+                lines.append(f"- **[{type_label}]** {title}{id_suffix}")
+            else:
+                lines.append(f"- **[{node_type}]** {title}{id_suffix}")
 
             if i < full_content_count:
                 content = node.get("content", "").strip()
                 if content and content != title:
+                    if compact_mode:
+                        content = _truncate_at_word_boundary(content, max_len=compact_content_chars)
                     lines.append(f"  {content}")
 
-            lines.append("")
+            if not compact_mode:
+                lines.append("")
 
         body = "\n".join(lines).rstrip()
 
@@ -648,7 +673,8 @@ class ContextBuilder:
         if not body:
             result = ""
         else:
-            result = _WHISPER_FRAMING + "\n\n" + body
+            framing = _WHISPER_FRAMING_COMPACT if compact_mode else _WHISPER_FRAMING
+            result = framing + "\n\n" + body
 
         logger.info(
             "Whisper diagnostics: prompt=%r intent=%s identity_only=%s temporal=%s "

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -20,6 +20,13 @@ _WHISPER_FRAMING = (
 )
 
 
+_DECAY_ALERT_FRAMING = (
+    "\n\n## Ormah: memory fading\n"
+    "The following {count} {word} {verb} low retrievability and {may} be demoted to archival soon. "
+    "Recalling them will reset their stability.\n\n"
+    "{items}"
+)
+
 _REVIEW_FRAMING = (
     "\n\n## Ormah: one thing to review when you get a chance\n"
     "In a recent session, the user was working on:\n"
@@ -713,6 +720,39 @@ class ContextBuilder:
                     result = result + review_block
             except Exception as e:
                 logger.warning("Review mechanism failed: %s", e)
+
+        # Decay alerts: surface fading memories once per session (first message only).
+        if recent_prompts is None and self.engine is not None:
+            settings = getattr(self.engine, "settings", None)
+            if settings and getattr(settings, "decay_alert_enabled", True):
+                try:
+                    alert_rows = self.graph.conn.execute(
+                        """
+                        SELECT dal.id, dal.node_id, dal.retrievability, dal.tier,
+                               n.title, n.type
+                        FROM decay_alert_log dal
+                        JOIN nodes n ON n.id = dal.node_id
+                        WHERE dal.acknowledged = 0
+                        ORDER BY dal.retrievability ASC
+                        LIMIT 5
+                        """
+                    ).fetchall()
+                    if alert_rows:
+                        count = len(alert_rows)
+                        word = "memory" if count == 1 else "memories"
+                        verb = "has" if count == 1 else "have"
+                        may = "may" if alert_rows[0]["tier"] == "core" else "will"
+                        items = "\n".join(
+                            f"- **{r['title'] or r['node_id'][:8]}** "
+                            f"[{r['type']}/{r['tier']}] R={r['retrievability']:.2f} "
+                            f"(id: {r['node_id'][:8]}...)"
+                            for r in alert_rows
+                        )
+                        result = result + _DECAY_ALERT_FRAMING.format(
+                            count=count, word=word, verb=verb, may=may, items=items
+                        )
+                except Exception as e:
+                    logger.warning("Decay alert surfacing failed: %s", e)
 
         if _return_debug:
             return result, _injected_ids

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -462,6 +462,15 @@ class MemoryEngine:
             formatted += f"\nAuto-linked to {len(auto_links)} related memories:"
             for link_id, link_title, sim in auto_links:
                 formatted += f"\n  → {link_title} ({sim:.0%} similar)"
+
+        # Pre-storage contradiction check (inline, rule-based — no LLM)
+        if getattr(self.settings, "contradiction_prestorage_enabled", True):
+            conflicts = self._check_contradiction_prestorage(node)
+            if conflicts:
+                formatted += "\n⚠ Possible contradiction with existing memories:"
+                for cid, ctitle, csim in conflicts:
+                    formatted += f"\n  · {ctitle} (id: {cid[:8]}, {csim:.0%} similar) — review with recall(node_id='{cid[:8]}')"
+
         return node.id, formatted
 
     def _encode_feedback_prompt_vec(self, prompt_text: str) -> bytes:
@@ -1944,6 +1953,69 @@ class MemoryEngine:
 
         except Exception as e:
             logger.debug("Auto-link on remember failed: %s", e)
+            return []
+
+    def _check_contradiction_prestorage(
+        self,
+        node: MemoryNode,
+        similarity_threshold: float | None = None,
+        top_k: int = 5,
+    ) -> list[tuple[str, str, float]]:
+        """Return a list of (node_id, title, similarity) for existing nodes that
+        may contradict the incoming node.
+
+        Only nodes in the same space (or both space-less) are considered — cross-
+        space matches are never flagged. The threshold defaults to
+        ``settings.contradiction_prestorage_threshold`` (default 0.88).
+
+        Entirely rule-based (no LLM call) so it stays fast at store-time. The
+        background conflict_detector handles deeper LLM-powered checks later.
+        """
+        threshold = similarity_threshold
+        if threshold is None:
+            threshold = getattr(
+                self.settings, "contradiction_prestorage_threshold", 0.88
+            )
+
+        try:
+            from ormah.embeddings.vector_store import VectorStore
+            from ormah.embeddings.encoder import get_encoder
+
+            encoder = get_encoder(self.settings)
+            vec_store = VectorStore(self.db)
+
+            text = _embedding_text(node.title, node.content, self.settings.embedding_max_content_chars)
+            if not text:
+                return []
+
+            query_vec = encoder.encode(text)
+            similar = vec_store.search(query_vec, limit=top_k + 1)
+
+            flagged = []
+            node_space = node.space or ""
+
+            for match in similar:
+                if match["id"] == node.id:
+                    continue
+                if match["similarity"] < threshold:
+                    continue
+
+                other = self.graph.get_node(match["id"])
+                if other is None:
+                    continue
+
+                # Only flag same-space pairs
+                other_space = (other.get("space") or "")
+                if other_space != node_space:
+                    continue
+
+                title = other.get("title") or (other.get("content") or "")[:50]
+                flagged.append((match["id"], title, match["similarity"]))
+
+            return flagged
+
+        except Exception as e:
+            logger.debug("Pre-storage contradiction check failed: %s", e)
             return []
 
     # --- Provenance ---

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -943,6 +943,8 @@ class MemoryEngine:
             topic_shift_enabled=self.settings.whisper_topic_shift_enabled,
             topic_shift_threshold=self.settings.whisper_topic_shift_threshold,
             session_id=session_id,
+            compact_mode=self.settings.whisper_compact_mode,
+            compact_content_chars=self.settings.whisper_compact_content_chars,
             _return_debug=_return_debug,
         )
         if not onboarding:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -927,7 +927,7 @@ class MemoryEngine:
             reranker_blend_alpha=self.settings.whisper_reranker_blend_alpha,
             reranker_max_doc_chars=self.settings.whisper_reranker_max_doc_chars,
             recent_prompts=recent_prompts,
-            injection_gate=self.settings.whisper_injection_gate,
+            injection_gate=self.get_gate(),
             topic_shift_enabled=self.settings.whisper_topic_shift_enabled,
             topic_shift_threshold=self.settings.whisper_topic_shift_threshold,
             session_id=session_id,
@@ -2098,7 +2098,56 @@ class MemoryEngine:
                     (resolved_node_id,),
                 )
 
+        if getattr(self.settings, "gate_tuning_enabled", True):
+            self._update_gate(signal)
+
         return f"Feedback recorded for node {resolved_node_id[:8]}..."
+
+    def get_gate(self) -> float:
+        """Return the current injection gate value.
+
+        Reads from the gate_state table if gate tuning is enabled, falling
+        back to the static config value otherwise.
+        """
+        if not getattr(self.settings, "gate_tuning_enabled", True):
+            return self.settings.whisper_injection_gate
+        row = self.db.conn.execute(
+            "SELECT value FROM gate_state WHERE key = 'injection_gate'"
+        ).fetchone()
+        if row is None:
+            return self.settings.whisper_injection_gate
+        return float(row["value"])
+
+    def _update_gate(self, signal: int) -> None:
+        """Nudge the injection gate based on a feedback signal.
+
+        Uses a proportional update rule:
+          +1 → gate += lr * (1 - gate)   (pulls toward gate_max)
+          -1 → gate -= lr * gate          (pulls toward gate_min)
+        Result is clamped to [gate_min, gate_max].
+        """
+        current = self.get_gate()
+        lr = getattr(self.settings, "gate_learning_rate", 0.02)
+        gate_min = getattr(self.settings, "gate_min", 0.30)
+        gate_max = getattr(self.settings, "gate_max", 0.80)
+
+        if signal > 0:
+            new_gate = current + lr * (gate_max - current)
+        else:
+            new_gate = current - lr * (current - gate_min)
+
+        new_gate = max(gate_min, min(gate_max, new_gate))
+
+        with self.db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO gate_state (key, value, updated_at)
+                VALUES ('injection_gate', ?, datetime('now'))
+                ON CONFLICT (key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+                """,
+                (new_gate,),
+            )
+        logger.debug("Gate tuning: signal=%+d %.4f → %.4f", signal, current, new_gate)
 
     def _is_duplicate_memory(self, content: str) -> bool:
         """Check if a very similar memory already exists using vector search."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1021,10 +1021,68 @@ class MemoryEngine:
             }),
         )
 
-        return (
+        result = (
             f"Marked outdated [{node.type.value}]: {node.title or node.content[:80]}\n"
             f"ID: {node.id} | valid_until: {node.valid_until.isoformat()}"
         )
+
+        # Tag-cascade: surface sibling nodes sharing any tags so user can batch-review
+        if node.tags and getattr(self.settings, "tag_cascade_invalidation_enabled", True):
+            cascade_nodes = self._find_tag_siblings(
+                node_id=node.id,
+                tags=node.tags,
+                space=node.space,
+                limit=getattr(self.settings, "tag_cascade_max_results", 10),
+            )
+            if cascade_nodes:
+                result += f"\n\n{len(cascade_nodes)} other node(s) share tag(s) {node.tags} — consider reviewing:"
+                for sibling_id, sibling_title, shared_tags in cascade_nodes:
+                    tag_str = ", ".join(shared_tags)
+                    result += f"\n  · {sibling_title} (id: {sibling_id[:8]}, tags: {tag_str})"
+
+        return result
+
+    def _find_tag_siblings(
+        self,
+        node_id: str,
+        tags: list[str],
+        space: str | None,
+        limit: int = 10,
+    ) -> list[tuple[str, str, list[str]]]:
+        """Return [(node_id, title, shared_tags)] for active nodes sharing any of *tags*.
+
+        Excludes *node_id* itself. Restricts to the same space when space is set.
+        Only returns nodes that are NOT already marked outdated (valid_until IS NULL
+        or valid_until > now).
+        """
+        if not tags:
+            return []
+
+        placeholders = ",".join("?" * len(tags))
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        rows = self.db.conn.execute(
+            f"""
+            SELECT n.id, n.title, n.content, GROUP_CONCAT(nt.tag) AS shared_tags
+              FROM node_tags nt
+              JOIN nodes n ON n.id = nt.node_id
+             WHERE nt.tag IN ({placeholders})
+               AND nt.node_id != ?
+               AND (n.valid_until IS NULL OR n.valid_until > ?)
+               {'AND n.space = ?' if space else ''}
+             GROUP BY n.id
+             ORDER BY COUNT(nt.tag) DESC, n.id
+             LIMIT ?
+            """,
+            [*tags, node_id, now_iso, *(([space]) if space else []), limit],
+        ).fetchall()
+
+        result = []
+        for r in rows:
+            title = r["title"] or (r["content"] or "")[:50]
+            shared = r["shared_tags"].split(",") if r["shared_tags"] else []
+            result.append((r["id"], title, shared))
+        return result
 
     def rebuild_index(self) -> int:
         """Full rebuild of the index from markdown files, including embeddings."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -533,6 +533,14 @@ class MemoryEngine:
         # Touch access
         self._touch_access(resolved_node_id)
 
+        # Acknowledge any pending decay alerts for this node
+        with self.db.transaction() as conn:
+            conn.execute(
+                "UPDATE decay_alert_log SET acknowledged = 1 "
+                "WHERE node_id = ? AND acknowledged = 0",
+                (resolved_node_id,),
+            )
+
         edges = self.graph.get_edges_for(resolved_node_id)
         neighbors = self.graph.get_neighbors(resolved_node_id, depth=1)
         self._log_feedback_candidates(

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2044,6 +2044,7 @@ class MemoryEngine:
             created.append({
                 "node_id": node_id,
                 "title": mem_title,
+                "type": node_type.value,
             })
 
         if skipped:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -811,12 +811,16 @@ class MemoryEngine:
                     (node_id, node_id),
                 )
 
-        # Audit log
+        # Audit log — store old snapshot in node_snapshot, new snapshot + changed fields in detail
+        new_snapshot = node.model_dump(mode="json")
         self._write_audit_log(
             operation="update",
             node_id=node_id,
             node_snapshot=json.dumps(old_snapshot),
-            detail=json.dumps({"changed_fields": changed_fields}),
+            detail=json.dumps({
+                "changed_fields": changed_fields,
+                "new_snapshot": new_snapshot,
+            }),
         )
 
         return f"Updated [{node.type.value}]: {node.title or node.content[:80]}\nID: {node.id}"
@@ -1349,6 +1353,79 @@ class MemoryEngine:
                     datetime.now(timezone.utc).isoformat(),
                 ),
             )
+
+    def recall_history(self, node_id: str) -> str:
+        """Return a human-readable changelog for a node.
+
+        Each audit entry shows the operation, timestamp, and a field-by-field
+        diff between old and new snapshots for update operations.
+        """
+        node = self.graph.get_node(node_id)
+        if node is None:
+            return f"Node {node_id} not found."
+
+        entries = self.list_audit_log(node_id=node["id"], limit=50)
+        if not entries:
+            return f"No history found for node {node_id[:8]}..."
+
+        title = node.get("title") or node.get("content", "")[:60]
+        lines = [f"# History: {title}", f"ID: {node['id']}", ""]
+
+        for entry in reversed(entries):  # oldest first
+            op = entry["operation"]
+            when = entry["performed_at"]
+            lines.append(f"## {op.upper()} — {when}")
+
+            if op == "update":
+                detail = {}
+                try:
+                    detail = json.loads(entry.get("detail") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+                changed = detail.get("changed_fields", [])
+                old = {}
+                new = {}
+                try:
+                    old = json.loads(entry.get("node_snapshot") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+                try:
+                    new = detail.get("new_snapshot") or {}
+                except Exception:
+                    pass
+
+                if changed and (old or new):
+                    for field in changed:
+                        old_val = old.get(field, "—")
+                        new_val = new.get(field, "—")
+                        if old_val != new_val:
+                            old_str = str(old_val)[:200]
+                            new_str = str(new_val)[:200]
+                            lines.append(f"  **{field}**: `{old_str}` → `{new_str}`")
+                elif changed:
+                    lines.append(f"  Changed: {', '.join(changed)}")
+                else:
+                    lines.append("  (no field details)")
+
+            elif op == "mark_outdated":
+                detail = {}
+                try:
+                    detail = json.loads(entry.get("detail") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+                reason = detail.get("reason", "no reason given")
+                new_confidence = detail.get("new_confidence")
+                lines.append(f"  Reason: {reason}")
+                if new_confidence is not None:
+                    lines.append(f"  Confidence set to: {new_confidence}")
+
+            elif op == "delete":
+                lines.append("  Node was deleted.")
+
+            lines.append("")
+
+        return "\n".join(lines)
 
     def list_audit_log(
         self,

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -168,6 +168,17 @@ class Database:
                     "CREATE INDEX IF NOT EXISTS idx_review_log_node ON review_log(node_id)"
                 )
 
+            if "gate_state" not in existing_tables:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS gate_state (
+                        key         TEXT PRIMARY KEY,
+                        value       REAL NOT NULL,
+                        updated_at  TEXT NOT NULL
+                    )
+                    """
+                )
+
         # Migrate FTS table to porter stemmer if needed
         self._migrate_fts_tokenizer()
 

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -179,6 +179,23 @@ class Database:
                     """
                 )
 
+            if "decay_alert_log" not in existing_tables:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS decay_alert_log (
+                        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                        node_id        TEXT NOT NULL,
+                        alerted_at     TEXT NOT NULL,
+                        retrievability REAL NOT NULL,
+                        tier           TEXT NOT NULL,
+                        acknowledged   INTEGER DEFAULT 0
+                    )
+                    """
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_decay_alert_node ON decay_alert_log(node_id)"
+                )
+
         # Migrate FTS table to porter stemmer if needed
         self._migrate_fts_tokenizer()
 

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -137,3 +137,13 @@ CREATE TABLE IF NOT EXISTS gate_state (
     value       REAL NOT NULL,
     updated_at  TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS decay_alert_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id        TEXT NOT NULL,
+    alerted_at     TEXT NOT NULL,
+    retrievability REAL NOT NULL,
+    tier           TEXT NOT NULL,
+    acknowledged   INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_decay_alert_node ON decay_alert_log(node_id);

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -131,3 +131,9 @@ CREATE TABLE IF NOT EXISTS review_log (
     answered    INTEGER DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_review_log_node ON review_log(node_id);
+
+CREATE TABLE IF NOT EXISTS gate_state (
+    key         TEXT PRIMARY KEY,      -- always 'injection_gate'
+    value       REAL NOT NULL,
+    updated_at  TEXT NOT NULL
+);

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -112,6 +112,65 @@ def configure_claude_hooks(ormah_bin: str) -> None:
             }
         ],
     }
+    # PostToolUse checkpoint — fires after high-impact operations and prompts
+    # the agent to call remember() before continuing, enabling mid-session
+    # write-back rather than waiting until session end.
+    checkpoint_script = Path(settings_path).parent / "hooks" / "ormah-checkpoint.sh"
+    checkpoint_script.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint_script.write_text(
+        "#!/usr/bin/env bash\n"
+        "# Ormah mid-session checkpoint hook (installed by ormah setup).\n"
+        "# Reads PostToolUse JSON from stdin; outputs a checkpoint reminder\n"
+        "# after high-impact operations so agents save state immediately.\n"
+        "set -euo pipefail\n"
+        "input=$(cat)\n"
+        'tool_name=$(echo "$input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(d.get(\'tool_name\',\'\'))" 2>/dev/null || echo "")\n'
+        'tool_input=$(echo "$input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(json.dumps(d.get(\'tool_input\',\'\')))" 2>/dev/null || echo "")\n'
+        "is_high_impact=0\n"
+        'case "$tool_name" in\n'
+        "  Bash)\n"
+        '    cmd=$(echo "$tool_input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(d.get(\'command\',\'\'))" 2>/dev/null || echo "")\n'
+        '    if echo "$cmd" | grep -qiE '
+        '"git (commit|push|merge|rebase)|systemctl|deploy|docker|kubectl|npm publish|pip install|uv (sync|add|remove)|rm -rf|DROP|ALTER TABLE"; then\n'
+        "      is_high_impact=1\n"
+        "    fi\n"
+        "    ;;\n"
+        "  Write)\n"
+        "    is_high_impact=1\n"
+        "    ;;\n"
+        "  Edit)\n"
+        '    file=$(echo "$tool_input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(d.get(\'file_path\',\'\'))" 2>/dev/null || echo "")\n'
+        '    if echo "$file" | grep -qiE '
+        r'"\.(env|json|toml|yaml|yml|sh|service|conf|ini)$|CLAUDE\.md|settings"; then'
+        "\n"
+        "      is_high_impact=1\n"
+        "    fi\n"
+        "    ;;\n"
+        "esac\n"
+        'if [ "$is_high_impact" -eq 1 ]; then\n'
+        '  echo "CHECKPOINT: A high-impact operation just completed. '
+        "If a decision was made, a config changed, or a milestone was reached — "
+        'call remember() now to save it before continuing."\n'
+        "fi\n"
+    )
+    checkpoint_script.chmod(0o755)
+
+    hooks["PostToolUse"] = [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": str(checkpoint_script),
+                    "timeout": 5,
+                }
+            ]
+        }
+    ]
+
     hooks["PreCompact"] = [
         {
             "hooks": [

--- a/src/ormah/store/write_buffer.py
+++ b/src/ormah/store/write_buffer.py
@@ -1,0 +1,77 @@
+"""Durable write buffer for remember calls when the Ormah server is unreachable.
+
+Pending writes are stored as JSONL at <memory_dir_parent>/pending_writes.jsonl.
+The buffer is drained automatically before the next successful remember call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_BUFFER_FILENAME = "pending_writes.jsonl"
+
+
+class WriteBuffer:
+    """File-backed queue for buffering remember calls that fail due to server downtime.
+
+    Thread safety: uses atomic rename for writes to avoid partial reads.
+    """
+
+    def __init__(self, buffer_path: Path) -> None:
+        self.path = buffer_path
+
+    def is_empty(self) -> bool:
+        return not self.path.exists() or self.path.stat().st_size == 0
+
+    def append(self, args: dict, params: dict) -> None:
+        """Append a pending remember call to the buffer."""
+        entry = json.dumps({"args": args, "params": params})
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(entry + "\n")
+        logger.info("Buffered remember call (server unreachable). Buffer: %s", self.path)
+
+    def load(self) -> list[dict]:
+        """Load all pending entries without clearing the file."""
+        if self.is_empty():
+            return []
+        entries = []
+        with self.path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    logger.warning("Skipping malformed buffer entry: %r", line)
+        return entries
+
+    def clear(self) -> None:
+        """Remove the buffer file."""
+        try:
+            self.path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning("Failed to clear write buffer: %s", e)
+
+    def rewrite(self, entries: list[dict]) -> None:
+        """Replace buffer contents with the given entries (used after partial drain)."""
+        if not entries:
+            self.clear()
+            return
+        tmp = self.path.with_suffix(".tmp")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with tmp.open("w", encoding="utf-8") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+        os.replace(tmp, self.path)
+
+
+def buffer_path_for(memory_dir: Path) -> Path:
+    """Derive the buffer file path from the configured memory directory."""
+    return memory_dir.parent / _BUFFER_FILENAME

--- a/tests/test_adapters/test_mcp_adapter.py
+++ b/tests/test_adapters/test_mcp_adapter.py
@@ -36,3 +36,89 @@ async def test_run_mcp_stdio_generates_session_id_and_runs_server(monkeypatch):
         session_id=fake_uuid,
     )
     run.assert_awaited_once_with("read-stream", "write-stream", {"name": "ormah"})
+
+
+# ---------------------------------------------------------------------------
+# Durable write buffer integration tests
+# ---------------------------------------------------------------------------
+
+import httpx
+from ormah.store.write_buffer import WriteBuffer
+
+
+class TestWriteBufferIntegration:
+    """_dispatch remember — buffer-on-failure and drain-on-success behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_remember_buffered_on_connect_error(self, tmp_path, monkeypatch):
+        """ConnectError on remember → entry queued in buffer, not lost."""
+        buf = WriteBuffer(tmp_path / "pending_writes.jsonl")
+        monkeypatch.setattr(mcp_adapter, "_write_buffer", buf)
+
+        async def _raise(*_, **__):
+            raise httpx.ConnectError("down")
+
+        # Patch AsyncClient.post to simulate server down
+        monkeypatch.setattr(httpx.AsyncClient, "post", _raise)
+
+        result = await mcp_adapter._dispatch(
+            "http://localhost:9999",
+            "remember",
+            {"content": "must not be lost", "type": "fact", "tier": "working"},
+        )
+
+        assert "queued" in result.lower() or "buffer" in result.lower()
+        assert not buf.is_empty()
+        entries = buf.load()
+        assert entries[0]["args"]["content"] == "must not be lost"
+
+    @pytest.mark.asyncio
+    async def test_buffered_writes_drained_on_next_success(self, tmp_path, monkeypatch):
+        """Buffered entries are replayed before the next successful remember call."""
+        buf = WriteBuffer(tmp_path / "pending_writes.jsonl")
+        buf.append(args={"content": "buffered-one", "type": "fact", "tier": "working"}, params={})
+        monkeypatch.setattr(mcp_adapter, "_write_buffer", buf)
+
+        responses = iter([
+            # First call: drain the buffered entry
+            MagicMock(is_success=True, json=lambda: {"text": "ok-drained"}),
+            # Second call: the new remember
+            MagicMock(is_success=True, json=lambda: {"text": "ok-new"}),
+        ])
+
+        async def _fake_post(self_client, url, **kwargs):
+            return next(responses)
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post)
+
+        result = await mcp_adapter._dispatch(
+            "http://localhost:9999",
+            "remember",
+            {"content": "new-write", "type": "fact", "tier": "working"},
+        )
+
+        assert buf.is_empty()
+        assert "Replayed" in result or "ok-new" in result
+
+    @pytest.mark.asyncio
+    async def test_no_drain_when_buffer_empty(self, tmp_path, monkeypatch):
+        """No extra HTTP call is made when the buffer is empty."""
+        buf = WriteBuffer(tmp_path / "pending_writes.jsonl")
+        monkeypatch.setattr(mcp_adapter, "_write_buffer", buf)
+
+        call_count = 0
+
+        async def _fake_post(self_client, url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return MagicMock(is_success=True, json=lambda: {"text": "stored"})
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post)
+
+        await mcp_adapter._dispatch(
+            "http://localhost:9999",
+            "remember",
+            {"content": "single write", "type": "fact", "tier": "working"},
+        )
+
+        assert call_count == 1

--- a/tests/test_api/test_agent_power_tools.py
+++ b/tests/test_api/test_agent_power_tools.py
@@ -1,0 +1,210 @@
+"""Tests for agent-facing power tools: update_memory, connect_memories, promote_memory."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api.routes_agent import router as agent_router
+from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+from ormah.models.node import CreateNodeRequest, NodeType, Tier, UpdateNodeRequest
+
+
+@pytest.fixture
+def client(tmp_memory_dir):
+    settings = Settings(memory_dir=tmp_memory_dir)
+    eng = MemoryEngine(settings)
+    eng.startup()
+
+    app = FastAPI()
+    app.include_router(agent_router)
+    app.state.engine = eng
+
+    with TestClient(app) as c:
+        yield c, eng
+
+    eng.shutdown()
+
+
+def _make_node(eng, content="Test content", tier=Tier.working, title="Test node"):
+    req = CreateNodeRequest(content=content, type=NodeType.fact, title=title, tier=tier)
+    node_id, _ = eng.remember(req)
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# update_memory route
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMemoryRoute:
+
+    def _get(self, eng, node_id):
+        return eng.graph.get_node(node_id)
+
+    def test_update_content(self, client):
+        c, eng = client
+        node_id = _make_node(eng, content="Original content")
+        resp = c.post(f"/agent/update/{node_id}", json={"content": "Updated content"})
+        assert resp.status_code == 200
+        assert self._get(eng, node_id)["content"] == "Updated content"
+
+    def test_update_title(self, client):
+        c, eng = client
+        node_id = _make_node(eng, title="Old title")
+        resp = c.post(f"/agent/update/{node_id}", json={"title": "New title"})
+        assert resp.status_code == 200
+        assert self._get(eng, node_id)["title"] == "New title"
+
+    def test_update_tier(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.working)
+        resp = c.post(f"/agent/update/{node_id}", json={"tier": "archival"})
+        assert resp.status_code == 200
+        assert self._get(eng, node_id)["tier"] == "archival"
+
+    def test_update_confidence(self, client):
+        c, eng = client
+        node_id = _make_node(eng)
+        resp = c.post(f"/agent/update/{node_id}", json={"confidence": 0.6})
+        assert resp.status_code == 200
+        assert abs(self._get(eng, node_id)["confidence"] - 0.6) < 1e-6
+
+    def test_update_unknown_node_returns_404(self, client):
+        c, _ = client
+        resp = c.post("/agent/update/nonexistent-id", json={"content": "x"})
+        assert resp.status_code == 404
+
+    def test_update_multiple_fields(self, client):
+        c, eng = client
+        node_id = _make_node(eng, content="old", title="old title")
+        resp = c.post(f"/agent/update/{node_id}", json={"content": "new", "title": "new title"})
+        assert resp.status_code == 200
+        node = self._get(eng, node_id)
+        assert node["content"] == "new"
+        assert node["title"] == "new title"
+
+
+# ---------------------------------------------------------------------------
+# connect_memories route
+# ---------------------------------------------------------------------------
+
+
+class TestConnectMemoriesRoute:
+
+    def test_connect_creates_edge(self, client):
+        c, eng = client
+        src = _make_node(eng, content="Source memory")
+        tgt = _make_node(eng, content="Target memory")
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": tgt})
+        assert resp.status_code == 200
+        edges = eng.db.conn.execute(
+            "SELECT edge_type FROM edges WHERE source_id = ? AND target_id = ?", (src, tgt)
+        ).fetchall()
+        assert len(edges) == 1
+        assert edges[0][0] == "related_to"
+
+    def test_connect_with_edge_type(self, client):
+        c, eng = client
+        src = _make_node(eng, content="Decision A")
+        tgt = _make_node(eng, content="Decision B")
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": tgt, "edge": "supports"})
+        assert resp.status_code == 200
+        row = eng.db.conn.execute(
+            "SELECT edge_type FROM edges WHERE source_id = ? AND target_id = ?", (src, tgt)
+        ).fetchone()
+        assert row[0] == "supports"
+
+    def test_connect_with_weight(self, client):
+        c, eng = client
+        src = _make_node(eng)
+        tgt = _make_node(eng)
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": tgt, "weight": 0.9})
+        assert resp.status_code == 200
+        row = eng.db.conn.execute(
+            "SELECT weight FROM edges WHERE source_id = ? AND target_id = ?", (src, tgt)
+        ).fetchone()
+        assert abs(row[0] - 0.9) < 1e-6
+
+    def test_connect_invalid_source_returns_error(self, client):
+        c, eng = client
+        tgt = _make_node(eng)
+        resp = c.post("/agent/connect", json={"source_id": "bad-id", "target_id": tgt})
+        assert resp.status_code == 200
+        assert "not found" in resp.json()["text"].lower()
+
+    def test_connect_invalid_target_returns_error(self, client):
+        c, eng = client
+        src = _make_node(eng)
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": "bad-id"})
+        assert resp.status_code == 200
+        assert "not found" in resp.json()["text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# promote_memory route
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteMemoryRoute:
+
+    def _tier(self, eng, node_id):
+        return eng.graph.get_node(node_id)["tier"]
+
+    def test_promote_working_to_core(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.working)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "core"})
+        assert resp.status_code == 200
+        assert self._tier(eng, node_id) == "core"
+
+    def test_promote_archival_to_working(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.archival)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "working"})
+        assert resp.status_code == 200
+        assert self._tier(eng, node_id) == "working"
+
+    def test_promote_default_tier_is_core(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.working)
+        resp = c.post(f"/agent/promote/{node_id}", json={})
+        assert resp.status_code == 200
+        assert self._tier(eng, node_id) == "core"
+
+    def test_promote_already_at_tier_returns_ok(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.core)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "core"})
+        assert resp.status_code == 200
+        assert "already" in resp.json()["text"].lower()
+
+    def test_promote_unknown_node_returns_404(self, client):
+        c, _ = client
+        resp = c.post("/agent/promote/nonexistent", json={"tier": "core"})
+        assert resp.status_code == 404
+
+    def test_promote_invalid_tier_returns_422(self, client):
+        c, eng = client
+        node_id = _make_node(eng)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "invalid"})
+        assert resp.status_code == 422
+
+    def test_promote_respects_core_cap(self, client):
+        c, eng = client
+        # Set a very small cap
+        eng.tier_manager.core_cap = 2
+        # Fill core tier
+        id1 = _make_node(eng, tier=Tier.core, title="Core 1", content="Core memory 1")
+        id2 = _make_node(eng, tier=Tier.core, title="Core 2", content="Core memory 2")
+        # Promote a 3rd node — cap enforced, least important core gets demoted
+        id3 = _make_node(eng, tier=Tier.working, title="Promote me", content="Important new memory")
+        resp = c.post(f"/agent/promote/{id3}", json={"tier": "core"})
+        assert resp.status_code == 200
+        # Count core nodes — should still be <= 2 after cap enforcement
+        core_count = eng.db.conn.execute(
+            "SELECT COUNT(*) FROM nodes WHERE tier = 'core'"
+        ).fetchone()[0]
+        assert core_count <= 2

--- a/tests/test_background/test_recall_promoter.py
+++ b/tests/test_background/test_recall_promoter.py
@@ -1,0 +1,174 @@
+"""Tests for the recall-based auto-promotion background job."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from ormah.background.recall_promoter import run_recall_promotion
+from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+
+def _get_tier(engine, node_id: str) -> str:
+    row = engine.db.conn.execute(
+        "SELECT tier FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    return row["tier"] if row else None
+
+
+def _add_affinity(engine, node_id: str, sessions: list[str], signal: int = 1) -> None:
+    """Insert affinity rows for the given node across the listed session IDs."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    for session_id in sessions:
+        engine.db.conn.execute(
+            """
+            INSERT INTO affinity
+                (prompt_vec, prompt_text, node_id, signal, source, confirmed_at, space, session_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (node_id, session_id) DO NOTHING
+            """,
+            (b"", "test prompt", node_id, signal, "explicit", now_iso, None, session_id),
+        )
+    engine.db.conn.commit()
+
+
+class TestRecallPromoterBasics:
+    def test_working_node_promoted_after_enough_sessions(self, engine):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Useful working memory",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Useful fact",
+        ))
+        _add_affinity(engine, node_id, ["s1", "s2", "s3"])
+
+        run_recall_promotion(engine)
+
+        assert _get_tier(engine, node_id) == "core"
+
+    def test_working_node_not_promoted_with_too_few_sessions(self, engine):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Rarely recalled memory",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Rare fact",
+        ))
+        _add_affinity(engine, node_id, ["s1", "s2"])  # only 2, default threshold is 3
+
+        run_recall_promotion(engine)
+
+        assert _get_tier(engine, node_id) == "working"
+
+    def test_negative_signals_do_not_count(self, engine):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Disliked memory",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Disliked",
+        ))
+        _add_affinity(engine, node_id, ["s1", "s2", "s3"], signal=-1)
+
+        run_recall_promotion(engine)
+
+        assert _get_tier(engine, node_id) == "working"
+
+    def test_already_core_node_unaffected(self, engine):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Already core memory",
+            type=NodeType.fact,
+            tier=Tier.core,
+            title="Core fact",
+        ))
+        _add_affinity(engine, node_id, ["s1", "s2", "s3"])
+
+        run_recall_promotion(engine)
+
+        assert _get_tier(engine, node_id) == "core"
+
+    def test_archival_node_not_promoted(self, engine):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Archived memory",
+            type=NodeType.fact,
+            tier=Tier.archival,
+            title="Archived fact",
+        ))
+        _add_affinity(engine, node_id, ["s1", "s2", "s3"])
+
+        run_recall_promotion(engine)
+
+        assert _get_tier(engine, node_id) == "archival"
+
+    def test_no_nodes_to_promote_is_safe(self, engine):
+        """Empty affinity table should not raise."""
+        run_recall_promotion(engine)
+
+    def test_duplicate_session_id_counts_once(self, engine):
+        """Multiple affinity rows for the same session should count as one."""
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Memory with repeat sessions",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Repeat sessions",
+        ))
+        # Insert two rows for s1 manually via low-level to bypass UNIQUE constraint
+        # by using different signals — but only one session distinct.
+        now_iso = datetime.now(timezone.utc).isoformat()
+        engine.db.conn.execute(
+            """
+            INSERT INTO affinity
+                (prompt_vec, prompt_text, node_id, signal, source, confirmed_at, space, session_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (node_id, session_id) DO NOTHING
+            """,
+            (b"", "p1", node_id, 1, "explicit", now_iso, None, "s1"),
+        )
+        # s2 only — total 2 distinct sessions, below threshold of 3
+        engine.db.conn.execute(
+            """
+            INSERT INTO affinity
+                (prompt_vec, prompt_text, node_id, signal, source, confirmed_at, space, session_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (node_id, session_id) DO NOTHING
+            """,
+            (b"", "p2", node_id, 1, "explicit", now_iso, None, "s2"),
+        )
+        engine.db.conn.commit()
+
+        run_recall_promotion(engine)
+
+        assert _get_tier(engine, node_id) == "working"
+
+
+class TestRecallPromoterConfig:
+    def test_custom_session_threshold_respected(self, engine):
+        engine.settings.recall_promotion_sessions = 2
+
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Memory promoted at threshold 2",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Threshold 2",
+        ))
+        _add_affinity(engine, node_id, ["s1", "s2"])
+
+        run_recall_promotion(engine)
+
+        assert _get_tier(engine, node_id) == "core"
+
+    def test_promotion_updates_db_tier(self, engine):
+        """DB row should reflect the new tier after promotion."""
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="DB tier check",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="DB check",
+        ))
+        _add_affinity(engine, node_id, ["s1", "s2", "s3"])
+
+        run_recall_promotion(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT tier FROM nodes WHERE id = ?", (node_id,)
+        ).fetchone()
+        assert row["tier"] == "core"

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -248,3 +248,98 @@ def test_nonexistent_watch_dir(engine, tmp_path):
 
     observers = start_session_watcher(engine)
     assert observers == []
+
+
+# --- Session summary tests ---
+
+def test_session_summary_created_after_ingestion(engine, tmp_path):
+    """A session summary [event] node is created after successful ingestion."""
+    engine.settings.session_summary_enabled = True
+    engine.settings.session_summary_min_turns = 3
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "sum_session.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) >= 1
+    node = summaries[0]["node"]
+    assert node["type"] == "event"
+    assert "myproject" in node["content"]
+    # Verify tag via DB
+    tags = [r[0] for r in engine.db.conn.execute(
+        "SELECT tag FROM node_tags WHERE node_id = ?", (node["id"],)
+    ).fetchall()]
+    assert "session-summary" in tags
+
+
+def test_session_summary_disabled_creates_no_node(engine, tmp_path):
+    """No summary node when session_summary_enabled=False."""
+    engine.settings.session_summary_enabled = False
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-nosum"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "nosummary.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) == 0
+
+
+def test_session_summary_skipped_for_trivial_session(engine, tmp_path):
+    """No summary when user_turn_count < session_summary_min_turns."""
+    engine.settings.session_summary_enabled = True
+    engine.settings.session_summary_min_turns = 10
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-trivial"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "trivial.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) == 0
+
+
+def test_session_summary_includes_type_breakdown(engine, tmp_path):
+    """Summary content includes memory type breakdown."""
+    engine.settings.session_summary_enabled = True
+    engine.settings.session_summary_min_turns = 3
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-breakdown"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "breakdown.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) >= 1
+    content = summaries[0]["node"]["content"]
+    assert "decision" in content

--- a/tests/test_engine/test_contradiction_prestorage.py
+++ b/tests/test_engine/test_contradiction_prestorage.py
@@ -1,0 +1,213 @@
+"""Tests for the pre-storage contradiction check in MemoryEngine."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+
+class TestContradictionPrestorage:
+    def test_warning_appended_when_contradiction_found(self, engine):
+        """remember() output should contain a warning when similar nodes exist."""
+        with patch.object(
+            engine,
+            "_check_contradiction_prestorage",
+            return_value=[("abc12345", "Conflicting fact", 0.92)],
+        ):
+            _, text = engine.remember(CreateNodeRequest(
+                content="New fact that may conflict",
+                type=NodeType.fact,
+                title="New Fact",
+            ))
+
+        assert "⚠ Possible contradiction" in text
+        assert "Conflicting fact" in text
+        assert "abc12345" in text
+
+    def test_no_warning_when_no_contradictions(self, engine):
+        """remember() output should be clean when check returns empty list."""
+        with patch.object(
+            engine,
+            "_check_contradiction_prestorage",
+            return_value=[],
+        ):
+            _, text = engine.remember(CreateNodeRequest(
+                content="Unique new fact",
+                type=NodeType.fact,
+                title="Unique Fact",
+            ))
+
+        assert "⚠" not in text
+        assert "contradiction" not in text.lower()
+
+    def test_check_disabled_via_config(self, engine):
+        """When contradiction_prestorage_enabled=False, check should not run."""
+        engine.settings.contradiction_prestorage_enabled = False
+
+        with patch.object(
+            engine, "_check_contradiction_prestorage"
+        ) as mock_check:
+            engine.remember(CreateNodeRequest(
+                content="Fact with disabled check",
+                type=NodeType.fact,
+                title="Disabled Check",
+            ))
+
+        mock_check.assert_not_called()
+
+    def test_check_enabled_by_default(self, engine):
+        """contradiction_prestorage_enabled defaults to True."""
+        assert engine.settings.contradiction_prestorage_enabled is True
+
+
+class TestCheckContradictionPrestorage:
+    def test_returns_empty_when_vector_store_unavailable(self, engine):
+        """Should not raise if encoder/vector store import fails."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Test node",
+            content="Test content",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder", side_effect=ImportError):
+            result = engine._check_contradiction_prestorage(node)
+
+        assert result == []
+
+    def test_cross_space_nodes_not_flagged(self, engine):
+        """Nodes from a different space should never be flagged."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Project A fact",
+            content="Using Postgres for project A",
+            space="project-a",
+        )
+
+        # Simulate a high-similarity match from a different space
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": "other-node-id", "similarity": 0.95},
+            ]
+
+            # other node is in a different space
+            with patch.object(
+                engine.graph,
+                "get_node",
+                return_value={"id": "other-node-id", "space": "project-b", "title": "Project B fact", "content": ""},
+            ):
+                result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert result == []
+
+    def test_same_space_high_similarity_flagged(self, engine):
+        """High-similarity same-space node should appear in flagged list."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Same space fact",
+            content="Uses Redis for caching",
+            space="project-x",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": "existing-node-id", "similarity": 0.93},
+            ]
+
+            with patch.object(
+                engine.graph,
+                "get_node",
+                return_value={
+                    "id": "existing-node-id",
+                    "space": "project-x",
+                    "title": "Cache technology choice",
+                    "content": "Uses Memcached for caching",
+                },
+            ):
+                result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert len(result) == 1
+        assert result[0][0] == "existing-node-id"
+        assert result[0][2] == 0.93
+
+    def test_below_threshold_not_flagged(self, engine):
+        """Similarity below threshold should not produce a warning."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Some fact",
+            content="Some content",
+            space="project-x",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": "existing-node-id", "similarity": 0.75},
+            ]
+
+            with patch.object(
+                engine.graph,
+                "get_node",
+                return_value={"id": "existing-node-id", "space": "project-x", "title": "Related", "content": ""},
+            ):
+                result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert result == []
+
+    def test_self_excluded_from_results(self, engine):
+        """The node being stored should not flag itself as a contradiction."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Self check",
+            content="Content",
+            space="proj",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": node.id, "similarity": 0.99},  # self
+            ]
+
+            result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert result == []

--- a/tests/test_engine/test_decay_alerts.py
+++ b/tests/test_engine/test_decay_alerts.py
@@ -1,0 +1,188 @@
+"""Tests for proactive decay alerts."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ormah.background.decay_manager import run_decay
+from ormah.models.node import CreateNodeRequest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_node(conn, node_id, tier="working", stability=1.0, last_accessed=None):
+    """Insert a minimal node directly into the DB with controllable stability."""
+    if last_accessed is None:
+        # Default: accessed long ago so R is very low
+        last_accessed = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    conn.execute(
+        "INSERT INTO nodes "
+        "(id, type, tier, source, title, content, created, updated, "
+        "last_accessed, access_count, confidence, importance, stability, file_path, file_hash) "
+        "VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), "
+        "?, 0, 1.0, 0.3, ?, ?, ?)",
+        (node_id, "fact", tier, "test", f"title-{node_id}", "content",
+         last_accessed, stability, f"/tmp/{node_id}.md", "abc"),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# TestDecayAlertCreation
+# ---------------------------------------------------------------------------
+
+
+class TestDecayAlertCreation:
+
+    def test_alert_created_for_working_node_below_threshold(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-working-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["tier"] == "working"
+        assert row["retrievability"] < 0.40
+        assert row["acknowledged"] == 0
+
+    def test_alert_created_for_core_node_below_threshold(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-core-001"
+        _insert_node(engine.db.conn, node_id, tier="core", stability=1.0)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["tier"] == "core"
+
+    def test_no_alert_for_healthy_node(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-healthy-001"
+        # Accessed just now → R ≈ 1.0
+        recent = datetime.now(timezone.utc).isoformat()
+        _insert_node(engine.db.conn, node_id, tier="working", stability=30.0,
+                     last_accessed=recent)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is None
+
+    def test_alert_not_refired_within_refire_window(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+        engine.settings.decay_alert_refire_days = 7
+
+        node_id = "alert-refire-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+
+        run_decay(engine)
+        run_decay(engine)
+
+        rows = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchall()
+        assert len(rows) == 1  # not duplicated
+
+    def test_alert_disabled_creates_no_rows(self, engine):
+        engine.settings.decay_alert_enabled = False
+
+        node_id = "alert-disabled-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is None
+
+
+# ---------------------------------------------------------------------------
+# TestDecayAlertAcknowledgement
+# ---------------------------------------------------------------------------
+
+
+class TestDecayAlertAcknowledgement:
+
+    def test_recall_node_acknowledges_alert(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-ack-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+        run_decay(engine)
+
+        # Verify alert exists and is unacknowledged
+        row = engine.db.conn.execute(
+            "SELECT acknowledged FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row["acknowledged"] == 0
+
+        # recall_node should acknowledge it
+        engine.recall_node(node_id, session_id="test-session")
+
+        row = engine.db.conn.execute(
+            "SELECT acknowledged FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row["acknowledged"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestDecayAlertWhisper
+# ---------------------------------------------------------------------------
+
+
+class TestDecayAlertWhisper:
+
+    def test_alert_appears_in_first_message_whisper(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-whisper-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+        run_decay(engine)
+
+        # First message of session: recent_prompts=None triggers the alert block
+        result = engine.get_whisper_context(
+            prompt="what did we decide about auth",
+            session_id="test-whisper-session",
+        )
+        assert "memory fading" in result.lower() or "fading" in result.lower() or node_id[:8] in result
+
+    def test_alert_not_surfaced_mid_session(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-midsession-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+        run_decay(engine)
+
+        # Mid-session: pass a non-None recent_prompts list → no alert block
+        result = engine.get_whisper_context(
+            prompt="what did we decide about auth",
+            recent_prompts=["previous prompt"],
+            session_id="test-mid-session",
+        )
+        assert "memory fading" not in result.lower()

--- a/tests/test_engine/test_memory_versioning.py
+++ b/tests/test_engine/test_memory_versioning.py
@@ -1,0 +1,164 @@
+"""Tests for memory versioning — new snapshot storage and recall_history."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ormah.models.node import CreateNodeRequest, NodeType, Tier, UpdateNodeRequest
+
+
+def _make_node(engine, title="Versioned node", content="Original content"):
+    req = CreateNodeRequest(content=content, type=NodeType.fact, title=title)
+    node_id, _ = engine.remember(req)
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# New snapshot stored in detail
+# ---------------------------------------------------------------------------
+
+
+class TestNewSnapshotStorage:
+
+    def test_update_stores_new_snapshot_in_detail(self, engine):
+        node_id = _make_node(engine)
+        engine.update_node(node_id, UpdateNodeRequest(content="Updated content"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        assert len(entries) == 1
+        detail = json.loads(entries[0]["detail"])
+        assert "new_snapshot" in detail
+        assert detail["new_snapshot"]["content"] == "Updated content"
+
+    def test_update_stores_old_snapshot_in_node_snapshot(self, engine):
+        node_id = _make_node(engine, content="Before update")
+        engine.update_node(node_id, UpdateNodeRequest(content="After update"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        old = json.loads(entries[0]["node_snapshot"])
+        assert old["content"] == "Before update"
+
+    def test_update_records_changed_fields(self, engine):
+        node_id = _make_node(engine, title="Old title")
+        engine.update_node(node_id, UpdateNodeRequest(title="New title"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        detail = json.loads(entries[0]["detail"])
+        assert "title" in detail["changed_fields"]
+
+    def test_multiple_updates_produce_multiple_entries(self, engine):
+        node_id = _make_node(engine)
+        engine.update_node(node_id, UpdateNodeRequest(content="v2"))
+        engine.update_node(node_id, UpdateNodeRequest(content="v3"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        assert len(entries) == 2
+
+    def test_tier_change_stored_in_new_snapshot(self, engine):
+        node_id = _make_node(engine)
+        engine.update_node(node_id, UpdateNodeRequest(tier=Tier.archival))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        detail = json.loads(entries[0]["detail"])
+        assert detail["new_snapshot"]["tier"] == "archival"
+
+
+# ---------------------------------------------------------------------------
+# recall_history formatting
+# ---------------------------------------------------------------------------
+
+
+class TestRecallHistory:
+
+    def test_no_history_returns_not_found(self, engine):
+        result = engine.recall_history("nonexistent-id")
+        assert "not found" in result.lower()
+
+    def test_empty_history_message(self, engine):
+        node_id = _make_node(engine)
+        result = engine.recall_history(node_id)
+        assert "No history" in result
+
+    def test_update_history_shows_diff(self, engine):
+        node_id = _make_node(engine, content="original body")
+        engine.update_node(node_id, UpdateNodeRequest(content="updated body"))
+
+        result = engine.recall_history(node_id)
+        assert "UPDATE" in result
+        assert "original body" in result
+        assert "updated body" in result
+
+    def test_history_shows_title_change(self, engine):
+        node_id = _make_node(engine, title="Old title")
+        engine.update_node(node_id, UpdateNodeRequest(title="New title"))
+
+        result = engine.recall_history(node_id)
+        assert "Old title" in result
+        assert "New title" in result
+
+    def test_history_shows_mark_outdated(self, engine):
+        node_id = _make_node(engine)
+        engine.mark_outdated(node_id, reason="superseded by v2")
+
+        result = engine.recall_history(node_id)
+        assert "MARK_OUTDATED" in result
+        assert "superseded by v2" in result
+
+    def test_history_chronological_order(self, engine):
+        node_id = _make_node(engine, content="v1")
+        engine.update_node(node_id, UpdateNodeRequest(content="v2"))
+        engine.update_node(node_id, UpdateNodeRequest(content="v3"))
+
+        result = engine.recall_history(node_id)
+        v1_pos = result.find("v1")
+        v2_pos = result.find("v2")
+        v3_pos = result.find("v3")
+        assert v1_pos < v2_pos < v3_pos
+
+
+# ---------------------------------------------------------------------------
+# HTTP route
+# ---------------------------------------------------------------------------
+
+
+class TestRecallHistoryRoute:
+
+    @pytest.fixture
+    def client(self, tmp_memory_dir):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from ormah.api.routes_agent import router as agent_router
+        from ormah.config import Settings
+        from ormah.engine.memory_engine import MemoryEngine
+
+        settings = Settings(memory_dir=tmp_memory_dir)
+        eng = MemoryEngine(settings)
+        eng.startup()
+
+        test_app = FastAPI()
+        test_app.include_router(agent_router)
+        test_app.state.engine = eng
+
+        with TestClient(test_app) as c:
+            yield c, eng
+
+        eng.shutdown()
+
+    def test_history_route_returns_200(self, client):
+        c, eng = client
+        req = CreateNodeRequest(content="test content", type=NodeType.fact, title="Route test")
+        node_id, _ = eng.remember(req)
+        eng.update_node(node_id, UpdateNodeRequest(content="updated content"))
+
+        resp = c.get(f"/agent/recall/{node_id}/history")
+        assert resp.status_code == 200
+        assert "UPDATE" in resp.json()["text"]
+
+    def test_history_route_unknown_node(self, client):
+        c, _ = client
+        resp = c.get("/agent/recall/nonexistent/history")
+        assert resp.status_code == 200
+        assert "not found" in resp.json()["text"].lower()

--- a/tests/test_engine/test_submit_feedback.py
+++ b/tests/test_engine/test_submit_feedback.py
@@ -315,3 +315,63 @@ class TestSubmitFeedbackRoute:
         assert row is not None
         assert row["session_id"] == "route-recall-node-session"
         assert row["prompt_text"] == f"recall_node:{node_id}"
+
+
+# ---------------------------------------------------------------------------
+# TestGateTuning
+# ---------------------------------------------------------------------------
+
+
+class TestGateTuning:
+
+    def test_get_gate_returns_config_default_when_no_db_row(self, engine):
+        gate = engine.get_gate()
+        assert gate == engine.settings.whisper_injection_gate
+
+    def test_positive_signal_raises_gate(self, engine):
+        node_id = "node-gate-pos-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        initial = engine.get_gate()
+        engine.submit_feedback(node_id, 1)
+        assert engine.get_gate() > initial
+
+    def test_negative_signal_lowers_gate(self, engine):
+        node_id = "node-gate-neg-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        initial = engine.get_gate()
+        engine.submit_feedback(node_id, -1)
+        assert engine.get_gate() < initial
+
+    def test_gate_persists_in_db(self, engine):
+        node_id = "node-gate-persist-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        engine.submit_feedback(node_id, 1)
+        row = engine.db.conn.execute(
+            "SELECT value FROM gate_state WHERE key = 'injection_gate'"
+        ).fetchone()
+        assert row is not None
+        assert row["value"] > engine.settings.whisper_injection_gate
+
+    def test_gate_clamps_to_max(self, engine):
+        engine.settings.gate_max = 0.52
+        engine.settings.whisper_injection_gate = 0.50
+        for _ in range(50):
+            engine._update_gate(1)
+        assert engine.get_gate() <= 0.52
+
+    def test_gate_clamps_to_min(self, engine):
+        engine.settings.gate_min = 0.48
+        engine.settings.whisper_injection_gate = 0.50
+        for _ in range(50):
+            engine._update_gate(-1)
+        assert engine.get_gate() >= 0.48
+
+    def test_gate_tuning_disabled_skips_update(self, engine):
+        engine.settings.gate_tuning_enabled = False
+        node_id = "node-gate-disabled-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        engine.submit_feedback(node_id, 1)
+        row = engine.db.conn.execute(
+            "SELECT value FROM gate_state WHERE key = 'injection_gate'"
+        ).fetchone()
+        assert row is None

--- a/tests/test_engine/test_tag_cascade.py
+++ b/tests/test_engine/test_tag_cascade.py
@@ -1,0 +1,189 @@
+"""Tests for tag-cascade invalidation in mark_outdated()."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+
+class TestTagCascadeInvalidation:
+    def test_siblings_surfaced_in_mark_outdated_response(self, engine):
+        """mark_outdated() should list nodes that share tags."""
+        node_a_id, _ = engine.remember(CreateNodeRequest(
+            content="Decision about Python",
+            type=NodeType.decision,
+            tier=Tier.working,
+            title="Python choice",
+            tags=["python", "language"],
+        ))
+        node_b_id, _ = engine.remember(CreateNodeRequest(
+            content="Another python note",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Python note",
+            tags=["python"],
+        ))
+
+        result = engine.mark_outdated(node_a_id, reason="Switched to Go")
+
+        assert "python" in result
+        assert "Python note" in result
+        assert node_b_id[:8] in result
+
+    def test_no_cascade_when_node_has_no_tags(self, engine):
+        """Nodes without tags should not trigger any cascade output."""
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Untagged memory",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="No tags",
+            tags=[],
+        ))
+
+        result = engine.mark_outdated(node_id)
+
+        assert "share tag" not in result
+        assert "consider reviewing" not in result
+
+    def test_already_outdated_siblings_excluded(self, engine):
+        """Nodes already marked outdated should not appear in cascade."""
+        node_a_id, _ = engine.remember(CreateNodeRequest(
+            content="Stale memory",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Stale",
+            tags=["legacy"],
+        ))
+        node_b_id, _ = engine.remember(CreateNodeRequest(
+            content="Also stale memory",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Also stale",
+            tags=["legacy"],
+        ))
+
+        # Mark B outdated first
+        engine.mark_outdated(node_b_id, reason="Old")
+
+        # Now mark A outdated — B should not appear in cascade
+        result = engine.mark_outdated(node_a_id, reason="Old too")
+
+        assert "Also stale" not in result
+
+    def test_cascade_disabled_via_config(self, engine):
+        """tag_cascade_invalidation_enabled=False skips cascade entirely."""
+        engine.settings.tag_cascade_invalidation_enabled = False
+
+        node_a_id, _ = engine.remember(CreateNodeRequest(
+            content="First node",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Node A",
+            tags=["shared-tag"],
+        ))
+        engine.remember(CreateNodeRequest(
+            content="Second node",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Node B",
+            tags=["shared-tag"],
+        ))
+
+        result = engine.mark_outdated(node_a_id)
+
+        assert "share tag" not in result
+        assert "consider reviewing" not in result
+
+    def test_self_not_included_in_cascade(self, engine):
+        """The invalidated node itself should not appear in its own cascade list."""
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="Self check",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Self",
+            tags=["mytag"],
+        ))
+
+        result = engine.mark_outdated(node_id)
+
+        # The node being invalidated should appear as the primary entry, but not
+        # again in the cascade siblings list
+        lines = result.split("\n")
+        cascade_lines = [l for l in lines if l.strip().startswith("·")]
+        for line in cascade_lines:
+            assert node_id[:8] not in line
+
+
+class TestFindTagSiblings:
+    def test_returns_siblings_with_shared_tags(self, engine):
+        """_find_tag_siblings returns nodes sharing any of the queried tags."""
+        target_id, _ = engine.remember(CreateNodeRequest(
+            content="Target node",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Target",
+            tags=["a", "b"],
+        ))
+        sibling_id, _ = engine.remember(CreateNodeRequest(
+            content="Sibling node",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Sibling",
+            tags=["a"],
+        ))
+
+        results = engine._find_tag_siblings(node_id=target_id, tags=["a", "b"], space=None)
+
+        ids = [r[0] for r in results]
+        assert sibling_id in ids
+
+    def test_respects_space_filter(self, engine):
+        """Nodes in a different space should not appear in cascade."""
+        target_id, _ = engine.remember(CreateNodeRequest(
+            content="Project A node",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Proj A",
+            tags=["shared"],
+            space="project-a",
+        ))
+        other_id, _ = engine.remember(CreateNodeRequest(
+            content="Project B node",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Proj B",
+            tags=["shared"],
+            space="project-b",
+        ))
+
+        results = engine._find_tag_siblings(
+            node_id=target_id, tags=["shared"], space="project-a"
+        )
+
+        ids = [r[0] for r in results]
+        assert other_id not in ids
+
+    def test_max_results_limit_respected(self, engine):
+        """Result count should not exceed limit."""
+        target_id, _ = engine.remember(CreateNodeRequest(
+            content="Target",
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Target",
+            tags=["bulk"],
+        ))
+        for i in range(5):
+            engine.remember(CreateNodeRequest(
+                content=f"Sibling {i}",
+                type=NodeType.fact,
+                tier=Tier.working,
+                title=f"Sibling {i}",
+                tags=["bulk"],
+            ))
+
+        results = engine._find_tag_siblings(node_id=target_id, tags=["bulk"], space=None, limit=3)
+
+        assert len(results) <= 3

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -2271,3 +2271,150 @@ class TestWhisperFlatRankedDisplay:
 
         assert "The most relevant memories are shown in full" in result
         assert "use recall with its node ID" in result
+
+
+class TestWhisperCompactMode:
+    """Compact mode emits abbreviated type labels, truncated content, and shorter framing."""
+
+    def _make_node_long(self, node_id, title, node_type="fact"):
+        node = _make_node_dict(node_id, title, node_type=node_type)
+        node["content"] = "A" * 500  # 500-char content
+        return node
+
+    def test_compact_framing_used(self, mock_graph):
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        mock_engine.recall_search_structured.return_value = [
+            {"node": _make_node_dict("n1", "Alpha"), "score": 0.9, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(
+            prompt="test", injection_gate=0.0, compact_mode=True
+        )
+
+        assert "Top memories (full)" in result
+        # Normal framing should not appear
+        assert "The most relevant memories are shown in full" not in result
+
+    def test_normal_framing_when_compact_off(self, mock_graph):
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        mock_engine.recall_search_structured.return_value = [
+            {"node": _make_node_dict("n1", "Alpha"), "score": 0.9, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(
+            prompt="test", injection_gate=0.0, compact_mode=False
+        )
+
+        assert "The most relevant memories are shown in full" in result
+
+    def test_type_labels_abbreviated(self, mock_graph):
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        nodes = [
+            _make_node_dict("n1", "A fact node", node_type="fact"),
+            _make_node_dict("n2", "A concept node", node_type="concept"),
+            _make_node_dict("n3", "A decision node", node_type="decision"),
+        ]
+        mock_engine.recall_search_structured.return_value = [
+            {"node": nodes[0], "score": 0.9, "source": "hybrid"},
+            {"node": nodes[1], "score": 0.8, "source": "hybrid"},
+            {"node": nodes[2], "score": 0.7, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(
+            prompt="test", injection_gate=0.0, compact_mode=True, full_content_count=0
+        )
+
+        assert "[F]" in result
+        assert "[C]" in result
+        assert "[D]" in result
+        # Full type names should not appear
+        assert "[fact]" not in result
+        assert "[concept]" not in result
+        assert "[decision]" not in result
+
+    def test_content_truncated_in_compact_mode(self, mock_graph):
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        node = self._make_node_long("n1", "Long content node")
+        mock_engine.recall_search_structured.return_value = [
+            {"node": node, "score": 0.9, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(
+            prompt="test",
+            injection_gate=0.0,
+            compact_mode=True,
+            compact_content_chars=100,
+            full_content_count=1,
+        )
+
+        # Content should be truncated to ~100 chars (with ellipsis)
+        assert "…" in result
+        # Full 500-char string should not appear
+        assert "A" * 101 not in result
+
+    def test_content_not_truncated_when_compact_off(self, mock_graph):
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        node = self._make_node_long("n1", "Long content node")
+        mock_engine.recall_search_structured.return_value = [
+            {"node": node, "score": 0.9, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(
+            prompt="test",
+            injection_gate=0.0,
+            compact_mode=False,
+            full_content_count=1,
+        )
+
+        # Full content should appear unchanged
+        assert "A" * 500 in result
+
+    def test_no_blank_lines_between_items_in_compact_mode(self, mock_graph):
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        nodes = [
+            _make_node_dict("n1", "First"),
+            _make_node_dict("n2", "Second"),
+        ]
+        mock_engine.recall_search_structured.return_value = [
+            {"node": nodes[0], "score": 0.9, "source": "hybrid"},
+            {"node": nodes[1], "score": 0.8, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(
+            prompt="test", injection_gate=0.0, compact_mode=True, full_content_count=0
+        )
+
+        # Items are separated by single newline only (no blank lines between them)
+        assert "First (id: n1)\n- " in result
+
+    def test_blank_lines_present_in_normal_mode(self, mock_graph):
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        nodes = [
+            _make_node_dict("n1", "First"),
+            _make_node_dict("n2", "Second"),
+        ]
+        mock_engine.recall_search_structured.return_value = [
+            {"node": nodes[0], "score": 0.9, "source": "hybrid"},
+            {"node": nodes[1], "score": 0.8, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(
+            prompt="test", injection_gate=0.0, compact_mode=False, full_content_count=0
+        )
+
+        # Normal mode has blank separator lines between items
+        assert "First (id: n1)\n\n- " in result

--- a/tests/test_store/test_write_buffer.py
+++ b/tests/test_store/test_write_buffer.py
@@ -1,0 +1,105 @@
+"""Tests for the durable write buffer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ormah.store.write_buffer import WriteBuffer, buffer_path_for
+
+
+@pytest.fixture
+def buf(tmp_path):
+    return WriteBuffer(tmp_path / "pending_writes.jsonl")
+
+
+class TestWriteBufferBasics:
+    def test_is_empty_when_file_missing(self, buf):
+        assert buf.is_empty()
+
+    def test_append_creates_file(self, buf):
+        buf.append(args={"content": "test"}, params={})
+        assert buf.path.exists()
+
+    def test_append_multiple_entries(self, buf):
+        buf.append(args={"content": "one"}, params={})
+        buf.append(args={"content": "two"}, params={})
+        entries = buf.load()
+        assert len(entries) == 2
+        assert entries[0]["args"]["content"] == "one"
+        assert entries[1]["args"]["content"] == "two"
+
+    def test_clear_removes_file(self, buf):
+        buf.append(args={"content": "x"}, params={})
+        buf.clear()
+        assert not buf.path.exists()
+
+    def test_clear_on_missing_file_is_safe(self, buf):
+        buf.clear()  # should not raise
+
+    def test_load_empty_when_no_file(self, buf):
+        assert buf.load() == []
+
+    def test_is_empty_after_clear(self, buf):
+        buf.append(args={"content": "x"}, params={})
+        buf.clear()
+        assert buf.is_empty()
+
+
+class TestWriteBufferRewrite:
+    def test_rewrite_replaces_contents(self, buf):
+        buf.append(args={"content": "old"}, params={})
+        new_entries = [{"args": {"content": "new"}, "params": {}}]
+        buf.rewrite(new_entries)
+        loaded = buf.load()
+        assert len(loaded) == 1
+        assert loaded[0]["args"]["content"] == "new"
+
+    def test_rewrite_empty_list_clears_file(self, buf):
+        buf.append(args={"content": "x"}, params={})
+        buf.rewrite([])
+        assert not buf.path.exists()
+
+    def test_rewrite_atomic_via_tmp(self, buf):
+        """tmp file should not persist after rewrite."""
+        buf.rewrite([{"args": {"content": "a"}, "params": {}}])
+        tmp = buf.path.with_suffix(".tmp")
+        assert not tmp.exists()
+
+
+class TestWriteBufferRoundtrip:
+    def test_full_args_preserved(self, buf):
+        args = {
+            "content": "my memory",
+            "type": "decision",
+            "tier": "core",
+            "title": "My Title",
+            "space": "project-x",
+            "tags": ["tag1", "tag2"],
+            "confidence": 0.8,
+        }
+        params = {"default_space": "project-x"}
+        buf.append(args=args, params=params)
+        entries = buf.load()
+        assert entries[0]["args"] == args
+        assert entries[0]["params"] == params
+
+    def test_malformed_line_skipped(self, buf, tmp_path):
+        buf.path.parent.mkdir(parents=True, exist_ok=True)
+        with buf.path.open("w") as f:
+            f.write('{"args": {"content": "good"}, "params": {}}\n')
+            f.write("NOT_VALID_JSON\n")
+            f.write('{"args": {"content": "also good"}, "params": {}}\n')
+        entries = buf.load()
+        assert len(entries) == 2
+        assert entries[0]["args"]["content"] == "good"
+        assert entries[1]["args"]["content"] == "also good"
+
+
+class TestBufferPathHelper:
+    def test_buffer_path_is_sibling_of_memory_dir(self, tmp_path):
+        memory_dir = tmp_path / "memory"
+        path = buffer_path_for(memory_dir)
+        assert path == tmp_path / "pending_writes.jsonl"


### PR DESCRIPTION
Five improvements from the `feat/improvements` branch — **791 tests pass**.

---

## 1. Surface tension conflicts as queryable observation nodes

Tension conflicts create a queryable `[observation]` node tagged `conflict` and `needs-review`, surfaced in whisper and linked to both conflicting memories.

---

## 2. Feedback-driven injection gate tuning

Each `submit_feedback` call nudges the global whisper injection gate via a proportional learning rule, persisted in `gate_state`. Accepting whispers raises it (more selective); rejecting lowers it (wider window).

New config: `ORMAH_GATE_TUNING_ENABLED` (true), `ORMAH_GATE_MIN` (0.30), `ORMAH_GATE_MAX` (0.80), `ORMAH_GATE_LEARNING_RATE` (0.02)

---

## 3. Proactive decay alerts before archival demotion

The decay manager writes `decay_alert_log` rows when core/working nodes drop below `decay_alert_threshold` (R < 0.40). First whisper of each session surfaces up to 5 unacknowledged alerts. `recall_node()` auto-acknowledges.

New config: `ORMAH_DECAY_ALERT_ENABLED` (true), `ORMAH_DECAY_ALERT_THRESHOLD` (0.40), `ORMAH_DECAY_ALERT_REFIRE_DAYS` (7)

---

## 4. Memory versioning — field-by-field diffs and recall_history

`update_node` stores both old and new snapshots in `audit_log`. New `recall_history()` formats a human-readable changelog with `field: old → new` diffs. Exposed via `GET /agent/recall/{id}/history` and the `recall_history` MCP tool.

---

## 5. Session summary hook

After `session_watcher` ingests a transcript, it creates a concise `[event]` memory with: space, turn count, memory type breakdown, and top extracted titles. Tagged `session-summary` for easy recall and whisper surfacing. Does not require LLM — built from the already-extracted nodes.

New config: `ORMAH_SESSION_SUMMARY_ENABLED` (true), `ORMAH_SESSION_SUMMARY_MIN_TURNS` (3)

Also fixes `ingest_conversation` to include `type` in returned dicts so breakdown counts are accurate.

---

## Test plan

```bash
uv run pytest tests/   # 791 tests pass
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)