### PR TITLE
fix(setup): skip FastEmbed preload for non-local embeddings

### DIFF
--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -65,13 +65,19 @@ def _preload_local_models() -> None:
     step("Preloading local models")
     info(f"Model cache: {cache_dir}")
 
-    try:
-        from fastembed import TextEmbedding
+    if settings.embedding_provider == "local":
+        try:
+            from fastembed import TextEmbedding
 
-        TextEmbedding(settings.embedding_model, cache_dir=str(cache_dir))
-        ok(f"Embedding model ready: {settings.embedding_model}")
-    except Exception as e:
-        warn(f"Could not preload embedding model {settings.embedding_model}: {e}")
+            TextEmbedding(settings.embedding_model, cache_dir=str(cache_dir))
+            ok(f"Embedding model ready: {settings.embedding_model}")
+        except Exception as e:
+            warn(f"Could not preload embedding model {settings.embedding_model}: {e}")
+    else:
+        info(
+            "Skipping FastEmbed embedding preload for "
+            f"{settings.embedding_provider} model: {settings.embedding_model}"
+        )
 
     if not settings.whisper_reranker_enabled:
         info("Whisper reranker disabled — skipping reranker preload")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1898,6 +1898,7 @@ class TestRemoveFastembedCache:
 class TestPreloadLocalModels:
     def test_preloads_embedding_and_reranker_into_shared_cache(self, tmp_path):
         fake_settings = MagicMock()
+        fake_settings.embedding_provider = "local"
         fake_settings.embedding_model = "BAAI/bge-base-en-v1.5"
         fake_settings.whisper_reranker_enabled = True
         fake_settings.whisper_reranker_model = "Xenova/ms-marco-MiniLM-L-6-v2"
@@ -1915,6 +1916,7 @@ class TestPreloadLocalModels:
 
     def test_skips_reranker_preload_when_disabled(self, tmp_path):
         fake_settings = MagicMock()
+        fake_settings.embedding_provider = "local"
         fake_settings.embedding_model = "BAAI/bge-base-en-v1.5"
         fake_settings.whisper_reranker_enabled = False
         fake_settings.whisper_reranker_model = "Xenova/ms-marco-MiniLM-L-6-v2"
@@ -1929,6 +1931,27 @@ class TestPreloadLocalModels:
 
         embed_cls.assert_called_once()
         reranker_cls.assert_not_called()
+
+    def test_skips_fastembed_embedding_preload_for_ollama(self, tmp_path):
+        fake_settings = MagicMock()
+        fake_settings.embedding_provider = "ollama"
+        fake_settings.embedding_model = "bge-m3:latest"
+        fake_settings.whisper_reranker_enabled = True
+        fake_settings.whisper_reranker_model = "Xenova/ms-marco-MiniLM-L-6-v2"
+
+        with (
+            patch("ormah.setup.settings", fake_settings),
+            patch("ormah.setup.get_fastembed_cache_dir", return_value=tmp_path),
+            patch("fastembed.TextEmbedding") as embed_cls,
+            patch("fastembed.rerank.cross_encoder.TextCrossEncoder") as reranker_cls,
+        ):
+            _preload_local_models()
+
+        embed_cls.assert_not_called()
+        reranker_cls.assert_called_once_with(
+            "Xenova/ms-marco-MiniLM-L-6-v2",
+            cache_dir=str(tmp_path),
+        )
 
 
 class TestUninstallMemoryDirResolution:


### PR DESCRIPTION
## Summary

Fixes #11.

- Only preload embedding models through FastEmbed when `ORMAH_EMBEDDING_PROVIDER=local`.
- Skip FastEmbed embedding preload for non-local embedding providers such as Ollama and LiteLLM.
- Keep the existing local whisper reranker preload behavior unchanged.
- Add regression coverage for Ollama embedding setup using `bge-m3:latest`.

## Verification

- `uv run pytest tests/test_setup.py::TestPreloadLocalModels -q`
- `uv run pytest tests/test_setup.py tests/test_embeddings/test_adapters.py -q`
- `uv run ruff check src/ormah/setup.py tests/test_setup.py`
- `uv run pytest -q` - 881 passed, 1 deselected

Manual issue-style validation:

```bash
env \
  ORMAH_EMBEDDING_PROVIDER=ollama \
  ORMAH_EMBEDDING_MODEL=bge-m3:latest \
  ORMAH_EMBEDDING_DIM=1024 \
  ORMAH_LLM_BASE_URL=http://localhost:11434 \
  ORMAH_WHISPER_RERANKER_ENABLED=false \
  uv run python -c 'from ormah.setup import _preload_local_models; _preload_local_models()'
```

Output included:

```text
Skipping FastEmbed embedding preload for ollama model: bge-m3:latest
```
