### PR TITLE
fix(llm): add num_predict to Ollama adapter to prevent truncated JSON responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,8 @@ ORMAH_LLM_MODEL=llama3.2
 
 # ── Ollama settings (only when ORMAH_LLM_PROVIDER=ollama) ────────────────────
 ORMAH_LLM_BASE_URL=http://localhost:11434
+# Maximum tokens Ollama may generate for one LLM response.
+# ORMAH_LLM_NUM_PREDICT=4096
 
 # ── LLM timeout (applies to all providers) ───────────────────────────────────
 # Maximum seconds to wait for an LLM response before giving up.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Today, setup can wire up:
 - Codex
 - Claude Desktop (MCP)
 
-Local search, embeddings, storage, the graph UI, and whisper retrieval do not require an API key. If you want Ormah's LLM-backed features to run independently of your agent, setup can opt into a provider explicitly. Ormah stores only provider policy in `~/.config/ormah/.env`; it does not copy API key values into its config.
+Local search, embeddings, storage, the graph UI, and whisper retrieval do not require an API key. If you want Ormah's LLM-backed features to run independently of your agent, setup can opt into a provider explicitly. Ormah stores only provider policy in `~/.config/ormah/.env`; it does not copy API key values into its config. Local Ollama generation uses a configurable `ORMAH_LLM_NUM_PREDICT` token budget.
 
 ## Features
 

--- a/docs/11 - Setup and Installation.md
+++ b/docs/11 - Setup and Installation.md
@@ -1,6 +1,6 @@
 # Setup and Installation
 
-Verified against the current repository state on 2026-04-07.
+Verified against the current repository state on 2026-06-09.
 
 Ormah ships with an interactive setup flow that configures the server, supported client integrations, and optional transcript backfill.
 
@@ -63,6 +63,7 @@ Repository defaults in `config.py` are:
 - `llm_provider = none`
 - `llm_model = claude-haiku-4-5-20251001`
 - `llm_base_url = http://localhost:11434`
+- `llm_num_predict = 4096`
 - `llm_inherit_api_key = false`
 
 `ormah setup` can rewrite the persisted `.env` to:

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -1,6 +1,6 @@
 # Configuration Reference
 
-Verified against the current repository state on 2026-04-26.
+Verified against the current repository state on 2026-06-09.
 
 All settings live in `src/ormah/config.py` and use the `ORMAH_` prefix.
 
@@ -59,10 +59,11 @@ for manual backup workflows.
 | `llm_model` | `claude-haiku-4-5-20251001` |
 | `llm_base_url` | `http://localhost:11434` |
 | `llm_timeout_seconds` | `60` |
+| `llm_num_predict` | `4096` |
 | `llm_api_key_env_var` | unset |
 | `llm_inherit_api_key` | `false` |
 
-Note: setup may persist different values in `.env`. For remote providers, Ormah stores only key policy, such as `ORMAH_LLM_API_KEY_ENV_VAR=ANTHROPIC_API_KEY`; it does not store API key values.
+Note: setup may persist different values in `.env`. For remote providers, Ormah stores only key policy, such as `ORMAH_LLM_API_KEY_ENV_VAR=ANTHROPIC_API_KEY`; it does not store API key values. `llm_num_predict` maps to Ollama's `options.num_predict` request field.
 
 ## Background Intervals
 

--- a/src/ormah/background/llm/__init__.py
+++ b/src/ormah/background/llm/__init__.py
@@ -28,6 +28,7 @@ def get_adapter(settings) -> LLMAdapter | None:
             model=settings.llm_model,
             base_url=settings.llm_base_url,
             timeout=timeout,
+            num_predict=getattr(settings, "llm_num_predict", 4096),
         )
 
     if provider == "litellm":

--- a/src/ormah/background/llm/ollama_adapter.py
+++ b/src/ormah/background/llm/ollama_adapter.py
@@ -15,10 +15,12 @@ class OllamaAdapter(LLMAdapter):
         model: str,
         base_url: str = "http://localhost:11434",
         timeout: int = 60,
+        num_predict: int = 4096,
     ) -> None:
         self.model = model
         self.base_url = base_url
         self.timeout = timeout
+        self.num_predict = num_predict
 
     def generate(self, prompt: str, json_mode: bool = True) -> str | None:
         import httpx
