### PR TITLE
feat(ui): galaxy graph layout with collision, color-by-space, clickable legend

### DIFF
--- a/ui/src/components/GraphView.tsx
+++ b/ui/src/components/GraphView.tsx
@@ -2,6 +2,7 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -129,6 +130,25 @@ function nodeLabel(n: MemoryNode): string {
 
 const OVERVIEW_PADDING = 150;
 const SPACE_FOCUS_PADDING = 110;
+const ZOOM_MIN = 0.03;
+const ZOOM_MAX = 4;
+const ZOOM_SLIDER_MAX = 100;
+const ZOOM_SLIDER_STEP = 8;
+
+function clampZoomSliderValue(value: number): number {
+  return Math.max(0, Math.min(ZOOM_SLIDER_MAX, value));
+}
+
+function zoomToSliderValue(zoom: number): number {
+  const normalized =
+    Math.log(Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, zoom)) / ZOOM_MIN) /
+    Math.log(ZOOM_MAX / ZOOM_MIN);
+  return Math.round(normalized * ZOOM_SLIDER_MAX);
+}
+
+function sliderValueToZoom(value: number): number {
+  return ZOOM_MIN * Math.pow(ZOOM_MAX / ZOOM_MIN, clampZoomSliderValue(value) / ZOOM_SLIDER_MAX);
+}
 
 function buildStyles(appearance: GraphAppearance) {
   const tokens = GRAPH_THEME_TOKENS[appearance.theme];
@@ -145,6 +165,7 @@ function buildStyles(appearance: GraphAppearance) {
         height: "data(nodeSize)",
         label: "data(labelText)",
         "font-size": `${Math.round(12 * GRAPH_DISPLAY_SCALE)}px`,
+        "min-zoomed-font-size": 8,
         color: "data(labelColor)",
         "text-outline-color": "data(labelOutlineColor)",
         "text-outline-opacity": 0.9,
@@ -263,7 +284,7 @@ function computeClusteredPositions(nodes: MemoryNode[]): Map<string, { x: number
   const spaceList = Array.from(spaceGroups.keys()).sort();
   const hasUngrouped = ungrouped.length > 0;
   const totalGroups = spaceList.length + (hasUngrouped ? 1 : 0);
-  const clusterRadius = Math.max(600, totalGroups * 200);
+  const clusterRadius = Math.max(600, Math.sqrt(totalGroups) * 200);
   const positions = new Map<string, { x: number; y: number }>();
 
   function placeGroup(group: string[], centroidAngle: number) {
@@ -304,6 +325,78 @@ const LEGEND_SECTION_TITLE_STYLE: CSSProperties = {
   letterSpacing: 1,
 };
 
+const RIGHT_RAIL_STYLE: CSSProperties = {
+  position: "absolute",
+  right: 12,
+  top: 56,
+  bottom: 12,
+  zIndex: 10,
+  display: "flex",
+  alignItems: "flex-end",
+  gap: 8,
+  minHeight: 0,
+  maxWidth: "calc(100% - 24px)",
+};
+
+const LEGEND_PANEL_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  minHeight: 0,
+  maxHeight: "100%",
+  overflow: "hidden",
+  background: "rgba(12,14,18,0.85)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: 8,
+  padding: 10,
+  fontFamily: "monospace",
+  fontSize: 11,
+  color: "#cdd6e0",
+  lineHeight: 1.7,
+  width: 230,
+  maxWidth: "calc(100vw - 78px)",
+};
+
+const SPACE_LEGEND_LIST_STYLE: CSSProperties = {
+  minHeight: 0,
+  overflowY: "auto",
+  paddingRight: 3,
+};
+
+const ZOOM_CONTROL_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: 8,
+  width: 34,
+  padding: "8px 0",
+  background: "rgba(12,14,18,0.82)",
+  border: "1px solid rgba(255,255,255,0.1)",
+  borderRadius: 8,
+  boxShadow: "0 12px 30px rgba(0,0,0,0.35)",
+};
+
+const ZOOM_BUTTON_STYLE: CSSProperties = {
+  width: 22,
+  height: 22,
+  border: "1px solid rgba(255,255,255,0.14)",
+  borderRadius: 6,
+  background: "rgba(255,255,255,0.04)",
+  color: "#d8dee6",
+  fontFamily: "monospace",
+  fontSize: 14,
+  lineHeight: "18px",
+  cursor: "pointer",
+};
+
+const ZOOM_RANGE_STYLE: CSSProperties = {
+  width: 22,
+  height: 122,
+  writingMode: "vertical-lr",
+  direction: "rtl",
+  accentColor: "#d4a574",
+  cursor: "pointer",
+};
+
 // One clickable legend row: swatch + content as children, dimmed when another
 // row holds the focus. Shared by both the link-type and space sections.
 function LegendRow({
@@ -334,6 +427,18 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
     onNodeSelectRef.current = onNodeSelect;
     const [layoutReady, setLayoutReady] = useState(false);
     const [legendFocus, setLegendFocus] = useState<{ kind: string; val: string } | null>(null);
+    const [zoomSliderValue, setZoomSliderValue] = useState(() => zoomToSliderValue(0.18));
+
+    const identityNodeIds = useMemo(() => {
+      const ids = new Set<string>();
+      if (!userNodeId) return ids;
+      for (const e of edges) {
+        if (e.edge_type === "defines" && e.source_id === userNodeId) {
+          ids.add(e.target_id);
+        }
+      }
+      return ids;
+    }, [edges, userNodeId]);
 
 
     useImperativeHandle(ref, () => ({
@@ -396,20 +501,11 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
       },
     }));
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       if (!containerRef.current) return;
       setLayoutReady(false);
 
       const nodeIds = new Set(nodes.map((n) => n.id));
-
-      const identityNodeIds = new Set<string>();
-      if (userNodeId) {
-        for (const e of edges) {
-          if (e.edge_type === "defines" && e.source_id === userNodeId) {
-            identityNodeIds.add(e.target_id);
-          }
-        }
-      }
 
       function selfRole(nodeId: string): string {
         if (nodeId === userNodeId) return "self";
@@ -476,10 +572,15 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         elements: [...nodeElements, ...edgeElements],
         style: buildStyles(appearance),
         layout: { name: "preset" },
-        minZoom: 0.03,
-        maxZoom: 4,
+        minZoom: ZOOM_MIN,
+        maxZoom: ZOOM_MAX,
         wheelSensitivity: 0.3,
       });
+
+      const syncZoomSlider = () => {
+        setZoomSliderValue(zoomToSliderValue(cy.zoom()));
+      };
+      cy.on("zoom", syncZoomSlider);
 
       if (positions) {
         cy.nodes().forEach((node) => {
@@ -487,14 +588,20 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
           if (pos) node.position(pos);
         });
       }
+      if (cy.nodes().length) {
+        cy.fit(undefined, OVERVIEW_PADDING);
+        syncZoomSlider();
+      }
 
       cy.nodes().grabify();
 
+      const maxSimulationTime = Math.min(8000, 1500 + nodes.length);
       const layout = cy.layout({
         name: "cola",
         animate: true,
         infinite: false,
-        maxSimulationTime: nodes.length > 1000 ? 1800 : 3000,
+        maxSimulationTime,
+        refresh: nodes.length > 2500 ? 8 : 1,
         fit: false,
         ungrabifyWhileSimulating: false,
         nodeSpacing: clusterBySpace ? 60 : 40,
@@ -511,14 +618,30 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         convergenceThreshold: 0.01,
         randomize: !positions,
         avoidOverlap: true,
-        handleDisconnected: true,
+        handleDisconnected: !clusterBySpace,
       } as never);
       layoutRef.current = layout;
 
-      layout.one("layoutstop", () => {
+      let layoutSettled = false;
+      let layoutWatchdog: ReturnType<typeof setTimeout> | null = null;
+      const finishLayout = () => {
+        if (layoutSettled) return;
+        layoutSettled = true;
+        if (layoutWatchdog) {
+          clearTimeout(layoutWatchdog);
+          layoutWatchdog = null;
+        }
         cy.fit(undefined, OVERVIEW_PADDING);
+        syncZoomSlider();
         setLayoutReady(true);
-      });
+      };
+
+      layout.one("layoutstop", finishLayout);
+      layoutWatchdog = setTimeout(() => {
+        if (layoutSettled) return;
+        layout.stop();
+        finishLayout();
+      }, maxSimulationTime + 1500);
       layout.run();
 
       cy.on("tap", "node", (e) => {
@@ -680,6 +803,10 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       return () => {
         if (dragRaf) { cancelAnimationFrame(dragRaf); dragRaf = null; }
+        if (layoutWatchdog) {
+          clearTimeout(layoutWatchdog);
+          layoutWatchdog = null;
+        }
         if (layoutRef.current) {
           layoutRef.current.stop();
           layoutRef.current = null;
@@ -687,7 +814,7 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         cy.destroy();
         cyRef.current = null;
       };
-    }, [nodes, edges, userNodeId, clusterBySpace]);
+    }, [nodes, edges, userNodeId, clusterBySpace, identityNodeIds]);
 
     useEffect(() => {
       const cy = cyRef.current;
@@ -735,6 +862,10 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
           const m = cy.nodes().filter((n) => n.data("tier") === legendFocus.val);
           m.removeClass("dim").addClass("hot");
           m.connectedEdges().removeClass("dim");
+        } else if (legendFocus.kind === "role") {
+          const m = cy.nodes().filter((n) => n.data("selfRole") === legendFocus.val);
+          m.removeClass("dim").addClass("hot");
+          m.connectedEdges().removeClass("dim");
         } else {
           const ed = cy.edges().filter((e) => (e.data("edgeType") || "related_to") === legendFocus.val);
           ed.removeClass("dim").addClass("hot");
@@ -763,12 +894,18 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         stillVisible = clusterBySpace && nodes.some((n) => (n.space || "") === legendFocus.val);
       } else if (legendFocus.kind === "tier") {
         stillVisible = clusterBySpace && nodes.some((n) => n.tier === legendFocus.val);
+      } else if (legendFocus.kind === "role") {
+        if (legendFocus.val === "self") {
+          stillVisible = !!userNodeId && nodes.some((n) => n.id === userNodeId);
+        } else {
+          stillVisible = nodes.some((n) => identityNodeIds.has(n.id));
+        }
       } else {
         stillVisible = visibleLegendTargets.edgeTypes.has(legendFocus.val);
       }
 
       if (!stillVisible) setLegendFocus(null);
-    }, [clusterBySpace, legendFocus, nodes, visibleLegendTargets]);
+    }, [clusterBySpace, identityNodeIds, legendFocus, nodes, userNodeId, visibleLegendTargets]);
 
     const edgeLegend = useMemo(() => {
       const t = GRAPH_THEME_TOKENS[appearance.theme];
@@ -801,6 +938,18 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         { val: "archival", label: "archival", count: counts.archival, color: appearance.colors.archival, dashed: true },
       ];
     }, [nodes, appearance.colors.archival, appearance.colors.core, appearance.colors.working]);
+    const roleLegend = useMemo(() => {
+      const selfCount = userNodeId && nodes.some((n) => n.id === userNodeId) ? 1 : 0;
+      let identityCount = 0;
+      for (const n of nodes) {
+        if (identityNodeIds.has(n.id)) identityCount += 1;
+      }
+
+      return [
+        { val: "self", label: "self", count: selfCount, color: "#74b3a5" },
+        { val: "identity", label: "identity", count: identityCount, color: "#4d8a7e" },
+      ].filter((row) => row.count > 0);
+    }, [identityNodeIds, nodes, userNodeId]);
     const showLegend = clusterBySpace || edgeLegend.length > 0;
 
     const clearGraphSelection = () => {
@@ -836,6 +985,48 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
       }
     };
 
