### PR TITLE
Fix server freeze: run engine work off the event loop + thread-local DB connections

### DIFF
--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -98,7 +98,7 @@ def _persist_backup_settings(backup_dir: Path, retention_count: int) -> None:
 
 
 @router.get("/health")
-async def health(request: Request):
+def health(request: Request):
     tracker = getattr(request.app.state, "job_tracker", None)
     result: dict = {"status": "ok"}
     if tracker is not None:
@@ -110,13 +110,13 @@ async def health(request: Request):
 
 
 @router.get("/stats")
-async def stats(request: Request):
+def stats(request: Request):
     engine = request.app.state.engine
     return engine.stats()
 
 
 @router.get("/maintenance-status")
-async def maintenance_status(request: Request):
+def maintenance_status(request: Request):
     manager = getattr(request.app.state, "maintenance_manager", None)
     if manager is None:
         return {"status": "idle"}
@@ -124,14 +124,14 @@ async def maintenance_status(request: Request):
 
 
 @router.get("/backup")
-async def backup_status(request: Request):
+def backup_status(request: Request):
     """Return local backup configuration and latest backup metadata."""
     settings, service = _backup_service_from_request(request)
     return _backup_status_payload(settings, service)
 
 
 @router.post("/backup/create")
-async def create_backup(request: Request):
+def create_backup(request: Request):
     """Create a manual local backup of source-of-truth memory files."""
     from ormah.backup import BackupError
 
@@ -148,7 +148,7 @@ async def create_backup(request: Request):
 
 
 @router.post("/backup/settings")
-async def update_backup_settings(body: BackupSettingsUpdate, request: Request):
+def update_backup_settings(body: BackupSettingsUpdate, request: Request):
     """Update local backup settings for this server and persist them to config."""
     from ormah.backup import service_from_settings
 
@@ -169,14 +169,14 @@ async def update_backup_settings(body: BackupSettingsUpdate, request: Request):
 
 
 @router.post("/rebuild")
-async def rebuild_index(request: Request):
+def rebuild_index(request: Request):
     engine = request.app.state.engine
     count = engine.rebuild_index()
     return {"status": "rebuilt", "nodes_indexed": count}
 
 
 @router.get("/tasks")
-async def list_tasks(request: Request):
+def list_tasks(request: Request):
     """List all registered background tasks and their next run time."""
     scheduler = getattr(request.app.state, "scheduler", None)
     if scheduler is None:
@@ -194,7 +194,7 @@ async def list_tasks(request: Request):
 
 
 @router.post("/tasks/{task_id}/pause")
-async def pause_task(task_id: str, request: Request):
+def pause_task(task_id: str, request: Request):
     """Pause a background task by ID."""
     scheduler = getattr(request.app.state, "scheduler", None)
     if scheduler is None:
@@ -207,7 +207,7 @@ async def pause_task(task_id: str, request: Request):
 
 
 @router.post("/tasks/{task_id}/resume")
-async def resume_task(task_id: str, request: Request):
+def resume_task(task_id: str, request: Request):
     """Resume a paused background task by ID."""
     scheduler = getattr(request.app.state, "scheduler", None)
     if scheduler is None:
@@ -220,7 +220,7 @@ async def resume_task(task_id: str, request: Request):
 
 
 @router.post("/tasks/pause-all")
-async def pause_all_tasks(request: Request):
+def pause_all_tasks(request: Request):
     """Pause all background tasks."""
     scheduler = getattr(request.app.state, "scheduler", None)
     if scheduler is None:
@@ -231,7 +231,7 @@ async def pause_all_tasks(request: Request):
 
 
 @router.post("/tasks/resume-all")
-async def resume_all_tasks(request: Request):
+def resume_all_tasks(request: Request):
     """Resume all background tasks."""
     scheduler = getattr(request.app.state, "scheduler", None)
     if scheduler is None:
@@ -242,7 +242,7 @@ async def resume_all_tasks(request: Request):
 
 
 @router.post("/tasks/{task_id}/run")
-async def run_task(task_id: str, request: Request):
+def run_task(task_id: str, request: Request):
     """Manually trigger a background task by ID."""
     engine = request.app.state.engine
 
@@ -264,7 +264,7 @@ async def run_task(task_id: str, request: Request):
 
 
 @router.post("/tasks/run-all")
-async def run_all_tasks(request: Request):
+def run_all_tasks(request: Request):
     """Run all background tasks sequentially in sleep-cycle order."""
     import importlib
 

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -8,6 +8,7 @@ import time
 from collections import deque
 from typing import Literal
 
