### PR TITLE
feat: pre-storage contradiction check on remember()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Before each hooked prompt, Ormah:
 4. Reranks candidates for precision
 5. Avoids repeating recently-whispered context when the topic has not shifted
 6. Applies a relevance gate so silence beats noise
+7. Adjusts that gate over time based on your feedback — accepted whispers raise it, rejected ones lower it
 
 The result is a compact block of context added before the model sees your message.
 
@@ -418,6 +419,12 @@ ORMAH_SIMILARITY_THRESHOLD=0.4
 ORMAH_WHISPER_MAX_NODES=6
 ORMAH_WHISPER_INJECTION_GATE=0.50
 ORMAH_WHISPER_RERANKER_ENABLED=true
+
+# Feedback-driven gate tuning (adjusts injection gate based on submit_feedback signals)
+ORMAH_GATE_TUNING_ENABLED=true
+ORMAH_GATE_MIN=0.30
+ORMAH_GATE_MAX=0.80
+ORMAH_GATE_LEARNING_RATE=0.02
 
 # FSRS decay
 ORMAH_FSRS_INITIAL_STABILITY=1.0

--- a/README.md
+++ b/README.md
@@ -193,13 +193,40 @@ Ormah does not just collect memories. It keeps the graph healthy.
 Background jobs:
 
 - link related memories
-- detect contradictions and belief evolution
+- detect contradictions and belief evolution — surfaced as queryable `[observation]` nodes
 - merge near-duplicates
 - score importance from access, centrality, and recency
 - decay stale memories with FSRS-style retrievability
 - consolidate overlapping working memories
 - assign spaces to orphaned memories
 - refresh indexes incrementally
+
+### Conflict surfacing
+
+When the conflict detector finds a genuine **tension** between two beliefs — both simultaneously held and irreconcilable — it no longer just adds a silent `contradicts` edge. It creates a new `[observation]` node that makes the conflict visible and actionable.
+
+The observation node:
+
+- Is tagged `conflict` and `needs-review` so it surfaces in whisper when related topics come up
+- Includes the explanation of why the two memories contradict each other
+- Links directly to both conflicting nodes via `contradicts` edges
+- Stays in the graph until resolved
+
+**To resolve a conflict**, recall it first:
+
+```bash
+ormah recall "conflict needs-review"
+```
+
+Then mark the outdated belief:
+
+```bash
+ormah outdated <node-id> --reason "superseded by newer decision"
+```
+
+Or use the `mark_outdated` MCP tool from within your agent.
+
+**Evolution is handled differently.** When the detector finds that a newer belief superseded an older one — the person's view simply changed over time — it creates an `evolved_from` edge instead. No observation node is created because there is nothing to resolve; the history is just recorded.
 
 ### Agent-in-the-loop maintenance
 

--- a/docs/09 - Affinity and Feedback.md
+++ b/docs/09 - Affinity and Feedback.md
@@ -141,9 +141,44 @@ flowchart LR
     SEARCH[hybrid search] --> RERANK[rerank]
     RERANK --> AFF[affinity boost]
     AFF --> GATE[injection gate]