@@ -27,6 +29,7 @@ class OllamaAdapter(LLMAdapter):
             "model": self.model,
             "prompt": prompt,
             "stream": False,
+            "options": {"num_predict": self.num_predict},
         }
         if json_mode:
             payload["format"] = "json"

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -45,6 +45,7 @@ class Settings(BaseSettings):
     llm_model: str = "claude-haiku-4-5-20251001"
     llm_base_url: str = "http://localhost:11434"
     llm_timeout_seconds: int = 60
+    llm_num_predict: int = 4096
     llm_api_key_env_var: str | None = None
     llm_inherit_api_key: bool = False
 
@@ -260,6 +261,13 @@ class Settings(BaseSettings):
     def _llm_timeout_positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError(f"llm_timeout_seconds must be >= 1, got {v}")
+        return v
+
+    @field_validator("llm_num_predict")
+    @classmethod
+    def _llm_num_predict_positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(f"llm_num_predict must be >= 1, got {v}")
         return v
 
     @field_validator("embedding_dim")

--- a/tests/test_background/test_llm_adapters.py
+++ b/tests/test_background/test_llm_adapters.py
@@ -14,6 +14,7 @@ class _FakeSettings:
     llm_provider: str = "ollama"
     llm_model: str = "llama3.2"
     llm_base_url: str = "http://localhost:11434"
+    llm_num_predict: int = 2048
 
 
 # --- OllamaAdapter ---
@@ -30,6 +31,23 @@ def test_ollama_adapter_success():
     assert result == '{"answer": 42}'
     call_kwargs = mock_post.call_args
     assert call_kwargs[1]["json"]["format"] == "json"
+    assert call_kwargs[1]["json"]["options"] == {"num_predict": 4096}
+
+
+def test_ollama_adapter_custom_num_predict():
+    adapter = OllamaAdapter(model="llama3.2", num_predict=1024)
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": '{"answer": 42}'}
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("httpx.post", return_value=mock_resp) as mock_post:
+        result = adapter.generate("test prompt", json_mode=False)
+
+    assert result == '{"answer": 42}'
+    call_kwargs = mock_post.call_args
+    payload = call_kwargs[1]["json"]
+    assert payload["options"] == {"num_predict": 1024}
+    assert "format" not in payload
 
 
 def test_ollama_adapter_timeout():
@@ -80,6 +98,7 @@ def test_get_adapter_ollama():
     settings.llm_provider = "ollama"
     adapter = get_adapter(settings)
     assert isinstance(adapter, OllamaAdapter)
+    assert adapter.num_predict == 2048
 
 
 def test_get_adapter_litellm():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,6 +67,22 @@ def test_timeout_zero():
         _settings(llm_timeout_seconds=0)
 
 
+def test_llm_num_predict_default():
+    s = _settings()
+    assert s.llm_num_predict == 4096
+
+
+def test_llm_num_predict_env(monkeypatch):
+    monkeypatch.setenv("ORMAH_LLM_NUM_PREDICT", "1024")
+    s = Settings(memory_dir="/tmp/ormah_test")
+    assert s.llm_num_predict == 1024
+
+
+def test_llm_num_predict_zero():
+    with pytest.raises(ValidationError, match="llm_num_predict must be >= 1"):
+        _settings(llm_num_predict=0)
+
+
 # --- Embedding dim ---
 
 def test_embedding_dim_zero():


### PR DESCRIPTION
## Summary

- `OllamaAdapter` now sends `options: {"num_predict": self.num_predict}` with every `/api/generate` request (default 4096 tokens)
- New `ORMAH_LLM_NUM_PREDICT` env var / `Settings.llm_num_predict` field lets users tune the budget for constrained setups
- Validated against a live `gemma3:4b` instance: `num_predict=100` silently returns `{}`, `num_predict=4096` returns all extracted memories correctly

## Root cause

`dict.get(key, default)` on the Ollama payload had no `options` key at all. Ollama's default `num_predict` was 128 tokens on older versions (≤ 0.2.x), causing hard truncation mid-JSON and `JSONDecodeError`. On newer Ollama (0.3.x+) the default flipped to unlimited, but an explicit value is still needed for predictable behaviour across versions.

## Test plan

- [x] `uv run pytest tests/test_background/test_llm_adapters.py tests/test_config.py` — 42 passed
- [x] Live smoke test against `gemma3:4b`: confirmed truncated JSON with low `num_predict`, full extraction with 4096

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)