### PR TITLE
fix(server): exit cleanly on port conflict instead of KeepAlive respawn loop

### DIFF
--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -61,6 +61,19 @@ def _cmd_server_start(args):
     else:
         import uvicorn
         from ormah.config import settings
+        from ormah.console import info
+        from ormah.server_manager import is_port_in_use
+
+        # Pre-flight: if the port is already taken (typically by an existing
+        # ormah server), exit cleanly instead of letting uvicorn crash on bind.
+        # Under launchd/systemd KeepAlive this prevents a respawn loop that would
+        # re-run expensive startup work on every restart.
+        if is_port_in_use(settings.host, settings.port):
+            info(
+                f"A process is already listening on {settings.host}:{settings.port}; "
+                "assuming an ormah server is already running. Exiting."
+            )
+            return
 
         uvicorn.run(
             "ormah.main:app",

--- a/src/ormah/server_manager.py
+++ b/src/ormah/server_manager.py
@@ -9,6 +9,7 @@ import re
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -59,7 +60,11 @@ PLIST_TEMPLATE = """\
     <key>PATH</key><string>{bin_dir}:/usr/local/bin:/usr/bin:/bin</string>
   </dict>
   <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key><false/>
+  </dict>
+  <key>ThrottleInterval</key><integer>30</integer>
 </dict>
 </plist>
 """
@@ -86,6 +91,18 @@ def is_server_running() -> bool:
             return r.status_code == 200
     except Exception:
         return False
+
+
+def is_port_in_use(host: str, port: int) -> bool:
+    """Return True if something is already accepting connections on host:port.
+
+    Used as a pre-flight before binding: if another process (typically an
+    already-running ormah server) owns the port, the launcher exits cleanly
+    instead of letting uvicorn crash on bind and KeepAlive respawn it in a loop.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex((host, port)) == 0
 
 
 def install_launchd_agent(ormah_bin: str, wrapper_path: str | None = None) -> None:

--- a/src/ormah/server_manager.py
+++ b/src/ormah/server_manager.py
@@ -100,9 +100,11 @@ def is_port_in_use(host: str, port: int) -> bool:
     already-running ormah server) owns the port, the launcher exits cleanly
     instead of letting uvicorn crash on bind and KeepAlive respawn it in a loop.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(0.5)
-        return sock.connect_ex((host, port)) == 0
+    try:
+        with socket.create_connection((host, port), timeout=0.5):
+            return True
+    except OSError:
+        return False
 
 
 def install_launchd_agent(ormah_bin: str, wrapper_path: str | None = None) -> None:

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import socket
 from unittest import mock
 
+import pytest
+
 from ormah import server_manager
 
 
@@ -24,6 +26,24 @@ def test_is_port_in_use_false_when_nothing_listening():
         probe.bind(("127.0.0.1", 0))
         host, port = probe.getsockname()
     assert server_manager.is_port_in_use(host, port) is False
+
+
+def test_is_port_in_use_false_for_unused_ipv6_literal():
+    """An IPv6 host literal must not fail the pre-flight probe."""
+    assert server_manager.is_port_in_use("::1", 0) is False
+
+
+def test_is_port_in_use_true_when_ipv6_socket_listening():
+    """An IPv6 listening socket is reported as in use when IPv6 is available."""
+    with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as srv:
+        try:
+            srv.bind(("::1", 0))
+        except OSError as exc:
+            pytest.skip(f"IPv6 loopback unavailable: {exc}")
+
+        srv.listen(1)
+        _host, port, *_rest = srv.getsockname()
+        assert server_manager.is_port_in_use("::1", port) is True
 
 
 def test_plist_keepalive_only_on_unsuccessful_exit():

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -1,0 +1,73 @@
+"""Tests for server lifecycle helpers: port-conflict detection and launchd plist."""
+
+from __future__ import annotations
+
+import socket
+from unittest import mock
+
+from ormah import server_manager
+
+
+def test_is_port_in_use_true_when_socket_listening():
+    """A bound, listening socket is reported as in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        host, port = srv.getsockname()
+        assert server_manager.is_port_in_use(host, port) is True
+
+
+def test_is_port_in_use_false_when_nothing_listening():
+    """A port with no listener is reported as free."""
+    # Grab an ephemeral port, then close it so nothing is listening.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        host, port = probe.getsockname()
+    assert server_manager.is_port_in_use(host, port) is False
+
+
+def test_plist_keepalive_only_on_unsuccessful_exit():
+    """KeepAlive must not be unconditional: a clean exit (port already taken)
+    must not trigger a launchd respawn storm."""
+    plist = server_manager.PLIST_TEMPLATE.format(
+        label="com.ormah.server",
+        wrapper_path="/tmp/wrapper",
+        bin_dir="/tmp/bin",
+    )
+    assert "<key>SuccessfulExit</key><false/>" in plist.replace(" ", "").replace("\n", "")
+    # The old unconditional form must be gone.
+    assert "<key>KeepAlive</key><true/>" not in plist.replace(" ", "").replace("\n", "")
+
+
+def test_plist_has_throttle_interval():
+    """A ThrottleInterval backstops genuine crash loops."""
+    plist = server_manager.PLIST_TEMPLATE.format(
+        label="com.ormah.server",
+        wrapper_path="/tmp/wrapper",
+        bin_dir="/tmp/bin",
+    )
+    compact = plist.replace(" ", "").replace("\n", "")
+    assert "<key>ThrottleInterval</key>" in compact
+
+
+def test_server_start_exits_clean_when_port_in_use():
+    """`ormah server start` must NOT launch uvicorn when the port is already
+    owned by another server — it returns cleanly so KeepAlive does not respawn."""
+    from ormah import cli
+
+    args = mock.Mock(daemon=False, reload=False)
+    with mock.patch("ormah.server_manager.is_port_in_use", return_value=True), \
+         mock.patch("uvicorn.run") as run:
+        cli._cmd_server_start(args)
+    run.assert_not_called()
+
+
+def test_server_start_runs_uvicorn_when_port_free():
+    """When the port is free, uvicorn is launched as normal."""
+    from ormah import cli
+
+    args = mock.Mock(daemon=False, reload=False)
+    with mock.patch("ormah.server_manager.is_port_in_use", return_value=False), \
+         mock.patch("uvicorn.run") as run:
+        cli._cmd_server_start(args)
+    run.assert_called_once()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -114,7 +114,12 @@ class TestPlistTemplate:
         assert "<string>com.ormah.server</string>" in rendered
         assert "<string>/home/user/.config/ormah/ormah-server</string>" in rendered
         assert "<key>RunAtLoad</key><true/>" in rendered
-        assert "<key>KeepAlive</key><true/>" in rendered
+        # KeepAlive must only respawn on failure — a clean exit (e.g. the port
+        # is already owned by another server) must not trigger a respawn loop.
+        compact = rendered.replace(" ", "").replace("\n", "")
+        assert "<key>KeepAlive</key><true/>" not in compact
+        assert "<key>SuccessfulExit</key><false/>" in compact
+        assert "<key>ThrottleInterval</key>" in compact
         assert "StandardOutPath" not in rendered
         assert "StandardErrorPath" not in rendered
 


### PR DESCRIPTION
## Problem

The autostart server has no defense against its port being unavailable. On macOS the launchd plist uses unconditional `<key>KeepAlive</key><true/>` with **no `ThrottleInterval`**, and `ormah server start` lets uvicorn crash on bind. So whenever `127.0.0.1:8787` is already taken, the job enters an **infinite hot respawn loop**:

1. launchd starts `ormah server start`
2. uvicorn fails to bind → process exits non-zero
3. `KeepAlive` respawns it **immediately** (no backoff)
4. → back to 1, forever — pegging CPU and re-running startup work each time

This fires for **any** occupant of the port, not just a duplicate ormah instance:

- another application is already listening on 8787;
- the user started `ormah server start` in a terminal and the launchd job also comes up;
- `ormah setup` is re-run while the previous server still holds the socket (or it's in `TIME_WAIT`).

In one observed case a leftover autostart job crash-looped **2968 times**, holding the CPU at ~30% continuously while another process owned the port — but the underlying defect is the missing throttle + unconditional respawn + crash-on-bind, which any of the scenarios above can trigger.

## Fix

Defensive hardening of the autostart lifecycle, both ends of the loop:

- **`_cmd_server_start`** pre-checks the port via a new `is_port_in_use()` before launching uvicorn. If something already listens there, it logs and **exits 0** instead of crashing on bind.
- **launchd plist** now uses `KeepAlive={SuccessfulExit: false}` + a `ThrottleInterval` of 30s, so a clean exit does **not** respawn and any genuine crash loop is throttled. (The systemd unit already uses `Restart=on-failure` + `RestartSec=5`, so no change needed there.)

The two changes compose: the port check makes a redundant instance exit cleanly, and `SuccessfulExit:false` ensures that clean exit isn't immediately respawned.

## Tests

`tests/test_server_manager.py` (new):
- `is_port_in_use` returns True for a listening socket, False for a free port
- `ormah server start` does **not** launch uvicorn when the port is already in use
- uvicorn **is** launched when the port is free
- plist renders `SuccessfulExit:false` + `ThrottleInterval`, and no longer the unconditional `KeepAlive=true`

`tests/test_setup.py::TestPlistTemplate` updated to assert the new KeepAlive shape.

```
8 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)