### PR TITLE
fix(llm): disable Ollama thinking so it doesn't starve JSON extraction

### DIFF
--- a/src/ormah/background/llm/ollama_adapter.py
+++ b/src/ormah/background/llm/ollama_adapter.py
@@ -29,6 +29,10 @@ class OllamaAdapter(LLMAdapter):
             "model": self.model,
             "prompt": prompt,
             "stream": False,
+            # Disable thinking: reasoning tokens consume the num_predict budget
+            # and on large transcripts starve the JSON, yielding empty/truncated
+            # extractions. Non-thinking models ignore this flag.
+            "think": False,
             "options": {"num_predict": self.num_predict},
         }
         if json_mode:

--- a/tests/test_background/test_llm_adapters.py
+++ b/tests/test_background/test_llm_adapters.py
@@ -32,6 +32,10 @@ def test_ollama_adapter_success():
     call_kwargs = mock_post.call_args
     assert call_kwargs[1]["json"]["format"] == "json"
     assert call_kwargs[1]["json"]["options"] == {"num_predict": 4096}
+    # Thinking is disabled so the num_predict budget is spent on the JSON, not
+    # on reasoning tokens (which starved extraction and produced empty/truncated
+    # responses on large transcripts). Safely ignored by non-thinking models.
+    assert call_kwargs[1]["json"]["think"] is False
 
 
 def test_ollama_adapter_custom_num_predict():
@@ -48,6 +52,8 @@ def test_ollama_adapter_custom_num_predict():
     payload = call_kwargs[1]["json"]
     assert payload["options"] == {"num_predict": 1024}
     assert "format" not in payload
+    # think:False is sent regardless of json_mode
+    assert payload["think"] is False
 
 
 def test_ollama_adapter_timeout():


### PR DESCRIPTION
## Problem

qwen3-family models (e.g. `qwen3.5:4b`) are thinking-on by default. Ollama counts the reasoning tokens against `num_predict`, so on large transcripts the model spends the budget thinking and returns an **empty or truncated** response. The structured-JSON extraction in `OllamaAdapter.generate(json_mode=True)` then fails with `Expecting value: line 1 column 1` / `Extra data` / truncated JSON, and the memory is silently dropped.

## Fix

Send `think: false` on the `/api/generate` payload (top-level, alongside `format: json`).

## Evidence

Measured on a real ~2,000-file transcript ingest with `qwen3.5:4b-mlx`:

| | LLM attempts | failures | rate |
|---|---|---|---|
| think on (default) | 80 | 21 | **26%** |
| think off | 22 | 3 | **14%** |

Re-running over the previously-failing files, **19 of 22 were recovered** with thinking disabled.

## Safety

Non-thinking models ignore the flag — verified against `gemma3:4b` (clean `{"ok": true}` response, no error). So this is safe for every Ollama LLM backend, not just thinking-capable ones.

## Tests

`tests/test_background/test_llm_adapters.py` asserts `think: false` is present in the payload regardless of `json_mode`. Full adapter suite green (9 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)