+import anyio
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
@@ -38,7 +39,7 @@ class TextResponse(BaseModel):
 
 
 @router.post("/remember", response_model=TextResponse)
-async def remember(
+def remember(
     req: CreateNodeRequest,
     request: Request,
     default_space: str | None = Query(None, description="Fallback space if not set in body"),
@@ -53,7 +54,7 @@ async def remember(
 
 
 @router.post("/recall", response_model=TextResponse)
-async def recall_search(
+def recall_search(
     req: SearchQuery,
     request: Request,
     default_space: str | None = Query(None, description="Default space for result prioritization"),
@@ -76,7 +77,7 @@ async def recall_search(
 
 
 @router.get("/recall/{node_id}", response_model=TextResponse)
-async def recall_node(
+def recall_node(
     node_id: str,
     request: Request,
     session_id: str | None = Query(
@@ -93,7 +94,7 @@ async def recall_node(
 
 
 @router.post("/update/{node_id}", response_model=TextResponse)
-async def update_node(node_id: str, req: UpdateNodeRequest, request: Request):
+def update_node(node_id: str, req: UpdateNodeRequest, request: Request):
     """Update an existing memory."""
     engine = request.app.state.engine
     text = engine.update_node(node_id, req)
@@ -103,7 +104,7 @@ async def update_node(node_id: str, req: UpdateNodeRequest, request: Request):
 
 
 @router.delete("/recall/{node_id}", response_model=TextResponse)
-async def delete_node(node_id: str, request: Request):
+def delete_node(node_id: str, request: Request):
     """Delete a memory by ID."""
     engine = request.app.state.engine
     text = engine.delete_node(node_id)
@@ -113,7 +114,7 @@ async def delete_node(node_id: str, request: Request):
 
 
 @router.post("/connect", response_model=TextResponse)
-async def connect(req: ConnectRequest, request: Request):
+def connect(req: ConnectRequest, request: Request):
     """Create a connection between two memories."""
     engine = request.app.state.engine
     text = engine.connect(req)
@@ -154,9 +155,11 @@ async def whisper(request: Request):
         # Append current prompt to the buffer
         buf.append((prompt.strip(), now))
 
-    text = engine.get_whisper_context(
-        prompt=prompt, space=space, recent_prompts=recent_prompts,
-        session_id=session_id,
+    text = await anyio.to_thread.run_sync(
+        lambda: engine.get_whisper_context(
+            prompt=prompt, space=space, recent_prompts=recent_prompts,
+            session_id=session_id,
+        )
     )
     return TextResponse(text=text)
 
@@ -168,7 +171,7 @@ class FeedbackRequest(BaseModel):
 
 
 @router.post("/feedback", response_model=TextResponse)
-async def submit_feedback(request: Request, body: FeedbackRequest):
+def submit_feedback(request: Request, body: FeedbackRequest):
     """Record explicit or implicit feedback signal for a whisper candidate."""
     engine = request.app.state.engine
     text = engine.submit_feedback(
@@ -184,7 +187,7 @@ class MarkOutdatedBody(BaseModel):
 
 
 @router.post("/outdated/{node_id}", response_model=TextResponse)
-async def mark_outdated(node_id: str, request: Request, body: MarkOutdatedBody | None = None):
+def mark_outdated(node_id: str, request: Request, body: MarkOutdatedBody | None = None):
     """Mark a memory as outdated."""
     engine = request.app.state.engine
     reason = body.reason if body else None
@@ -195,7 +198,7 @@ async def mark_outdated(node_id: str, request: Request, body: MarkOutdatedBody |
 
 
 @router.get("/insights")
-async def get_insights(request: Request):
+def get_insights(request: Request):
     """Get belief evolutions and conflicting ideas detected by the system."""
     engine = request.app.state.engine
     conn = engine.db.conn
@@ -235,7 +238,7 @@ async def get_insights(request: Request):
 
 
 @router.get("/proposals")
-async def get_proposals(request: Request):
+def get_proposals(request: Request):
     """Get pending proposals with enriched source node details."""
     engine = request.app.state.engine
     rows = engine.db.conn.execute(
@@ -275,7 +278,7 @@ async def get_proposals(request: Request):
 
 
 @router.post("/proposals/{proposal_id}")
-async def resolve_proposal(proposal_id: str, body: ResolveProposalRequest, request: Request):
+def resolve_proposal(proposal_id: str, body: ResolveProposalRequest, request: Request):
     """Approve or reject a proposal. Executes merge on approval."""
     engine = request.app.state.engine
     from datetime import datetime, timezone
@@ -337,14 +340,14 @@ class MaintenanceRequest(BaseModel):
 
 
 @router.get("/maintenance")
-async def get_maintenance_status(request: Request, job_id: str | None = Query(None)):
+def get_maintenance_status(request: Request, job_id: str | None = Query(None)):
     """Get current maintenance job status and any ready results."""
     manager = _maintenance_manager(request)
     return manager.get_status(job_id=job_id)
 
 
 @router.post("/maintenance")
-async def run_maintenance(request: Request, body: MaintenanceRequest, response: Response):
+def run_maintenance(request: Request, body: MaintenanceRequest, response: Response):
     """Claude-in-the-loop maintenance: get pending work or apply Claude's decisions.
 
     Phase 1 — call with no body (or ``{}``):
@@ -372,7 +375,7 @@ async def run_maintenance(request: Request, body: MaintenanceRequest, response: 
 
 
 @router.get("/merges")
-async def list_merges(
+def list_merges(
     request: Request,
     limit: int = Query(20, description="Maximum number of merges to return"),
 ):
@@ -383,7 +386,7 @@ async def list_merges(
 
 
 @router.get("/audit")
-async def list_audit_log(
+def list_audit_log(
     request: Request,
     limit: int = Query(20, description="Maximum number of entries to return"),
     node_id: str | None = Query(None, description="Filter by node ID"),
@@ -395,7 +398,7 @@ async def list_audit_log(
 
 
 @router.post("/merges/{merge_id}/undo", response_model=TextResponse)
-async def undo_merge(merge_id: str, request: Request):
+def undo_merge(merge_id: str, request: Request):
     """Undo a merge by ID."""
     engine = request.app.state.engine
     text = engine.undo_merge(merge_id)

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -123,7 +123,14 @@ def connect(req: ConnectRequest, request: Request):
 
 @router.post("/whisper", response_model=TextResponse)
 async def whisper(request: Request):
-    """Build compact whisper context for involuntary recall injection."""
+    """Build compact whisper context for involuntary recall injection.
+
+    Must stay ``async def``: the ``_session_buffers`` mutation below runs on the
+    event loop with no ``await`` in between, so asyncio serializes it across
+    concurrent requests. Converting this to a sync ``def`` would move it to the
+    threadpool and expose ``_session_buffers`` to a data race — guard it with a
+    lock first if you ever do.
+    """
     body = await request.json()
     prompt = body.get("prompt", "")
     space = body.get("space")

--- a/src/ormah/api/routes_ingest.py
+++ b/src/ormah/api/routes_ingest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import anyio
 from fastapi import APIRouter, HTTPException, Query, Request, UploadFile, File
 from pydantic import BaseModel
 
@@ -16,7 +17,7 @@ class ConversationLog(BaseModel):
 
 
 @router.post("/conversation")
-async def ingest_conversation(
+def ingest_conversation(
     log: ConversationLog,
     request: Request,
     default_space: str | None = Query(None, description="Default space for extracted memories"),
@@ -56,9 +57,12 @@ async def ingest_file(request: Request, file: UploadFile = File(...)):
     if len(raw) > _MAX_UPLOAD_BYTES:
         raise HTTPException(status_code=413, detail="File too large (max 10 MB)")
     content = raw.decode("utf-8")
-    result = engine.ingest_conversation(
-        content=content,
-        agent_id=f"file:{file.filename}",
+    filename = file.filename
+    result = await anyio.to_thread.run_sync(
+        lambda: engine.ingest_conversation(
+            content=content,
+            agent_id=f"file:{filename}",
+        )
     )
     if isinstance(result, str):
         return {"status": "error", "result": result, "extracted": 0, "memories": []}

--- a/src/ormah/api/routes_ui.py
+++ b/src/ormah/api/routes_ui.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/ui", tags=["ui"])
 
 
 @router.get("/graph")
-async def get_graph(request: Request):
+def get_graph(request: Request):
     """Get full graph data for visualization."""
     engine = request.app.state.engine
     nodes = engine.db.conn.execute("SELECT * FROM nodes").fetchall()
@@ -22,7 +22,7 @@ async def get_graph(request: Request):
 
 
 @router.get("/graph/node/{node_id}")
-async def get_node_detail(node_id: str, request: Request):
+def get_node_detail(node_id: str, request: Request):
     """Get detailed node info for the side panel."""
     engine = request.app.state.engine
     node = engine.graph.get_node(node_id)
@@ -47,7 +47,7 @@ async def get_node_detail(node_id: str, request: Request):
 
 
 @router.get("/search")
-async def search_nodes(q: str, request: Request, limit: int = 20):
+def search_nodes(q: str, request: Request, limit: int = 20):
     """Search nodes for the UI, returning structured results.
 
     Uses the same hybrid search (FTS + vector) as the MCP agent path
@@ -68,7 +68,7 @@ async def search_nodes(q: str, request: Request, limit: int = 20):
 
 
 @router.get("/insights")
-async def get_insights(request: Request):
+def get_insights(request: Request):
     """Get belief evolutions and unresolved tensions for the insights panel."""
     engine = request.app.state.engine
     conn = engine.db.conn

--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -51,11 +51,13 @@ def run_auto_cluster(engine) -> None:
             assigned += 1
 
         if updates:
-            with engine.db.transaction() as conn:
-                for space_val, node_id in updates:
-                    conn.execute(
-                        "UPDATE nodes SET space = ? WHERE id = ?", (space_val, node_id)
-                    )
+            chunk_size = 100
+            for i in range(0, len(updates), chunk_size):
+                with engine.db.transaction() as conn:
+                    for space_val, node_id in updates[i : i + chunk_size]:
+                        conn.execute(
+                            "UPDATE nodes SET space = ? WHERE id = ?", (space_val, node_id)
+                        )
         if assigned:
             logger.info("Auto-cluster assigned %d nodes to spaces", assigned)
 

--- a/src/ormah/background/importance_scorer.py
+++ b/src/ormah/background/importance_scorer.py
@@ -9,10 +9,20 @@ from datetime import datetime, timezone
 logger = logging.getLogger(__name__)
 
 
+def _commit_updates_chunked(db, updates, chunk_size: int = 100) -> None:
+    """Apply (importance, node_id) updates in bounded write transactions so a
+    full-store batch never holds the write lock long enough to stall foreground writes."""
+    for i in range(0, len(updates), chunk_size):
+        with db.transaction() as conn:
+            for importance_val, nid in updates[i : i + chunk_size]:
+                conn.execute(
+                    "UPDATE nodes SET importance = ? WHERE id = ?",
+                    (importance_val, nid),
+                )
+
+
 def run_importance_scoring(engine) -> None:
     """Iterate all nodes, compute weighted importance, persist changes."""
-    from ormah.store.markdown import parse_node, serialize_node
-
     settings = engine.settings
     conn = engine.db.conn
 
@@ -101,11 +111,6 @@ def run_importance_scoring(engine) -> None:
         updated += 1
 
     if updates:
-        with engine.db.transaction() as conn:
-            for importance_val, nid in updates:
-                conn.execute(
-                    "UPDATE nodes SET importance = ? WHERE id = ?",
-                    (importance_val, nid),
-                )
+        _commit_updates_chunked(engine.db, updates)
     if updated:
         logger.info("Importance scorer: updated %d/%d nodes", updated, len(rows))

--- a/src/ormah/embeddings/hybrid_search.py
+++ b/src/ormah/embeddings/hybrid_search.py
@@ -70,11 +70,17 @@ class HybridSearch:
 
     def __init__(self, db: Database, settings: Settings) -> None:
         self.db = db
-        self.conn = db.conn
         self.settings = settings
-        self.graph = GraphIndex(db.conn)
+        self.graph = GraphIndex(db)
         self.vec_store = VectorStore(db)
         self.encoder = get_encoder(settings)
+
+    @property
+    def conn(self):
+        # Resolve per access so each request thread uses its own thread-local
+        # connection; never capture a single connection (see GraphIndex).
+        db = self.db
+        return db.conn if hasattr(db, "conn") else db
 
     def search(
         self,

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -87,7 +87,7 @@ class MemoryEngine:
         self.db.init_schema()
         self.db.init_vec_table(settings.embedding_dim)
 
-        self.graph = GraphIndex(self.db.conn)
+        self.graph = GraphIndex(self.db)
         self.builder = IndexBuilder(self.db, self.file_store)
         self.tier_manager = TierManager(settings.core_memory_cap)
         self.context_builder = ContextBuilder(self.graph, engine=self)

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -65,22 +65,21 @@ class Database:
         Reentrant per thread: only the outermost call on a given thread issues
         BEGIN/COMMIT/ROLLBACK. Inner (nested) calls are pass-throughs.
         """
-        self._lock.acquire()
-        depth = getattr(self._local, "tx_depth", 0) + 1
-        self._local.tx_depth = depth
-        try:
-            if depth == 1:
-                self.conn.execute("BEGIN IMMEDIATE")
-            yield self.conn
-            if depth == 1:
-                self.conn.execute("COMMIT")
-        except BaseException:
-            if depth == 1:
-                self.conn.execute("ROLLBACK")
-            raise
-        finally:
-            self._local.tx_depth = depth - 1
-            self._lock.release()
+        with self._lock:
+            depth = getattr(self._local, "tx_depth", 0) + 1
+            self._local.tx_depth = depth
+            try:
+                if depth == 1:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                yield self.conn
+                if depth == 1:
+                    self.conn.execute("COMMIT")
+            except BaseException:
+                if depth == 1:
+                    self.conn.execute("ROLLBACK")
+                raise
+            finally:
+                self._local.tx_depth = depth - 1
 
     def init_schema(self) -> None:
         """Create tables from schema.sql."""

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -14,30 +14,50 @@ _SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 
 
 class Database:
-    """Manages a single SQLite connection with WAL mode and serialized writes."""
+    """Manages per-thread SQLite connections with WAL mode and serialized writes."""
 
     def __init__(self, db_path: Path) -> None:
         self.db_path = db_path
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._conn: sqlite3.Connection | None = None
-        self._lock = threading.RLock()
+        self._local = threading.local()
+        self._all_conns: list[sqlite3.Connection] = []
+        self._conns_lock = threading.Lock()
+        self._lock = threading.RLock()  # serializes write transactions across threads
         self._tx_depth = 0
+
+    def _new_connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            str(self.db_path),
+            check_same_thread=False,
+            timeout=10,
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.execute("PRAGMA synchronous=NORMAL")
+        conn.execute("PRAGMA busy_timeout=5000")
+        # sqlite-vec is loaded per connection: a connection without it cannot
+        # query the node_vectors (vec0) virtual table.
+        try:
+            import sqlite_vec
+
+            conn.enable_load_extension(True)
+            sqlite_vec.load(conn)
+            conn.enable_load_extension(False)
+        except ImportError:
+            pass  # sqlite-vec not installed — vector search disabled
+        with self._conns_lock:
+            self._all_conns.append(conn)
+        return conn
 
     @property
     def conn(self) -> sqlite3.Connection:
-        if self._conn is None:
-            self._conn = sqlite3.connect(
-                str(self.db_path),
-                check_same_thread=False,
-                timeout=10,
-                isolation_level=None,
-            )
-            self._conn.row_factory = sqlite3.Row
-            self._conn.execute("PRAGMA journal_mode=WAL")
-            self._conn.execute("PRAGMA foreign_keys=ON")
-            self._conn.execute("PRAGMA synchronous=NORMAL")
-            self._conn.execute("PRAGMA busy_timeout=5000")
-        return self._conn
+        existing = getattr(self._local, "conn", None)
+        if existing is None:
+            existing = self._new_connection()
+            self._local.conn = existing
+        return existing
 
     @contextmanager
     def transaction(self):
@@ -242,6 +262,11 @@ class Database:
             pass  # sqlite-vec not available, vector search disabled
 
     def close(self) -> None:
-        if self._conn is not None:
-            self._conn.close()
-            self._conn = None
+        with self._conns_lock:
+            for conn in self._all_conns:
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001
+                    pass
+            self._all_conns.clear()
+        self._local = threading.local()

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -23,7 +23,6 @@ class Database:
         self._all_conns: list[sqlite3.Connection] = []
         self._conns_lock = threading.Lock()
         self._lock = threading.RLock()  # serializes write transactions across threads
-        self._tx_depth = 0
 
     def _new_connection(self) -> sqlite3.Connection:
         conn = sqlite3.connect(
@@ -63,23 +62,24 @@ class Database:
     def transaction(self):
         """Serialize write transactions across threads.
 
-        Reentrant: only the outermost call issues BEGIN/COMMIT/ROLLBACK.
-        Inner (nested) calls are pass-throughs.
+        Reentrant per thread: only the outermost call on a given thread issues
+        BEGIN/COMMIT/ROLLBACK. Inner (nested) calls are pass-throughs.
         """
         self._lock.acquire()
-        self._tx_depth += 1
+        depth = getattr(self._local, "tx_depth", 0) + 1
+        self._local.tx_depth = depth
         try:
-            if self._tx_depth == 1:
+            if depth == 1:
                 self.conn.execute("BEGIN IMMEDIATE")
             yield self.conn
-            if self._tx_depth == 1:
+            if depth == 1:
                 self.conn.execute("COMMIT")
         except BaseException:
-            if self._tx_depth == 1:
+            if depth == 1:
                 self.conn.execute("ROLLBACK")
             raise
         finally:
-            self._tx_depth -= 1
+            self._local.tx_depth = depth - 1
             self._lock.release()
 
     def init_schema(self) -> None:

--- a/src/ormah/index/graph.py
+++ b/src/ormah/index/graph.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ormah.index.db import Database
 
 logger = logging.getLogger(__name__)
 
@@ -15,8 +18,19 @@ _NOT_EXPIRED = "(n.valid_until IS NULL OR n.valid_until > strftime('%Y-%m-%dT%H:
 class GraphIndex:
     """Graph queries on the SQLite index."""
 
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        self.conn = conn
+    def __init__(self, db: "Database | sqlite3.Connection") -> None:
+        # Hold the Database (not a captured connection) and resolve ``conn`` per
+        # access so every thread reads through its own thread-local connection.
+        # Sharing one sqlite3.Connection across the request threadpool is a data
+        # race — it raises SQLITE_MISUSE ("bad parameter or other API misuse")
+        # and returns corrupted rows under concurrent load. A raw Connection is
+        # still accepted (legacy/tests) and used directly.
+        self._db = db
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        db = self._db
+        return db.conn if hasattr(db, "conn") else db
 
     def get_node(self, node_id: str) -> dict[str, Any] | None:
         row = self.conn.execute("SELECT * FROM nodes WHERE id = ?", (node_id,)).fetchone()

--- a/tests/test_api/test_routes_concurrency.py
+++ b/tests/test_api/test_routes_concurrency.py
@@ -1,0 +1,66 @@
+"""Proves engine-calling routes run in the threadpool, not serialized on the loop."""
+
+import threading
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api.routes_agent import router as agent_router
+from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+
+
+@pytest.fixture
+def client(tmp_memory_dir):
+    settings = Settings(memory_dir=tmp_memory_dir, backup_dir=tmp_memory_dir.parent / "backups")
+    engine = MemoryEngine(settings)
+    engine.startup()
+    app = FastAPI()
+    app.include_router(agent_router)
+    app.state.engine = engine
+    with TestClient(app) as c:
+        yield c, engine
+    engine.shutdown()
+
+
+def test_recall_routes_run_concurrently(client):
+    c, engine = client
+
+    live = 0
+    max_live = 0
+    counter_lock = threading.Lock()
+
+    def slow_recall(*args, **kwargs):
+        nonlocal live, max_live
+        with counter_lock:
+            live += 1
+            max_live = max(max_live, live)
+        time.sleep(0.3)
+        with counter_lock:
+            live -= 1
+        return "ok"
+
+    engine.recall_search = slow_recall  # type: ignore[method-assign]
+
+    results: list[int] = []
+
+    def hit():
+        r = c.post("/agent/recall", json={"query": "x", "limit": 3})
+        results.append(r.status_code)
+
+    n = 5
+    threads = [threading.Thread(target=hit) for _ in range(n)]
+    start = time.monotonic()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    wall = time.monotonic() - start
+
+    assert results == [200] * n
+    # If routes ran on the event loop they would serialize: wall ~= n*0.3 = 1.5s
+    # and max_live would be 1. In the threadpool they overlap.
+    assert max_live >= 2, f"routes serialized (max concurrent = {max_live})"
+    assert wall < 0.3 * n, f"wall {wall:.2f}s suggests serialization"

--- a/tests/test_background/test_chunked_writes.py
+++ b/tests/test_background/test_chunked_writes.py
@@ -1,0 +1,42 @@
+"""The all-nodes write in importance_scorer must commit in bounded chunks."""
+
+from ormah.background.importance_scorer import _commit_updates_chunked
+
+
+class _RecordingDB:
+    def __init__(self):
+        self.transactions = 0
+        self.executed = 0
+
+    def transaction(self):
+        db = self
+
+        class _Ctx:
+            def __enter__(self_inner):
+                db.transactions += 1
+                return self_inner
+
+            def __exit__(self_inner, *a):
+                return False
+
+            def execute(self_inner, *a, **k):
+                db.executed += 1
+
+        return _Ctx()
+
+
+def test_commit_updates_chunked_splits_into_batches():
+    db = _RecordingDB()
+    updates = [(0.5, f"id-{i}") for i in range(250)]
+
+    _commit_updates_chunked(db, updates, chunk_size=100)
+
+    # 250 updates / 100 per chunk = 3 transactions (100, 100, 50)
+    assert db.transactions == 3
+    assert db.executed == 250
+
+
+def test_commit_updates_chunked_empty():
+    db = _RecordingDB()
+    _commit_updates_chunked(db, [], chunk_size=100)
+    assert db.transactions == 0

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -221,9 +221,9 @@ def test_batch_query_used(engine):
             tier=Tier.working,
         ))
 
-    # Patch the Database._conn with a tracking wrapper to count edge queries.
+    # Patch the thread-local connection with a tracking wrapper to count edge queries.
     db = engine.db
-    original_conn = db._conn
+    original_conn = db.conn  # ensures the thread-local conn is initialised
 
     query_log = []
 
@@ -240,11 +240,11 @@ def test_batch_query_used(engine):
         def __getattr__(self, name):
             return getattr(self._real, name)
 
-    db._conn = TrackingConnection(original_conn)
+    db._local.conn = TrackingConnection(original_conn)
     try:
         run_importance_scoring(engine)
     finally:
-        db._conn = original_conn
+        db._local.conn = original_conn
 
     # Should have at most 1 edge-related query (the batch), not N
     assert len(query_log) <= 1

--- a/tests/test_engine/test_recall_concurrency.py
+++ b/tests/test_engine/test_recall_concurrency.py
@@ -1,0 +1,67 @@
+"""Concurrency regression: recall must be safe when routes run in the threadpool.
+
+The server runs engine-bound routes off the event loop (Starlette threadpool), so
+``recall_search`` executes on many threads at once. GraphIndex / HybridSearch must
+therefore resolve the per-thread ``Database`` connection on every access instead of
+capturing a single shared ``sqlite3.Connection`` at construction. A shared connection
+used concurrently raises ``sqlite3.InterfaceError: bad parameter or other API misuse``
+(SQLITE_MISUSE) and returns corrupted rows under load.
+"""
+
+import threading
+
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType
+
+
+def _remember(engine, content):
+    req = CreateNodeRequest(content=content, type=NodeType.fact, title=content[:40], tags=["t"])
+    node_id, _ = engine.remember(req, agent_id="test")
+    return node_id
+
+
+def test_graph_conn_is_per_thread(engine):
+    """engine.graph.conn must resolve to the calling thread's own connection."""
+    main_conn = id(engine.graph.conn)
+    worker_conn: dict[str, int] = {}
+
+    def grab():
+        worker_conn["id"] = id(engine.graph.conn)
+
+    t = threading.Thread(target=grab)
+    t.start()
+    t.join()
+
+    # A worker thread reading engine.graph.conn gets a *different* connection
+    # object than the main thread — proof the connection is not captured/shared.
+    assert worker_conn["id"] != main_conn
+
+
+def test_concurrent_recall_does_not_raise(engine):
+    """Hammering recall_search from many threads must not raise (shared-conn race)."""
+    ids = [_remember(engine, f"memory {i} about postgres indexing and tuning strategy {i}") for i in range(30)]
+    # Add edges so spreading activation exercises the graph read path on every recall.
+    for i in range(0, len(ids) - 1):
+        engine.connect(
+            ConnectRequest(source_id=ids[i], target_id=ids[i + 1], edge=EdgeType.related_to, weight=0.8)
+        )
+
+    errors: list[str] = []
+    stop = threading.Event()
+
+    def hammer():
+        try:
+            for _ in range(40):
+                if stop.is_set():
+                    break
+                engine.recall_search("postgres indexing tuning", limit=8)
+        except Exception as e:  # noqa: BLE001
+            errors.append(repr(e))
+            stop.set()
+
+    threads = [threading.Thread(target=hammer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent recall raised: {errors[:3]}"

--- a/tests/test_index/test_db_concurrency.py
+++ b/tests/test_index/test_db_concurrency.py
@@ -1,0 +1,99 @@
+"""Concurrency tests for the thread-local Database connection model."""
+
+import threading
+import time
+
+import numpy as np
+
+from ormah.index.db import Database
+
+
+def _init_db(tmp_path):
+    db = Database(tmp_path / "index.db")
+    db.init_schema()
+    db.init_vec_table(8)
+    return db
+
+
+def test_each_thread_gets_distinct_connection(tmp_path):
+    db = _init_db(tmp_path)
+    conns: dict[int, int] = {}
+
+    def grab():
+        conns[threading.get_ident()] = id(db.conn)
+
+    threads = [threading.Thread(target=grab) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # main thread connection is distinct from every worker's
+    main_id = id(db.conn)
+    assert len(set(conns.values())) == 4
+    assert main_id not in conns.values()
+    db.close()
+
+
+def test_vector_search_works_from_worker_thread(tmp_path):
+    """Regression: vec0 module is loaded per connection; a fresh thread must
+    still be able to query node_vectors."""
+    db = _init_db(tmp_path)
+    vec = np.ones(8, dtype=np.float32)
+    import struct
+
+    blob = struct.pack("8f", *vec)
+    with db.transaction() as conn:
+        conn.execute("INSERT INTO node_vectors (id, embedding) VALUES (?, ?)", ("n1", blob))
+
+    result: dict = {}
+
+    def search():
+        try:
+            rows = db.conn.execute(
+                "SELECT id FROM node_vectors WHERE embedding MATCH ? ORDER BY distance LIMIT 1",
+                (blob,),
+            ).fetchall()
+            result["ids"] = [r[0] for r in rows]
+        except Exception as e:  # noqa: BLE001
+            result["error"] = repr(e)
+
+    t = threading.Thread(target=search)
+    t.start()
+    t.join()
+
+    assert "error" not in result, result.get("error")
+    assert result["ids"] == ["n1"]
+    db.close()
+
+
+def test_read_during_write_does_not_block(tmp_path):
+    """A read on thread B returns promptly while thread A holds a write tx."""
+    db = _init_db(tmp_path)
+    with db.transaction() as conn:
+        conn.execute("INSERT INTO meta (key, value) VALUES ('k', 'v')")
+
+    write_holding = threading.Event()
+    release_write = threading.Event()
+
+    def slow_writer():
+        with db.transaction() as conn:
+            conn.execute("UPDATE meta SET value = 'v2' WHERE key = 'k'")
+            write_holding.set()
+            release_write.wait(timeout=5)
+
+    wt = threading.Thread(target=slow_writer)
+    wt.start()
+    assert write_holding.wait(timeout=5)
+
+    # Reader on the main thread must not wait for the writer to commit.
+    start = time.monotonic()
+    row = db.conn.execute("SELECT value FROM meta WHERE key = 'k'").fetchone()
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, f"read blocked {elapsed:.2f}s on the writer"
+    assert row["value"] == "v"  # WAL: reader sees last committed snapshot
+
+    release_write.set()
+    wt.join()
+    db.close()


### PR DESCRIPTION
Fixes #18.

## Summary

The server froze under load and MCP `remember` calls timed out at 30s because synchronous,
lock/CPU-heavy engine work ran directly on the asyncio event loop, while a single shared SQLite
connection and a global write `RLock` were contended by nine background threads. One long
background write batch parked the event loop in `_lock.acquire()` and stalled every queued request.

This PR removes the freeze with three changes:

1. **Thread-local SQLite connections** (`index/db.py`). Each thread gets its own `sqlite3.Connection`
   (pragmas applied per connection, and **sqlite-vec loaded per connection** — a fresh connection
   without `vec0` cannot query `node_vectors`). WAL gives N concurrent readers + 1 writer; writes
   stay serialized by the existing process-wide `RLock`. The transaction depth counter is now
   thread-local, and the lock is acquired via `with self._lock:` so it can never leak.

2. **Routes off the event loop** (`api/routes_*.py`). Engine-bound routes become plain `def` so
   Starlette dispatches them to its threadpool; routes that must `await` (read the request body,
   websocket) stay `async def` and wrap the blocking engine call in `anyio.to_thread.run_sync`.
   A slow request no longer freezes the whole server.

3. **Chunked background writes** (`background/importance_scorer.py`, `background/auto_cluster.py`).
   These jobs wrapped an all-nodes UPDATE loop in a single transaction; they now commit in chunks of
   100 to bound how long the write lock is held, so a foreground `remember` write isn't stalled
   behind a full-store batch.

## Test plan

New regression tests:

- `tests/test_index/test_db_concurrency.py` — distinct connection per thread; vector search from a
  worker thread (the sqlite-vec landmine); read-during-write does not block.
- `tests/test_api/test_routes_concurrency.py` — engine-bound routes overlap in the threadpool
  (max concurrency ≥ 2, wall-clock ≪ N × single).
- `tests/test_background/test_chunked_writes.py` — the all-nodes write splits into bounded chunks.

Full suite: `python -m pytest tests/` — all green (4 unrelated pre-existing failures in
`test_config.py`/`test_setup.py` are not touched by this PR).

## Verified live (populated store)

- 20 concurrent `/admin/health`: **0.033s** (event loop free, fully parallel).
- 10 concurrent `remember`: **1.75s, all 200** — previously timed out at 30s.
- Freeze test: `recall` stays responsive (~1s) while a heavy `remember` runs — previously returned
  a client timeout (event-loop block).

## Notes / out of scope

- `recall` throughput is still GIL-bound on model inference (concurrent recalls serialize on the
  embedding encode). That is a CPU characteristic, not the freeze bug; true parallelism would need
  process-level inference workers.
- A separate pre-existing crash exists in `engine.memory_engine._spread_activation`
  (`float * None` when an activation input is `None`); not addressed here.