+    GATE --> TUNE[gate tuning]
 ```
 
 It can rescue a borderline candidate or slightly suppress a noisy one, but it is capped.
+
+## Feedback-driven Gate Tuning
+
+Beyond per-node affinity boosts, each `submit_feedback` call also nudges the **global injection gate** — the minimum blended score required for any memory to be whispered.
+
+The update rule is proportional:
+
+```python
+if signal > 0:
+    new_gate = current + lr * (gate_max - current)   # pull toward gate_max
+else:
+    new_gate = current - lr * (current - gate_min)   # pull toward gate_min
+
+new_gate = clamp(new_gate, gate_min, gate_max)
+```
+
+This means:
+
+- Accepting whispers (`signal=+1`) gradually raises the gate, making future whispers more selective.
+- Rejecting whispers (`signal=-1`) gradually lowers it, widening the window.
+- The gate converges toward the implicit "right level" the user's feedback reveals over time.
+
+The gate value is persisted in the `gate_state` table and survives server restarts. It replaces the static `ORMAH_WHISPER_INJECTION_GATE` config value at runtime.
+
+### Gate tuning config
+
+| Setting | Default | Meaning |
+|---|---:|---|
+| `ORMAH_GATE_TUNING_ENABLED` | `true` | Enable/disable gate tuning. `false` falls back to static config. |
+| `ORMAH_GATE_MIN` | `0.30` | Floor — gate never goes below this |
+| `ORMAH_GATE_MAX` | `0.80` | Ceiling — gate never goes above this |
+| `ORMAH_GATE_LEARNING_RATE` | `0.02` | Step size per feedback signal |
+
+The initial gate value is `ORMAH_WHISPER_INJECTION_GATE` (default `0.50`) until the first feedback signal shifts it.
 
 ## Review Loop
 

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -336,6 +336,13 @@ async def _dispatch(
                 )
             return "\n\n".join(lines)
 
+        elif name == "recall_history":
+            node_id = args.get("node_id", "")
+            resp = await client.get(f"/agent/recall/{node_id}/history")
+            if not resp.is_success:
+                return _handle_error(resp)
+            return resp.json().get("text", "")
+
         elif name == "undo_merge":
             resp = await client.post(f"/agent/merges/{args['merge_id']}/undo")
             if not resp.is_success:

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -248,6 +248,13 @@ async def _dispatch(
                 return _handle_error(resp)
             return resp.json()["text"]
 
+        elif name == "promote_memory":
+            body = {"tier": args.get("tier", "core")}
+            resp = await client.post(f"/agent/promote/{args['node_id']}", json=body)
+            if not resp.is_success:
+                return _handle_error(resp)
+            return resp.json()["text"]
+
         elif name == "mark_outdated":
             body = {}
             if args.get("reason"):

--- a/src/ormah/adapters/tool_schemas.py
+++ b/src/ormah/adapters/tool_schemas.py
@@ -442,6 +442,24 @@ ADMIN_TOOLS = [
             },
         },
     },
+    {
+        "name": "recall_history",
+        "description": (
+            "Show the full human-readable edit history for a specific memory node. "
+            "Returns a chronological changelog of all updates, outdating, and deletions, "
+            "with field-by-field diffs showing old → new values for each change."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "string",
+                    "description": "The ID of the memory node to show history for.",
+                },
+            },
+            "required": ["node_id"],
+        },
+    },
 ]
 
 ALL_TOOLS = TOOLS + ADMIN_TOOLS

--- a/src/ormah/adapters/tool_schemas.py
+++ b/src/ormah/adapters/tool_schemas.py
@@ -1,7 +1,7 @@
 """Canonical tool definitions shared across MCP and OpenAI adapters.
 
-TOOLS: The core set of tools exposed via MCP to AI agents (6 tools).
-ADMIN_TOOLS: Tools for human administration via CLI/API only (7 tools).
+TOOLS: The core set of tools exposed via MCP to AI agents (10 tools).
+ADMIN_TOOLS: Tools for human administration via CLI/API only (4 tools).
 ALL_TOOLS: Combined list for adapters that want the full set.
 """
 
@@ -286,16 +286,12 @@ TOOLS = [
             },
         },
     },
-]
-
-# Admin tools — available via CLI and HTTP API but not exposed to AI agents via MCP.
-# These are for human review and administration of the memory system.
-ADMIN_TOOLS = [
     {
         "name": "update_memory",
         "description": (
-            "Update an existing memory's content, type, tier, or tags. "
-            "Use this to correct or enhance stored memories."
+            "Correct or enhance an existing memory. Use this when you find that a stored memory "
+            "has wrong content, an outdated type/tier, or needs better tags. "
+            "Only pass the fields you want to change — omitted fields are left unchanged."
         ),
         "parameters": {
             "type": "object",
@@ -304,16 +300,42 @@ ADMIN_TOOLS = [
                     "type": "string",
                     "description": "The UUID of the memory to update.",
                 },
-                "content": {"type": "string", "description": "New content."},
-                "type": {"type": "string", "description": "New type."},
-                "tier": {"type": "string", "description": "New tier."},
+                "content": {
+                    "type": "string",
+                    "description": "Corrected or updated content.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "New short title.",
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "fact", "decision", "preference", "event", "person",
+                        "project", "concept", "procedure", "goal", "observation",
+                    ],
+                    "description": "New memory type.",
+                },
+                "tier": {
+                    "type": "string",
+                    "enum": ["core", "working", "archival"],
+                    "description": "New importance tier. Use 'core' to pin permanently, 'archival' to deprioritize.",
+                },
+                "confidence": {
+                    "type": "number",
+                    "description": "Updated confidence 0.0–1.0.",
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                },
                 "tags": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "New tags.",
+                    "description": "Replacement tag list (replaces existing tags entirely).",
                 },
-                "title": {"type": "string", "description": "New title."},
-                "space": {"type": "string", "description": "New space/project scope. Use null for global memories."},
+                "space": {
+                    "type": "string",
+                    "description": "New space/project scope. Use null to make the memory global.",
+                },
             },
             "required": ["node_id"],
         },
@@ -321,8 +343,10 @@ ADMIN_TOOLS = [
     {
         "name": "connect_memories",
         "description": (
-            "Create a typed connection between two memories. "
-            "Use this to build relationships in the knowledge graph."
+            "Create a typed edge between two memories. Use this when you recognise a meaningful "
+            "relationship between nodes — e.g. one decision supports another, a fact is part of a "
+            "concept, or two observations contradict each other. "
+            "Background auto-linker runs periodically, but call this for immediate graph updates."
         ),
         "parameters": {
             "type": "object",
@@ -333,20 +357,68 @@ ADMIN_TOOLS = [
                     "type": "string",
                     "enum": [
                         "related_to", "supports", "contradicts", "part_of",
-                        "derived_from", "depends_on", "defines",
+                        "derived_from", "depends_on", "defines", "evolved_from",
                     ],
-                    "description": "The type of connection.",
+                    "description": "The relationship type.",
                     "default": "related_to",
                 },
                 "weight": {
                     "type": "number",
-                    "description": "Connection strength 0.0-1.0.",
+                    "description": "Connection strength 0.0–1.0.",
                     "default": 0.5,
                 },
             },
             "required": ["source_id", "target_id"],
         },
     },
+    {
+        "name": "promote_memory",
+        "description": (
+            "Promote a memory to core tier, marking it as permanently important. "
+            "Use this when you discover a memory that should always be accessible — "
+            "key decisions, identity facts, architectural constants. "
+            "Core memories are never decayed and always surface in whisper context."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "string",
+                    "description": "UUID of the memory to promote.",
+                },
+                "tier": {
+                    "type": "string",
+                    "enum": ["core", "working"],
+                    "description": "Target tier (default: core). Use 'working' to un-archive a demoted memory.",
+                    "default": "core",
+                },
+            },
+            "required": ["node_id"],
+        },
+    },
+    {
+        "name": "recall_history",
+        "description": (
+            "Show the full edit history for a memory. Returns a chronological changelog "
+            "of all updates with field-by-field old→new diffs. "
+            "Use this to understand how a memory has changed over time."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "node_id": {
+                    "type": "string",
+                    "description": "The UUID of the memory to show history for.",
+                },
+            },
+            "required": ["node_id"],
+        },
+    },
+]
+
+# Admin tools — available via CLI and HTTP API but not exposed to AI agents via MCP.
+# These are for human review and administration of the memory system.
+ADMIN_TOOLS = [
     {
         "name": "list_proposals",
         "description": (
@@ -440,24 +512,6 @@ ADMIN_TOOLS = [
                     "description": "Filter by operation type.",
                 },
             },
-        },
-    },
-    {
-        "name": "recall_history",
-        "description": (
-            "Show the full human-readable edit history for a specific memory node. "
-            "Returns a chronological changelog of all updates, outdating, and deletions, "
-            "with field-by-field diffs showing old → new values for each change."
-        ),
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "node_id": {
-                    "type": "string",
-                    "description": "The ID of the memory node to show history for.",
-                },
-            },
-            "required": ["node_id"],
         },
     },
 ]

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -104,6 +104,14 @@ async def delete_node(node_id: str, request: Request):
     return TextResponse(text=text, node_id=node_id)
 
 
+@router.get("/recall/{node_id}/history", response_model=TextResponse)
+async def recall_history(node_id: str, request: Request):
+    """Get the full edit history for a specific memory."""
+    engine = request.app.state.engine
+    text = engine.recall_history(node_id)
+    return TextResponse(text=text, node_id=node_id)
+
+
 @router.post("/connect", response_model=TextResponse)
 async def connect(req: ConnectRequest, request: Request):
     """Create a connection between two memories."""

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -112,6 +112,57 @@ async def recall_history(node_id: str, request: Request):
     return TextResponse(text=text, node_id=node_id)
 
 
+class PromoteRequest(BaseModel):
+    tier: str = "core"
+
+
+@router.post("/promote/{node_id}", response_model=TextResponse)
+async def promote_node(node_id: str, request: Request, body: PromoteRequest | None = None):
+    """Promote a memory to a higher tier (default: core)."""
+    from ormah.models.node import Tier
+
+    target_tier_str = (body.tier if body else None) or "core"
+    try:
+        target_tier = Tier(target_tier_str)
+    except ValueError:
+        raise HTTPException(status_code=422, detail=f"Invalid tier: {target_tier_str!r}")
+
+    engine = request.app.state.engine
+    node = engine.graph.get_node(node_id)
+    if node is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    tier_order = [Tier.archival, Tier.working, Tier.core]
+    current_tier = Tier(node["tier"])
+    current_idx = tier_order.index(current_tier)
+    target_idx = tier_order.index(target_tier)
+
+    if target_idx <= current_idx:
+        return TextResponse(
+            text=f"Memory is already at {current_tier.value} tier — no promotion needed.",
+            node_id=node_id,
+        )
+
+    text = engine.update_node(node_id, UpdateNodeRequest(tier=target_tier))
+    if text is None:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    # Enforce core cap after promotion
+    if target_tier == Tier.core:
+        protected = {engine.user_node_id} if engine.user_node_id else set()
+        core_nodes = [
+            engine.file_store.load(r["id"])
+            for r in engine.graph.get_nodes_by_tier("core")
+        ]
+        core_nodes = [n for n in core_nodes if n is not None]
+        demoted = engine.tier_manager.enforce_core_cap(core_nodes, protected_ids=protected)
+        for d in demoted:
+            path = engine.file_store.save(d)
+            engine.builder.index_single(path)
+
+    return TextResponse(text=text, node_id=node_id)
+
+
 @router.post("/connect", response_model=TextResponse)
 async def connect(req: ConnectRequest, request: Request):
     """Create a connection between two memories."""

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -7,7 +7,8 @@ import logging
 from datetime import datetime, timezone
 
 from ormah.background.llm import normalize_conflict_type
-from ormah.models.node import Connection, EdgeType
+from ormah.models.node import Connection, EdgeType, NodeType, Tier
+from ormah.models.node import CreateNodeRequest
 
 logger = logging.getLogger(__name__)
 
@@ -205,6 +206,38 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
         return []
 
 
+def _store_conflict_node(engine, node_a: dict, node_b: dict, explanation: str) -> None:
+    """Create a queryable observation node surfacing a tension conflict."""
+    try:
+        title_a = (node_a.get("title") or node_a["id"][:8])[:50]
+        title_b = (node_b.get("title") or node_b["id"][:8])[:50]
+        space = node_a.get("space") or None
+
+        content = (
+            f"{explanation}\n\n"
+            f"Node A: {title_a} (id: {node_a['id']})\n"
+            f"Node B: {title_b} (id: {node_b['id']})\n\n"
+            f"Resolve by marking the outdated node with `mark_outdated`."
+        )
+
+        req = CreateNodeRequest(
+            type=NodeType.observation,
+            tier=Tier.working,
+            title=f"Conflict: {title_a} vs {title_b}",
+            content=content,
+            tags=["conflict", "needs-review"],
+            space=space,
+            source="conflict-detector",
+            connections=[
+                Connection(target=node_a["id"], edge=EdgeType.contradicts, weight=0.9),
+                Connection(target=node_b["id"], edge=EdgeType.contradicts, weight=0.9),
+            ],
+        )
+        engine.remember(req, agent_id="conflict-detector")
+    except Exception as e:
+        logger.debug("Failed to store conflict node: %s", e)
+
+
 def run_conflict_detection(engine) -> None:
     """Find potentially contradicting nodes and create edges."""
     try:
@@ -257,6 +290,9 @@ def run_conflict_detection(engine) -> None:
                     )
                     edge_type_str = "contradicts"
                     source_id, target_id = node_a["id"], node_b["id"]
+
+                    # Surface tension conflicts as queryable observation nodes
+                    _store_conflict_node(engine, node_a, node_b, explanation)
 
             md_conn = Connection(
                 target=target_id,

--- a/src/ormah/background/decay_manager.py
+++ b/src/ormah/background/decay_manager.py
@@ -11,11 +11,29 @@ from ormah.models.node import Tier, UpdateNodeRequest
 logger = logging.getLogger(__name__)
 
 
+def _compute_retrievability(row, now: datetime) -> float | None:
+    """Return FSRS retrievability for a node row, or None if uncomputable."""
+    stability = row["stability"] if row["stability"] else 1.0
+    anchor_str = row["last_review"] or row["last_accessed"]
+    try:
+        anchor = datetime.fromisoformat(anchor_str)
+    except (ValueError, TypeError):
+        return None
+    days_since = max((now - anchor).total_seconds() / 86400, 0.001)
+    return math.exp(-days_since / stability)
+
+
 def run_decay(engine) -> None:
-    """Auto-demote working nodes whose FSRS retrievability drops below threshold."""
+    """Auto-demote working nodes whose FSRS retrievability drops below threshold.
+
+    Also writes proactive decay alerts for core and working nodes whose
+    retrievability has dropped below ``decay_alert_threshold`` so that
+    context_builder can whisper a warning before demotion occurs.
+    """
     try:
         settings = engine.settings
         now = datetime.now(timezone.utc)
+        now_iso = now.isoformat()
 
         # One-time cleanup: remove legacy pending decay proposals
         with engine.db.transaction() as conn:
@@ -23,6 +41,51 @@ def run_decay(engine) -> None:
                 "DELETE FROM proposals WHERE type = 'decay' AND status = 'pending'"
             )
 
+        # --- Proactive decay alerts ------------------------------------------
+        if getattr(settings, "decay_alert_enabled", True):
+            alert_threshold = getattr(settings, "decay_alert_threshold", 0.40)
+            refire_days = getattr(settings, "decay_alert_refire_days", 7)
+            user_node_id = getattr(engine, "user_node_id", None)
+
+            alert_rows = engine.db.conn.execute(
+                "SELECT id, tier, importance, stability, last_review, last_accessed "
+                "FROM nodes WHERE tier IN ('core', 'working')"
+            ).fetchall()
+
+            alerted = 0
+            for row in alert_rows:
+                if row["id"] == user_node_id:
+                    continue
+                r = _compute_retrievability(row, now)
+                if r is None or r >= alert_threshold:
+                    continue
+
+                # Suppress if already alerted recently
+                recent = engine.db.conn.execute(
+                    """
+                    SELECT id FROM decay_alert_log
+                    WHERE node_id = ? AND acknowledged = 0
+                      AND alerted_at > datetime(?, '-' || ? || ' days')
+                    LIMIT 1
+                    """,
+                    (row["id"], now_iso, refire_days),
+                ).fetchone()
+                if recent:
+                    continue
+
+                with engine.db.transaction() as conn:
+                    conn.execute(
+                        "INSERT INTO decay_alert_log "
+                        "(node_id, alerted_at, retrievability, tier) "
+                        "VALUES (?, ?, ?, ?)",
+                        (row["id"], now_iso, r, row["tier"]),
+                    )
+                alerted += 1
+
+            if alerted:
+                logger.info("Decay manager created %d proactive alerts", alerted)
+
+        # --- Demotion --------------------------------------------------------
         rows = engine.db.conn.execute(
             "SELECT id, importance, stability, last_review, last_accessed "
             "FROM nodes WHERE tier = 'working'"
@@ -44,17 +107,8 @@ def run_decay(engine) -> None:
             if node_importance >= importance_threshold:
                 continue
 
-            # Compute FSRS retrievability
-            stability = row["stability"] if row["stability"] else 1.0
-            anchor_str = row["last_review"] or row["last_accessed"]
-            try:
-                anchor = datetime.fromisoformat(anchor_str)
-            except (ValueError, TypeError):
-                continue
-            days_since = max((now - anchor).total_seconds() / 86400, 0.001)
-            retrievability = math.exp(-days_since / stability)
-
-            if retrievability >= r_threshold:
+            r = _compute_retrievability(row, now)
+            if r is None or r >= r_threshold:
                 continue
 
             result = engine.update_node(row["id"], UpdateNodeRequest(tier=Tier.archival))

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -122,7 +122,85 @@ def _ingest_session(
         "Session watcher ingested %s (%d turns, %d memories extracted)",
         rel, result.user_turn_count, count,
     )
+
+    # Session summary: create an [event] node summarising what was extracted.
+    settings = engine.settings
+    if (
+        getattr(settings, "session_summary_enabled", True)
+        and result.user_turn_count >= getattr(settings, "session_summary_min_turns", 3)
+        and new_node_ids
+    ):
+        _create_session_summary(engine, ingested, result, space)
+
     return True
+
+
+def _create_session_summary(
+    engine: MemoryEngine,
+    ingested: list,
+    result,
+    space: str | None,
+) -> None:
+    """Create a concise [event] memory summarising a completed session.
+
+    Counts extracted nodes by type, picks the top titles, and stores a
+    self-contained summary so the session is searchable and whisper-able
+    without re-reading the full transcript.
+    """
+    from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+    # Count nodes by type
+    type_counts: dict[str, int] = {}
+    titles: list[str] = []
+    for m in ingested:
+        ntype = m.get("type", "fact")
+        type_counts[ntype] = type_counts.get(ntype, 0) + 1
+        title = m.get("title") or m.get("content", "")[:60]
+        if title:
+            titles.append(title)
+
+    type_summary_parts = []
+    for ntype in ("decision", "fact", "event", "preference", "procedure", "observation"):
+        n = type_counts.get(ntype, 0)
+        if n:
+            type_summary_parts.append(f"{n} {ntype}{'s' if n > 1 else ''}")
+    for ntype, n in type_counts.items():
+        if ntype not in ("decision", "fact", "event", "preference", "procedure", "observation") and n:
+            type_summary_parts.append(f"{n} {ntype}{'s' if n > 1 else ''}")
+
+    space_label = space or "global"
+    date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    total = len(ingested)
+
+    body_lines = [
+        f"Session on {date_str} in space '{space_label}': "
+        f"{result.user_turn_count} turns, {total} {'memory' if total == 1 else 'memories'} extracted.",
+    ]
+    if type_summary_parts:
+        body_lines.append("Extracted: " + ", ".join(type_summary_parts) + ".")
+    if titles:
+        preview = titles[:5]
+        body_lines.append("Key memories: " + "; ".join(f'"{t}"' for t in preview) + ".")
+
+    session_id_short = (result.session_id or "")[:8] or "unknown"
+    try:
+        engine.remember(
+            CreateNodeRequest(
+                title=f"Session summary — {date_str} [{space_label}]",
+                content="\n".join(body_lines),
+                type=NodeType.event,
+                tier=Tier.working,
+                space=space,
+                tags=["session-summary", space_label] if space_label != "global" else ["session-summary"],
+            ),
+            agent_id="session-watcher",
+        )
+        logger.info(
+            "Session watcher created summary for session %s (%d memories)",
+            session_id_short, total,
+        )
+    except Exception as e:
+        logger.warning("Session summary creation failed: %s", e)
 
 
 def _scan_sessions(

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -164,6 +164,12 @@ class Settings(BaseSettings):
     # Whisper injection gate (minimum blended score to justify injection)
     whisper_injection_gate: float = 0.50
 
+    # Feedback-driven gate tuning
+    gate_tuning_enabled: bool = True
+    gate_min: float = 0.30
+    gate_max: float = 0.80
+    gate_learning_rate: float = 0.02
+
     # Affinity boost (adaptive feedback loop)
     affinity_similarity_threshold: float = 0.70
     affinity_half_life_days: float = 30.0

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -59,6 +59,8 @@ class Settings(BaseSettings):
     session_watcher_debounce_seconds: float = 60.0
     session_watcher_min_turns: int = 5
     session_watcher_lookback_hours: int = 72
+    session_summary_enabled: bool = True
+    session_summary_min_turns: int = 3  # skip summary for trivial sessions
 
     # Tier limits
     core_memory_cap: int = 50

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -117,6 +117,10 @@ class Settings(BaseSettings):
     # Auto-merge
     auto_merge_threshold: float = 0.85
 
+    # Pre-storage contradiction check (inline, rule-based — no LLM)
+    contradiction_prestorage_enabled: bool = True
+    contradiction_prestorage_threshold: float = 0.88  # cosine similarity to flag
+
     # Importance scoring weights (3 dynamic signals)
     importance_access_weight: float = 0.34
     importance_edge_weight: float = 0.33

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -131,6 +131,11 @@ class Settings(BaseSettings):
     # Decay: skip nodes above this importance
     decay_importance_threshold: float = 0.5
 
+    # Proactive decay alerts (warn before demotion)
+    decay_alert_enabled: bool = True
+    decay_alert_threshold: float = 0.40   # alert when R drops below this (above fsrs_decay_threshold)
+    decay_alert_refire_days: int = 7      # suppress repeat alerts for this many days
+
     # Whisper-out (involuntary storage on compaction / session end)
     whisper_out_enabled: bool = True
     whisper_out_min_turns: int = 3

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -20,6 +20,13 @@ _WHISPER_FRAMING = (
 )
 
 
+_DECAY_ALERT_FRAMING = (
+    "\n\n## Ormah: memory fading\n"
+    "The following {count} {word} {verb} low retrievability and {may} be demoted to archival soon. "
+    "Recalling them will reset their stability.\n\n"
+    "{items}"
+)
+
 _REVIEW_FRAMING = (
     "\n\n## Ormah: one thing to review when you get a chance\n"
     "In a recent session, the user was working on:\n"
@@ -713,6 +720,39 @@ class ContextBuilder:
                     result = result + review_block
             except Exception as e:
                 logger.warning("Review mechanism failed: %s", e)
+
+        # Decay alerts: surface fading memories once per session (first message only).
+        if recent_prompts is None and self.engine is not None:
+            settings = getattr(self.engine, "settings", None)
+            if settings and getattr(settings, "decay_alert_enabled", True):
+                try:
+                    alert_rows = self.graph.conn.execute(
+                        """
+                        SELECT dal.id, dal.node_id, dal.retrievability, dal.tier,
+                               n.title, n.type
+                        FROM decay_alert_log dal
+                        JOIN nodes n ON n.id = dal.node_id
+                        WHERE dal.acknowledged = 0
+                        ORDER BY dal.retrievability ASC
+                        LIMIT 5
+                        """
+                    ).fetchall()
+                    if alert_rows:
+                        count = len(alert_rows)
+                        word = "memory" if count == 1 else "memories"
+                        verb = "has" if count == 1 else "have"
+                        may = "may" if alert_rows[0]["tier"] == "core" else "will"
+                        items = "\n".join(
+                            f"- **{r['title'] or r['node_id'][:8]}** "
+                            f"[{r['type']}/{r['tier']}] R={r['retrievability']:.2f} "
+                            f"(id: {r['node_id'][:8]}...)"
+                            for r in alert_rows
+                        )
+                        result = result + _DECAY_ALERT_FRAMING.format(
+                            count=count, word=word, verb=verb, may=may, items=items
+                        )
+                except Exception as e:
+                    logger.warning("Decay alert surfacing failed: %s", e)
 
         if _return_debug:
             return result, _injected_ids

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -462,6 +462,15 @@ class MemoryEngine:
             formatted += f"\nAuto-linked to {len(auto_links)} related memories:"
             for link_id, link_title, sim in auto_links:
                 formatted += f"\n  → {link_title} ({sim:.0%} similar)"
+
+        # Pre-storage contradiction check (inline, rule-based — no LLM)
+        if getattr(self.settings, "contradiction_prestorage_enabled", True):
+            conflicts = self._check_contradiction_prestorage(node)
+            if conflicts:
+                formatted += "\n⚠ Possible contradiction with existing memories:"
+                for cid, ctitle, csim in conflicts:
+                    formatted += f"\n  · {ctitle} (id: {cid[:8]}, {csim:.0%} similar) — review with recall(node_id='{cid[:8]}')"
+
         return node.id, formatted
 
     def _encode_feedback_prompt_vec(self, prompt_text: str) -> bytes:
@@ -1944,6 +1953,69 @@ class MemoryEngine:
 
         except Exception as e:
             logger.debug("Auto-link on remember failed: %s", e)
+            return []
+
+    def _check_contradiction_prestorage(
+        self,
+        node: MemoryNode,
+        similarity_threshold: float | None = None,
+        top_k: int = 5,
+    ) -> list[tuple[str, str, float]]:
+        """Return a list of (node_id, title, similarity) for existing nodes that
+        may contradict the incoming node.
+
+        Only nodes in the same space (or both space-less) are considered — cross-
+        space matches are never flagged. The threshold defaults to
+        ``settings.contradiction_prestorage_threshold`` (default 0.88).
+
+        Entirely rule-based (no LLM call) so it stays fast at store-time. The
+        background conflict_detector handles deeper LLM-powered checks later.
+        """
+        threshold = similarity_threshold
+        if threshold is None:
+            threshold = getattr(
+                self.settings, "contradiction_prestorage_threshold", 0.88
+            )
+
+        try:
+            from ormah.embeddings.vector_store import VectorStore
+            from ormah.embeddings.encoder import get_encoder
+
+            encoder = get_encoder(self.settings)
+            vec_store = VectorStore(self.db)
+
+            text = _embedding_text(node.title, node.content, self.settings.embedding_max_content_chars)
+            if not text:
+                return []
+
+            query_vec = encoder.encode(text)
+            similar = vec_store.search(query_vec, limit=top_k + 1)
+
+            flagged = []
+            node_space = node.space or ""
+
+            for match in similar:
+                if match["id"] == node.id:
+                    continue
+                if match["similarity"] < threshold:
+                    continue
+
+                other = self.graph.get_node(match["id"])
+                if other is None:
+                    continue
+
+                # Only flag same-space pairs
+                other_space = (other.get("space") or "")
+                if other_space != node_space:
+                    continue
+
+                title = other.get("title") or (other.get("content") or "")[:50]
+                flagged.append((match["id"], title, match["similarity"]))
+
+            return flagged
+
+        except Exception as e:
+            logger.debug("Pre-storage contradiction check failed: %s", e)
             return []
 
     # --- Provenance ---

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -927,7 +927,7 @@ class MemoryEngine:
             reranker_blend_alpha=self.settings.whisper_reranker_blend_alpha,
             reranker_max_doc_chars=self.settings.whisper_reranker_max_doc_chars,
             recent_prompts=recent_prompts,
-            injection_gate=self.settings.whisper_injection_gate,
+            injection_gate=self.get_gate(),
             topic_shift_enabled=self.settings.whisper_topic_shift_enabled,
             topic_shift_threshold=self.settings.whisper_topic_shift_threshold,
             session_id=session_id,
@@ -2098,7 +2098,56 @@ class MemoryEngine:
                     (resolved_node_id,),
                 )
 
+        if getattr(self.settings, "gate_tuning_enabled", True):
+            self._update_gate(signal)
+
         return f"Feedback recorded for node {resolved_node_id[:8]}..."
+
+    def get_gate(self) -> float:
+        """Return the current injection gate value.
+
+        Reads from the gate_state table if gate tuning is enabled, falling
+        back to the static config value otherwise.
+        """
+        if not getattr(self.settings, "gate_tuning_enabled", True):
+            return self.settings.whisper_injection_gate
+        row = self.db.conn.execute(
+            "SELECT value FROM gate_state WHERE key = 'injection_gate'"
+        ).fetchone()
+        if row is None:
+            return self.settings.whisper_injection_gate
+        return float(row["value"])
+
+    def _update_gate(self, signal: int) -> None:
+        """Nudge the injection gate based on a feedback signal.
+
+        Uses a proportional update rule:
+          +1 → gate += lr * (1 - gate)   (pulls toward gate_max)
+          -1 → gate -= lr * gate          (pulls toward gate_min)
+        Result is clamped to [gate_min, gate_max].
+        """
+        current = self.get_gate()
+        lr = getattr(self.settings, "gate_learning_rate", 0.02)
+        gate_min = getattr(self.settings, "gate_min", 0.30)
+        gate_max = getattr(self.settings, "gate_max", 0.80)
+
+        if signal > 0:
+            new_gate = current + lr * (gate_max - current)
+        else:
+            new_gate = current - lr * (current - gate_min)
+
+        new_gate = max(gate_min, min(gate_max, new_gate))
+
+        with self.db.transaction() as conn:
+            conn.execute(
+                """
+                INSERT INTO gate_state (key, value, updated_at)
+                VALUES ('injection_gate', ?, datetime('now'))
+                ON CONFLICT (key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+                """,
+                (new_gate,),
+            )
+        logger.debug("Gate tuning: signal=%+d %.4f → %.4f", signal, current, new_gate)
 
     def _is_duplicate_memory(self, content: str) -> bool:
         """Check if a very similar memory already exists using vector search."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -533,6 +533,14 @@ class MemoryEngine:
         # Touch access
         self._touch_access(resolved_node_id)
 
+        # Acknowledge any pending decay alerts for this node
+        with self.db.transaction() as conn:
+            conn.execute(
+                "UPDATE decay_alert_log SET acknowledged = 1 "
+                "WHERE node_id = ? AND acknowledged = 0",
+                (resolved_node_id,),
+            )
+
         edges = self.graph.get_edges_for(resolved_node_id)
         neighbors = self.graph.get_neighbors(resolved_node_id, depth=1)
         self._log_feedback_candidates(

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2044,6 +2044,7 @@ class MemoryEngine:
             created.append({
                 "node_id": node_id,
                 "title": mem_title,
+                "type": node_type.value,
             })
 
         if skipped:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -811,12 +811,16 @@ class MemoryEngine:
                     (node_id, node_id),
                 )
 
-        # Audit log
+        # Audit log — store old snapshot in node_snapshot, new snapshot + changed fields in detail
+        new_snapshot = node.model_dump(mode="json")
         self._write_audit_log(
             operation="update",
             node_id=node_id,
             node_snapshot=json.dumps(old_snapshot),
-            detail=json.dumps({"changed_fields": changed_fields}),
+            detail=json.dumps({
+                "changed_fields": changed_fields,
+                "new_snapshot": new_snapshot,
+            }),
         )
 
         return f"Updated [{node.type.value}]: {node.title or node.content[:80]}\nID: {node.id}"
@@ -1349,6 +1353,79 @@ class MemoryEngine:
                     datetime.now(timezone.utc).isoformat(),
                 ),
             )
+
+    def recall_history(self, node_id: str) -> str:
+        """Return a human-readable changelog for a node.
+
+        Each audit entry shows the operation, timestamp, and a field-by-field
+        diff between old and new snapshots for update operations.
+        """
+        node = self.graph.get_node(node_id)
+        if node is None:
+            return f"Node {node_id} not found."
+
+        entries = self.list_audit_log(node_id=node["id"], limit=50)
+        if not entries:
+            return f"No history found for node {node_id[:8]}..."
+
+        title = node.get("title") or node.get("content", "")[:60]
+        lines = [f"# History: {title}", f"ID: {node['id']}", ""]
+
+        for entry in reversed(entries):  # oldest first
+            op = entry["operation"]
+            when = entry["performed_at"]
+            lines.append(f"## {op.upper()} — {when}")
+
+            if op == "update":
+                detail = {}
+                try:
+                    detail = json.loads(entry.get("detail") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+                changed = detail.get("changed_fields", [])
+                old = {}
+                new = {}
+                try:
+                    old = json.loads(entry.get("node_snapshot") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+                try:
+                    new = detail.get("new_snapshot") or {}
+                except Exception:
+                    pass
+
+                if changed and (old or new):
+                    for field in changed:
+                        old_val = old.get(field, "—")
+                        new_val = new.get(field, "—")
+                        if old_val != new_val:
+                            old_str = str(old_val)[:200]
+                            new_str = str(new_val)[:200]
+                            lines.append(f"  **{field}**: `{old_str}` → `{new_str}`")
+                elif changed:
+                    lines.append(f"  Changed: {', '.join(changed)}")
+                else:
+                    lines.append("  (no field details)")
+
+            elif op == "mark_outdated":
+                detail = {}
+                try:
+                    detail = json.loads(entry.get("detail") or "{}")
+                except (json.JSONDecodeError, TypeError):
+                    pass
+                reason = detail.get("reason", "no reason given")
+                new_confidence = detail.get("new_confidence")
+                lines.append(f"  Reason: {reason}")
+                if new_confidence is not None:
+                    lines.append(f"  Confidence set to: {new_confidence}")
+
+            elif op == "delete":
+                lines.append("  Node was deleted.")
+
+            lines.append("")
+
+        return "\n".join(lines)
 
     def list_audit_log(
         self,

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -168,6 +168,17 @@ class Database:
                     "CREATE INDEX IF NOT EXISTS idx_review_log_node ON review_log(node_id)"
                 )
 
+            if "gate_state" not in existing_tables:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS gate_state (
+                        key         TEXT PRIMARY KEY,
+                        value       REAL NOT NULL,
+                        updated_at  TEXT NOT NULL
+                    )
+                    """
+                )
+
         # Migrate FTS table to porter stemmer if needed
         self._migrate_fts_tokenizer()
 

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -179,6 +179,23 @@ class Database:
                     """
                 )
 
+            if "decay_alert_log" not in existing_tables:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS decay_alert_log (
+                        id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                        node_id        TEXT NOT NULL,
+                        alerted_at     TEXT NOT NULL,
+                        retrievability REAL NOT NULL,
+                        tier           TEXT NOT NULL,
+                        acknowledged   INTEGER DEFAULT 0
+                    )
+                    """
+                )
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_decay_alert_node ON decay_alert_log(node_id)"
+                )
+
         # Migrate FTS table to porter stemmer if needed
         self._migrate_fts_tokenizer()
 

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -137,3 +137,13 @@ CREATE TABLE IF NOT EXISTS gate_state (
     value       REAL NOT NULL,
     updated_at  TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS decay_alert_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    node_id        TEXT NOT NULL,
+    alerted_at     TEXT NOT NULL,
+    retrievability REAL NOT NULL,
+    tier           TEXT NOT NULL,
+    acknowledged   INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_decay_alert_node ON decay_alert_log(node_id);

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -131,3 +131,9 @@ CREATE TABLE IF NOT EXISTS review_log (
     answered    INTEGER DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_review_log_node ON review_log(node_id);
+
+CREATE TABLE IF NOT EXISTS gate_state (
+    key         TEXT PRIMARY KEY,      -- always 'injection_gate'
+    value       REAL NOT NULL,
+    updated_at  TEXT NOT NULL
+);

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -112,6 +112,65 @@ def configure_claude_hooks(ormah_bin: str) -> None:
             }
         ],
     }
+    # PostToolUse checkpoint — fires after high-impact operations and prompts
+    # the agent to call remember() before continuing, enabling mid-session
+    # write-back rather than waiting until session end.
+    checkpoint_script = Path(settings_path).parent / "hooks" / "ormah-checkpoint.sh"
+    checkpoint_script.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint_script.write_text(
+        "#!/usr/bin/env bash\n"
+        "# Ormah mid-session checkpoint hook (installed by ormah setup).\n"
+        "# Reads PostToolUse JSON from stdin; outputs a checkpoint reminder\n"
+        "# after high-impact operations so agents save state immediately.\n"
+        "set -euo pipefail\n"
+        "input=$(cat)\n"
+        'tool_name=$(echo "$input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(d.get(\'tool_name\',\'\'))" 2>/dev/null || echo "")\n'
+        'tool_input=$(echo "$input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(json.dumps(d.get(\'tool_input\',\'\')))" 2>/dev/null || echo "")\n'
+        "is_high_impact=0\n"
+        'case "$tool_name" in\n'
+        "  Bash)\n"
+        '    cmd=$(echo "$tool_input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(d.get(\'command\',\'\'))" 2>/dev/null || echo "")\n'
+        '    if echo "$cmd" | grep -qiE '
+        '"git (commit|push|merge|rebase)|systemctl|deploy|docker|kubectl|npm publish|pip install|uv (sync|add|remove)|rm -rf|DROP|ALTER TABLE"; then\n'
+        "      is_high_impact=1\n"
+        "    fi\n"
+        "    ;;\n"
+        "  Write)\n"
+        "    is_high_impact=1\n"
+        "    ;;\n"
+        "  Edit)\n"
+        '    file=$(echo "$tool_input" | python3 -c '
+        '"import sys,json; d=json.load(sys.stdin); print(d.get(\'file_path\',\'\'))" 2>/dev/null || echo "")\n'
+        '    if echo "$file" | grep -qiE '
+        r'"\.(env|json|toml|yaml|yml|sh|service|conf|ini)$|CLAUDE\.md|settings"; then'
+        "\n"
+        "      is_high_impact=1\n"
+        "    fi\n"
+        "    ;;\n"
+        "esac\n"
+        'if [ "$is_high_impact" -eq 1 ]; then\n'
+        '  echo "CHECKPOINT: A high-impact operation just completed. '
+        "If a decision was made, a config changed, or a milestone was reached — "
+        'call remember() now to save it before continuing."\n'
+        "fi\n"
+    )
+    checkpoint_script.chmod(0o755)
+
+    hooks["PostToolUse"] = [
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": str(checkpoint_script),
+                    "timeout": 5,
+                }
+            ]
+        }
+    ]
+
     hooks["PreCompact"] = [
         {
             "hooks": [

--- a/tests/test_api/test_agent_power_tools.py
+++ b/tests/test_api/test_agent_power_tools.py
@@ -1,0 +1,210 @@
+"""Tests for agent-facing power tools: update_memory, connect_memories, promote_memory."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api.routes_agent import router as agent_router
+from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+from ormah.models.node import CreateNodeRequest, NodeType, Tier, UpdateNodeRequest
+
+
+@pytest.fixture
+def client(tmp_memory_dir):
+    settings = Settings(memory_dir=tmp_memory_dir)
+    eng = MemoryEngine(settings)
+    eng.startup()
+
+    app = FastAPI()
+    app.include_router(agent_router)
+    app.state.engine = eng
+
+    with TestClient(app) as c:
+        yield c, eng
+
+    eng.shutdown()
+
+
+def _make_node(eng, content="Test content", tier=Tier.working, title="Test node"):
+    req = CreateNodeRequest(content=content, type=NodeType.fact, title=title, tier=tier)
+    node_id, _ = eng.remember(req)
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# update_memory route
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMemoryRoute:
+
+    def _get(self, eng, node_id):
+        return eng.graph.get_node(node_id)
+
+    def test_update_content(self, client):
+        c, eng = client
+        node_id = _make_node(eng, content="Original content")
+        resp = c.post(f"/agent/update/{node_id}", json={"content": "Updated content"})
+        assert resp.status_code == 200
+        assert self._get(eng, node_id)["content"] == "Updated content"
+
+    def test_update_title(self, client):
+        c, eng = client
+        node_id = _make_node(eng, title="Old title")
+        resp = c.post(f"/agent/update/{node_id}", json={"title": "New title"})
+        assert resp.status_code == 200
+        assert self._get(eng, node_id)["title"] == "New title"
+
+    def test_update_tier(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.working)
+        resp = c.post(f"/agent/update/{node_id}", json={"tier": "archival"})
+        assert resp.status_code == 200
+        assert self._get(eng, node_id)["tier"] == "archival"
+
+    def test_update_confidence(self, client):
+        c, eng = client
+        node_id = _make_node(eng)
+        resp = c.post(f"/agent/update/{node_id}", json={"confidence": 0.6})
+        assert resp.status_code == 200
+        assert abs(self._get(eng, node_id)["confidence"] - 0.6) < 1e-6
+
+    def test_update_unknown_node_returns_404(self, client):
+        c, _ = client
+        resp = c.post("/agent/update/nonexistent-id", json={"content": "x"})
+        assert resp.status_code == 404
+
+    def test_update_multiple_fields(self, client):
+        c, eng = client
+        node_id = _make_node(eng, content="old", title="old title")
+        resp = c.post(f"/agent/update/{node_id}", json={"content": "new", "title": "new title"})
+        assert resp.status_code == 200
+        node = self._get(eng, node_id)
+        assert node["content"] == "new"
+        assert node["title"] == "new title"
+
+
+# ---------------------------------------------------------------------------
+# connect_memories route
+# ---------------------------------------------------------------------------
+
+
+class TestConnectMemoriesRoute:
+
+    def test_connect_creates_edge(self, client):
+        c, eng = client
+        src = _make_node(eng, content="Source memory")
+        tgt = _make_node(eng, content="Target memory")
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": tgt})
+        assert resp.status_code == 200
+        edges = eng.db.conn.execute(
+            "SELECT edge_type FROM edges WHERE source_id = ? AND target_id = ?", (src, tgt)
+        ).fetchall()
+        assert len(edges) == 1
+        assert edges[0][0] == "related_to"
+
+    def test_connect_with_edge_type(self, client):
+        c, eng = client
+        src = _make_node(eng, content="Decision A")
+        tgt = _make_node(eng, content="Decision B")
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": tgt, "edge": "supports"})
+        assert resp.status_code == 200
+        row = eng.db.conn.execute(
+            "SELECT edge_type FROM edges WHERE source_id = ? AND target_id = ?", (src, tgt)
+        ).fetchone()
+        assert row[0] == "supports"
+
+    def test_connect_with_weight(self, client):
+        c, eng = client
+        src = _make_node(eng)
+        tgt = _make_node(eng)
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": tgt, "weight": 0.9})
+        assert resp.status_code == 200
+        row = eng.db.conn.execute(
+            "SELECT weight FROM edges WHERE source_id = ? AND target_id = ?", (src, tgt)
+        ).fetchone()
+        assert abs(row[0] - 0.9) < 1e-6
+
+    def test_connect_invalid_source_returns_error(self, client):
+        c, eng = client
+        tgt = _make_node(eng)
+        resp = c.post("/agent/connect", json={"source_id": "bad-id", "target_id": tgt})
+        assert resp.status_code == 200
+        assert "not found" in resp.json()["text"].lower()
+
+    def test_connect_invalid_target_returns_error(self, client):
+        c, eng = client
+        src = _make_node(eng)
+        resp = c.post("/agent/connect", json={"source_id": src, "target_id": "bad-id"})
+        assert resp.status_code == 200
+        assert "not found" in resp.json()["text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# promote_memory route
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteMemoryRoute:
+
+    def _tier(self, eng, node_id):
+        return eng.graph.get_node(node_id)["tier"]
+
+    def test_promote_working_to_core(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.working)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "core"})
+        assert resp.status_code == 200
+        assert self._tier(eng, node_id) == "core"
+
+    def test_promote_archival_to_working(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.archival)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "working"})
+        assert resp.status_code == 200
+        assert self._tier(eng, node_id) == "working"
+
+    def test_promote_default_tier_is_core(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.working)
+        resp = c.post(f"/agent/promote/{node_id}", json={})
+        assert resp.status_code == 200
+        assert self._tier(eng, node_id) == "core"
+
+    def test_promote_already_at_tier_returns_ok(self, client):
+        c, eng = client
+        node_id = _make_node(eng, tier=Tier.core)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "core"})
+        assert resp.status_code == 200
+        assert "already" in resp.json()["text"].lower()
+
+    def test_promote_unknown_node_returns_404(self, client):
+        c, _ = client
+        resp = c.post("/agent/promote/nonexistent", json={"tier": "core"})
+        assert resp.status_code == 404
+
+    def test_promote_invalid_tier_returns_422(self, client):
+        c, eng = client
+        node_id = _make_node(eng)
+        resp = c.post(f"/agent/promote/{node_id}", json={"tier": "invalid"})
+        assert resp.status_code == 422
+
+    def test_promote_respects_core_cap(self, client):
+        c, eng = client
+        # Set a very small cap
+        eng.tier_manager.core_cap = 2
+        # Fill core tier
+        id1 = _make_node(eng, tier=Tier.core, title="Core 1", content="Core memory 1")
+        id2 = _make_node(eng, tier=Tier.core, title="Core 2", content="Core memory 2")
+        # Promote a 3rd node — cap enforced, least important core gets demoted
+        id3 = _make_node(eng, tier=Tier.working, title="Promote me", content="Important new memory")
+        resp = c.post(f"/agent/promote/{id3}", json={"tier": "core"})
+        assert resp.status_code == 200
+        # Count core nodes — should still be <= 2 after cap enforcement
+        core_count = eng.db.conn.execute(
+            "SELECT COUNT(*) FROM nodes WHERE tier = 'core'"
+        ).fetchone()[0]
+        assert core_count <= 2

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -248,3 +248,98 @@ def test_nonexistent_watch_dir(engine, tmp_path):
 
     observers = start_session_watcher(engine)
     assert observers == []
+
+
+# --- Session summary tests ---
+
+def test_session_summary_created_after_ingestion(engine, tmp_path):
+    """A session summary [event] node is created after successful ingestion."""
+    engine.settings.session_summary_enabled = True
+    engine.settings.session_summary_min_turns = 3
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "sum_session.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) >= 1
+    node = summaries[0]["node"]
+    assert node["type"] == "event"
+    assert "myproject" in node["content"]
+    # Verify tag via DB
+    tags = [r[0] for r in engine.db.conn.execute(
+        "SELECT tag FROM node_tags WHERE node_id = ?", (node["id"],)
+    ).fetchall()]
+    assert "session-summary" in tags
+
+
+def test_session_summary_disabled_creates_no_node(engine, tmp_path):
+    """No summary node when session_summary_enabled=False."""
+    engine.settings.session_summary_enabled = False
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-nosum"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "nosummary.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) == 0
+
+
+def test_session_summary_skipped_for_trivial_session(engine, tmp_path):
+    """No summary when user_turn_count < session_summary_min_turns."""
+    engine.settings.session_summary_enabled = True
+    engine.settings.session_summary_min_turns = 10
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-trivial"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "trivial.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) == 0
+
+
+def test_session_summary_includes_type_breakdown(engine, tmp_path):
+    """Summary content includes memory type breakdown."""
+    engine.settings.session_summary_enabled = True
+    engine.settings.session_summary_min_turns = 3
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-breakdown"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "breakdown.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        _ingest_session(engine, jsonl, state, watch_dir, min_turns=3)
+
+    summaries = engine.recall_search_structured(
+        "session summary", tags=["session-summary"], touch_access=False
+    )
+    assert len(summaries) >= 1
+    content = summaries[0]["node"]["content"]
+    assert "decision" in content

--- a/tests/test_engine/test_contradiction_prestorage.py
+++ b/tests/test_engine/test_contradiction_prestorage.py
@@ -1,0 +1,213 @@
+"""Tests for the pre-storage contradiction check in MemoryEngine."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+
+class TestContradictionPrestorage:
+    def test_warning_appended_when_contradiction_found(self, engine):
+        """remember() output should contain a warning when similar nodes exist."""
+        with patch.object(
+            engine,
+            "_check_contradiction_prestorage",
+            return_value=[("abc12345", "Conflicting fact", 0.92)],
+        ):
+            _, text = engine.remember(CreateNodeRequest(
+                content="New fact that may conflict",
+                type=NodeType.fact,
+                title="New Fact",
+            ))
+
+        assert "⚠ Possible contradiction" in text
+        assert "Conflicting fact" in text
+        assert "abc12345" in text
+
+    def test_no_warning_when_no_contradictions(self, engine):
+        """remember() output should be clean when check returns empty list."""
+        with patch.object(
+            engine,
+            "_check_contradiction_prestorage",
+            return_value=[],
+        ):
+            _, text = engine.remember(CreateNodeRequest(
+                content="Unique new fact",
+                type=NodeType.fact,
+                title="Unique Fact",
+            ))
+
+        assert "⚠" not in text
+        assert "contradiction" not in text.lower()
+
+    def test_check_disabled_via_config(self, engine):
+        """When contradiction_prestorage_enabled=False, check should not run."""
+        engine.settings.contradiction_prestorage_enabled = False
+
+        with patch.object(
+            engine, "_check_contradiction_prestorage"
+        ) as mock_check:
+            engine.remember(CreateNodeRequest(
+                content="Fact with disabled check",
+                type=NodeType.fact,
+                title="Disabled Check",
+            ))
+
+        mock_check.assert_not_called()
+
+    def test_check_enabled_by_default(self, engine):
+        """contradiction_prestorage_enabled defaults to True."""
+        assert engine.settings.contradiction_prestorage_enabled is True
+
+
+class TestCheckContradictionPrestorage:
+    def test_returns_empty_when_vector_store_unavailable(self, engine):
+        """Should not raise if encoder/vector store import fails."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Test node",
+            content="Test content",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder", side_effect=ImportError):
+            result = engine._check_contradiction_prestorage(node)
+
+        assert result == []
+
+    def test_cross_space_nodes_not_flagged(self, engine):
+        """Nodes from a different space should never be flagged."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Project A fact",
+            content="Using Postgres for project A",
+            space="project-a",
+        )
+
+        # Simulate a high-similarity match from a different space
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": "other-node-id", "similarity": 0.95},
+            ]
+
+            # other node is in a different space
+            with patch.object(
+                engine.graph,
+                "get_node",
+                return_value={"id": "other-node-id", "space": "project-b", "title": "Project B fact", "content": ""},
+            ):
+                result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert result == []
+
+    def test_same_space_high_similarity_flagged(self, engine):
+        """High-similarity same-space node should appear in flagged list."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Same space fact",
+            content="Uses Redis for caching",
+            space="project-x",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": "existing-node-id", "similarity": 0.93},
+            ]
+
+            with patch.object(
+                engine.graph,
+                "get_node",
+                return_value={
+                    "id": "existing-node-id",
+                    "space": "project-x",
+                    "title": "Cache technology choice",
+                    "content": "Uses Memcached for caching",
+                },
+            ):
+                result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert len(result) == 1
+        assert result[0][0] == "existing-node-id"
+        assert result[0][2] == 0.93
+
+    def test_below_threshold_not_flagged(self, engine):
+        """Similarity below threshold should not produce a warning."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Some fact",
+            content="Some content",
+            space="project-x",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": "existing-node-id", "similarity": 0.75},
+            ]
+
+            with patch.object(
+                engine.graph,
+                "get_node",
+                return_value={"id": "existing-node-id", "space": "project-x", "title": "Related", "content": ""},
+            ):
+                result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert result == []
+
+    def test_self_excluded_from_results(self, engine):
+        """The node being stored should not flag itself as a contradiction."""
+        from ormah.models.node import MemoryNode, NodeType, Tier
+
+        node = MemoryNode(
+            type=NodeType.fact,
+            tier=Tier.working,
+            title="Self check",
+            content="Content",
+            space="proj",
+        )
+
+        with patch("ormah.embeddings.encoder.get_encoder") as mock_enc, \
+             patch("ormah.embeddings.vector_store.VectorStore") as mock_vs:
+
+            import numpy as np
+            mock_encoder = mock_enc.return_value
+            mock_encoder.encode.return_value = np.zeros(128, dtype="float32")
+
+            mock_vs.return_value.search.return_value = [
+                {"id": node.id, "similarity": 0.99},  # self
+            ]
+
+            result = engine._check_contradiction_prestorage(node, similarity_threshold=0.88)
+
+        assert result == []

--- a/tests/test_engine/test_decay_alerts.py
+++ b/tests/test_engine/test_decay_alerts.py
@@ -1,0 +1,188 @@
+"""Tests for proactive decay alerts."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ormah.background.decay_manager import run_decay
+from ormah.models.node import CreateNodeRequest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_node(conn, node_id, tier="working", stability=1.0, last_accessed=None):
+    """Insert a minimal node directly into the DB with controllable stability."""
+    if last_accessed is None:
+        # Default: accessed long ago so R is very low
+        last_accessed = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    conn.execute(
+        "INSERT INTO nodes "
+        "(id, type, tier, source, title, content, created, updated, "
+        "last_accessed, access_count, confidence, importance, stability, file_path, file_hash) "
+        "VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'), "
+        "?, 0, 1.0, 0.3, ?, ?, ?)",
+        (node_id, "fact", tier, "test", f"title-{node_id}", "content",
+         last_accessed, stability, f"/tmp/{node_id}.md", "abc"),
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# TestDecayAlertCreation
+# ---------------------------------------------------------------------------
+
+
+class TestDecayAlertCreation:
+
+    def test_alert_created_for_working_node_below_threshold(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-working-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["tier"] == "working"
+        assert row["retrievability"] < 0.40
+        assert row["acknowledged"] == 0
+
+    def test_alert_created_for_core_node_below_threshold(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-core-001"
+        _insert_node(engine.db.conn, node_id, tier="core", stability=1.0)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["tier"] == "core"
+
+    def test_no_alert_for_healthy_node(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-healthy-001"
+        # Accessed just now → R ≈ 1.0
+        recent = datetime.now(timezone.utc).isoformat()
+        _insert_node(engine.db.conn, node_id, tier="working", stability=30.0,
+                     last_accessed=recent)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is None
+
+    def test_alert_not_refired_within_refire_window(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+        engine.settings.decay_alert_refire_days = 7
+
+        node_id = "alert-refire-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+
+        run_decay(engine)
+        run_decay(engine)
+
+        rows = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchall()
+        assert len(rows) == 1  # not duplicated
+
+    def test_alert_disabled_creates_no_rows(self, engine):
+        engine.settings.decay_alert_enabled = False
+
+        node_id = "alert-disabled-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+
+        run_decay(engine)
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is None
+
+
+# ---------------------------------------------------------------------------
+# TestDecayAlertAcknowledgement
+# ---------------------------------------------------------------------------
+
+
+class TestDecayAlertAcknowledgement:
+
+    def test_recall_node_acknowledges_alert(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-ack-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+        run_decay(engine)
+
+        # Verify alert exists and is unacknowledged
+        row = engine.db.conn.execute(
+            "SELECT acknowledged FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row["acknowledged"] == 0
+
+        # recall_node should acknowledge it
+        engine.recall_node(node_id, session_id="test-session")
+
+        row = engine.db.conn.execute(
+            "SELECT acknowledged FROM decay_alert_log WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row["acknowledged"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestDecayAlertWhisper
+# ---------------------------------------------------------------------------
+
+
+class TestDecayAlertWhisper:
+
+    def test_alert_appears_in_first_message_whisper(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-whisper-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+        run_decay(engine)
+
+        # First message of session: recent_prompts=None triggers the alert block
+        result = engine.get_whisper_context(
+            prompt="what did we decide about auth",
+            session_id="test-whisper-session",
+        )
+        assert "memory fading" in result.lower() or "fading" in result.lower() or node_id[:8] in result
+
+    def test_alert_not_surfaced_mid_session(self, engine):
+        engine.settings.decay_alert_enabled = True
+        engine.settings.decay_alert_threshold = 0.40
+
+        node_id = "alert-midsession-001"
+        _insert_node(engine.db.conn, node_id, tier="working", stability=1.0)
+        run_decay(engine)
+
+        # Mid-session: pass a non-None recent_prompts list → no alert block
+        result = engine.get_whisper_context(
+            prompt="what did we decide about auth",
+            recent_prompts=["previous prompt"],
+            session_id="test-mid-session",
+        )
+        assert "memory fading" not in result.lower()

--- a/tests/test_engine/test_memory_versioning.py
+++ b/tests/test_engine/test_memory_versioning.py
@@ -1,0 +1,164 @@
+"""Tests for memory versioning — new snapshot storage and recall_history."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ormah.models.node import CreateNodeRequest, NodeType, Tier, UpdateNodeRequest
+
+
+def _make_node(engine, title="Versioned node", content="Original content"):
+    req = CreateNodeRequest(content=content, type=NodeType.fact, title=title)
+    node_id, _ = engine.remember(req)
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# New snapshot stored in detail
+# ---------------------------------------------------------------------------
+
+
+class TestNewSnapshotStorage:
+
+    def test_update_stores_new_snapshot_in_detail(self, engine):
+        node_id = _make_node(engine)
+        engine.update_node(node_id, UpdateNodeRequest(content="Updated content"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        assert len(entries) == 1
+        detail = json.loads(entries[0]["detail"])
+        assert "new_snapshot" in detail
+        assert detail["new_snapshot"]["content"] == "Updated content"
+
+    def test_update_stores_old_snapshot_in_node_snapshot(self, engine):
+        node_id = _make_node(engine, content="Before update")
+        engine.update_node(node_id, UpdateNodeRequest(content="After update"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        old = json.loads(entries[0]["node_snapshot"])
+        assert old["content"] == "Before update"
+
+    def test_update_records_changed_fields(self, engine):
+        node_id = _make_node(engine, title="Old title")
+        engine.update_node(node_id, UpdateNodeRequest(title="New title"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        detail = json.loads(entries[0]["detail"])
+        assert "title" in detail["changed_fields"]
+
+    def test_multiple_updates_produce_multiple_entries(self, engine):
+        node_id = _make_node(engine)
+        engine.update_node(node_id, UpdateNodeRequest(content="v2"))
+        engine.update_node(node_id, UpdateNodeRequest(content="v3"))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        assert len(entries) == 2
+
+    def test_tier_change_stored_in_new_snapshot(self, engine):
+        node_id = _make_node(engine)
+        engine.update_node(node_id, UpdateNodeRequest(tier=Tier.archival))
+
+        entries = engine.list_audit_log(node_id=node_id, operation="update")
+        detail = json.loads(entries[0]["detail"])
+        assert detail["new_snapshot"]["tier"] == "archival"
+
+
+# ---------------------------------------------------------------------------
+# recall_history formatting
+# ---------------------------------------------------------------------------
+
+
+class TestRecallHistory:
+
+    def test_no_history_returns_not_found(self, engine):
+        result = engine.recall_history("nonexistent-id")
+        assert "not found" in result.lower()
+
+    def test_empty_history_message(self, engine):
+        node_id = _make_node(engine)
+        result = engine.recall_history(node_id)
+        assert "No history" in result
+
+    def test_update_history_shows_diff(self, engine):
+        node_id = _make_node(engine, content="original body")
+        engine.update_node(node_id, UpdateNodeRequest(content="updated body"))
+
+        result = engine.recall_history(node_id)
+        assert "UPDATE" in result
+        assert "original body" in result
+        assert "updated body" in result
+
+    def test_history_shows_title_change(self, engine):
+        node_id = _make_node(engine, title="Old title")
+        engine.update_node(node_id, UpdateNodeRequest(title="New title"))
+
+        result = engine.recall_history(node_id)
+        assert "Old title" in result
+        assert "New title" in result
+
+    def test_history_shows_mark_outdated(self, engine):
+        node_id = _make_node(engine)
+        engine.mark_outdated(node_id, reason="superseded by v2")
+
+        result = engine.recall_history(node_id)
+        assert "MARK_OUTDATED" in result
+        assert "superseded by v2" in result
+
+    def test_history_chronological_order(self, engine):
+        node_id = _make_node(engine, content="v1")
+        engine.update_node(node_id, UpdateNodeRequest(content="v2"))
+        engine.update_node(node_id, UpdateNodeRequest(content="v3"))
+
+        result = engine.recall_history(node_id)
+        v1_pos = result.find("v1")
+        v2_pos = result.find("v2")
+        v3_pos = result.find("v3")
+        assert v1_pos < v2_pos < v3_pos
+
+
+# ---------------------------------------------------------------------------
+# HTTP route
+# ---------------------------------------------------------------------------
+
+
+class TestRecallHistoryRoute:
+
+    @pytest.fixture
+    def client(self, tmp_memory_dir):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from ormah.api.routes_agent import router as agent_router
+        from ormah.config import Settings
+        from ormah.engine.memory_engine import MemoryEngine
+
+        settings = Settings(memory_dir=tmp_memory_dir)
+        eng = MemoryEngine(settings)
+        eng.startup()
+
+        test_app = FastAPI()
+        test_app.include_router(agent_router)
+        test_app.state.engine = eng
+
+        with TestClient(test_app) as c:
+            yield c, eng
+
+        eng.shutdown()
+
+    def test_history_route_returns_200(self, client):
+        c, eng = client
+        req = CreateNodeRequest(content="test content", type=NodeType.fact, title="Route test")
+        node_id, _ = eng.remember(req)
+        eng.update_node(node_id, UpdateNodeRequest(content="updated content"))
+
+        resp = c.get(f"/agent/recall/{node_id}/history")
+        assert resp.status_code == 200
+        assert "UPDATE" in resp.json()["text"]
+
+    def test_history_route_unknown_node(self, client):
+        c, _ = client
+        resp = c.get("/agent/recall/nonexistent/history")
+        assert resp.status_code == 200
+        assert "not found" in resp.json()["text"].lower()

--- a/tests/test_engine/test_submit_feedback.py
+++ b/tests/test_engine/test_submit_feedback.py
@@ -315,3 +315,63 @@ class TestSubmitFeedbackRoute:
         assert row is not None
         assert row["session_id"] == "route-recall-node-session"
         assert row["prompt_text"] == f"recall_node:{node_id}"
+
+
+# ---------------------------------------------------------------------------
+# TestGateTuning
+# ---------------------------------------------------------------------------
+
+
+class TestGateTuning:
+
+    def test_get_gate_returns_config_default_when_no_db_row(self, engine):
+        gate = engine.get_gate()
+        assert gate == engine.settings.whisper_injection_gate
+
+    def test_positive_signal_raises_gate(self, engine):
+        node_id = "node-gate-pos-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        initial = engine.get_gate()
+        engine.submit_feedback(node_id, 1)
+        assert engine.get_gate() > initial
+
+    def test_negative_signal_lowers_gate(self, engine):
+        node_id = "node-gate-neg-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        initial = engine.get_gate()
+        engine.submit_feedback(node_id, -1)
+        assert engine.get_gate() < initial
+
+    def test_gate_persists_in_db(self, engine):
+        node_id = "node-gate-persist-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        engine.submit_feedback(node_id, 1)
+        row = engine.db.conn.execute(
+            "SELECT value FROM gate_state WHERE key = 'injection_gate'"
+        ).fetchone()
+        assert row is not None
+        assert row["value"] > engine.settings.whisper_injection_gate
+
+    def test_gate_clamps_to_max(self, engine):
+        engine.settings.gate_max = 0.52
+        engine.settings.whisper_injection_gate = 0.50
+        for _ in range(50):
+            engine._update_gate(1)
+        assert engine.get_gate() <= 0.52
+
+    def test_gate_clamps_to_min(self, engine):
+        engine.settings.gate_min = 0.48
+        engine.settings.whisper_injection_gate = 0.50
+        for _ in range(50):
+            engine._update_gate(-1)
+        assert engine.get_gate() >= 0.48
+
+    def test_gate_tuning_disabled_skips_update(self, engine):
+        engine.settings.gate_tuning_enabled = False
+        node_id = "node-gate-disabled-001"
+        _insert_whisper_log(engine.db.conn, node_id)
+        engine.submit_feedback(node_id, 1)
+        row = engine.db.conn.execute(
+            "SELECT value FROM gate_state WHERE key = 'injection_gate'"
+        ).fetchone()
+        assert row is None


### PR DESCRIPTION
## Summary

- Adds a fast, rule-based contradiction scan at `remember()` time — before the background conflict_detector runs its deeper LLM-powered checks
- High-similarity (≥ 0.88 cosine) nodes in the **same space** are surfaced as warnings in the `remember()` response, giving users immediate feedback
- Cross-space pairs are never flagged; check gracefully no-ops if embeddings are unavailable

## Details

**`MemoryEngine._check_contradiction_prestorage()`** (new method):
- Uses `VectorStore.search()` + `GraphIndex.get_node()` to find same-space neighbors above threshold
- Returns `list[tuple[node_id, title, similarity]]`
- No LLM call — purely cosine similarity (fast, synchronous, zero cost)

**`MemoryEngine.remember()`** — appended to formatted output:
```
⚠ Possible contradiction with existing memories:
  · Cache technology choice (id: abc12345, 93% similar) — review with recall(node_id='abc12345')
```

**Config** `src/ormah/config.py`:
- `contradiction_prestorage_enabled: bool = True`
- `contradiction_prestorage_threshold: float = 0.88`

## Test plan

- [ ] `test_warning_appended_when_contradiction_found`
- [ ] `test_no_warning_when_no_contradictions`
- [ ] `test_check_disabled_via_config`
- [ ] `test_check_enabled_by_default`
- [ ] `test_returns_empty_when_vector_store_unavailable`
- [ ] `test_cross_space_nodes_not_flagged`
- [ ] `test_same_space_high_similarity_flagged`
- [ ] `test_below_threshold_not_flagged`
- [ ] `test_self_excluded_from_results`
- [ ] Full suite: 818 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)