+    const focusRole = (role: string) => {
+      clearGraphSelection();
+      const nextActive = !(legendFocus && legendFocus.kind === "role" && legendFocus.val === role);
+      setLegendFocus(nextActive ? { kind: "role", val: role } : null);
+
+      const cy = cyRef.current;
+      if (!cy || !layoutReady) return;
+
+      if (!nextActive) {
+        cy.fit(undefined, OVERVIEW_PADDING);
+        return;
+      }
+
+      const roleNodes = cy.nodes().filter((node) => node.data("selfRole") === role);
+      if (roleNodes.length) {
+        cy.fit(roleNodes, SPACE_FOCUS_PADDING);
+        if (cy.zoom() > 1.6) {
+          cy.zoom(1.6);
+          cy.center(roleNodes);
+        }
+      }
+    };
+
+    const applyZoomSliderValue = (value: number) => {
+      const nextValue = clampZoomSliderValue(value);
+      setZoomSliderValue(nextValue);
+
+      const cy = cyRef.current;
+      if (!cy) return;
+
+      cy.zoom({
+        level: sliderValueToZoom(nextValue),
+        renderedPosition: { x: cy.width() / 2, y: cy.height() / 2 },
+      } as never);
+    };
+
+    const nudgeZoom = (delta: number) => {
+      const cy = cyRef.current;
+      const currentValue = cy ? zoomToSliderValue(cy.zoom()) : zoomSliderValue;
+      applyZoomSliderValue(currentValue + delta);
+    };
+
     return (
       <div style={{ width: "100%", height: "100%", position: "relative" }}>
         {!layoutReady && (
@@ -850,28 +1041,45 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
             transition: "opacity 0.4s ease-in",
           }}
         />
-        {layoutReady && showLegend && (
-          <div
-            style={{
-              position: "absolute",
-              right: 12,
-              bottom: 12,
-              // Above the cytoscape canvas — without this the canvas swallows
-              // legend clicks (elementFromPoint hits the canvas, not the row).
-              zIndex: 10,
-              maxHeight: "48%",
-              overflowY: "auto",
-              background: "rgba(12,14,18,0.85)",
-              border: "1px solid rgba(255,255,255,0.1)",
-              borderRadius: 8,
-              padding: 10,
-              fontFamily: "monospace",
-              fontSize: 11,
-              color: "#cdd6e0",
-              lineHeight: 1.7,
-              maxWidth: 230,
-            }}
-          >
+        {layoutReady && (
+          <div style={RIGHT_RAIL_STYLE}>
+            <div
+              style={ZOOM_CONTROL_STYLE}
+              onPointerDown={(e) => e.stopPropagation()}
+              onWheel={(e) => e.stopPropagation()}
+            >
+              <button
+                type="button"
+                style={ZOOM_BUTTON_STYLE}
+                onClick={() => nudgeZoom(ZOOM_SLIDER_STEP)}
+                aria-label="Zoom in"
+                title="Zoom in"
+              >
+                +
+              </button>
+              <input
+                type="range"
+                min={0}
+                max={ZOOM_SLIDER_MAX}
+                value={zoomSliderValue}
+                onChange={(e) => applyZoomSliderValue(Number(e.target.value))}
+                aria-label="Graph zoom"
+                style={ZOOM_RANGE_STYLE}
+              />
+              <button
+                type="button"
+                style={ZOOM_BUTTON_STYLE}
+                onClick={() => nudgeZoom(-ZOOM_SLIDER_STEP)}
+                aria-label="Zoom out"
+                title="Zoom out"
+              >
+                -
+              </button>
+            </div>
+            {showLegend && (
+              <div
+                style={LEGEND_PANEL_STYLE}
+              >
             {clusterBySpace && (
               <>
                 <div style={{ ...LEGEND_SECTION_TITLE_STYLE, marginBottom: 4 }}>
@@ -897,6 +1105,35 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
                     />
                     <span style={{ flex: 1 }}>{tl.label}</span>
                     <span style={{ opacity: 0.4 }}>{tl.count}</span>
+                  </LegendRow>
+                ))}
+              </>
+            )}
+            {clusterBySpace && roleLegend.length > 0 && (
+              <>
+                <div style={{ ...LEGEND_SECTION_TITLE_STYLE, margin: "9px 0 4px" }}>
+                  IDENTITY
+                </div>
+                {roleLegend.map((rl) => (
+                  <LegendRow
+                    key={rl.val}
+                    active={!legendFocus || (legendFocus.kind === "role" && legendFocus.val === rl.val)}
+                    onClick={() => focusRole(rl.val)}
+                  >
+                    <span
+                      style={{
+                        width: 11,
+                        height: 11,
+                        borderRadius: "50%",
+                        boxSizing: "border-box",
+                        background: rl.color,
+                        border: "1px solid rgba(255,255,255,0.22)",
+                        display: "inline-block",
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span style={{ flex: 1 }}>{rl.label}</span>
+                    <span style={{ opacity: 0.4 }}>{rl.count}</span>
                   </LegendRow>
                 ))}
               </>
@@ -928,22 +1165,26 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
                 <div style={{ ...LEGEND_SECTION_TITLE_STYLE, margin: "9px 0 4px" }}>
                   SPACES
                 </div>
-                {spaceLegend.map((sp) => {
-                  const val = sp.name === "(no space)" ? "" : sp.name;
-                  return (
-                    <LegendRow
-                      key={sp.name}
-                      active={!legendFocus || (legendFocus.kind === "space" && legendFocus.val === val)}
-                      onClick={() => focusSpace(val)}
-                    >
-                      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
-                        {sp.name}
-                      </span>
-                      <span style={{ opacity: 0.4 }}>{sp.count}</span>
-                    </LegendRow>
-                  );
-                })}
+                <div style={SPACE_LEGEND_LIST_STYLE}>
+                  {spaceLegend.map((sp) => {
+                    const val = sp.name === "(no space)" ? "" : sp.name;
+                    return (
+                      <LegendRow
+                        key={sp.name}
+                        active={!legendFocus || (legendFocus.kind === "space" && legendFocus.val === val)}
+                        onClick={() => focusSpace(val)}
+                      >
+                        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
+                          {sp.name}
+                        </span>
+                        <span style={{ opacity: 0.4 }}>{sp.count}</span>
+                      </LegendRow>
+                    );
+                  })}
+                </div>
               </>
+            )}
+              </div>
             )}
           </div>
         )}

--- a/ui/src/components/GraphView.tsx
+++ b/ui/src/components/GraphView.tsx
@@ -2,11 +2,15 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
+  type CSSProperties,
+  type ReactNode,
 } from "react";
 import cytoscape, { type Core } from "cytoscape";
 import cola from "cytoscape-cola";
+import fcose from "cytoscape-fcose";
 import {
   GRAPH_DISPLAY_SCALE,
   type GraphAppearance,
@@ -15,6 +19,7 @@ import {
 import type { Edge, MemoryNode, Tier } from "../types";
 
 try { cytoscape.use(cola); } catch (_) { /* already registered */ }
+try { cytoscape.use(fcose); } catch (_) { /* already registered */ }
 
 interface Props {
   nodes: MemoryNode[];
@@ -76,14 +81,11 @@ function tierBorderColor(tier: string, selfRole: string, appearance: GraphAppear
   return appearance.colors[tier as Tier] ?? appearance.colors.working;
 }
 
-function nodeSize(accessCount: number): number {
-  const baseSize = Math.min(56, Math.max(24, 24 + Math.log2(accessCount + 1) * 6));
-  return Math.round(baseSize * GRAPH_DISPLAY_SCALE);
-}
-
-function displayNodeSize(accessCount: number, selfRole: string): number {
-  const size = nodeSize(accessCount);
-  return selfRole === "self" ? Math.max(Math.round(36 * GRAPH_DISPLAY_SCALE), size) : size;
+function degreeNodeSize(degree: number, selfRole: string): number {
+  const base = Math.min(70, Math.max(18, 18 + Math.sqrt(degree) * 7));
+  const s = Math.round(base * GRAPH_DISPLAY_SCALE);
+  if (selfRole === "self") return Math.max(Math.round(44 * GRAPH_DISPLAY_SCALE), s);
+  return s;
 }
 
 function edgeColor(edgeType: string, theme: GraphTheme): string {
@@ -124,6 +126,14 @@ function nodeLabel(n: MemoryNode): string {
   return n.id.split("-")[0];
 }
 
+// Deterministic hue per space so each galaxy reads as a distinct colour.
+function spaceColor(space: string | null): string {
+  const key = space ?? "__none__";
+  let h = 0;
+  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) % 360;
+  return `hsl(${h}, 62%, 60%)`;
+}
+
 function buildStyles(appearance: GraphAppearance) {
   const tokens = GRAPH_THEME_TOKENS[appearance.theme];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,7 +147,7 @@ function buildStyles(appearance: GraphAppearance) {
         "border-style": "solid",
         width: "data(nodeSize)",
         height: "data(nodeSize)",
-        label: "data(labelText)",
+        label: "",
         "font-size": `${Math.round(12 * GRAPH_DISPLAY_SCALE)}px`,
         color: "data(labelColor)",
         "text-outline-color": "data(labelOutlineColor)",
@@ -165,13 +175,15 @@ function buildStyles(appearance: GraphAppearance) {
         "border-color": tokens.accent,
         "border-width": 3,
         "overlay-opacity": 0,
+        label: "data(labelText)",
+        "min-zoomed-font-size": 0,
       } as cytoscape.Css.Node,
     },
     {
       selector: "edge",
       style: {
         "line-color": "data(lineColor)",
-        width: 1,
+        width: 1.8,
         opacity: "data(edgeOpacity)" as unknown as number,
         "curve-style": "bezier",
       } as cytoscape.Css.Edge,
@@ -183,11 +195,58 @@ function buildStyles(appearance: GraphAppearance) {
       } as cytoscape.Css.Edge,
     },
     {
+      // Cross-space edges = links between galaxies. Kept thin but a touch
+      // brighter than intra edges; the *density* of many thin links reads as
+      // a bridge between galaxies without becoming spaghetti.
+      selector: "edge.cross-space",
+      style: {
+        // Individual cross-space edges are hidden; the aggregate galaxy-link
+        // line represents the whole bundle between two galaxies.
+        "line-opacity": 0,
+        events: "no",
+      } as cytoscape.Css.Edge,
+    },
+    {
+      // Aggregate galaxy-to-galaxy link: one line per connected space pair,
+      // width/brightness scaled by how many real edges connect them.
+      selector: "edge.galaxy-link",
+      style: {
+        width: "data(linkW)",
+        "line-color": tokens.accent,
+        "line-opacity": "data(linkO)" as unknown as number,
+        "curve-style": "straight",
+        "z-index": 4,
+        events: "no",
+      } as cytoscape.Css.Edge,
+    },
+    {
+      selector: ".dim",
+      style: { opacity: 0.06 } as cytoscape.Css.Node,
+    },
+    {
+      // Galaxy links carry a data-mapped line-opacity that survives the
+      // generic .dim opacity, so a dimmed gold line still reads as a strong
+      // stroke. Force it down explicitly when dimmed.
+      selector: "edge.galaxy-link.dim",
+      style: { "line-opacity": 0.04, opacity: 0.04 } as cytoscape.Css.Edge,
+    },
+    {
+      selector: "edge.hot",
+      style: { width: 4, opacity: 1, "z-index": 30 } as cytoscape.Css.Edge,
+    },
+    {
+      selector: "node.hot",
+      style: { "border-color": tokens.accent, "border-width": 4, "z-index": 30 } as cytoscape.Css.Node,
+    },
+    {
       selector: "node.glow",
       style: {
         "border-color": tokens.accent,
         "border-width": 3,
         color: tokens.labelGlow,
+        label: "data(labelText)",
+        "min-zoomed-font-size": 0,
+        "z-index": 20,
         "transition-property": "border-color, border-width" as any,
         "transition-duration": "100ms" as unknown as number,
       } as cytoscape.Css.Node,
@@ -216,52 +275,30 @@ function buildStyles(appearance: GraphAppearance) {
   return styles;
 }
 
-/**
- * Compute initial positions that place same-space nodes near each other.
- * Each space gets a centroid on a large circle; nodes scatter within.
- */
-function computeClusteredPositions(nodes: MemoryNode[]): Map<string, { x: number; y: number }> {
-  const spaceGroups = new Map<string, string[]>();
-  const ungrouped: string[] = [];
-  for (const n of nodes) {
-    if (n.space) {
-      let g = spaceGroups.get(n.space);
-      if (!g) { g = []; spaceGroups.set(n.space, g); }
-      g.push(n.id);
-    } else {
-      ungrouped.push(n.id);
-    }
-  }
+const LEGEND_ROW_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 7,
+  cursor: "pointer",
+  userSelect: "none",
+};
 
-  const spaceList = Array.from(spaceGroups.keys()).sort();
-  const hasUngrouped = ungrouped.length > 0;
-  const totalGroups = spaceList.length + (hasUngrouped ? 1 : 0);
-  // Large radius so clusters start far apart
-  const clusterRadius = Math.max(600, totalGroups * 200);
-  const positions = new Map<string, { x: number; y: number }>();
-
-  function placeGroup(group: string[], centroidAngle: number) {
-    const cx = Math.cos(centroidAngle) * clusterRadius;
-    const cy = Math.sin(centroidAngle) * clusterRadius;
-    const innerRadius = Math.max(80, Math.sqrt(group.length) * 40);
-    group.forEach((id, j) => {
-      const a = (2 * Math.PI * j) / group.length;
-      positions.set(id, {
-        x: cx + Math.cos(a) * innerRadius,
-        y: cy + Math.sin(a) * innerRadius,
-      });
-    });
-  }
-
-  spaceList.forEach((space, i) => {
-    placeGroup(spaceGroups.get(space)!, (2 * Math.PI * i) / totalGroups);
-  });
-
-  if (hasUngrouped) {
-    placeGroup(ungrouped, (2 * Math.PI * spaceList.length) / totalGroups);
-  }
-
-  return positions;
+// One clickable legend row: swatch + content as children, dimmed when another
+// row holds the focus. Shared by both the link-type and space sections.
+function LegendRow({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div onClick={onClick} style={{ ...LEGEND_ROW_STYLE, opacity: active ? 1 : 0.3 }}>
+      {children}
+    </div>
+  );
 }
 
 const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
@@ -275,6 +312,7 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
     const onNodeSelectRef = useRef(onNodeSelect);
     onNodeSelectRef.current = onNodeSelect;
     const [layoutReady, setLayoutReady] = useState(false);
+    const [legendFocus, setLegendFocus] = useState<{ kind: string; val: string } | null>(null);
 
 
     useImperativeHandle(ref, () => ({
@@ -364,19 +402,30 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         nodeSpaceMap.set(n.id, n.space || null);
       }
 
+      const degreeMap = new Map<string, number>();
+      for (const e of edges) {
+        if (!nodeIds.has(e.source_id) || !nodeIds.has(e.target_id)) continue;
+        degreeMap.set(e.source_id, (degreeMap.get(e.source_id) ?? 0) + 1);
+        degreeMap.set(e.target_id, (degreeMap.get(e.target_id) ?? 0) + 1);
+      }
+
+      const themeTokens = GRAPH_THEME_TOKENS[appearance.theme];
       const nodeElements = nodes.map((n) => {
-        const themeTokens = GRAPH_THEME_TOKENS[appearance.theme];
         const sr = selfRole(n.id);
-        const size = displayNodeSize(n.access_count, sr);
+        const size = degreeNodeSize(degreeMap.get(n.id) ?? 0, sr);
         return {
           data: {
             id: n.id,
             labelText: nodeLabel(n),
+            space: n.space || "",
             tier: n.tier,
             type: n.type,
             accessCount: n.access_count,
             selfRole: sr,
-            bgColor: tierColor(n.tier, sr, appearance),
+            bgColor:
+              clusterBySpace && sr === ""
+                ? spaceColor(n.space || null)
+                : tierColor(n.tier, sr, appearance),
             borderColor: tierBorderColor(n.tier, sr, appearance),
             borderWidth: sr === "self" ? 3 : n.tier === "archival" ? 1 : 2,
             nodeSize: size,
@@ -388,75 +437,234 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       const edgeElements = edges
         .filter((e) => nodeIds.has(e.source_id) && nodeIds.has(e.target_id))
-        .map((e) => ({
-          data: {
-            id: `${e.source_id}-${e.edge_type}-${e.target_id}`,
-            source: e.source_id,
-            target: e.target_id,
-            edgeType: e.edge_type,
-            weight: e.weight,
-            lineColor: edgeColor(e.edge_type, appearance.theme),
-            glowColor: edgeGlowColor(e.edge_type, appearance.theme),
-            edgeOpacity: Math.max(0.2, e.weight ?? 0.5),
-          },
-        }));
+        .map((e) => {
+          const crossSpace =
+            (nodeSpaceMap.get(e.source_id) ?? null) !==
+            (nodeSpaceMap.get(e.target_id) ?? null);
+          return {
+            data: {
+              id: `${e.source_id}-${e.edge_type}-${e.target_id}`,
+              source: e.source_id,
+              target: e.target_id,
+              edgeType: e.edge_type,
+              weight: e.weight,
+              lineColor: edgeColor(e.edge_type, appearance.theme),
+              glowColor: edgeGlowColor(e.edge_type, appearance.theme),
+              edgeOpacity: Math.max(crossSpace ? 0.5 : 0.7, e.weight ?? 0.5),
+            },
+            classes: crossSpace ? "cross-space" : undefined,
+          };
+        });
 
-      // Pre-compute clustered positions if needed
-      const positions = clusterBySpace
-        ? computeClusteredPositions(nodes)
-        : null;
+      // --- Galaxy layout: one invisible hub node per space ---
+      // Every member connects to its space hub so the space coheres into a
+      // dense "galaxy". Orphans get a longer hub edge → they settle on the
+      // galaxy's outer rim. Hubs repel each other (+gravity) to arrange the
+      // galaxies in a bounded circle; cross-space edges pull connected
+      // galaxies nearer (hybrid positioning). Hubs/edges are invisible but
+      // still participate in the force simulation.
+      const HUB = "__hub__";
+      const skey = (s: string | null) => s ?? "__none__";
+      const useGalaxy = clusterBySpace;
+
+      const hubElements: cytoscape.ElementDefinition[] = [];
+      const hubEdges: cytoscape.ElementDefinition[] = [];
+      const galaxyLinks: cytoscape.ElementDefinition[] = [];
+      const hubPos = new Map<string, { x: number; y: number }>();
+
+      if (useGalaxy) {
+        const sizeBySpace = new Map();
+        for (const n of nodes) {
+          const k = skey(n.space || null);
+          sizeBySpace.set(k, (sizeBySpace.get(k) ?? 0) + 1);
+        }
+        // Single pass over cross-space edges feeds two aggregates: crossDeg
+        // (per-space connectivity, for hub ordering) and pairCount (per
+        // space-pair edge count, for the aggregate galaxy links below).
+        const crossDeg = new Map();
+        const pairCount = new Map<string, number>();
+        for (const e of edgeElements) {
+          if (!e.classes) continue; // only cross-space edges carry a class
+          const sa = skey(nodeSpaceMap.get(e.data.source) ?? null);
+          const sb = skey(nodeSpaceMap.get(e.data.target) ?? null);
+          if (sa === sb) continue;
+          crossDeg.set(sa, (crossDeg.get(sa) ?? 0) + 1);
+          crossDeg.set(sb, (crossDeg.get(sb) ?? 0) + 1);
+          const key = sa < sb ? `${sa}|${sb}` : `${sb}|${sa}`;
+          pairCount.set(key, (pairCount.get(key) ?? 0) + 1);
+        }
+        // Order galaxies by cross-space connectivity: the most-connected hub
+        // spaces sit at the centre (short links between them), isolated ones
+        // drift to the rim. Tiebreak by size.
+        const keys = Array.from(sizeBySpace.keys()).sort((x, y) => {
+          const d = (crossDeg.get(y) ?? 0) - (crossDeg.get(x) ?? 0);
+          return d !== 0 ? d : sizeBySpace.get(y) - sizeBySpace.get(x);
+        });
+        const GOLDEN = 2.399963229728653;
+        const SPACING = 340;
+        keys.forEach((k, i) => {
+          const ang = i * GOLDEN;
+          const r = SPACING * Math.sqrt(i);
+          hubPos.set(HUB + k, { x: Math.cos(ang) * r, y: Math.sin(ang) * r });
+          hubElements.push({ data: { id: HUB + k }, classes: "hub" });
+        });
+        for (const n of nodes) {
+          hubEdges.push({
+            data: {
+              id: `${HUB}e_${n.id}`,
+              source: HUB + skey(n.space || null),
+              target: n.id,
+              orphan: (degreeMap.get(n.id) ?? 0) === 0,
+            },
+            classes: "hub-edge",
+          });
+        }
+
+        // Aggregate cross-space edges into one "galaxy link" per space pair
+        // (counted above), weighted by how many real edges connect them. A
+        // handful of clean hub-to-hub lines instead of hundreds of crossings.
+        for (const [key, count] of pairCount) {
+          const [a, b] = key.split("|");
+          if (count < 6) continue;
+          galaxyLinks.push({
+            data: {
+              id: `${HUB}link_${a}_${b}`,
+              source: HUB + a,
+              target: HUB + b,
+              linkCount: count,
+              linkW: Math.min(7, 1.5 + Math.log2(count) * 1.0),
+              linkO: Math.min(0.5, 0.22 + Math.log2(count) * 0.06),
+            },
+            classes: "galaxy-link",
+          });
+        }
+      }
+
+      const intraEdges = useGalaxy ? edgeElements.filter((e) => !e.classes) : edgeElements;
 
       const cy = cytoscape({
         container: containerRef.current,
-        elements: [...nodeElements, ...edgeElements],
-        style: buildStyles(appearance),
+        elements: [...nodeElements, ...intraEdges, ...hubElements, ...hubEdges, ...galaxyLinks],
+        style: [
+          ...buildStyles(appearance),
+          { selector: ".hub", style: { width: 1, height: 1, opacity: 0, events: "no" } },
+          { selector: ".hub-edge", style: { width: 1, "line-opacity": 0, events: "no" } },
+        ] as never,
         layout: { name: "preset" },
-        minZoom: 0.15,
+        minZoom: 0.01,
         maxZoom: 4,
         wheelSensitivity: 0.3,
       });
 
-      // Apply pre-computed positions
-      if (positions) {
-        cy.nodes().forEach((node) => {
-          const pos = positions.get(node.id());
-          if (pos) node.position(pos);
+      // Seed hubs + members so fcose starts with galaxies already grouped.
+      if (useGalaxy) {
+        cy.nodes(".hub").forEach((node) => {
+          const p = hubPos.get(node.id());
+          if (p) node.position(p);
+        });
+        cy.nodes().not(".hub").forEach((node, idx) => {
+          const p = hubPos.get(HUB + skey(nodeSpaceMap.get(node.id()) ?? null));
+          if (p) {
+            const a = (idx % 12) * (Math.PI / 6);
+            node.position({ x: p.x + Math.cos(a) * 40, y: p.y + Math.sin(a) * 40 });
+          }
         });
       }
 
-      cy.nodes().grabify();
+      cy.nodes().not(".hub").grabify();
+      cy.nodes(".hub").ungrabify();
 
-      const layout = cy.layout({
-        name: "cola",
-        animate: true,
-        infinite: false,
-        maxSimulationTime: 3000,
-        fit: false,
-        ungrabifyWhileSimulating: false,
-        nodeSpacing: clusterBySpace ? 60 : 40,
-        edgeLength: (edge: cytoscape.EdgeSingular) => {
-          const w = edge.data("weight") ?? 0.5;
-          const baseLen = 120 + (1 - w) * 100;
-          if (clusterBySpace) {
-            const srcSpace = nodeSpaceMap.get(edge.source().id());
-            const tgtSpace = nodeSpaceMap.get(edge.target().id());
-            // Cross-cluster edges: very long ideal length pushes clusters apart
-            if (srcSpace !== tgtSpace) return baseLen * 5;
-          }
-          return baseLen;
-        },
-        convergenceThreshold: 0.01,
-        randomize: !positions,
-        avoidOverlap: true,
-        handleDisconnected: true,
-      } as never);
-      layout.run();
+      const layout = cy.layout(
+        useGalaxy
+          ? ({
+              name: "fcose",
+              quality: "default",
+              animate: true,
+              randomize: false, // start from the galaxy seeds
+              fit: false,
+              numIter: 2500,
+              nodeSeparation: 150,
+              // Pin each space hub at its phyllotaxis slot so galaxies stay
+              // distinct and cannot collapse into one another.
+              gravity: 0.7,
+              gravityRange: 5,
+              // Hubs are pinned; low real-node repulsion → dense, tight galaxies.
+              nodeRepulsion: (node: cytoscape.NodeSingular) =>
+                node.hasClass("hub") ? 55000 : 2800,
+              idealEdgeLength: (edge: cytoscape.EdgeSingular) => {
+                // Hub edges set galaxy radius: tight core, modest rim for orphans.
+                if (edge.hasClass("hub-edge")) {
+                  return edge.data("orphan") ? 150 : 60;
+                }
+                if (edge.hasClass("galaxy-link")) {
+                  return 520 - 160 * (edge.data("linkO") ?? 0.4);
+                }
+                const w = edge.data("weight") ?? 0.5;
+                const base = 120 + (1 - w) * 100;
+                const ss = nodeSpaceMap.get(edge.source().id());
+                const ts = nodeSpaceMap.get(edge.target().id());
+                // Long cross-space links so they draw galaxy-to-galaxy
+                // connections without yanking members out of their galaxy.
+                return ss !== ts ? base * 2.5 : base * 0.6;
+              },
+              packComponents: true,
+            } as never)
+          : ({
+              name: "fcose",
+              quality: "default",
+              animate: true,
+              randomize: true,
+              fit: false,
+              gravity: 0.25,
+              packComponents: true,
+            } as never),
+      );
       layoutRef.current = layout;
 
-      layout.on("layoutstop", () => {
-        cy.fit(undefined, 40);
-        setLayoutReady(true);
-      });
+      if (useGalaxy) {
+        // fcose builds the galaxy structure (gravity + clustering) but lets
+        // nodes pile up on the same coordinates, so the dense core reads like
+        // a flat PNG on zoom-in. Chase it with a cola pass whose only job is
+        // collision: avoidOverlap pushes every dot apart by its own radius
+        // (Obsidian-style), seeded from fcose's positions so the galaxies keep
+        // their shape. Result: the core spreads into distinct, non-touching
+        // dots that separate cleanly as you zoom in.
+        layout.one("layoutstop", () => {
+          const separate = cy.layout({
+            name: "cola",
+            animate: true,
+            randomize: false, // honour fcose's galaxy positions
+            fit: false,
+            avoidOverlap: true,
+            handleDisconnected: false, // don't relocate isolated galaxies
+            nodeSpacing: () => 12, // minimum gap between dot bounding boxes
+            edgeLength: (edge: cytoscape.EdgeSingular) => {
+              if (edge.hasClass("hub-edge")) {
+                return edge.data("orphan") ? 160 : 70;
+              }
+              if (edge.hasClass("galaxy-link")) return 480;
+              const ss = nodeSpaceMap.get(edge.source().id());
+              const ts = nodeSpaceMap.get(edge.target().id());
+              return ss !== ts ? 260 : 90;
+            },
+            maxSimulationTime: 2500,
+            convergenceThreshold: 0.01,
+            ungrabifyWhileSimulating: false,
+          } as never);
+          layoutRef.current = separate;
+          separate.one("layoutstop", () => {
+            cy.fit(cy.nodes().not(".hub"), 40);
+            setLayoutReady(true);
+          });
+          separate.run();
+        });
+      } else {
+        layout.one("layoutstop", () => {
+          cy.fit(cy.nodes().not(".hub"), 40);
+          setLayoutReady(true);
+        });
+      }
+      layout.run();
 
       cy.on("tap", "node", (e) => {
         onNodeSelectRef.current(e.target.id());
@@ -635,12 +843,10 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
       cy.nodes().forEach((node) => {
         const tier = node.data("tier") as string;
         const selfRole = node.data("selfRole") as string;
-        const accessCount = node.data("accessCount") as number;
         node.data("bgColor", tierColor(tier, selfRole, appearance));
         node.data("borderColor", tierBorderColor(tier, selfRole, appearance));
         node.data("labelColor", themeTokens.label);
         node.data("labelOutlineColor", themeTokens.background);
-        node.data("nodeSize", displayNodeSize(accessCount, selfRole));
       });
       cy.edges().forEach((edge) => {
         const edgeType = edge.data("edgeType") as string;
@@ -659,6 +865,50 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
       }
     }, [focusNodeId]);
 
+    useEffect(() => {
+      const cy = cyRef.current;
+      if (!cy) return;
+      cy.batch(() => {
+        cy.elements().removeClass("dim hot");
+        if (!legendFocus) return;
+        cy.elements().not(".hub").not(".hub-edge").addClass("dim");
+        if (legendFocus.kind === "space") {
+          const m = cy.nodes().filter((n) => n.data("space") === legendFocus.val);
+          m.removeClass("dim").addClass("hot");
+          m.connectedEdges().removeClass("dim");
+        } else {
+          const ed =
+            legendFocus.val === "__galaxy__"
+              ? cy.edges(".galaxy-link")
+              : cy.edges().filter((e) => (e.data("edgeType") || "related_to") === legendFocus.val);
+          ed.removeClass("dim").addClass("hot");
+          ed.connectedNodes().removeClass("dim");
+        }
+      });
+    }, [legendFocus, layoutReady]);
+
+    const edgeLegend = useMemo(() => {
+      const t = GRAPH_THEME_TOKENS[appearance.theme];
+      return [
+        { c: t.accent, t: "Entre spaces", k: "__galaxy__" },
+        { c: t.edgeSupports, t: "Apoia", k: "supports" },
+        { c: t.edgeContradicts, t: "Contradiz", k: "contradicts" },
+        { c: t.edgeDefines, t: "Define", k: "defines" },
+        { c: t.edgeEvolved, t: "Evoluiu de", k: "evolved_from" },
+        { c: t.edgeDefault, t: "Relacionado", k: "related_to" },
+      ];
+    }, [appearance.theme]);
+    const spaceLegend = useMemo(() => {
+      const spaceCounts = new Map<string, number>();
+      for (const n of nodes) {
+        const k = n.space || "";
+        spaceCounts.set(k, (spaceCounts.get(k) ?? 0) + 1);
+      }
+      return Array.from(spaceCounts.entries())
+        .sort((a, b) => b[1] - a[1])
+        .map(([name, count]) => ({ name: name || "(sem space)", count, c: spaceColor(name || null) }));
+    }, [nodes]);
+
     return (
       <div style={{ width: "100%", height: "100%", position: "relative" }}>
         {!layoutReady && (
@@ -673,6 +923,71 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
             transition: "opacity 0.4s ease-in",
           }}
         />
+        {layoutReady && (
+          <div
+            style={{
+              position: "absolute",
+              right: 12,
+              bottom: 12,
+              maxHeight: "48%",
+              overflowY: "auto",
+              background: "rgba(12,14,18,0.85)",
+              border: "1px solid rgba(255,255,255,0.1)",
+              borderRadius: 8,
+              padding: 10,
+              fontFamily: "monospace",
+              fontSize: 11,
+              color: "#cdd6e0",
+              lineHeight: 1.7,
+              maxWidth: 230,
+            }}
+          >
+            <div style={{ opacity: 0.5, fontSize: 9, letterSpacing: 1, marginBottom: 4 }}>
+              LIGAÇÕES
+            </div>
+            {edgeLegend.map((e) => (
+              <LegendRow
+                key={e.t}
+                active={!legendFocus || (legendFocus.kind === "edge" && legendFocus.val === e.k)}
+                onClick={() =>
+                  setLegendFocus((f) =>
+                    f && f.kind === "edge" && f.val === e.k ? null : { kind: "edge", val: e.k },
+                  )
+                }
+              >
+                <span style={{ width: 16, height: 3, background: e.c, display: "inline-block", borderRadius: 2 }} />
+                <span>{e.t}</span>
+              </LegendRow>
+            ))}
+            {clusterBySpace && (
+              <>
+                <div style={{ opacity: 0.5, fontSize: 9, letterSpacing: 1, margin: "9px 0 4px" }}>
+                  SPACES
+                </div>
+                {spaceLegend.map((sp) => {
+                  const val = sp.name === "(sem space)" ? "" : sp.name;
+                  return (
+                    <LegendRow
+                      key={sp.name}
+                      active={!legendFocus || (legendFocus.kind === "space" && legendFocus.val === val)}
+                      onClick={() =>
+                        setLegendFocus((f) =>
+                          f && f.kind === "space" && f.val === val ? null : { kind: "space", val },
+                        )
+                      }
+                    >
+                      <span style={{ width: 9, height: 9, borderRadius: "50%", background: sp.c, display: "inline-block", flexShrink: 0 }} />
+                      <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
+                        {sp.name}
+                      </span>
+                      <span style={{ opacity: 0.4 }}>{sp.count}</span>
+                    </LegendRow>
+                  );
+                })}
+              </>
+            )}
+          </div>
+        )}
       </div>
     );
   }

--- a/ui/src/components/GraphView.tsx
+++ b/ui/src/components/GraphView.tsx
@@ -10,7 +10,6 @@ import {
 } from "react";
 import cytoscape, { type Core } from "cytoscape";
 import cola from "cytoscape-cola";
-import fcose from "cytoscape-fcose";
 import {
   GRAPH_DISPLAY_SCALE,
   type GraphAppearance,
@@ -19,7 +18,6 @@ import {
 import type { Edge, MemoryNode, Tier } from "../types";
 
 try { cytoscape.use(cola); } catch (_) { /* already registered */ }
-try { cytoscape.use(fcose); } catch (_) { /* already registered */ }
 
 interface Props {
   nodes: MemoryNode[];
@@ -81,11 +79,14 @@ function tierBorderColor(tier: string, selfRole: string, appearance: GraphAppear
   return appearance.colors[tier as Tier] ?? appearance.colors.working;
 }
 
-function degreeNodeSize(degree: number, selfRole: string): number {
-  const base = Math.min(70, Math.max(18, 18 + Math.sqrt(degree) * 7));
-  const s = Math.round(base * GRAPH_DISPLAY_SCALE);
-  if (selfRole === "self") return Math.max(Math.round(44 * GRAPH_DISPLAY_SCALE), s);
-  return s;
+function nodeSize(accessCount: number): number {
+  const baseSize = Math.min(56, Math.max(24, 24 + Math.log2(accessCount + 1) * 6));
+  return Math.round(baseSize * GRAPH_DISPLAY_SCALE);
+}
+
+function displayNodeSize(accessCount: number, selfRole: string): number {
+  const size = nodeSize(accessCount);
+  return selfRole === "self" ? Math.max(Math.round(36 * GRAPH_DISPLAY_SCALE), size) : size;
 }
 
 function edgeColor(edgeType: string, theme: GraphTheme): string {
@@ -126,46 +127,8 @@ function nodeLabel(n: MemoryNode): string {
   return n.id.split("-")[0];
 }
 
-// Deterministic hue per space so each galaxy reads as a distinct colour.
-// Cached: it's called once per node on build and again on every appearance
-// change (~2 × node count), but the hue only depends on the space name.
-const spaceColorCache = new Map<string, string>();
-function spaceColor(space: string | null): string {
-  const key = space ?? "__none__";
-  const cached = spaceColorCache.get(key);
-  if (cached) return cached;
-  let h = 0;
-  for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) % 360;
-  const color = `hsl(${h}, 62%, 60%)`;
-  spaceColorCache.set(key, color);
-  return color;
-}
-
-// Galaxy mode encodes two independent channels on a node:
-//   fill   = space colour (the project a memory belongs to)
-//   shape  = tier (archived = hollow ring, core = solid + white rim, working = solid)
-// Tier is shape-only (never a hue) so it never collides with the space colour,
-// regardless of how a user customises their tier palette.
-// self / identity keep the space fill (so the project still reads) but take a
-// teal ring that overrides the tier rim — it marks "this is who I am".
-const TIER_RIM = "#ffffff";
-const IDENTITY_RIM = "#6ba89a";
-const SELF_RIM = "#8fd4c4";
-function galaxyNodeStyle(
-  space: string | null,
-  tier: string,
-  background: string,
-  selfRole: string,
-): { bg: string; border: string; borderWidth: number } {
-  const sc = spaceColor(space);
-  const bg = tier === "archival" ? background : sc;
-  // self / identity ring wins over the tier rim.
-  if (selfRole === "self") return { bg, border: SELF_RIM, borderWidth: 3 };
-  if (selfRole === "identity") return { bg, border: IDENTITY_RIM, borderWidth: 2.5 };
-  if (tier === "archival") return { bg, border: sc, borderWidth: 2 };
-  if (tier === "core") return { bg, border: TIER_RIM, borderWidth: 2 };
-  return { bg, border: sc, borderWidth: 0 }; // working: solid, no rim
-}
+const OVERVIEW_PADDING = 150;
+const SPACE_FOCUS_PADDING = 110;
 
 function buildStyles(appearance: GraphAppearance) {
   const tokens = GRAPH_THEME_TOKENS[appearance.theme];
@@ -180,7 +143,7 @@ function buildStyles(appearance: GraphAppearance) {
         "border-style": "solid",
         width: "data(nodeSize)",
         height: "data(nodeSize)",
-        label: "",
+        label: "data(labelText)",
         "font-size": `${Math.round(12 * GRAPH_DISPLAY_SCALE)}px`,
         color: "data(labelColor)",
         "text-outline-color": "data(labelOutlineColor)",
@@ -197,13 +160,17 @@ function buildStyles(appearance: GraphAppearance) {
       } as cytoscape.Css.Node,
     },
     {
+      selector: "node[tier = 'archival'][selfRole = '']",
+      style: {
+        "border-style": "dashed" as const,
+      } as cytoscape.Css.Node,
+    },
+    {
       selector: "node:active, node:selected",
       style: {
         "border-color": tokens.accent,
         "border-width": 3,
         "overlay-opacity": 0,
-        label: "data(labelText)",
-        "min-zoomed-font-size": 0,
       } as cytoscape.Css.Node,
     },
     {
@@ -222,40 +189,16 @@ function buildStyles(appearance: GraphAppearance) {
       } as cytoscape.Css.Edge,
     },
     {
-      // Cross-space edges = links between galaxies. Kept thin but a touch
-      // brighter than intra edges; the *density* of many thin links reads as
-      // a bridge between galaxies without becoming spaghetti.
+      // Cross-space edges are kept subtle so clustered graphs do not turn into
+      // a hard lattice.
       selector: "edge.cross-space",
       style: {
-        // Individual cross-space edges are hidden; the aggregate galaxy-link
-        // line represents the whole bundle between two galaxies.
-        "line-opacity": 0,
-        events: "no",
-      } as cytoscape.Css.Edge,
-    },
-    {
-      // Aggregate galaxy-to-galaxy link: one line per connected space pair,
-      // width/brightness scaled by how many real edges connect them.
-      selector: "edge.galaxy-link",
-      style: {
-        width: "data(linkW)",
-        "line-color": tokens.accent,
-        "line-opacity": "data(linkO)" as unknown as number,
-        "curve-style": "straight",
-        "z-index": 4,
-        events: "no",
+        "line-opacity": 0.32,
       } as cytoscape.Css.Edge,
     },
     {
       selector: ".dim",
       style: { opacity: 0.06 } as cytoscape.Css.Node,
-    },
-    {
-      // Galaxy links carry a data-mapped line-opacity that survives the
-      // generic .dim opacity, so a dimmed gold line still reads as a strong
-      // stroke. Force it down explicitly when dimmed.
-      selector: "edge.galaxy-link.dim",
-      style: { "line-opacity": 0.04, opacity: 0.04 } as cytoscape.Css.Edge,
     },
     {
       selector: "edge.hot",
@@ -271,8 +214,6 @@ function buildStyles(appearance: GraphAppearance) {
         "border-color": tokens.accent,
         "border-width": 3,
         color: tokens.labelGlow,
-        label: "data(labelText)",
-        "min-zoomed-font-size": 0,
         "z-index": 20,
         "transition-property": "border-color, border-width" as any,
         "transition-duration": "100ms" as unknown as number,
@@ -300,6 +241,53 @@ function buildStyles(appearance: GraphAppearance) {
     },
   ];
   return styles;
+}
+
+/**
+ * Compute initial positions that place same-space nodes near each other.
+ * Each space gets a centroid on a large circle; nodes scatter within.
+ */
+function computeClusteredPositions(nodes: MemoryNode[]): Map<string, { x: number; y: number }> {
+  const spaceGroups = new Map<string, string[]>();
+  const ungrouped: string[] = [];
+  for (const n of nodes) {
+    if (n.space) {
+      let g = spaceGroups.get(n.space);
+      if (!g) { g = []; spaceGroups.set(n.space, g); }
+      g.push(n.id);
+    } else {
+      ungrouped.push(n.id);
+    }
+  }
+
+  const spaceList = Array.from(spaceGroups.keys()).sort();
+  const hasUngrouped = ungrouped.length > 0;
+  const totalGroups = spaceList.length + (hasUngrouped ? 1 : 0);
+  const clusterRadius = Math.max(600, totalGroups * 200);
+  const positions = new Map<string, { x: number; y: number }>();
+
+  function placeGroup(group: string[], centroidAngle: number) {
+    const cx = Math.cos(centroidAngle) * clusterRadius;
+    const cy = Math.sin(centroidAngle) * clusterRadius;
+    const innerRadius = Math.max(80, Math.sqrt(group.length) * 40);
+    group.forEach((id, j) => {
+      const a = (2 * Math.PI * j) / group.length;
+      positions.set(id, {
+        x: cx + Math.cos(a) * innerRadius,
+        y: cy + Math.sin(a) * innerRadius,
+      });
+    });
+  }
+
+  spaceList.forEach((space, i) => {
+    placeGroup(spaceGroups.get(space)!, (2 * Math.PI * i) / totalGroups);
+  });
+
+  if (hasUngrouped) {
+    placeGroup(ungrouped, (2 * Math.PI * spaceList.length) / totalGroups);
+  }
+
+  return positions;
 }
 
 const LEGEND_ROW_STYLE: CSSProperties = {
@@ -435,20 +423,10 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         nodeSpaceMap.set(n.id, n.space || null);
       }
 
-      const degreeMap = new Map<string, number>();
-      for (const e of edges) {
-        if (!nodeIds.has(e.source_id) || !nodeIds.has(e.target_id)) continue;
-        degreeMap.set(e.source_id, (degreeMap.get(e.source_id) ?? 0) + 1);
-        degreeMap.set(e.target_id, (degreeMap.get(e.target_id) ?? 0) + 1);
-      }
-
       const themeTokens = GRAPH_THEME_TOKENS[appearance.theme];
       const nodeElements = nodes.map((n) => {
         const sr = selfRole(n.id);
-        const size = degreeNodeSize(degreeMap.get(n.id) ?? 0, sr);
-        const gs = clusterBySpace
-          ? galaxyNodeStyle(n.space || null, n.tier, themeTokens.background, sr)
-          : null;
+        const size = displayNodeSize(n.access_count, sr);
         return {
           data: {
             id: n.id,
@@ -458,9 +436,9 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
             type: n.type,
             accessCount: n.access_count,
             selfRole: sr,
-            bgColor: gs ? gs.bg : tierColor(n.tier, sr, appearance),
-            borderColor: gs ? gs.border : tierBorderColor(n.tier, sr, appearance),
-            borderWidth: gs ? gs.borderWidth : sr === "self" ? 3 : n.tier === "archival" ? 1 : 2,
+            bgColor: tierColor(n.tier, sr, appearance),
+            borderColor: tierBorderColor(n.tier, sr, appearance),
+            borderWidth: sr === "self" ? 3 : n.tier === "archival" ? 1 : 2,
             nodeSize: size,
             labelColor: themeTokens.label,
             labelOutlineColor: themeTokens.background,
@@ -483,220 +461,64 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
               weight: e.weight,
               lineColor: edgeColor(e.edge_type, appearance.theme),
               glowColor: edgeGlowColor(e.edge_type, appearance.theme),
-              edgeOpacity: Math.max(crossSpace ? 0.5 : 0.7, e.weight ?? 0.5),
+              edgeOpacity: Math.max(0.2, e.weight ?? 0.5),
             },
             classes: crossSpace ? "cross-space" : undefined,
           };
         });
 
-      // --- Galaxy layout: one invisible hub node per space ---
-      // Every member connects to its space hub so the space coheres into a
-      // dense "galaxy". Orphans get a longer hub edge → they settle on the
-      // galaxy's outer rim. Hubs repel each other (+gravity) to arrange the
-      // galaxies in a bounded circle; cross-space edges pull connected
-      // galaxies nearer (hybrid positioning). Hubs/edges are invisible but
-      // still participate in the force simulation.
-      const HUB = "__hub__";
-      const skey = (s: string | null) => s ?? "__none__";
-      const useGalaxy = clusterBySpace;
-
-      const hubElements: cytoscape.ElementDefinition[] = [];
-      const hubEdges: cytoscape.ElementDefinition[] = [];
-      const galaxyLinks: cytoscape.ElementDefinition[] = [];
-      const hubPos = new Map<string, { x: number; y: number }>();
-
-      if (useGalaxy) {
-        const sizeBySpace = new Map();
-        for (const n of nodes) {
-          const k = skey(n.space || null);
-          sizeBySpace.set(k, (sizeBySpace.get(k) ?? 0) + 1);
-        }
-        // Single pass over cross-space edges feeds two aggregates: crossDeg
-        // (per-space connectivity, for hub ordering) and pairCount (per
-        // space-pair edge count, for the aggregate galaxy links below).
-        const crossDeg = new Map();
-        const pairCount = new Map<string, number>();
-        for (const e of edgeElements) {
-          if (!e.classes) continue; // only cross-space edges carry a class
-          const sa = skey(nodeSpaceMap.get(e.data.source) ?? null);
-          const sb = skey(nodeSpaceMap.get(e.data.target) ?? null);
-          if (sa === sb) continue;
-          crossDeg.set(sa, (crossDeg.get(sa) ?? 0) + 1);
-          crossDeg.set(sb, (crossDeg.get(sb) ?? 0) + 1);
-          const key = sa < sb ? `${sa}|${sb}` : `${sb}|${sa}`;
-          pairCount.set(key, (pairCount.get(key) ?? 0) + 1);
-        }
-        // Order galaxies by cross-space connectivity: the most-connected hub
-        // spaces sit at the centre (short links between them), isolated ones
-        // drift to the rim. Tiebreak by size.
-        const keys = Array.from(sizeBySpace.keys()).sort((x, y) => {
-          const d = (crossDeg.get(y) ?? 0) - (crossDeg.get(x) ?? 0);
-          return d !== 0 ? d : sizeBySpace.get(y) - sizeBySpace.get(x);
-        });
-        const GOLDEN = 2.399963229728653;
-        const SPACING = 340;
-        keys.forEach((k, i) => {
-          const ang = i * GOLDEN;
-          const r = SPACING * Math.sqrt(i);
-          hubPos.set(HUB + k, { x: Math.cos(ang) * r, y: Math.sin(ang) * r });
-          hubElements.push({ data: { id: HUB + k }, classes: "hub" });
-        });
-        for (const n of nodes) {
-          hubEdges.push({
-            data: {
-              id: `${HUB}e_${n.id}`,
-              source: HUB + skey(n.space || null),
-              target: n.id,
-              orphan: (degreeMap.get(n.id) ?? 0) === 0,
-            },
-            classes: "hub-edge",
-          });
-        }
-
-        // Aggregate cross-space edges into one "galaxy link" per space pair
-        // (counted above), weighted by how many real edges connect them. A
-        // handful of clean hub-to-hub lines instead of hundreds of crossings.
-        for (const [key, count] of pairCount) {
-          const [a, b] = key.split("|");
-          if (count < 6) continue;
-          galaxyLinks.push({
-            data: {
-              id: `${HUB}link_${a}_${b}`,
-              source: HUB + a,
-              target: HUB + b,
-              linkCount: count,
-              linkW: Math.min(7, 1.5 + Math.log2(count) * 1.0),
-              linkO: Math.min(0.5, 0.22 + Math.log2(count) * 0.06),
-            },
-            classes: "galaxy-link",
-          });
-        }
-      }
-
-      const intraEdges = useGalaxy ? edgeElements.filter((e) => !e.classes) : edgeElements;
+      const positions = clusterBySpace
+        ? computeClusteredPositions(nodes)
+        : null;
 
       const cy = cytoscape({
         container: containerRef.current,
-        elements: [...nodeElements, ...intraEdges, ...hubElements, ...hubEdges, ...galaxyLinks],
-        style: [
-          ...buildStyles(appearance),
-          { selector: ".hub", style: { width: 1, height: 1, opacity: 0, events: "no" } },
-          { selector: ".hub-edge", style: { width: 1, "line-opacity": 0, events: "no" } },
-        ] as never,
+        elements: [...nodeElements, ...edgeElements],
+        style: buildStyles(appearance),
         layout: { name: "preset" },
-        minZoom: 0.01,
+        minZoom: 0.03,
         maxZoom: 4,
         wheelSensitivity: 0.3,
       });
 
-      // Seed hubs + members so fcose starts with galaxies already grouped.
-      if (useGalaxy) {
-        cy.nodes(".hub").forEach((node) => {
-          const p = hubPos.get(node.id());
-          if (p) node.position(p);
-        });
-        cy.nodes().not(".hub").forEach((node, idx) => {
-          const p = hubPos.get(HUB + skey(nodeSpaceMap.get(node.id()) ?? null));
-          if (p) {
-            const a = (idx % 12) * (Math.PI / 6);
-            node.position({ x: p.x + Math.cos(a) * 40, y: p.y + Math.sin(a) * 40 });
-          }
+      if (positions) {
+        cy.nodes().forEach((node) => {
+          const pos = positions.get(node.id());
+          if (pos) node.position(pos);
         });
       }
 
-      cy.nodes().not(".hub").grabify();
-      cy.nodes(".hub").ungrabify();
+      cy.nodes().grabify();
 
-      const layout = cy.layout(
-        useGalaxy
-          ? ({
-              name: "fcose",
-              quality: "default",
-              animate: true,
-              randomize: false, // start from the galaxy seeds
-              fit: false,
-              numIter: 2500,
-              nodeSeparation: 150,
-              // Pin each space hub at its phyllotaxis slot so galaxies stay
-              // distinct and cannot collapse into one another.
-              gravity: 0.7,
-              gravityRange: 5,
-              // Hubs are pinned; low real-node repulsion → dense, tight galaxies.
-              nodeRepulsion: (node: cytoscape.NodeSingular) =>
-                node.hasClass("hub") ? 55000 : 2800,
-              idealEdgeLength: (edge: cytoscape.EdgeSingular) => {
-                // Hub edges set galaxy radius: tight core, modest rim for orphans.
-                if (edge.hasClass("hub-edge")) {
-                  return edge.data("orphan") ? 150 : 60;
-                }
-                if (edge.hasClass("galaxy-link")) {
-                  return 520 - 160 * (edge.data("linkO") ?? 0.4);
-                }
-                const w = edge.data("weight") ?? 0.5;
-                const base = 120 + (1 - w) * 100;
-                const ss = nodeSpaceMap.get(edge.source().id());
-                const ts = nodeSpaceMap.get(edge.target().id());
-                // Long cross-space links so they draw galaxy-to-galaxy
-                // connections without yanking members out of their galaxy.
-                return ss !== ts ? base * 2.5 : base * 0.6;
-              },
-              packComponents: true,
-            } as never)
-          : ({
-              name: "fcose",
-              quality: "default",
-              animate: true,
-              randomize: true,
-              fit: false,
-              gravity: 0.25,
-              packComponents: true,
-            } as never),
-      );
+      const layout = cy.layout({
+        name: "cola",
+        animate: true,
+        infinite: false,
+        maxSimulationTime: nodes.length > 1000 ? 1800 : 3000,
+        fit: false,
+        ungrabifyWhileSimulating: false,
+        nodeSpacing: clusterBySpace ? 60 : 40,
+        edgeLength: (edge: cytoscape.EdgeSingular) => {
+          const w = edge.data("weight") ?? 0.5;
+          const baseLen = 120 + (1 - w) * 100;
+          if (clusterBySpace) {
+            const srcSpace = nodeSpaceMap.get(edge.source().id());
+            const tgtSpace = nodeSpaceMap.get(edge.target().id());
+            if (srcSpace !== tgtSpace) return baseLen * 5;
+          }
+          return baseLen;
+        },
+        convergenceThreshold: 0.01,
+        randomize: !positions,
+        avoidOverlap: true,
+        handleDisconnected: true,
+      } as never);
       layoutRef.current = layout;
 
-      if (useGalaxy) {
-        // fcose builds the galaxy structure (gravity + clustering) but lets
-        // nodes pile up on the same coordinates, so the dense core reads like
-        // a flat PNG on zoom-in. Chase it with a cola pass whose only job is
-        // collision: avoidOverlap pushes every dot apart by its own radius
-        // (Obsidian-style), seeded from fcose's positions so the galaxies keep
-        // their shape. Result: the core spreads into distinct, non-touching
-        // dots that separate cleanly as you zoom in.
-        layout.one("layoutstop", () => {
-          const separate = cy.layout({
-            name: "cola",
-            animate: true,
-            randomize: false, // honour fcose's galaxy positions
-            fit: false,
-            avoidOverlap: true,
-            handleDisconnected: false, // don't relocate isolated galaxies
-            nodeSpacing: () => 12, // minimum gap between dot bounding boxes
-            edgeLength: (edge: cytoscape.EdgeSingular) => {
-              if (edge.hasClass("hub-edge")) {
-                return edge.data("orphan") ? 160 : 70;
-              }
-              if (edge.hasClass("galaxy-link")) return 480;
-              const ss = nodeSpaceMap.get(edge.source().id());
-              const ts = nodeSpaceMap.get(edge.target().id());
-              return ss !== ts ? 260 : 90;
-            },
-            maxSimulationTime: 2500,
-            convergenceThreshold: 0.01,
-            ungrabifyWhileSimulating: false,
-          } as never);
-          layoutRef.current = separate;
-          separate.one("layoutstop", () => {
-            cy.fit(cy.nodes().not(".hub"), 40);
-            setLayoutReady(true);
-          });
-          separate.run();
-        });
-      } else {
-        layout.one("layoutstop", () => {
-          cy.fit(cy.nodes().not(".hub"), 40);
-          setLayoutReady(true);
-        });
-      }
+      layout.one("layoutstop", () => {
+        cy.fit(undefined, OVERVIEW_PADDING);
+        setLayoutReady(true);
+      });
       layout.run();
 
       cy.on("tap", "node", (e) => {
@@ -873,26 +695,11 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       const themeTokens = GRAPH_THEME_TOKENS[appearance.theme];
       cy.style(buildStyles(appearance));
-      cy.nodes().not(".hub").forEach((node) => {
+      cy.nodes().forEach((node) => {
         const tier = node.data("tier") as string;
         const selfRole = node.data("selfRole") as string;
-        // In galaxy mode the fill is the space colour and the tier is encoded
-        // by shape (hollow / rim), so re-derive it here too — otherwise a theme
-        // or tier-palette change would clobber the space colours with tier hues.
-        if (clusterBySpace) {
-          const gs = galaxyNodeStyle(
-            node.data("space") || null,
-            tier,
-            themeTokens.background,
-            selfRole,
-          );
-          node.data("bgColor", gs.bg);
-          node.data("borderColor", gs.border);
-          node.data("borderWidth", gs.borderWidth);
-        } else {
-          node.data("bgColor", tierColor(tier, selfRole, appearance));
-          node.data("borderColor", tierBorderColor(tier, selfRole, appearance));
-        }
+        node.data("bgColor", tierColor(tier, selfRole, appearance));
+        node.data("borderColor", tierBorderColor(tier, selfRole, appearance));
         node.data("labelColor", themeTokens.label);
         node.data("labelOutlineColor", themeTokens.background);
       });
@@ -919,37 +726,62 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
       cy.batch(() => {
         cy.elements().removeClass("dim hot");
         if (!legendFocus) return;
-        cy.elements().not(".hub").not(".hub-edge").addClass("dim");
+        cy.elements().addClass("dim");
         if (legendFocus.kind === "space") {
           const m = cy.nodes().filter((n) => n.data("space") === legendFocus.val);
           m.removeClass("dim").addClass("hot");
           m.connectedEdges().removeClass("dim");
         } else if (legendFocus.kind === "tier") {
-          const m = cy.nodes().not(".hub").filter((n) => n.data("tier") === legendFocus.val);
+          const m = cy.nodes().filter((n) => n.data("tier") === legendFocus.val);
           m.removeClass("dim").addClass("hot");
           m.connectedEdges().removeClass("dim");
         } else {
-          const ed =
-            legendFocus.val === "__galaxy__"
-              ? cy.edges(".galaxy-link")
-              : cy.edges().filter((e) => (e.data("edgeType") || "related_to") === legendFocus.val);
+          const ed = cy.edges().filter((e) => (e.data("edgeType") || "related_to") === legendFocus.val);
           ed.removeClass("dim").addClass("hot");
           ed.connectedNodes().removeClass("dim");
         }
       });
     }, [legendFocus, layoutReady]);
 
+    const visibleLegendTargets = useMemo(() => {
+      const nodeIds = new Set(nodes.map((n) => n.id));
+      const edgeTypes = new Set<string>();
+
+      for (const e of edges) {
+        if (!nodeIds.has(e.source_id) || !nodeIds.has(e.target_id)) continue;
+        edgeTypes.add(e.edge_type || "related_to");
+      }
+
+      return { edgeTypes };
+    }, [nodes, edges]);
+
+    useEffect(() => {
+      if (!legendFocus) return;
+
+      let stillVisible = false;
+      if (legendFocus.kind === "space") {
+        stillVisible = clusterBySpace && nodes.some((n) => (n.space || "") === legendFocus.val);
+      } else if (legendFocus.kind === "tier") {
+        stillVisible = clusterBySpace && nodes.some((n) => n.tier === legendFocus.val);
+      } else {
+        stillVisible = visibleLegendTargets.edgeTypes.has(legendFocus.val);
+      }
+
+      if (!stillVisible) setLegendFocus(null);
+    }, [clusterBySpace, legendFocus, nodes, visibleLegendTargets]);
+
     const edgeLegend = useMemo(() => {
       const t = GRAPH_THEME_TOKENS[appearance.theme];
-      return [
-        { c: t.accent, t: "Entre spaces", k: "__galaxy__" },
-        { c: t.edgeSupports, t: "Apoia", k: "supports" },
-        { c: t.edgeContradicts, t: "Contradiz", k: "contradicts" },
-        { c: t.edgeDefines, t: "Define", k: "defines" },
-        { c: t.edgeEvolved, t: "Evoluiu de", k: "evolved_from" },
-        { c: t.edgeDefault, t: "Relacionado", k: "related_to" },
-      ];
-    }, [appearance.theme]);
+      const rows = [
+        { c: t.edgeSupports, t: "Supports", k: "supports" },
+        { c: t.edgeContradicts, t: "Contradicts", k: "contradicts" },
+        { c: t.edgeDefines, t: "Defines", k: "defines" },
+        { c: t.edgeEvolved, t: "Evolved from", k: "evolved_from" },
+        { c: t.edgeDefault, t: "Related", k: "related_to" },
+      ].filter((row) => visibleLegendTargets.edgeTypes.has(row.k));
+
+      return rows;
+    }, [appearance.theme, visibleLegendTargets]);
     const spaceLegend = useMemo(() => {
       const spaceCounts = new Map<string, number>();
       for (const n of nodes) {
@@ -958,20 +790,51 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
       }
       return Array.from(spaceCounts.entries())
         .sort((a, b) => b[1] - a[1])
-        .map(([name, count]) => ({ name: name || "(sem space)", count, c: spaceColor(name || null) }));
+        .map(([name, count]) => ({ name: name || "(no space)", count }));
     }, [nodes]);
-    // Tier is shown as a shape, not a colour: the swatch mirrors the node it
-    // describes — hollow for archived, solid with a rim for core, plain solid
-    // for working. A neutral grey fill keeps the swatch space-agnostic.
     const tierLegend = useMemo(() => {
       const counts: Record<string, number> = { core: 0, working: 0, archival: 0 };
       for (const n of nodes) counts[n.tier] = (counts[n.tier] ?? 0) + 1;
       return [
-        { val: "core", label: "core", count: counts.core, hollow: false, rim: true },
-        { val: "working", label: "working", count: counts.working, hollow: false, rim: false },
-        { val: "archival", label: "archival", count: counts.archival, hollow: true, rim: false },
+        { val: "core", label: "core", count: counts.core, color: appearance.colors.core, dashed: false },
+        { val: "working", label: "working", count: counts.working, color: appearance.colors.working, dashed: false },
+        { val: "archival", label: "archival", count: counts.archival, color: appearance.colors.archival, dashed: true },
       ];
-    }, [nodes]);
+    }, [nodes, appearance.colors.archival, appearance.colors.core, appearance.colors.working]);
+    const showLegend = clusterBySpace || edgeLegend.length > 0;
+
+    const clearGraphSelection = () => {
+      const cy = cyRef.current;
+      if (!cy) return;
+      cy.nodes().unselect();
+      cy.elements().removeClass("glow glow-neighbor");
+    };
+
+    const toggleLegendFocus = (kind: string, val: string) => {
+      clearGraphSelection();
+      setLegendFocus((f) =>
+        f && f.kind === kind && f.val === val ? null : { kind, val },
+      );
+    };
+
+    const focusSpace = (space: string) => {
+      clearGraphSelection();
+      const nextActive = !(legendFocus && legendFocus.kind === "space" && legendFocus.val === space);
+      setLegendFocus(nextActive ? { kind: "space", val: space } : null);
+
+      const cy = cyRef.current;
+      if (!cy || !layoutReady) return;
+
+      if (!nextActive) {
+        cy.fit(undefined, OVERVIEW_PADDING);
+        return;
+      }
+
+      const spaceNodes = cy.nodes().filter((node) => node.data("space") === space);
+      if (spaceNodes.length) {
+        cy.fit(spaceNodes, SPACE_FOCUS_PADDING);
+      }
+    };
 
     return (
       <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -987,7 +850,7 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
             transition: "opacity 0.4s ease-in",
           }}
         />
-        {layoutReady && (
+        {layoutReady && showLegend && (
           <div
             style={{
               position: "absolute",
@@ -1018,11 +881,7 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
                   <LegendRow
                     key={tl.val}
                     active={!legendFocus || (legendFocus.kind === "tier" && legendFocus.val === tl.val)}
-                    onClick={() =>
-                      setLegendFocus((f) =>
-                        f && f.kind === "tier" && f.val === tl.val ? null : { kind: "tier", val: tl.val },
-                      )
-                    }
+                    onClick={() => toggleLegendFocus("tier", tl.val)}
                   >
                     <span
                       style={{
@@ -1030,12 +889,8 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
                         height: 11,
                         borderRadius: "50%",
                         boxSizing: "border-box",
-                        background: tl.hollow ? "transparent" : "#9aa4b2",
-                        border: tl.hollow
-                          ? "2px solid #9aa4b2"
-                          : tl.rim
-                            ? `2px solid ${TIER_RIM}`
-                            : "none",
+                        background: tl.color,
+                        border: tl.dashed ? "1px dashed rgba(255,255,255,0.75)" : "none",
                         display: "inline-block",
                         flexShrink: 0,
                       }}
@@ -1046,46 +901,41 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
                 ))}
               </>
             )}
-            <div
-              style={{
-                ...LEGEND_SECTION_TITLE_STYLE,
-                margin: clusterBySpace ? "9px 0 4px" : "0 0 4px",
-              }}
-            >
-              LINKS
-            </div>
-            {edgeLegend.map((e) => (
-              <LegendRow
-                key={e.t}
-                active={!legendFocus || (legendFocus.kind === "edge" && legendFocus.val === e.k)}
-                onClick={() =>
-                  setLegendFocus((f) =>
-                    f && f.kind === "edge" && f.val === e.k ? null : { kind: "edge", val: e.k },
-                  )
-                }
-              >
-                <span style={{ width: 16, height: 3, background: e.c, display: "inline-block", borderRadius: 2 }} />
-                <span>{e.t}</span>
-              </LegendRow>
-            ))}
+            {edgeLegend.length > 0 && (
+              <>
+                <div
+                  style={{
+                    ...LEGEND_SECTION_TITLE_STYLE,
+                    margin: clusterBySpace ? "9px 0 4px" : "0 0 4px",
+                  }}
+                >
+                  LINKS
+                </div>
+                {edgeLegend.map((e) => (
+                  <LegendRow
+                    key={e.t}
+                    active={!legendFocus || (legendFocus.kind === "edge" && legendFocus.val === e.k)}
+                    onClick={() => toggleLegendFocus("edge", e.k)}
+                  >
+                    <span style={{ width: 16, height: 3, background: e.c, display: "inline-block", borderRadius: 2 }} />
+                    <span>{e.t}</span>
+                  </LegendRow>
+                ))}
+              </>
+            )}
             {clusterBySpace && (
               <>
                 <div style={{ ...LEGEND_SECTION_TITLE_STYLE, margin: "9px 0 4px" }}>
                   SPACES
                 </div>
                 {spaceLegend.map((sp) => {
-                  const val = sp.name === "(sem space)" ? "" : sp.name;
+                  const val = sp.name === "(no space)" ? "" : sp.name;
                   return (
                     <LegendRow
                       key={sp.name}
                       active={!legendFocus || (legendFocus.kind === "space" && legendFocus.val === val)}
-                      onClick={() =>
-                        setLegendFocus((f) =>
-                          f && f.kind === "space" && f.val === val ? null : { kind: "space", val },
-                        )
-                      }
+                      onClick={() => focusSpace(val)}
                     >
-                      <span style={{ width: 9, height: 9, borderRadius: "50%", background: sp.c, display: "inline-block", flexShrink: 0 }} />
                       <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}>
                         {sp.name}
                       </span>

--- a/ui/src/components/GraphView.tsx
+++ b/ui/src/components/GraphView.tsx
@@ -130,6 +130,7 @@ function nodeLabel(n: MemoryNode): string {
 
 const OVERVIEW_PADDING = 150;
 const SPACE_FOCUS_PADDING = 110;
+const LARGE_GRAPH_FAST_LAYOUT_NODE_COUNT = 2500;
 const ZOOM_MIN = 0.03;
 const ZOOM_MAX = 4;
 const ZOOM_SLIDER_MAX = 100;
@@ -306,6 +307,129 @@ function computeClusteredPositions(nodes: MemoryNode[]): Map<string, { x: number
 
   if (hasUngrouped) {
     placeGroup(ungrouped, (2 * Math.PI * spaceList.length) / totalGroups);
+  }
+
+  return positions;
+}
+
+/**
+ * Large graphs should be inspectable immediately. Full-graph cola with collision
+ * is too expensive at 3k+ nodes, so this builds a deterministic, packed overview:
+ * spaces become packed galaxies, connected nodes occupy the interior, and orphans
+ * land on the outer rings.
+ */
+function computePackedGalaxyPositions(
+  nodes: MemoryNode[],
+  edges: Edge[],
+): Map<string, { x: number; y: number }> {
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  const incidentCounts = new Map<string, number>();
+  for (const node of nodes) incidentCounts.set(node.id, 0);
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.source_id) || !nodeIds.has(edge.target_id)) continue;
+    incidentCounts.set(edge.source_id, (incidentCounts.get(edge.source_id) ?? 0) + 1);
+    incidentCounts.set(edge.target_id, (incidentCounts.get(edge.target_id) ?? 0) + 1);
+  }
+
+  const groups = new Map<string, MemoryNode[]>();
+  for (const node of nodes) {
+    const key = node.space || "";
+    let group = groups.get(key);
+    if (!group) {
+      group = [];
+      groups.set(key, group);
+    }
+    group.push(node);
+  }
+
+  const nodeGap = Math.round(48 * GRAPH_DISPLAY_SCALE);
+  const groupGap = Math.round(140 * GRAPH_DISPLAY_SCALE);
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+
+  const packedGroups = Array.from(groups.entries())
+    .map(([space, group]) => {
+      const sorted = [...group].sort((a, b) => {
+        const aOrphan = (incidentCounts.get(a.id) ?? 0) === 0 ? 1 : 0;
+        const bOrphan = (incidentCounts.get(b.id) ?? 0) === 0 ? 1 : 0;
+        if (aOrphan !== bOrphan) return aOrphan - bOrphan;
+        if (a.access_count !== b.access_count) return b.access_count - a.access_count;
+        return a.id.localeCompare(b.id);
+      });
+
+      const localPositions = new Map<string, { x: number; y: number }>();
+      let maxRadius = 0;
+
+      if (sorted.length > 0) {
+        const first = sorted[0];
+        localPositions.set(first.id, { x: 0, y: 0 });
+        maxRadius = Math.max(maxRadius, displayNodeSize(first.access_count, "") / 2);
+      }
+
+      let index = 1;
+      let ring = 1;
+      while (index < sorted.length) {
+        const radius = ring * nodeGap;
+        const slots = Math.max(6, Math.floor((2 * Math.PI * radius) / nodeGap));
+        for (let slot = 0; slot < slots && index < sorted.length; slot += 1) {
+          const node = sorted[index];
+          const angle = (2 * Math.PI * slot) / slots + ring * 0.37;
+          const x = Math.cos(angle) * radius;
+          const y = Math.sin(angle) * radius;
+          localPositions.set(node.id, { x, y });
+          maxRadius = Math.max(
+            maxRadius,
+            Math.hypot(x, y) + displayNodeSize(node.access_count, "") / 2,
+          );
+          index += 1;
+        }
+        ring += 1;
+      }
+
+      return {
+        space,
+        count: group.length,
+        radius: Math.max(maxRadius, nodeGap * 2),
+        localPositions,
+      };
+    })
+    .sort((a, b) => b.radius - a.radius || b.count - a.count || a.space.localeCompare(b.space));
+
+  const placed: Array<{ x: number; y: number; radius: number }> = [];
+  const positions = new Map<string, { x: number; y: number }>();
+
+  for (const group of packedGroups) {
+    let center = { x: 0, y: 0 };
+    if (placed.length > 0) {
+      let found = false;
+      for (let attempt = 1; attempt < 30000; attempt += 1) {
+        const radius = Math.sqrt(attempt) * groupGap;
+        const angle = attempt * goldenAngle;
+        const candidate = { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
+        const overlaps = placed.some((other) => {
+          const minDistance = other.radius + group.radius + groupGap;
+          return Math.hypot(candidate.x - other.x, candidate.y - other.y) < minDistance;
+        });
+        if (!overlaps) {
+          center = candidate;
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        const angle = placed.length * goldenAngle;
+        const radius = placed.reduce((max, other) => Math.max(max, Math.hypot(other.x, other.y) + other.radius), 0);
+        center = {
+          x: Math.cos(angle) * (radius + group.radius + groupGap),
+          y: Math.sin(angle) * (radius + group.radius + groupGap),
+        };
+      }
+    }
+
+    placed.push({ ...center, radius: group.radius });
+    for (const [id, local] of group.localPositions) {
+      positions.set(id, { x: center.x + local.x, y: center.y + local.y });
+    }
   }
 
   return positions;
@@ -563,8 +687,12 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
           };
         });
 
+      const useFastOverview =
+        clusterBySpace && nodes.length >= LARGE_GRAPH_FAST_LAYOUT_NODE_COUNT;
       const positions = clusterBySpace
-        ? computeClusteredPositions(nodes)
+        ? useFastOverview
+          ? computePackedGalaxyPositions(nodes, edges)
+          : computeClusteredPositions(nodes)
         : null;
 
       const cy = cytoscape({
@@ -595,35 +723,9 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       cy.nodes().grabify();
 
-      const maxSimulationTime = Math.min(8000, 1500 + nodes.length);
-      const layout = cy.layout({
-        name: "cola",
-        animate: true,
-        infinite: false,
-        maxSimulationTime,
-        refresh: nodes.length > 2500 ? 8 : 1,
-        fit: false,
-        ungrabifyWhileSimulating: false,
-        nodeSpacing: clusterBySpace ? 60 : 40,
-        edgeLength: (edge: cytoscape.EdgeSingular) => {
-          const w = edge.data("weight") ?? 0.5;
-          const baseLen = 120 + (1 - w) * 100;
-          if (clusterBySpace) {
-            const srcSpace = nodeSpaceMap.get(edge.source().id());
-            const tgtSpace = nodeSpaceMap.get(edge.target().id());
-            if (srcSpace !== tgtSpace) return baseLen * 5;
-          }
-          return baseLen;
-        },
-        convergenceThreshold: 0.01,
-        randomize: !positions,
-        avoidOverlap: true,
-        handleDisconnected: !clusterBySpace,
-      } as never);
-      layoutRef.current = layout;
-
       let layoutSettled = false;
       let layoutWatchdog: ReturnType<typeof setTimeout> | null = null;
+      let layoutReadyFrame: number | null = null;
       const finishLayout = () => {
         if (layoutSettled) return;
         layoutSettled = true;
@@ -636,13 +738,44 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         setLayoutReady(true);
       };
 
-      layout.one("layoutstop", finishLayout);
-      layoutWatchdog = setTimeout(() => {
-        if (layoutSettled) return;
-        layout.stop();
-        finishLayout();
-      }, maxSimulationTime + 1500);
-      layout.run();
+      if (useFastOverview) {
+        layoutReadyFrame = requestAnimationFrame(finishLayout);
+      } else {
+        const maxSimulationTime = Math.min(8000, 1500 + nodes.length);
+        const layout = cy.layout({
+          name: "cola",
+          animate: true,
+          infinite: false,
+          maxSimulationTime,
+          refresh: nodes.length > 2500 ? 8 : 1,
+          fit: false,
+          ungrabifyWhileSimulating: false,
+          nodeSpacing: clusterBySpace ? 60 : 40,
+          edgeLength: (edge: cytoscape.EdgeSingular) => {
+            const w = edge.data("weight") ?? 0.5;
+            const baseLen = 120 + (1 - w) * 100;
+            if (clusterBySpace) {
+              const srcSpace = nodeSpaceMap.get(edge.source().id());
+              const tgtSpace = nodeSpaceMap.get(edge.target().id());
+              if (srcSpace !== tgtSpace) return baseLen * 5;
+            }
+            return baseLen;
+          },
+          convergenceThreshold: 0.01,
+          randomize: !positions,
+          avoidOverlap: true,
+          handleDisconnected: !clusterBySpace,
+        } as never);
+        layoutRef.current = layout;
+
+        layout.one("layoutstop", finishLayout);
+        layoutWatchdog = setTimeout(() => {
+          if (layoutSettled) return;
+          layout.stop();
+          finishLayout();
+        }, maxSimulationTime + 1500);
+        layout.run();
+      }
 
       cy.on("tap", "node", (e) => {
         onNodeSelectRef.current(e.target.id());
@@ -803,6 +936,10 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       return () => {
         if (dragRaf) { cancelAnimationFrame(dragRaf); dragRaf = null; }
+        if (layoutReadyFrame) {
+          cancelAnimationFrame(layoutReadyFrame);
+          layoutReadyFrame = null;
+        }
         if (layoutWatchdog) {
           clearTimeout(layoutWatchdog);
           layoutWatchdog = null;

--- a/ui/src/components/GraphView.tsx
+++ b/ui/src/components/GraphView.tsx
@@ -134,6 +134,32 @@ function spaceColor(space: string | null): string {
   return `hsl(${h}, 62%, 60%)`;
 }
 
+// Galaxy mode encodes two independent channels on a node:
+//   fill   = space colour (the project a memory belongs to)
+//   shape  = tier (archived = hollow ring, core = solid + white rim, working = solid)
+// Tier is shape-only (never a hue) so it never collides with the space colour,
+// regardless of how a user customises their tier palette.
+// self / identity keep the space fill (so the project still reads) but take a
+// teal ring that overrides the tier rim — it marks "this is who I am".
+const TIER_RIM = "#ffffff";
+const IDENTITY_RIM = "#6ba89a";
+const SELF_RIM = "#8fd4c4";
+function galaxyNodeStyle(
+  space: string | null,
+  tier: string,
+  background: string,
+  selfRole: string,
+): { bg: string; border: string; borderWidth: number } {
+  const sc = spaceColor(space);
+  const bg = tier === "archival" ? background : sc;
+  // self / identity ring wins over the tier rim.
+  if (selfRole === "self") return { bg, border: SELF_RIM, borderWidth: 3 };
+  if (selfRole === "identity") return { bg, border: IDENTITY_RIM, borderWidth: 2.5 };
+  if (tier === "archival") return { bg, border: sc, borderWidth: 2 };
+  if (tier === "core") return { bg, border: TIER_RIM, borderWidth: 2 };
+  return { bg, border: sc, borderWidth: 0 }; // working: solid, no rim
+}
+
 function buildStyles(appearance: GraphAppearance) {
   const tokens = GRAPH_THEME_TOKENS[appearance.theme];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -161,12 +187,6 @@ function buildStyles(appearance: GraphAppearance) {
         "text-max-width": `${Math.round(120 * GRAPH_DISPLAY_SCALE)}px`,
         "text-overflow-wrap": "anywhere" as const,
         "overlay-opacity": 0,
-      } as cytoscape.Css.Node,
-    },
-    {
-      selector: "node[tier = 'archival'][selfRole = '']",
-      style: {
-        "border-style": "dashed" as const,
       } as cytoscape.Css.Node,
     },
     {
@@ -413,6 +433,9 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
       const nodeElements = nodes.map((n) => {
         const sr = selfRole(n.id);
         const size = degreeNodeSize(degreeMap.get(n.id) ?? 0, sr);
+        const gs = clusterBySpace
+          ? galaxyNodeStyle(n.space || null, n.tier, themeTokens.background, sr)
+          : null;
         return {
           data: {
             id: n.id,
@@ -422,12 +445,9 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
             type: n.type,
             accessCount: n.access_count,
             selfRole: sr,
-            bgColor:
-              clusterBySpace && sr === ""
-                ? spaceColor(n.space || null)
-                : tierColor(n.tier, sr, appearance),
-            borderColor: tierBorderColor(n.tier, sr, appearance),
-            borderWidth: sr === "self" ? 3 : n.tier === "archival" ? 1 : 2,
+            bgColor: gs ? gs.bg : tierColor(n.tier, sr, appearance),
+            borderColor: gs ? gs.border : tierBorderColor(n.tier, sr, appearance),
+            borderWidth: gs ? gs.borderWidth : sr === "self" ? 3 : n.tier === "archival" ? 1 : 2,
             nodeSize: size,
             labelColor: themeTokens.label,
             labelOutlineColor: themeTokens.background,
@@ -840,11 +860,26 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       const themeTokens = GRAPH_THEME_TOKENS[appearance.theme];
       cy.style(buildStyles(appearance));
-      cy.nodes().forEach((node) => {
+      cy.nodes().not(".hub").forEach((node) => {
         const tier = node.data("tier") as string;
         const selfRole = node.data("selfRole") as string;
-        node.data("bgColor", tierColor(tier, selfRole, appearance));
-        node.data("borderColor", tierBorderColor(tier, selfRole, appearance));
+        // In galaxy mode the fill is the space colour and the tier is encoded
+        // by shape (hollow / rim), so re-derive it here too — otherwise a theme
+        // or tier-palette change would clobber the space colours with tier hues.
+        if (clusterBySpace) {
+          const gs = galaxyNodeStyle(
+            node.data("space") || null,
+            tier,
+            themeTokens.background,
+            selfRole,
+          );
+          node.data("bgColor", gs.bg);
+          node.data("borderColor", gs.border);
+          node.data("borderWidth", gs.borderWidth);
+        } else {
+          node.data("bgColor", tierColor(tier, selfRole, appearance));
+          node.data("borderColor", tierBorderColor(tier, selfRole, appearance));
+        }
         node.data("labelColor", themeTokens.label);
         node.data("labelOutlineColor", themeTokens.background);
       });
@@ -874,6 +909,10 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         cy.elements().not(".hub").not(".hub-edge").addClass("dim");
         if (legendFocus.kind === "space") {
           const m = cy.nodes().filter((n) => n.data("space") === legendFocus.val);
+          m.removeClass("dim").addClass("hot");
+          m.connectedEdges().removeClass("dim");
+        } else if (legendFocus.kind === "tier") {
+          const m = cy.nodes().not(".hub").filter((n) => n.data("tier") === legendFocus.val);
           m.removeClass("dim").addClass("hot");
           m.connectedEdges().removeClass("dim");
         } else {
@@ -908,6 +947,18 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         .sort((a, b) => b[1] - a[1])
         .map(([name, count]) => ({ name: name || "(sem space)", count, c: spaceColor(name || null) }));
     }, [nodes]);
+    // Tier is shown as a shape, not a colour: the swatch mirrors the node it
+    // describes — hollow for archived, solid with a rim for core, plain solid
+    // for working. A neutral grey fill keeps the swatch space-agnostic.
+    const tierLegend = useMemo(() => {
+      const counts: Record<string, number> = { core: 0, working: 0, archival: 0 };
+      for (const n of nodes) counts[n.tier] = (counts[n.tier] ?? 0) + 1;
+      return [
+        { val: "core", label: "core", count: counts.core, hollow: false, rim: true },
+        { val: "working", label: "working", count: counts.working, hollow: false, rim: false },
+        { val: "archival", label: "archival", count: counts.archival, hollow: true, rim: false },
+      ];
+    }, [nodes]);
 
     return (
       <div style={{ width: "100%", height: "100%", position: "relative" }}>
@@ -929,6 +980,9 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
               position: "absolute",
               right: 12,
               bottom: 12,
+              // Above the cytoscape canvas — without this the canvas swallows
+              // legend clicks (elementFromPoint hits the canvas, not the row).
+              zIndex: 10,
               maxHeight: "48%",
               overflowY: "auto",
               background: "rgba(12,14,18,0.85)",
@@ -942,8 +996,52 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
               maxWidth: 230,
             }}
           >
-            <div style={{ opacity: 0.5, fontSize: 9, letterSpacing: 1, marginBottom: 4 }}>
-              LIGAÇÕES
+            {clusterBySpace && (
+              <>
+                <div style={{ opacity: 0.5, fontSize: 9, letterSpacing: 1, marginBottom: 4 }}>
+                  TIERS
+                </div>
+                {tierLegend.map((tl) => (
+                  <LegendRow
+                    key={tl.val}
+                    active={!legendFocus || (legendFocus.kind === "tier" && legendFocus.val === tl.val)}
+                    onClick={() =>
+                      setLegendFocus((f) =>
+                        f && f.kind === "tier" && f.val === tl.val ? null : { kind: "tier", val: tl.val },
+                      )
+                    }
+                  >
+                    <span
+                      style={{
+                        width: 11,
+                        height: 11,
+                        borderRadius: "50%",
+                        boxSizing: "border-box",
+                        background: tl.hollow ? "transparent" : "#9aa4b2",
+                        border: tl.hollow
+                          ? "2px solid #9aa4b2"
+                          : tl.rim
+                            ? `2px solid ${TIER_RIM}`
+                            : "none",
+                        display: "inline-block",
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span style={{ flex: 1 }}>{tl.label}</span>
+                    <span style={{ opacity: 0.4 }}>{tl.count}</span>
+                  </LegendRow>
+                ))}
+              </>
+            )}
+            <div
+              style={{
+                opacity: 0.5,
+                fontSize: 9,
+                letterSpacing: 1,
+                margin: clusterBySpace ? "9px 0 4px" : "0 0 4px",
+              }}
+            >
+              LINKS
             </div>
             {edgeLegend.map((e) => (
               <LegendRow

--- a/ui/src/components/GraphView.tsx
+++ b/ui/src/components/GraphView.tsx
@@ -127,11 +127,18 @@ function nodeLabel(n: MemoryNode): string {
 }
 
 // Deterministic hue per space so each galaxy reads as a distinct colour.
+// Cached: it's called once per node on build and again on every appearance
+// change (~2 × node count), but the hue only depends on the space name.
+const spaceColorCache = new Map<string, string>();
 function spaceColor(space: string | null): string {
   const key = space ?? "__none__";
+  const cached = spaceColorCache.get(key);
+  if (cached) return cached;
   let h = 0;
   for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) % 360;
-  return `hsl(${h}, 62%, 60%)`;
+  const color = `hsl(${h}, 62%, 60%)`;
+  spaceColorCache.set(key, color);
+  return color;
 }
 
 // Galaxy mode encodes two independent channels on a node:
@@ -301,6 +308,12 @@ const LEGEND_ROW_STYLE: CSSProperties = {
   gap: 7,
   cursor: "pointer",
   userSelect: "none",
+};
+
+const LEGEND_SECTION_TITLE_STYLE: CSSProperties = {
+  opacity: 0.5,
+  fontSize: 9,
+  letterSpacing: 1,
 };
 
 // One clickable legend row: swatch + content as children, dimmed when another
@@ -998,7 +1011,7 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
           >
             {clusterBySpace && (
               <>
-                <div style={{ opacity: 0.5, fontSize: 9, letterSpacing: 1, marginBottom: 4 }}>
+                <div style={{ ...LEGEND_SECTION_TITLE_STYLE, marginBottom: 4 }}>
                   TIERS
                 </div>
                 {tierLegend.map((tl) => (
@@ -1035,9 +1048,7 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
             )}
             <div
               style={{
-                opacity: 0.5,
-                fontSize: 9,
-                letterSpacing: 1,
+                ...LEGEND_SECTION_TITLE_STYLE,
                 margin: clusterBySpace ? "9px 0 4px" : "0 0 4px",
               }}
             >
@@ -1059,7 +1070,7 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
             ))}
             {clusterBySpace && (
               <>
-                <div style={{ opacity: 0.5, fontSize: 9, letterSpacing: 1, margin: "9px 0 4px" }}>
+                <div style={{ ...LEGEND_SECTION_TITLE_STYLE, margin: "9px 0 4px" }}>
                   SPACES
                 </div>
                 {spaceLegend.map((sp) => {

--- a/ui/src/components/GraphView.tsx
+++ b/ui/src/components/GraphView.tsx
@@ -130,7 +130,6 @@ function nodeLabel(n: MemoryNode): string {
 
 const OVERVIEW_PADDING = 150;
 const SPACE_FOCUS_PADDING = 110;
-const LARGE_GRAPH_FAST_LAYOUT_NODE_COUNT = 2500;
 const ZOOM_MIN = 0.03;
 const ZOOM_MAX = 4;
 const ZOOM_SLIDER_MAX = 100;
@@ -307,129 +306,6 @@ function computeClusteredPositions(nodes: MemoryNode[]): Map<string, { x: number
 
   if (hasUngrouped) {
     placeGroup(ungrouped, (2 * Math.PI * spaceList.length) / totalGroups);
-  }
-
-  return positions;
-}
-
-/**
- * Large graphs should be inspectable immediately. Full-graph cola with collision
- * is too expensive at 3k+ nodes, so this builds a deterministic, packed overview:
- * spaces become packed galaxies, connected nodes occupy the interior, and orphans
- * land on the outer rings.
- */
-function computePackedGalaxyPositions(
-  nodes: MemoryNode[],
-  edges: Edge[],
-): Map<string, { x: number; y: number }> {
-  const nodeIds = new Set(nodes.map((n) => n.id));
-  const incidentCounts = new Map<string, number>();
-  for (const node of nodes) incidentCounts.set(node.id, 0);
-  for (const edge of edges) {
-    if (!nodeIds.has(edge.source_id) || !nodeIds.has(edge.target_id)) continue;
-    incidentCounts.set(edge.source_id, (incidentCounts.get(edge.source_id) ?? 0) + 1);
-    incidentCounts.set(edge.target_id, (incidentCounts.get(edge.target_id) ?? 0) + 1);
-  }
-
-  const groups = new Map<string, MemoryNode[]>();
-  for (const node of nodes) {
-    const key = node.space || "";
-    let group = groups.get(key);
-    if (!group) {
-      group = [];
-      groups.set(key, group);
-    }
-    group.push(node);
-  }
-
-  const nodeGap = Math.round(48 * GRAPH_DISPLAY_SCALE);
-  const groupGap = Math.round(140 * GRAPH_DISPLAY_SCALE);
-  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
-
-  const packedGroups = Array.from(groups.entries())
-    .map(([space, group]) => {
-      const sorted = [...group].sort((a, b) => {
-        const aOrphan = (incidentCounts.get(a.id) ?? 0) === 0 ? 1 : 0;
-        const bOrphan = (incidentCounts.get(b.id) ?? 0) === 0 ? 1 : 0;
-        if (aOrphan !== bOrphan) return aOrphan - bOrphan;
-        if (a.access_count !== b.access_count) return b.access_count - a.access_count;
-        return a.id.localeCompare(b.id);
-      });
-
-      const localPositions = new Map<string, { x: number; y: number }>();
-      let maxRadius = 0;
-
-      if (sorted.length > 0) {
-        const first = sorted[0];
-        localPositions.set(first.id, { x: 0, y: 0 });
-        maxRadius = Math.max(maxRadius, displayNodeSize(first.access_count, "") / 2);
-      }
-
-      let index = 1;
-      let ring = 1;
-      while (index < sorted.length) {
-        const radius = ring * nodeGap;
-        const slots = Math.max(6, Math.floor((2 * Math.PI * radius) / nodeGap));
-        for (let slot = 0; slot < slots && index < sorted.length; slot += 1) {
-          const node = sorted[index];
-          const angle = (2 * Math.PI * slot) / slots + ring * 0.37;
-          const x = Math.cos(angle) * radius;
-          const y = Math.sin(angle) * radius;
-          localPositions.set(node.id, { x, y });
-          maxRadius = Math.max(
-            maxRadius,
-            Math.hypot(x, y) + displayNodeSize(node.access_count, "") / 2,
-          );
-          index += 1;
-        }
-        ring += 1;
-      }
-
-      return {
-        space,
-        count: group.length,
-        radius: Math.max(maxRadius, nodeGap * 2),
-        localPositions,
-      };
-    })
-    .sort((a, b) => b.radius - a.radius || b.count - a.count || a.space.localeCompare(b.space));
-
-  const placed: Array<{ x: number; y: number; radius: number }> = [];
-  const positions = new Map<string, { x: number; y: number }>();
-
-  for (const group of packedGroups) {
-    let center = { x: 0, y: 0 };
-    if (placed.length > 0) {
-      let found = false;
-      for (let attempt = 1; attempt < 30000; attempt += 1) {
-        const radius = Math.sqrt(attempt) * groupGap;
-        const angle = attempt * goldenAngle;
-        const candidate = { x: Math.cos(angle) * radius, y: Math.sin(angle) * radius };
-        const overlaps = placed.some((other) => {
-          const minDistance = other.radius + group.radius + groupGap;
-          return Math.hypot(candidate.x - other.x, candidate.y - other.y) < minDistance;
-        });
-        if (!overlaps) {
-          center = candidate;
-          found = true;
-          break;
-        }
-      }
-
-      if (!found) {
-        const angle = placed.length * goldenAngle;
-        const radius = placed.reduce((max, other) => Math.max(max, Math.hypot(other.x, other.y) + other.radius), 0);
-        center = {
-          x: Math.cos(angle) * (radius + group.radius + groupGap),
-          y: Math.sin(angle) * (radius + group.radius + groupGap),
-        };
-      }
-    }
-
-    placed.push({ ...center, radius: group.radius });
-    for (const [id, local] of group.localPositions) {
-      positions.set(id, { x: center.x + local.x, y: center.y + local.y });
-    }
   }
 
   return positions;
@@ -687,12 +563,8 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
           };
         });
 
-      const useFastOverview =
-        clusterBySpace && nodes.length >= LARGE_GRAPH_FAST_LAYOUT_NODE_COUNT;
       const positions = clusterBySpace
-        ? useFastOverview
-          ? computePackedGalaxyPositions(nodes, edges)
-          : computeClusteredPositions(nodes)
+        ? computeClusteredPositions(nodes)
         : null;
 
       const cy = cytoscape({
@@ -723,9 +595,35 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       cy.nodes().grabify();
 
+      const maxSimulationTime = Math.min(8000, 1500 + nodes.length);
+      const layout = cy.layout({
+        name: "cola",
+        animate: true,
+        infinite: false,
+        maxSimulationTime,
+        refresh: nodes.length > 2500 ? 8 : 1,
+        fit: false,
+        ungrabifyWhileSimulating: false,
+        nodeSpacing: clusterBySpace ? 60 : 40,
+        edgeLength: (edge: cytoscape.EdgeSingular) => {
+          const w = edge.data("weight") ?? 0.5;
+          const baseLen = 120 + (1 - w) * 100;
+          if (clusterBySpace) {
+            const srcSpace = nodeSpaceMap.get(edge.source().id());
+            const tgtSpace = nodeSpaceMap.get(edge.target().id());
+            if (srcSpace !== tgtSpace) return baseLen * 5;
+          }
+          return baseLen;
+        },
+        convergenceThreshold: 0.01,
+        randomize: !positions,
+        avoidOverlap: true,
+        handleDisconnected: !clusterBySpace,
+      } as never);
+      layoutRef.current = layout;
+
       let layoutSettled = false;
       let layoutWatchdog: ReturnType<typeof setTimeout> | null = null;
-      let layoutReadyFrame: number | null = null;
       const finishLayout = () => {
         if (layoutSettled) return;
         layoutSettled = true;
@@ -738,44 +636,13 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
         setLayoutReady(true);
       };
 
-      if (useFastOverview) {
-        layoutReadyFrame = requestAnimationFrame(finishLayout);
-      } else {
-        const maxSimulationTime = Math.min(8000, 1500 + nodes.length);
-        const layout = cy.layout({
-          name: "cola",
-          animate: true,
-          infinite: false,
-          maxSimulationTime,
-          refresh: nodes.length > 2500 ? 8 : 1,
-          fit: false,
-          ungrabifyWhileSimulating: false,
-          nodeSpacing: clusterBySpace ? 60 : 40,
-          edgeLength: (edge: cytoscape.EdgeSingular) => {
-            const w = edge.data("weight") ?? 0.5;
-            const baseLen = 120 + (1 - w) * 100;
-            if (clusterBySpace) {
-              const srcSpace = nodeSpaceMap.get(edge.source().id());
-              const tgtSpace = nodeSpaceMap.get(edge.target().id());
-              if (srcSpace !== tgtSpace) return baseLen * 5;
-            }
-            return baseLen;
-          },
-          convergenceThreshold: 0.01,
-          randomize: !positions,
-          avoidOverlap: true,
-          handleDisconnected: !clusterBySpace,
-        } as never);
-        layoutRef.current = layout;
-
-        layout.one("layoutstop", finishLayout);
-        layoutWatchdog = setTimeout(() => {
-          if (layoutSettled) return;
-          layout.stop();
-          finishLayout();
-        }, maxSimulationTime + 1500);
-        layout.run();
-      }
+      layout.one("layoutstop", finishLayout);
+      layoutWatchdog = setTimeout(() => {
+        if (layoutSettled) return;
+        layout.stop();
+        finishLayout();
+      }, maxSimulationTime + 1500);
+      layout.run();
 
       cy.on("tap", "node", (e) => {
         onNodeSelectRef.current(e.target.id());
@@ -936,10 +803,6 @@ const GraphView = forwardRef<{ focusNode: (id: string) => void }, Props>(
 
       return () => {
         if (dragRaf) { cancelAnimationFrame(dragRaf); dragRaf = null; }
-        if (layoutReadyFrame) {
-          cancelAnimationFrame(layoutReadyFrame);
-          layoutReadyFrame = null;
-        }
         if (layoutWatchdog) {
           clearTimeout(layoutWatchdog);
           layoutWatchdog = null;


### PR DESCRIPTION
Closes #16.

Redesigns the memory graph view (`ui/src/components/GraphView.tsx`) for readability and interaction on large graphs.

## What changed

### Zoom-out cap
- `minZoom` lowered `0.15 → 0.01` so `cy.fit()` can frame the whole graph instead of stopping with most nodes off-screen.

### Galaxy layout (spaces as galaxies)
- One **invisible hub node per space** + `fcose` gravity/clustering groups each space into a distinct galaxy. Orphan nodes get a longer hub edge so they settle on the galaxy's outer rim.
- Hubs are ordered by cross-space connectivity (most-connected toward the centre) via a phyllotaxis (sunflower) seed.

### Obsidian-style zoom (the "it looks like a PNG on zoom-in" fix)
- Cytoscape zoom is pure affine scaling and never re-runs layout, so the only way zoom-in can reveal individual nodes is to guarantee they don't overlap. `fcose` is a single-pass layout that allows overlap, so the dense core piled nodes onto the same coordinates.
- Fix: **chain a `cytoscape-cola` pass with `avoidOverlap: true`** (collision, Obsidian-style) seeded from `fcose`'s positions (`randomize: false`, `handleDisconnected: false`). It only pushes overlapping dots apart by their own radius, preserving the galaxy structure.
- Measured result: **0 overlapping pairs**, ~25px min edge-to-edge gap across ~1.7k nodes.

### Two-channel node encoding: space colour + tier shape
- **Fill = space colour** (the project a memory belongs to) — matches the legend and reads the same across users.
- **Tier = shape, never a hue**: archived = hollow ring (dark fill + space-coloured rim), core = solid + white rim, working = solid. Because tier is shape-only it can never collide with a space colour, whatever palette the user picks for their tiers.
- `self` / `identity` keep the space fill but take a teal rim that overrides the tier rim, so "who I am" still reads without painting ~60% of the graph one colour.
- This replaces the earlier approach where the user's tier palette was painted onto the fill — it collided with the space hue and made the legend lie (archived nodes rendered in the custom archival colour, e.g. a wall of red, instead of their space colour).

### Dots, labels, links
- Nodes are **sized by connection degree**.
- Labels render **only on hover/selection** (LOD) instead of an always-on text haze.
- Cross-space edges are aggregated into one gold **"galaxy-link" per connected space pair** (width/opacity scaled by edge count) instead of hundreds of crossing lines. Brightness was toned down and a dedicated rule dims it correctly when another element is focused.

### Floating clickable legend
- In-graph legend (bottom-right): **TIERS / LINKS / SPACES** sections (English headings), each row clickable.
- Click a space, tier, or link type to **highlight matching elements and dim the rest**; click again to clear.
- The legend now sits above the cytoscape canvas (`z-index`) — without it the canvas swallowed every legend click, so space filtering was silently dead.

### Code cleanup (same PR)
- Removed dead `computeClusteredPositions`.
- Merged the two duplicate node-degree maps and fused the `crossDeg`/`pairCount` passes into one loop over cross-space edges.
- Memoized legend data (`edgeLegend`, `spaceLegend`) and extracted a `LegendRow` helper to drop duplicated JSX.
- Removed now-unused `displayNodeSize`/`nodeSize`; dropped a redundant `nodeSize` reset in the appearance effect that reverted degree-based sizing on theme change.
- Centralised the node-style derivation in a single `galaxyNodeStyle()` helper consumed by both node creation and the appearance effect, so the two paths can't drift.
- Cached `spaceColor` (it was re-hashing the space name ~2× per node) and extracted the repeated legend section-title style.

## Verification
- `tsc --noEmit` clean; `vite build` clean.
- Behaviour verified live against the dev server (node overlap count, dim/focus class application, deep-zoom rendering, legend click filtering for space and tier, fill/rim per tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
