### PR TITLE
fix(engine): guard against None weight/score in _spread_activation

### DIFF
--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1719,7 +1719,8 @@ class MemoryEngine:
         for seed in seeds:
             seed_node = seed["node"] if "node" in seed else seed
             seed_id = seed_node["id"]
-            seed_score = seed.get("score", 1.0)
+            _s = seed.get("score")
+            seed_score = _s if _s is not None else 1.0
 
             edges = self.graph.get_edges_for(seed_id)
 
@@ -1733,7 +1734,8 @@ class MemoryEngine:
                     continue
 
                 edge_type = edge["edge_type"]
-                edge_weight = edge.get("weight", 0.5)
+                _w = edge.get("weight")
+                edge_weight = _w if _w is not None else 0.5
                 type_factor = _EDGE_TYPE_FACTORS.get(edge_type, 0.5)
                 score = seed_score * edge_weight * type_factor * decay
                 candidates.append((neighbor_id, score, edge_type))
@@ -1763,7 +1765,7 @@ class MemoryEngine:
 
         # Merge direct + activated results, sort by score descending
         merged = results + activated_results
-        merged.sort(key=lambda x: x.get("score", 0), reverse=True)
+        merged.sort(key=lambda x: (x.get("score") or 0), reverse=True)
 
         return merged[:limit]
 

--- a/tests/test_engine/test_spreading_activation.py
+++ b/tests/test_engine/test_spreading_activation.py
@@ -213,6 +213,29 @@ def test_merged_sort_order(engine):
     assert neighbor_pos < low_pos, "Activated neighbor should rank above low-score direct hit"
 
 
+def test_null_edge_weight_and_seed_score_do_not_raise(engine):
+    """_spread_activation must not crash when edge weight or seed score is None (issue #20).
+
+    dict.get(key, default) only uses the default when the key is absent; a present-but-None
+    value slips through and causes TypeError on the float multiplication.  This test exercises
+    both NULL-weight edges and None seed scores directly.
+    """
+    seed_id = _remember(engine, "Seed node for null-weight test")
+    neighbor_id = _remember(engine, "Neighbor node for null-weight test")
+    _connect(engine, seed_id, neighbor_id, EdgeType.supports, weight=0.8)
+
+    # Force the edge weight to None as it could arrive from a NULL DB column
+    for edge in engine.graph.get_edges_for(seed_id):
+        edge["weight"] = None
+
+    # Also simulate a seed whose score column was NULL
+    seed_result = {"node": engine.graph.get_node(seed_id), "score": None, "source": "hybrid"}
+
+    enriched = engine._spread_activation([seed_result], limit=10)
+    # Should not raise; neighbor may or may not appear, but we get a list back
+    assert isinstance(enriched, list)
+
+
 def test_spread_activation_honors_total_limit(engine):
     """Activated results compete within the requested total result budget."""
     low_hit = _remember(engine, "Low relevance node")


### PR DESCRIPTION
## Summary

- `dict.get(key, default)` only falls back when the key is **absent**; a `NULL` DB column produces a present-but-`None` value that bypasses the default and causes `TypeError` on the float multiplication
- Fixes three call sites in `_spread_activation`: `seed.get("score")`, `edge.get("weight")`, and the `merged.sort` key — all now treat `None` identically to a missing key
- Adds a regression test that forces both `score=None` and `edge["weight"]=None` and asserts no exception is raised

Closes #20

## Test plan

- [ ] `uv run pytest tests/test_engine/test_spreading_activation.py -v` → all 11 tests pass
- [ ] New test `test_null_edge_weight_and_seed_score_do_not_raise` exercises the exact conditions from the issue report

🤖 Generated with [Claude Code](https://claude.com/claude-code)