### PR TITLE
fix(embeddings): delta backfill (O(gap)) + continuous reconciliation, no more full re-embed (#32)

### DIFF
--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -111,6 +111,14 @@ def health(request: Request):
     result: dict = {"status": "ok"}
     if tracker is not None:
         result["jobs"] = tracker.snapshot()
+    else:
+        # No scheduler: the backfill fallback is the only healer. Surface a
+        # persistent outage that would otherwise be invisible (council CH2).
+        from ormah import main as _main
+
+        if getattr(_main, "_fallback_degraded", False):
+            result["status"] = "degraded"
+            result["embedding_backfill"] = "degraded: fallback retrying"
     manager = getattr(request.app.state, "maintenance_manager", None)
     if manager is not None:
         result["maintenance"] = manager.get_status()

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -110,7 +110,18 @@ def health(request: Request):
     tracker = getattr(request.app.state, "job_tracker", None)
     result: dict = {"status": "ok"}
     if tracker is not None:
-        result["jobs"] = tracker.snapshot()
+        snap = tracker.snapshot()
+        result["jobs"] = snap
+        # CR2: promote to degraded when embedding_backfill's most recent run
+        # failed — otherwise a scheduler-backed outage stays invisible to callers
+        # that only read the top-level status.
+        job = snap.get("embedding_backfill")
+        if job and job.get("last_error"):
+            ls = job.get("last_success")
+            let = job.get("last_error_time")
+            if ls is None or (let is not None and let > ls):
+                result["status"] = "degraded"
+                result["embedding_backfill"] = "degraded: last run failed"
     else:
         # No scheduler: the backfill fallback is the only healer. Surface a
         # persistent outage that would otherwise be invisible (council CH2).

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 router = APIRouter(prefix="/admin", tags=["admin"])
@@ -293,4 +294,12 @@ def run_all_tasks(request: Request):
         except Exception as exc:
             results[task_id] = f"error: {exc}"
 
+    has_errors = any(v.startswith("error:") for v in results.values())
+    if has_errors:
+        # I1: a partial failure must not look like success to HTTP-only callers
+        # (cron, scripts). Surface it as 503 while keeping the per-task body.
+        return JSONResponse(
+            status_code=503,
+            content={"status": "degraded", "results": results},
+        )
     return {"status": "completed", "results": results}

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -28,6 +28,7 @@ _TASK_RUNNERS = {
     "memory_backup": ("ormah.backup", "run_auto_backup"),
     "cloud_backup": ("ormah.cloud.jobs", "run_cloud_backup"),
     "restore_verification": ("ormah.cloud.jobs", "run_restore_verification"),
+    "embedding_backfill": ("ormah.background.embedding_backfill", "run_embedding_backfill"),
 }
 
 _TASK_DESCRIPTIONS = {
@@ -43,12 +44,14 @@ _TASK_DESCRIPTIONS = {
     "memory_backup": "Creates a local backup of memory source files when one is due.",
     "cloud_backup": "Encrypts and uploads a due cloud backup without changing the sync head.",
     "restore_verification": "Downloads, decrypts, rebuilds, and searches the latest cloud backup.",
+    "embedding_backfill": "Backfills missing vector embeddings (delta) or re-embeds all on an embedding-schema bump. Keeps vector search complete after restarts and overnight ingest (#32).",
 }
 
 # Order for sleep cycle (full maintenance pass)
 _SLEEP_CYCLE_ORDER = [
     "importance_scorer",
     "index_updater",
+    "embedding_backfill",
     "duplicate_merger",
     "conflict_detector",
     "auto_linker",

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -296,11 +296,14 @@ def run_task(task_id: str, request: Request):
 def run_all_tasks(request: Request):
     """Run all background tasks sequentially in sleep-cycle order."""
     import importlib
+    import time as _time
 
     engine = request.app.state.engine
+    tracker = getattr(request.app.state, "job_tracker", None)
     results: dict[str, str] = {}
 
     for task_id in _SLEEP_CYCLE_ORDER:
+        t0 = _time.monotonic()
         try:
             if task_id == "index_updater":
                 engine.builder.incremental_update()
@@ -310,8 +313,14 @@ def run_all_tasks(request: Request):
                 runner = getattr(module, func_name)
                 runner(engine)
             results[task_id] = "ok"
+            if tracker is not None:
+                tracker.record_success(task_id, (_time.monotonic() - t0) * 1000)
         except Exception as exc:
             results[task_id] = f"error: {exc}"
+            # CRC: persist the failure so /admin/health reflects this manual run
+            # instead of reverting to a stale ok.
+            if tracker is not None:
+                tracker.record_failure(task_id, str(exc), (_time.monotonic() - t0) * 1000)
 
     has_errors = any(v.startswith("error:") for v in results.values())
     if has_errors:

--- a/src/ormah/background/embedding_backfill.py
+++ b/src/ormah/background/embedding_backfill.py
@@ -1,0 +1,30 @@
+"""Vector-store reconciliation job: backfill missing embeddings (#32)."""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def run_embedding_backfill(engine) -> None:
+    """Reconcile the vector store. Raises if the store is left incomplete.
+
+    Unlike the other background jobs, this one does NOT swallow an incomplete
+    result: when the run ends with ``missing > 0`` (embeddable nodes still lack a
+    vector) it raises so ``tracked()`` records a job failure and ``/admin/health``
+    reflects the degradation -- the intended health signal. A permanently-failing
+    ("poison") node therefore stays visibly degraded instead of being masked.
+    """
+    result = engine.backfill_embeddings()
+    if result.get("embedded") or result.get("missing"):
+        logger.info(
+            "Embedding backfill (%s): embedded=%d failed=%d missing=%d vec=%d/%d",
+            result["mode"], result["embedded"], result["failed"], result["missing"],
+            result["vec_count"], result["node_count"],
+        )
+    if result.get("missing", 0) > 0:
+        raise RuntimeError(
+            f"Embedding backfill incomplete: {result['missing']} embeddable nodes "
+            f"still missing vectors (failed={result['failed']})"
+        )

--- a/src/ormah/background/embedding_backfill.py
+++ b/src/ormah/background/embedding_backfill.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def run_embedding_backfill(engine) -> None:
+def run_embedding_backfill(engine, stop_event=None) -> None:
     """Reconcile the vector store. Raises if the store is left incomplete.
 
     Unlike the other background jobs, this one does NOT swallow an incomplete
@@ -15,8 +15,12 @@ def run_embedding_backfill(engine) -> None:
     vector) it raises so ``tracked()`` records a job failure and ``/admin/health``
     reflects the degradation -- the intended health signal. A permanently-failing
     ("poison") node therefore stays visibly degraded instead of being masked.
+
+    If ``stop_event`` is provided and becomes set, the backfill exits early.
+    An interrupted run still raises if ``missing > 0`` — the incomplete state
+    is reported honestly so the caller knows to reschedule.
     """
-    result = engine.backfill_embeddings()
+    result = engine.backfill_embeddings(stop_event=stop_event)
     if result.get("embedded") or result.get("missing"):
         logger.info(
             "Embedding backfill (%s): embedded=%d failed=%d missing=%d vec=%d/%d",

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import logging
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -155,6 +155,24 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         id="restore_verification",
         name="Cloud restore verification",
         misfire_grace_time=_MISFIRE_GRACE,
+    )
+
+    from ormah.background.embedding_backfill import run_embedding_backfill
+
+    # Reconcile the vector store (delta + schema bump). A post-bind first run
+    # (~10s after start) guarantees recovery right after the port binds even when
+    # the operator sets the interval to a very large value (999999) to rely on the
+    # 02:00 sleep-cycle instead. max_instances=1: a slow run on a large gap must
+    # never overlap the next tick.
+    scheduler.add_job(
+        tracked(tracker, "embedding_backfill", run_embedding_backfill, engine),
+        "interval",
+        minutes=s.embedding_backfill_interval_minutes,
+        id="embedding_backfill",
+        name="Embedding backfill",
+        misfire_grace_time=_MISFIRE_GRACE,
+        max_instances=1,
+        next_run_time=datetime.now(timezone.utc) + timedelta(seconds=10),
     )
 
     scheduler.start()

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 import logging
+import threading
+from typing import Optional
 
 from apscheduler.schedulers.background import BackgroundScheduler
 
@@ -17,11 +19,17 @@ logger = logging.getLogger(__name__)
 _MISFIRE_GRACE = 120
 
 
-def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTracker]:
+def start_scheduler(
+    engine: MemoryEngine,
+    stop_event: Optional[threading.Event] = None,
+) -> tuple[BackgroundScheduler, JobTracker]:
     """Register and start all background jobs.
 
     Returns ``(scheduler, tracker)`` so the caller can inspect job health
     via ``tracker.snapshot()``.
+
+    ``stop_event``, when provided, is forwarded to the embedding_backfill job so
+    it can cancel cooperatively between encodes on scheduler shutdown.
     """
     scheduler = BackgroundScheduler()
     tracker = JobTracker()
@@ -159,13 +167,19 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
 
     from ormah.background.embedding_backfill import run_embedding_backfill
 
+    # Closure captures stop_event so the scheduler job can cancel cooperatively
+    # between encodes when shutdown is requested (C2). tracked() calls fn(*args);
+    # with a no-arg closure it calls _run_embedding_backfill() directly.
+    def _run_embedding_backfill():
+        run_embedding_backfill(engine, stop_event=stop_event)
+
     # Reconcile the vector store (delta + schema bump). A post-bind first run
     # (~10s after start) guarantees recovery right after the port binds even when
     # the operator sets the interval to a very large value (999999) to rely on the
     # 02:00 sleep-cycle instead. max_instances=1: a slow run on a large gap must
     # never overlap the next tick.
     scheduler.add_job(
-        tracked(tracker, "embedding_backfill", run_embedding_backfill, engine),
+        tracked(tracker, "embedding_backfill", _run_embedding_backfill),
         "interval",
         minutes=s.embedding_backfill_interval_minutes,
         id="embedding_backfill",

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -65,6 +65,13 @@ class Settings(BaseSettings):
     duplicate_check_interval_minutes: int = 1440
     auto_cluster_interval_minutes: int = 60
 
+    # Embedding backfill / vector-store reconciliation (#32).
+    # Set the interval to a very large value (e.g. 999999) to disable the
+    # in-process recurring job and let the 02:00 sleep-cycle (run-all) drive it.
+    embedding_backfill_interval_minutes: int = 60
+    embedding_index_max_retries: int = 2
+    embedding_index_retry_backoff_seconds: float = 0.5
+
     # Hippocampus (file watching & auto-ingestion)
     hippocampus_watch_dirs: list[Path] = []
     hippocampus_debounce_seconds: float = 2.0
@@ -366,11 +373,26 @@ class Settings(BaseSettings):
         "conflict_check_interval_minutes",
         "duplicate_check_interval_minutes",
         "auto_cluster_interval_minutes",
+        "embedding_backfill_interval_minutes",
     )
     @classmethod
     def _interval_minutes_positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError(f"interval must be >= 1 minute, got {v}")
+        return v
+
+    @field_validator("embedding_index_max_retries")
+    @classmethod
+    def _embedding_index_max_retries_nonneg(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(f"embedding_index_max_retries must be >= 0, got {v}")
+        return v
+
+    @field_validator("embedding_index_retry_backoff_seconds")
+    @classmethod
+    def _embedding_index_backoff_nonneg(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError(f"embedding_index_retry_backoff_seconds must be >= 0, got {v}")
         return v
 
     @field_validator("hippocampus_debounce_seconds")

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1197,15 +1197,34 @@ class MemoryEngine:
     def _embed_node_rows(self, nodes, stop_event=None) -> tuple[list[str], list[str]]:
         """Embed the given node rows into the vector store.
 
-        Builds embeddings, then upserts in chunks of 100 with a WAL checkpoint
-        between chunks (sqlite-vec vec0 can silently drop rows in large
-        transactions). Returns (embedded_ids, failed_ids). Nodes whose embedding
-        text is empty are skipped (in neither list). Logs a warning if the final
+        Encode and upsert are interleaved: every 100 encoded rows are flushed
+        to the vector store immediately, with a WAL checkpoint after each
+        flush (sqlite-vec vec0 can silently drop rows in large transactions).
+        Returns (embedded_ids, failed_ids). Nodes whose embedding text is
+        empty are skipped (in neither list). Logs a warning if the final
         vec_count is below the number upserted (possible silent vec0 drop).
 
-        If ``stop_event`` is provided and becomes set, the encode loop and the
-        upsert loop both exit early (cooperative cancellation). Only ids that
-        were actually written to the DB are returned as ``embedded_ids``.
+        Durability contract: persistence is atomic per chunk of 100 — a hard
+        kill mid-``upsert_batch`` rolls back at most the current chunk, and
+        every earlier chunk stays on disk. DELTA mode is restart-resumable
+        (the anti-join that selects rows to embed skips already-persisted
+        ones). SCHEMA mode still re-encodes every row until the schema
+        version advances at the end — the upserts are idempotent, so a
+        restart wastes compute but loses no data (schema-progress tracking
+        to skip already-migrated rows is a deferred follow-up).
+
+        A DB error raised while flushing a chunk (e.g. from ``upsert_batch``)
+        is NOT treated as a per-node encode failure: it propagates out of
+        this function so the caller's job tracking records it as an
+        aborted job, instead of being caught and misattributed to whichever
+        node happened to be encoding next (which would wrongly enter
+        ``failed_ids`` and, in schema mode, get its persisted vector deleted
+        by the failed-node cleanup).
+
+        If ``stop_event`` is provided and becomes set, the encode loop exits
+        early (cooperative cancellation) but pending encoded rows are still
+        flushed before returning. Only ids that were actually written to the
+        DB are returned as ``embedded_ids``.
         """
         from ormah.embeddings.vector_store import VectorStore
         from ormah.embeddings.encoder import get_encoder
@@ -1219,33 +1238,42 @@ class MemoryEngine:
         max_chars = self.settings.embedding_max_content_chars
         log_every = max(1, total // 10)
 
-        all_items: list[tuple[str, Any]] = []
+        chunk_size = 100
+        pending: list[tuple[str, Any]] = []
+        upserted_ids: list[str] = []
         failed_ids: list[str] = []
+
+        def _flush() -> None:
+            # Persistence errors are NOT per-node failures: they propagate so the
+            # job aborts loudly (tracked() records it) instead of polluting
+            # failed_ids — a failed_ids entry here would be wrong AND, in schema
+            # mode, would get its (possibly persisted) vector deleted by the
+            # failed-node cleanup.
+            if not pending:
+                return
+            vec_store.upsert_batch(pending)
+            self.db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            upserted_ids.extend(item[0] for item in pending)
+            pending.clear()
+
         for idx, n in enumerate(nodes):
             if stop_event is not None and stop_event.is_set():
-                break  # cooperative cancel — stop accumulating work
+                break  # cooperative cancel — the final _flush() below persists pending
             text = _embedding_text(n["title"], n["content"], max_chars)
             if text:
                 try:
                     embedding = encoder.encode(text)
-                    all_items.append((n["id"], embedding))
                 except Exception as e:
                     logger.warning("Failed to embed node %s: %s", n["id"][:8], e)
                     failed_ids.append(n["id"])
+                else:
+                    pending.append((n["id"], embedding))
+                    if len(pending) >= chunk_size:
+                        _flush()  # outside the encode try — DB errors propagate
             done = idx + 1
             if done % log_every == 0 or done == total:
                 logger.info("Embedding memories: %d/%d", done, total)
-
-        # Upsert in small chunks with WAL checkpoint after each.
-        chunk_size = 100
-        upserted_ids: list[str] = []
-        for i in range(0, len(all_items), chunk_size):
-            if stop_event is not None and stop_event.is_set():
-                break  # cooperative cancel — stop before this DB write
-            chunk = all_items[i : i + chunk_size]
-            vec_store.upsert_batch(chunk)
-            self.db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            upserted_ids.extend(item[0] for item in chunk)
+        _flush()  # final partial chunk — runs on natural end AND cooperative cancel
 
         embedded_ids = upserted_ids
         vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1194,7 +1194,7 @@ class MemoryEngine:
         self._reindex_all_embeddings()
         return count
 
-    def _embed_node_rows(self, nodes) -> tuple[list[str], list[str]]:
+    def _embed_node_rows(self, nodes, stop_event=None) -> tuple[list[str], list[str]]:
         """Embed the given node rows into the vector store.
 
         Builds embeddings, then upserts in chunks of 100 with a WAL checkpoint
@@ -1202,6 +1202,10 @@ class MemoryEngine:
         transactions). Returns (embedded_ids, failed_ids). Nodes whose embedding
         text is empty are skipped (in neither list). Logs a warning if the final
         vec_count is below the number upserted (possible silent vec0 drop).
+
+        If ``stop_event`` is provided and becomes set, the encode loop and the
+        upsert loop both exit early (cooperative cancellation). Only ids that
+        were actually written to the DB are returned as ``embedded_ids``.
         """
         from ormah.embeddings.vector_store import VectorStore
         from ormah.embeddings.encoder import get_encoder
@@ -1218,6 +1222,8 @@ class MemoryEngine:
         all_items: list[tuple[str, Any]] = []
         failed_ids: list[str] = []
         for idx, n in enumerate(nodes):
+            if stop_event is not None and stop_event.is_set():
+                break  # cooperative cancel — stop accumulating work
             text = _embedding_text(n["title"], n["content"], max_chars)
             if text:
                 try:
@@ -1232,12 +1238,16 @@ class MemoryEngine:
 
         # Upsert in small chunks with WAL checkpoint after each.
         chunk_size = 100
+        upserted_ids: list[str] = []
         for i in range(0, len(all_items), chunk_size):
+            if stop_event is not None and stop_event.is_set():
+                break  # cooperative cancel — stop before this DB write
             chunk = all_items[i : i + chunk_size]
             vec_store.upsert_batch(chunk)
             self.db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            upserted_ids.extend(item[0] for item in chunk)
 
-        embedded_ids = [item[0] for item in all_items]
+        embedded_ids = upserted_ids
         vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]
         logger.info(
             "Embedded %d/%d nodes (vec_count=%d, failed=%d)",
@@ -1348,7 +1358,7 @@ class MemoryEngine:
             f"WHERE v.id IS NULL AND {self._EMBEDDABLE_SQL}"
         ).fetchone()[0]
 
-    def backfill_embeddings(self) -> dict:
+    def backfill_embeddings(self, stop_event=None) -> dict:
         """Reconcile the vector store. Idempotent; safe to run repeatedly.
 
         Two modes:
@@ -1356,10 +1366,13 @@ class MemoryEngine:
           built under an old scheme, so re-embed all embeddable nodes in a single
           pass. For each node that fails to encode, delete its stale vector so it
           becomes genuinely missing (caught by future delta runs). Advance the
-          version unconditionally after the pass -- the store has been fully
-          reprocessed; nodes that could not be embedded are now honestly missing.
+          version only when the pass completes without interruption.
         - **delta** (stored version == current): embed only embeddable nodes
           missing from the vector store (anti-join), O(gap).
+
+        If ``stop_event`` is provided and becomes set, both the encode loop and
+        the upsert loop exit early. The schema version is NOT advanced on an
+        interrupted schema pass — the pass must be re-run as schema next time.
 
         A permanently-failing node simply stays in ``missing`` and is retried each
         tick -- never dropped, never masked. Returns a summary dict where
@@ -1390,7 +1403,9 @@ class MemoryEngine:
             if rows:
                 logger.info("Embedding backfill (delta): embedding %d missing nodes", len(rows))
 
-        embedded_ids, failed_ids = self._embed_node_rows(rows)
+        embedded_ids, failed_ids = self._embed_node_rows(rows, stop_event=stop_event)
+
+        interrupted = stop_event is not None and stop_event.is_set()
 
         # Schema mode: drop the stale vector of any node that failed to re-embed
         # under the new scheme, so it is genuinely missing (and retried by delta)
@@ -1400,8 +1415,10 @@ class MemoryEngine:
                 for nid in failed_ids:
                     conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
 
-        # Advance the schema version unconditionally after a full schema pass.
-        if mode == "schema":
+        # Only advance the version on a COMPLETE schema pass. An interrupted pass
+        # must be re-run as schema next time — advancing here would make a partial
+        # reprocess look complete and hide un-reprocessed nodes from delta runs.
+        if mode == "schema" and not interrupted:
             with self.db.transaction() as conn:
                 conn.execute(
                     "INSERT OR REPLACE INTO meta (key, value) VALUES "

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1453,11 +1453,6 @@ class MemoryEngine:
             "total_nodes": total,
             "by_tier": tier_counts,
             "total_edges": edge_count,
-            "vec_count": vec_count,
-            # Embeddable nodes still missing a vector -- the honest embedding gap.
-            # Stays > 0 for any node that cannot be embedded (visible, never masked).
-            "embedding_gap": self._missing_embeddable_count(),
-            "embedding_schema_version": int(ver_row["value"]) if ver_row else 0,
         }
         usage, window = self._usage_stats(now, days=days)
         whisper_health = compute_whisper_health(self.db.conn, now)
@@ -1471,6 +1466,11 @@ class MemoryEngine:
             "window": window,
             "usage": usage,
             "store": store,
+            "vec_count": vec_count,
+            # Embeddable nodes still missing a vector -- the honest embedding gap.
+            # Stays > 0 for any node that cannot be embedded (visible, never masked).
+            "embedding_gap": self._missing_embeddable_count(),
+            "embedding_schema_version": int(ver_row["value"]) if ver_row else 0,
             "whisper": {
                 "feedback_health": whisper_health,
                 "decisions": whisper_decisions,

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -8,6 +8,7 @@ import logging
 import math
 import re
 import threading
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -2210,17 +2211,32 @@ class MemoryEngine:
                 return None
 
     def _index_embedding(self, node: MemoryNode) -> None:
-        try:
-            from ormah.embeddings.vector_store import VectorStore
-            from ormah.embeddings.encoder import get_encoder
+        from ormah.embeddings.vector_store import VectorStore
+        from ormah.embeddings.encoder import get_encoder
 
-            encoder = get_encoder(self.settings)
-            vec_store = VectorStore(self.db)
-            text = _embedding_text(node.title, node.content, self.settings.embedding_max_content_chars)
-            embedding = encoder.encode(text)
-            vec_store.upsert(node.id, embedding)
-        except Exception as e:
-            logger.warning("Failed to index embedding for node %s: %s", node.id[:8], e)
+        text = _embedding_text(
+            node.title, node.content, self.settings.embedding_max_content_chars
+        )
+        if not text:
+            return
+
+        max_retries = self.settings.embedding_index_max_retries
+        backoff = self.settings.embedding_index_retry_backoff_seconds
+        for attempt in range(max_retries + 1):
+            try:
+                encoder = get_encoder(self.settings)
+                vec_store = VectorStore(self.db)
+                embedding = encoder.encode(text)
+                vec_store.upsert(node.id, embedding)
+                return
+            except Exception as e:
+                if attempt < max_retries:
+                    time.sleep(backoff * (2 ** attempt))
+                    continue
+                logger.warning(
+                    "Failed to index embedding for node %s after %d attempts: %s",
+                    node.id[:8], max_retries + 1, e,
+                )
 
     def _auto_link_node(self, node: MemoryNode) -> list[tuple[str, str, float]]:
         """Find similar existing nodes and create edges. Returns [(id, title, similarity)]."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1410,7 +1410,9 @@ class MemoryEngine:
         # Schema mode: drop the stale vector of any node that failed to re-embed
         # under the new scheme, so it is genuinely missing (and retried by delta)
         # rather than silently kept with an outdated embedding.
-        if mode == "schema" and failed_ids:
+        # Guard with `not interrupted`: an interrupted pass must not write anything —
+        # consistent with the version-advance guard immediately below (Fix B).
+        if mode == "schema" and failed_ids and not interrupted:
             with self.db.transaction() as conn:
                 for nid in failed_ids:
                     conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -117,24 +117,11 @@ class MemoryEngine:
                     "INSERT OR REPLACE INTO meta (key, value) VALUES ('fts_needs_rebuild', '0')"
                 )
 
-        # Re-embed nodes if the vector store is missing entries or schema version changed
-        vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]
-        stored_version_row = self.db.conn.execute(
-            "SELECT value FROM meta WHERE key = 'embedding_schema_version'"
-        ).fetchone()
-        stored_version = int(stored_version_row["value"]) if stored_version_row else 0
-        needs_reindex = (count > 0 and vec_count < count) or stored_version < _EMBEDDING_SCHEMA_VERSION
-
-        if needs_reindex:
-            reason = "schema version change" if stored_version < _EMBEDDING_SCHEMA_VERSION else "missing entries"
-            logger.info("Re-indexing embeddings (%s): vec=%d, nodes=%d, schema v%d→v%d",
-                        reason, vec_count, count, stored_version, _EMBEDDING_SCHEMA_VERSION)
-            self._reindex_all_embeddings()
-            with self.db.transaction() as conn:
-                conn.execute(
-                    "INSERT OR REPLACE INTO meta (key, value) VALUES ('embedding_schema_version', ?)",
-                    (str(_EMBEDDING_SCHEMA_VERSION),),
-                )
+        # Embedding recovery (delta + schema bump) is no longer done synchronously
+        # here -- it would block the port bind on a full O(n) re-embed. It now lives
+        # in backfill_embeddings(), driven by the embedding_backfill background job
+        # (and a scheduler-independent fallback). The encoder is still warmed below
+        # via _warmup_embedder(). (#32)
 
         # One-time FSRS data migration: seed stability from access patterns
         self._migrate_fsrs()

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1346,6 +1346,92 @@ class MemoryEngine:
             "outcome_breakdown": breakdown,
         }
 
+    # SQL proxy for "_embedding_text(title, content) is non-empty": a node is
+    # embeddable when it has non-whitespace content OR title.
+    _EMBEDDABLE_SQL = (
+        "COALESCE(NULLIF(TRIM(content), ''), NULLIF(TRIM(title), '')) IS NOT NULL"
+    )
+
+    def _missing_embeddable_count(self) -> int:
+        """Embeddable nodes with no row in the vector store (the honest gap)."""
+        return self.db.conn.execute(
+            f"SELECT count(*) FROM nodes n "
+            f"LEFT JOIN node_vectors_rowids v ON n.id = v.id "
+            f"WHERE v.id IS NULL AND {self._EMBEDDABLE_SQL}"
+        ).fetchone()[0]
+
+    def backfill_embeddings(self) -> dict:
+        """Reconcile the vector store. Idempotent; safe to run repeatedly.
+
+        Two modes:
+        - **schema bump** (stored version < current): every existing vector was
+          built under an old scheme, so re-embed all embeddable nodes in a single
+          pass. For each node that fails to encode, delete its stale vector so it
+          becomes genuinely missing (caught by future delta runs). Advance the
+          version unconditionally after the pass -- the store has been fully
+          reprocessed; nodes that could not be embedded are now honestly missing.
+        - **delta** (stored version == current): embed only embeddable nodes
+          missing from the vector store (anti-join), O(gap).
+
+        A permanently-failing node simply stays in ``missing`` and is retried each
+        tick -- never dropped, never masked. Returns a summary dict where
+        ``missing`` is the honest embedding gap after the run.
+        """
+        count = self.db.conn.execute("SELECT count(*) FROM nodes").fetchone()[0]
+        ver_row = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'embedding_schema_version'"
+        ).fetchone()
+        stored_version = int(ver_row["value"]) if ver_row else 0
+
+        if stored_version < _EMBEDDING_SCHEMA_VERSION:
+            mode = "schema"
+            rows = self.db.conn.execute(
+                f"SELECT id, title, content FROM nodes WHERE {self._EMBEDDABLE_SQL}"
+            ).fetchall()
+            logger.info(
+                "Embedding backfill (schema v%d->v%d): re-embedding %d nodes",
+                stored_version, _EMBEDDING_SCHEMA_VERSION, len(rows),
+            )
+        else:
+            mode = "delta"
+            rows = self.db.conn.execute(
+                f"SELECT n.id, n.title, n.content FROM nodes n "
+                f"LEFT JOIN node_vectors_rowids v ON n.id = v.id "
+                f"WHERE v.id IS NULL AND {self._EMBEDDABLE_SQL}"
+            ).fetchall()
+            if rows:
+                logger.info("Embedding backfill (delta): embedding %d missing nodes", len(rows))
+
+        embedded_ids, failed_ids = self._embed_node_rows(rows)
+
+        # Schema mode: drop the stale vector of any node that failed to re-embed
+        # under the new scheme, so it is genuinely missing (and retried by delta)
+        # rather than silently kept with an outdated embedding.
+        if mode == "schema" and failed_ids:
+            with self.db.transaction() as conn:
+                for nid in failed_ids:
+                    conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+
+        # Advance the schema version unconditionally after a full schema pass.
+        if mode == "schema":
+            with self.db.transaction() as conn:
+                conn.execute(
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                    "('embedding_schema_version', ?)",
+                    (str(_EMBEDDING_SCHEMA_VERSION),),
+                )
+
+        missing = self._missing_embeddable_count()
+        vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]
+        return {
+            "mode": mode,
+            "embedded": len(embedded_ids),
+            "failed": len(failed_ids),
+            "missing": missing,
+            "vec_count": vec_count,
+            "node_count": count,
+        }
+
     def stats(self, days: int | None = None) -> dict[str, Any]:
         """Return the canonical stats payload for tray, CLI, UI, and diagnostics."""
         now = datetime.now(timezone.utc)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1206,57 +1206,68 @@ class MemoryEngine:
         self._reindex_all_embeddings()
         return count
 
+    def _embed_node_rows(self, nodes) -> tuple[list[str], list[str]]:
+        """Embed the given node rows into the vector store.
+
+        Builds embeddings, then upserts in chunks of 100 with a WAL checkpoint
+        between chunks (sqlite-vec vec0 can silently drop rows in large
+        transactions). Returns (embedded_ids, failed_ids). Nodes whose embedding
+        text is empty are skipped (in neither list). Logs a warning if the final
+        vec_count is below the number upserted (possible silent vec0 drop).
+        """
+        from ormah.embeddings.vector_store import VectorStore
+        from ormah.embeddings.encoder import get_encoder
+
+        total = len(nodes)
+        if total == 0:
+            return [], []
+
+        encoder = get_encoder(self.settings)
+        vec_store = VectorStore(self.db)
+        max_chars = self.settings.embedding_max_content_chars
+        log_every = max(1, total // 10)
+
+        all_items: list[tuple[str, Any]] = []
+        failed_ids: list[str] = []
+        for idx, n in enumerate(nodes):
+            text = _embedding_text(n["title"], n["content"], max_chars)
+            if text:
+                try:
+                    embedding = encoder.encode(text)
+                    all_items.append((n["id"], embedding))
+                except Exception as e:
+                    logger.warning("Failed to embed node %s: %s", n["id"][:8], e)
+                    failed_ids.append(n["id"])
+            done = idx + 1
+            if done % log_every == 0 or done == total:
+                logger.info("Embedding memories: %d/%d", done, total)
+
+        # Upsert in small chunks with WAL checkpoint after each.
+        chunk_size = 100
+        for i in range(0, len(all_items), chunk_size):
+            chunk = all_items[i : i + chunk_size]
+            vec_store.upsert_batch(chunk)
+            self.db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+
+        embedded_ids = [item[0] for item in all_items]
+        vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]
+        logger.info(
+            "Embedded %d/%d nodes (vec_count=%d, failed=%d)",
+            len(embedded_ids), total, vec_count, len(failed_ids),
+        )
+        if vec_count < len(embedded_ids):
+            logger.warning(
+                "Vec table has fewer entries (%d) than embedded (%d) — "
+                "possible sqlite-vec persistence issue",
+                vec_count, len(embedded_ids),
+            )
+        return embedded_ids, failed_ids
+
     def _reindex_all_embeddings(self) -> None:
         """Re-embed all nodes in the index."""
         try:
-            from ormah.embeddings.vector_store import VectorStore
-            from ormah.embeddings.encoder import get_encoder
-
-            encoder = get_encoder(self.settings)
-            vec_store = VectorStore(self.db)
-
             nodes = self.db.conn.execute("SELECT id, title, content FROM nodes").fetchall()
-            max_chars = self.settings.embedding_max_content_chars
-            total = len(nodes)
-            log_every = max(1, total // 10)  # log every ~10%
-
-            # Build all embeddings first
-            all_items: list[tuple[str, Any]] = []
-            failed = 0
-            for idx, n in enumerate(nodes):
-                text = _embedding_text(n["title"], n["content"], max_chars)
-                if text:
-                    try:
-                        embedding = encoder.encode(text)
-                        all_items.append((n["id"], embedding))
-                    except Exception as e:
-                        logger.warning("Failed to embed node %s: %s", n["id"][:8], e)
-                        failed += 1
-                done = idx + 1
-                if done % log_every == 0 or done == total:
-                    logger.info("Re-embedding memories: %d/%d", done, total)
-
-            # Upsert in small chunks with WAL checkpoint after each.
-            # sqlite-vec vec0 virtual tables can silently drop rows in
-            # large transactions; chunking prevents this.
-            chunk_size = 100
-            for i in range(0, len(all_items), chunk_size):
-                chunk = all_items[i : i + chunk_size]
-                vec_store.upsert_batch(chunk)
-                self.db.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-
-            # Verify the count actually matches
-            vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]
-            logger.info(
-                "Re-embedded %d/%d nodes (vec_count=%d, failed=%d)",
-                len(all_items), len(nodes), vec_count, failed,
-            )
-            if vec_count < len(all_items):
-                logger.warning(
-                    "Vec table has fewer entries (%d) than embedded (%d) — "
-                    "possible sqlite-vec persistence issue",
-                    vec_count, len(all_items),
-                )
+            self._embed_node_rows(nodes)
         except Exception as e:
             logger.warning("Failed to reindex embeddings: %s", e)
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1426,10 +1426,19 @@ class MemoryEngine:
         tier_counts = self.graph.count_by_tier()
         total = sum(tier_counts.values())
         edge_count = self.db.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
+        vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]
+        ver_row = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'embedding_schema_version'"
+        ).fetchone()
         store = {
             "total_nodes": total,
             "by_tier": tier_counts,
             "total_edges": edge_count,
+            "vec_count": vec_count,
+            # Embeddable nodes still missing a vector -- the honest embedding gap.
+            # Stays > 0 for any node that cannot be embedded (visible, never masked).
+            "embedding_gap": self._missing_embeddable_count(),
+            "embedding_schema_version": int(ver_row["value"]) if ver_row else 0,
         }
         usage, window = self._usage_stats(now, days=days)
         whisper_health = compute_whisper_health(self.db.conn, now)

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -45,6 +45,47 @@ except PackageNotFoundError:
     APP_VERSION = "0.0.0"
 
 
+# Embedding-backfill fallback: how many times the daemon thread retries the
+# reconciliation (with exponential backoff) before giving up. The recurring job /
+# sleep-cycle remains the long-term net; this only covers a scheduler that failed
+# to start plus a transient encoder outage at boot.
+_BACKFILL_FALLBACK_MAX_ATTEMPTS = 5
+_BACKFILL_FALLBACK_BASE_BACKOFF = 30.0  # seconds
+_BACKFILL_FALLBACK_MAX_BACKOFF = 600.0  # seconds
+
+
+def _start_backfill_fallback(engine) -> None:
+    """Run embedding reconciliation off a daemon thread when the scheduler is
+    unavailable, so missing vectors are still healed without it (#32, council I1).
+    Off the bind path -- never blocks startup. Retries with exponential backoff
+    until the gap closes (``run_embedding_backfill`` raises while incomplete) or
+    the attempt budget is exhausted, instead of a single one-shot."""
+    import threading
+    import time
+
+    def _run():
+        from ormah.background.embedding_backfill import run_embedding_backfill
+
+        for attempt in range(_BACKFILL_FALLBACK_MAX_ATTEMPTS):
+            try:
+                run_embedding_backfill(engine)
+                return  # gap closed (the job raises while it is still incomplete)
+            except Exception as e:
+                logger.warning(
+                    "Embedding backfill fallback attempt %d/%d failed: %s",
+                    attempt + 1, _BACKFILL_FALLBACK_MAX_ATTEMPTS, e,
+                )
+                if attempt + 1 < _BACKFILL_FALLBACK_MAX_ATTEMPTS:
+                    time.sleep(min(
+                        _BACKFILL_FALLBACK_BASE_BACKOFF * (2 ** attempt),
+                        _BACKFILL_FALLBACK_MAX_BACKOFF,
+                    ))
+
+    threading.Thread(
+        target=_run, name="embedding-backfill-fallback", daemon=True
+    ).start()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -67,6 +108,12 @@ async def lifespan(app: FastAPI):
         logger.info("Background scheduler ready.")
     except Exception as e:
         logger.warning("Background scheduler not started: %s", e)
+
+    # If the scheduler did not start, its recurring embedding_backfill job won't
+    # run. Heal missing vectors off a daemon thread so recovery doesn't depend on
+    # the scheduler (#32, council I1). Off the bind path -- never blocks startup.
+    if not hasattr(app.state, "scheduler"):
+        _start_backfill_fallback(engine)
 
     if not hasattr(app.state, "maintenance_manager"):
         app.state.maintenance_manager = MaintenanceManager(engine)

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -55,6 +55,7 @@ import threading
 # /admin/health while no scheduler exists.
 _BACKFILL_FALLBACK_BASE_BACKOFF = 30.0  # seconds
 _BACKFILL_FALLBACK_MAX_BACKOFF = 600.0  # seconds
+_FALLBACK_JOIN_TIMEOUT = 5.0  # seconds — bound the shutdown wait on the fallback thread
 
 _fallback_thread: threading.Thread | None = None
 _fallback_stop_event: threading.Event | None = None
@@ -107,13 +108,25 @@ def _start_backfill_fallback(engine) -> None:
 
 
 def _stop_backfill_fallback() -> None:
-    """Signal the fallback thread to stop and join it (CH1). Idempotent."""
+    """Signal the fallback thread to stop and join it (CH1). Idempotent.
+    Only clears the handle when the thread actually exits. If it is still alive
+    after the join timeout (e.g. stuck in non-interruptible backfill IO), the
+    handle is kept so the singleton guard keeps blocking a second fallback from
+    starting against a closed/recreated engine (council CR1)."""
     global _fallback_thread
     if _fallback_stop_event is not None:
         _fallback_stop_event.set()
-    if _fallback_thread is not None:
-        _fallback_thread.join(timeout=5.0)
-        _fallback_thread = None
+    thread = _fallback_thread
+    if thread is not None:
+        thread.join(timeout=_FALLBACK_JOIN_TIMEOUT)
+        if thread.is_alive():
+            logger.warning(
+                "Embedding backfill fallback did not stop within %.1fs; keeping "
+                "the thread handle so no concurrent fallback can start.",
+                _FALLBACK_JOIN_TIMEOUT,
+            )
+        else:
+            _fallback_thread = None
 
 
 @asynccontextmanager

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -55,7 +55,6 @@ import threading
 # /admin/health while no scheduler exists.
 _BACKFILL_FALLBACK_BASE_BACKOFF = 30.0  # seconds
 _BACKFILL_FALLBACK_MAX_BACKOFF = 600.0  # seconds
-_FALLBACK_JOIN_TIMEOUT = 5.0  # seconds — bound the shutdown wait on the fallback thread
 
 _fallback_lock = threading.Lock()
 _fallback_thread: threading.Thread | None = None
@@ -108,21 +107,25 @@ def _start_backfill_fallback(engine) -> None:
 
 
 def _stop_backfill_fallback() -> None:
-    """Signal the fallback thread to stop and join it. Idempotent. With the
-    backfill now cancellable, the join succeeds quickly, so the handle is always
-    cleared — the engine can then be shut down safely (no use-after-close)."""
+    """Signal the fallback thread to stop and join it without a timeout. Idempotent.
+
+    Mirrors scheduler.shutdown(wait=True): the cooperative cancellation guarantees
+    the thread exits after the in-flight encode completes (the backfill loop is not
+    infinite — once stop_event is set and the current encode finishes, the loop
+    exits and _run returns). Joining without a timeout ensures the engine is never
+    closed while the thread can still touch the DB (C-A), and the handle is cleared
+    only after the thread is confirmed dead, so the singleton guard stays intact (C-B).
+
+    Lock discipline: signal + read handle under lock; join outside the lock (do not
+    hold the lock during a potentially long join); clear handle under lock after join.
+    """
     global _fallback_thread, _fallback_stop_event
     with _fallback_lock:
         if _fallback_stop_event is not None:
             _fallback_stop_event.set()
         thread = _fallback_thread
     if thread is not None:
-        thread.join(timeout=_FALLBACK_JOIN_TIMEOUT)
-        if thread.is_alive():
-            logger.warning(
-                "Embedding backfill fallback did not stop within %.1fs",
-                _FALLBACK_JOIN_TIMEOUT,
-            )
+        thread.join()  # no timeout — engine must not close until the thread is dead
     with _fallback_lock:
         _fallback_thread = None
         _fallback_stop_event = None

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -45,45 +45,75 @@ except PackageNotFoundError:
     APP_VERSION = "0.0.0"
 
 
-# Embedding-backfill fallback: how many times the daemon thread retries the
-# reconciliation (with exponential backoff) before giving up. The recurring job /
-# sleep-cycle remains the long-term net; this only covers a scheduler that failed
-# to start plus a transient encoder outage at boot.
-_BACKFILL_FALLBACK_MAX_ATTEMPTS = 5
+import threading
+
+# Embedding-backfill fallback (#32, council C2/CH1/CH2): when the scheduler fails
+# to start, a daemon thread heals missing vectors off the bind path. It retries
+# indefinitely with backoff (capped) so a persistent encoder outage recovers
+# automatically when the encoder returns. Lifecycle is controlled by a stop event
+# and a singleton guard; _fallback_degraded exposes a persistent outage to
+# /admin/health while no scheduler exists.
 _BACKFILL_FALLBACK_BASE_BACKOFF = 30.0  # seconds
 _BACKFILL_FALLBACK_MAX_BACKOFF = 600.0  # seconds
 
+_fallback_thread: threading.Thread | None = None
+_fallback_stop_event: threading.Event | None = None
+_fallback_degraded: bool = False
+
 
 def _start_backfill_fallback(engine) -> None:
-    """Run embedding reconciliation off a daemon thread when the scheduler is
-    unavailable, so missing vectors are still healed without it (#32, council I1).
-    Off the bind path -- never blocks startup. Retries with exponential backoff
-    until the gap closes (``run_embedding_backfill`` raises while incomplete) or
-    the attempt budget is exhausted, instead of a single one-shot."""
-    import threading
+    """Heal missing vectors off a daemon thread when the scheduler is unavailable
+    (#32). Off the bind path -- never blocks startup. Retries with backoff
+    (capped) until the gap closes; never gives up, so a persistent encoder outage
+    recovers automatically. Singleton: a second call while one thread is alive is
+    a no-op, so a lifespan restart cannot accumulate concurrent fallbacks."""
+    global _fallback_thread, _fallback_stop_event, _fallback_degraded
     import time
 
+    if _fallback_thread is not None and _fallback_thread.is_alive():
+        return  # singleton guard (CH1)
+
+    stop_event = threading.Event()
+    _fallback_stop_event = stop_event
+    _fallback_degraded = False
+
     def _run():
+        global _fallback_degraded
         from ormah.background.embedding_backfill import run_embedding_backfill
 
-        for attempt in range(_BACKFILL_FALLBACK_MAX_ATTEMPTS):
+        delay = _BACKFILL_FALLBACK_BASE_BACKOFF
+        attempt = 0
+        while not stop_event.is_set():
+            attempt += 1
             try:
                 run_embedding_backfill(engine)
-                return  # gap closed (the job raises while it is still incomplete)
+                _fallback_degraded = False  # gap closed (CH2: recovery observable)
+                return
             except Exception as e:
+                _fallback_degraded = True  # CH2: persistent outage is observable
                 logger.warning(
-                    "Embedding backfill fallback attempt %d/%d failed: %s",
-                    attempt + 1, _BACKFILL_FALLBACK_MAX_ATTEMPTS, e,
+                    "Embedding backfill fallback attempt %d failed: %s", attempt, e,
                 )
-                if attempt + 1 < _BACKFILL_FALLBACK_MAX_ATTEMPTS:
-                    time.sleep(min(
-                        _BACKFILL_FALLBACK_BASE_BACKOFF * (2 ** attempt),
-                        _BACKFILL_FALLBACK_MAX_BACKOFF,
-                    ))
+                # Interruptible sleep -- shutdown wakes us immediately (CH1).
+                if stop_event.wait(delay):
+                    return
+                delay = min(delay * 2, _BACKFILL_FALLBACK_MAX_BACKOFF)
 
-    threading.Thread(
+    thread = threading.Thread(
         target=_run, name="embedding-backfill-fallback", daemon=True
-    ).start()
+    )
+    _fallback_thread = thread
+    thread.start()
+
+
+def _stop_backfill_fallback() -> None:
+    """Signal the fallback thread to stop and join it (CH1). Idempotent."""
+    global _fallback_thread
+    if _fallback_stop_event is not None:
+        _fallback_stop_event.set()
+    if _fallback_thread is not None:
+        _fallback_thread.join(timeout=5.0)
+        _fallback_thread = None
 
 
 @asynccontextmanager
@@ -145,6 +175,9 @@ async def lifespan(app: FastAPI):
     # Shutdown — stop hippocampus watchers
     if hasattr(app.state, "hippocampus_observers"):
         stop_hippocampus(app.state.hippocampus_observers)
+
+    # Shutdown — stop the scheduler-independent backfill fallback if it is running
+    _stop_backfill_fallback()
 
     # Shutdown — wait for running jobs to finish (up to 10s)
     if hasattr(app.state, "scheduler"):

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -56,6 +56,7 @@ import threading
 _BACKFILL_FALLBACK_BASE_BACKOFF = 30.0  # seconds
 _BACKFILL_FALLBACK_MAX_BACKOFF = 600.0  # seconds
 _FALLBACK_JOIN_TIMEOUT = 30.0  # seconds — bounded join for the fallback thread (C1)
+_SHUTDOWN_TIMEOUT = 30.0  # seconds — bounded join for scheduler shutdown (Fix A)
 
 _fallback_lock = threading.Lock()
 _fallback_thread: threading.Thread | None = None
@@ -141,6 +142,44 @@ def _stop_backfill_fallback() -> bool:
     return False
 
 
+def _should_close_engine(*, fallback_alive: bool, scheduler_alive: bool) -> bool:
+    """Return True only when both background workers have confirmed exit.
+
+    Called at shutdown to decide whether engine.shutdown() is safe.  If either
+    worker is still alive it may hold a DB transaction, so closing the engine
+    would be a use-after-close.  The connection leaks until SIGTERM kills the
+    daemon threads — acceptable because (a) SQLite is not corrupted by an
+    unclosed reader, (b) the process is terminating anyway, and (c) a finalizer
+    would reopen the same race on hot-reload in the same process (Fix C).
+    """
+    return not fallback_alive and not scheduler_alive
+
+
+def _bounded_scheduler_shutdown(scheduler) -> bool:
+    """Run scheduler.shutdown(wait=True) in a daemon thread with a bounded join.
+
+    Returns True if the shutdown did not complete within _SHUTDOWN_TIMEOUT
+    (job likely stuck in a non-interruptible encoder.encode()); the caller must
+    then skip engine.shutdown() to avoid use-after-close — symmetric with the
+    bounded fallback join (Fix A).
+    """
+    shutdown_thread = threading.Thread(
+        target=lambda: scheduler.shutdown(wait=True),
+        name="scheduler-shutdown",
+        daemon=True,
+    )
+    shutdown_thread.start()
+    shutdown_thread.join(timeout=_SHUTDOWN_TIMEOUT)
+    if shutdown_thread.is_alive():
+        logger.critical(
+            "Scheduler shutdown did not complete within %.0fs (job likely stuck in a "
+            "non-interruptible encode); skipping engine shutdown to avoid use-after-close.",
+            _SHUTDOWN_TIMEOUT,
+        )
+        return True
+    return False
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -214,15 +253,26 @@ async def lifespan(app: FastAPI):
     # to avoid use-after-close (C-A/C-B); the handle is kept for the singleton guard.
     fallback_alive = _stop_backfill_fallback()
 
-    # Shutdown — wait for running jobs to finish (job cooperates via _lifecycle_stop_event)
+    # Shutdown — wait for running jobs to finish (job cooperates via _lifecycle_stop_event).
+    # Bounded join mirrors the fallback policy (Fix A): if a job is stuck inside a
+    # non-interruptible encoder.encode() the scheduler.shutdown(wait=True) would hang
+    # indefinitely; we join with _SHUTDOWN_TIMEOUT and treat survival as scheduler_alive.
+    scheduler_alive = False
     if hasattr(app.state, "scheduler"):
-        app.state.scheduler.shutdown(wait=True)
+        scheduler_alive = _bounded_scheduler_shutdown(app.state.scheduler)
 
-    if not fallback_alive:
+    # Fix C (best-effort limitation): when either worker survives its timeout, the
+    # engine is not closed cleanly — the SQLite connection leaks until process exit.
+    # Accepted because: (a) no corruption risk, (b) process is terminating (SIGTERM
+    # kills daemon threads), (c) a finalizer would reopen an engine-old-vs-new race
+    # on hot-reload in the same process.
+    if _should_close_engine(fallback_alive=fallback_alive, scheduler_alive=scheduler_alive):
         engine.shutdown()
     else:
         logger.critical(
-            "Skipping engine.shutdown(): fallback thread still alive (avoids use-after-close)"
+            "Skipping engine.shutdown(): background worker still in flight "
+            "(fallback_alive=%s scheduler_alive=%s) — avoids use-after-close",
+            fallback_alive, scheduler_alive,
         )
     logger.info("Ormah stopped")
 

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -63,9 +63,11 @@ _fallback_thread: threading.Thread | None = None
 _fallback_stop_event: threading.Event | None = None
 _fallback_degraded: bool = False
 
-# Signals the scheduler's embedding_backfill job to cancel on shutdown.
+# Per-lifespan stop event (R1): created fresh in app.state at each lifespan
+# startup — see lifespan() below. There is no module-level global so that a
+# reload in the same process cannot clear() a previous lifespan's event and
+# rearm an orphan embedding_backfill worker that is still observing it.
 # The fallback uses its own _fallback_stop_event; the two paths never coexist.
-_lifecycle_stop_event = threading.Event()
 
 
 def _start_backfill_fallback(engine) -> None:
@@ -190,13 +192,17 @@ async def lifespan(app: FastAPI):
     app.state.engine = engine
     logger.info("Memory engine ready.")
 
+    # Per-lifespan stop event (R1): a fresh Event per lifespan so that a prior
+    # lifespan's orphan worker (if shutdown timed out) can never be rearmed by
+    # a new startup — there is nothing to clear(), each lifespan owns its own.
+    app.state.lifecycle_stop_event = threading.Event()
+
     # Start background scheduler if available
     try:
         from ormah.background.scheduler import start_scheduler
 
-        _lifecycle_stop_event.clear()  # reset defensivo para reload no mesmo processo
         logger.info("Starting background scheduler...")
-        scheduler, tracker = start_scheduler(engine, stop_event=_lifecycle_stop_event)
+        scheduler, tracker = start_scheduler(engine, stop_event=app.state.lifecycle_stop_event)
         app.state.scheduler = scheduler
         app.state.job_tracker = tracker
         app.state.maintenance_manager = MaintenanceManager(engine, tracker=tracker)
@@ -238,7 +244,11 @@ async def lifespan(app: FastAPI):
     # encodes. A single encoder.encode() call mid-flight is not interruptible
     # (fundamental limit), but wait=True ensures the DB is released before any
     # close — no corruption.
-    _lifecycle_stop_event.set()
+    # Per-lifespan event (R1): always created in startup above, so direct
+    # attribute access is safe; getattr guard is kept for defensive clarity.
+    stop_ev = getattr(app.state, "lifecycle_stop_event", None)
+    if stop_ev is not None:
+        stop_ev.set()
 
     # Shutdown — stop session watcher first
     if hasattr(app.state, "session_watcher_observers"):
@@ -253,7 +263,7 @@ async def lifespan(app: FastAPI):
     # to avoid use-after-close (C-A/C-B); the handle is kept for the singleton guard.
     fallback_alive = _stop_backfill_fallback()
 
-    # Shutdown — wait for running jobs to finish (job cooperates via _lifecycle_stop_event).
+    # Shutdown — wait for running jobs to finish (job cooperates via app.state.lifecycle_stop_event).
     # Bounded join mirrors the fallback policy (Fix A): if a job is stuck inside a
     # non-interruptible encoder.encode() the scheduler.shutdown(wait=True) would hang
     # indefinitely; we join with _SHUTDOWN_TIMEOUT and treat survival as scheduler_alive.

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from contextlib import asynccontextmanager
 from importlib.metadata import PackageNotFoundError, version as pkg_version
 from pathlib import Path
@@ -43,9 +44,6 @@ try:
     APP_VERSION = pkg_version("ormah")
 except PackageNotFoundError:
     APP_VERSION = "0.0.0"
-
-
-import threading
 
 # Embedding-backfill fallback (#32, council C2/CH1/CH2): when the scheduler fails
 # to start, a daemon thread heals missing vectors off the bind path. It retries

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -55,11 +55,16 @@ import threading
 # /admin/health while no scheduler exists.
 _BACKFILL_FALLBACK_BASE_BACKOFF = 30.0  # seconds
 _BACKFILL_FALLBACK_MAX_BACKOFF = 600.0  # seconds
+_FALLBACK_JOIN_TIMEOUT = 30.0  # seconds — bounded join for the fallback thread (C1)
 
 _fallback_lock = threading.Lock()
 _fallback_thread: threading.Thread | None = None
 _fallback_stop_event: threading.Event | None = None
 _fallback_degraded: bool = False
+
+# Signals the scheduler's embedding_backfill job to cancel on shutdown.
+# The fallback uses its own _fallback_stop_event; the two paths never coexist.
+_lifecycle_stop_event = threading.Event()
 
 
 def _start_backfill_fallback(engine) -> None:
@@ -106,15 +111,12 @@ def _start_backfill_fallback(engine) -> None:
         thread.start()
 
 
-def _stop_backfill_fallback() -> None:
-    """Signal the fallback thread to stop and join it without a timeout. Idempotent.
+def _stop_backfill_fallback() -> bool:
+    """Signal stop and join the fallback thread with a bounded timeout.
 
-    Mirrors scheduler.shutdown(wait=True): the cooperative cancellation guarantees
-    the thread exits after the in-flight encode completes (the backfill loop is not
-    infinite — once stop_event is set and the current encode finishes, the loop
-    exits and _run returns). Joining without a timeout ensures the engine is never
-    closed while the thread can still touch the DB (C-A), and the handle is cleared
-    only after the thread is confirmed dead, so the singleton guard stays intact (C-B).
+    Returns True if the thread survived the join (caller must skip engine.shutdown()
+    to avoid use-after-close; the handle is kept so the singleton guard still blocks
+    a second fallback — C-A/C-B). Returns False when the thread is confirmed dead.
 
     Lock discipline: signal + read handle under lock; join outside the lock (do not
     hold the lock during a potentially long join); clear handle under lock after join.
@@ -125,10 +127,18 @@ def _stop_backfill_fallback() -> None:
             _fallback_stop_event.set()
         thread = _fallback_thread
     if thread is not None:
-        thread.join()  # no timeout — engine must not close until the thread is dead
+        thread.join(timeout=_FALLBACK_JOIN_TIMEOUT)
+        if thread.is_alive():
+            logger.critical(
+                "Embedding backfill fallback did not stop within %.0fs; keeping the "
+                "thread handle and skipping engine shutdown to avoid use-after-close.",
+                _FALLBACK_JOIN_TIMEOUT,
+            )
+            return True
     with _fallback_lock:
         _fallback_thread = None
         _fallback_stop_event = None
+    return False
 
 
 @asynccontextmanager
@@ -145,8 +155,9 @@ async def lifespan(app: FastAPI):
     try:
         from ormah.background.scheduler import start_scheduler
 
+        _lifecycle_stop_event.clear()  # reset defensivo para reload no mesmo processo
         logger.info("Starting background scheduler...")
-        scheduler, tracker = start_scheduler(engine)
+        scheduler, tracker = start_scheduler(engine, stop_event=_lifecycle_stop_event)
         app.state.scheduler = scheduler
         app.state.job_tracker = tracker
         app.state.maintenance_manager = MaintenanceManager(engine, tracker=tracker)
@@ -183,6 +194,13 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    # Ask the scheduler's embedding_backfill job to cancel cooperatively.
+    # scheduler.shutdown(wait=True) below honours this: the job exits between
+    # encodes. A single encoder.encode() call mid-flight is not interruptible
+    # (fundamental limit), but wait=True ensures the DB is released before any
+    # close — no corruption.
+    _lifecycle_stop_event.set()
+
     # Shutdown — stop session watcher first
     if hasattr(app.state, "session_watcher_observers"):
         stop_session_watcher(app.state.session_watcher_observers)
@@ -191,13 +209,21 @@ async def lifespan(app: FastAPI):
     if hasattr(app.state, "hippocampus_observers"):
         stop_hippocampus(app.state.hippocampus_observers)
 
-    # Shutdown — stop the scheduler-independent backfill fallback if it is running
-    _stop_backfill_fallback()
+    # Shutdown — stop the scheduler-independent backfill fallback if it is running.
+    # If the fallback thread survived the bounded join (C1), skip engine.shutdown()
+    # to avoid use-after-close (C-A/C-B); the handle is kept for the singleton guard.
+    fallback_alive = _stop_backfill_fallback()
 
-    # Shutdown — wait for running jobs to finish (up to 10s)
+    # Shutdown — wait for running jobs to finish (job cooperates via _lifecycle_stop_event)
     if hasattr(app.state, "scheduler"):
         app.state.scheduler.shutdown(wait=True)
-    engine.shutdown()
+
+    if not fallback_alive:
+        engine.shutdown()
+    else:
+        logger.critical(
+            "Skipping engine.shutdown(): fallback thread still alive (avoids use-after-close)"
+        )
     logger.info("Ormah stopped")
 
 

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -57,6 +57,7 @@ _BACKFILL_FALLBACK_BASE_BACKOFF = 30.0  # seconds
 _BACKFILL_FALLBACK_MAX_BACKOFF = 600.0  # seconds
 _FALLBACK_JOIN_TIMEOUT = 5.0  # seconds — bound the shutdown wait on the fallback thread
 
+_fallback_lock = threading.Lock()
 _fallback_thread: threading.Thread | None = None
 _fallback_stop_event: threading.Event | None = None
 _fallback_degraded: bool = False
@@ -69,64 +70,62 @@ def _start_backfill_fallback(engine) -> None:
     recovers automatically. Singleton: a second call while one thread is alive is
     a no-op, so a lifespan restart cannot accumulate concurrent fallbacks."""
     global _fallback_thread, _fallback_stop_event, _fallback_degraded
-    import time
+    with _fallback_lock:  # CRB: make the singleton check-and-set atomic
+        if _fallback_thread is not None and _fallback_thread.is_alive():
+            return  # singleton guard (CH1)
 
-    if _fallback_thread is not None and _fallback_thread.is_alive():
-        return  # singleton guard (CH1)
+        stop_event = threading.Event()
+        _fallback_stop_event = stop_event
+        _fallback_degraded = False
 
-    stop_event = threading.Event()
-    _fallback_stop_event = stop_event
-    _fallback_degraded = False
+        def _run():
+            global _fallback_degraded
+            from ormah.background.embedding_backfill import run_embedding_backfill
 
-    def _run():
-        global _fallback_degraded
-        from ormah.background.embedding_backfill import run_embedding_backfill
-
-        delay = _BACKFILL_FALLBACK_BASE_BACKOFF
-        attempt = 0
-        while not stop_event.is_set():
-            attempt += 1
-            try:
-                run_embedding_backfill(engine)
-                _fallback_degraded = False  # gap closed (CH2: recovery observable)
-                return
-            except Exception as e:
-                _fallback_degraded = True  # CH2: persistent outage is observable
-                logger.warning(
-                    "Embedding backfill fallback attempt %d failed: %s", attempt, e,
-                )
-                # Interruptible sleep -- shutdown wakes us immediately (CH1).
-                if stop_event.wait(delay):
+            delay = _BACKFILL_FALLBACK_BASE_BACKOFF
+            attempt = 0
+            while not stop_event.is_set():
+                attempt += 1
+                try:
+                    run_embedding_backfill(engine, stop_event=stop_event)
+                    _fallback_degraded = False  # gap closed (CH2: recovery observable)
                     return
-                delay = min(delay * 2, _BACKFILL_FALLBACK_MAX_BACKOFF)
+                except Exception as e:
+                    _fallback_degraded = True  # CH2: persistent outage is observable
+                    logger.warning(
+                        "Embedding backfill fallback attempt %d failed: %s", attempt, e,
+                    )
+                    # Interruptible sleep -- shutdown wakes us immediately (CH1).
+                    if stop_event.wait(delay):
+                        return
+                    delay = min(delay * 2, _BACKFILL_FALLBACK_MAX_BACKOFF)
 
-    thread = threading.Thread(
-        target=_run, name="embedding-backfill-fallback", daemon=True
-    )
-    _fallback_thread = thread
-    thread.start()
+        thread = threading.Thread(
+            target=_run, name="embedding-backfill-fallback", daemon=True
+        )
+        _fallback_thread = thread
+        thread.start()
 
 
 def _stop_backfill_fallback() -> None:
-    """Signal the fallback thread to stop and join it (CH1). Idempotent.
-    Only clears the handle when the thread actually exits. If it is still alive
-    after the join timeout (e.g. stuck in non-interruptible backfill IO), the
-    handle is kept so the singleton guard keeps blocking a second fallback from
-    starting against a closed/recreated engine (council CR1)."""
-    global _fallback_thread
-    if _fallback_stop_event is not None:
-        _fallback_stop_event.set()
-    thread = _fallback_thread
+    """Signal the fallback thread to stop and join it. Idempotent. With the
+    backfill now cancellable, the join succeeds quickly, so the handle is always
+    cleared — the engine can then be shut down safely (no use-after-close)."""
+    global _fallback_thread, _fallback_stop_event
+    with _fallback_lock:
+        if _fallback_stop_event is not None:
+            _fallback_stop_event.set()
+        thread = _fallback_thread
     if thread is not None:
         thread.join(timeout=_FALLBACK_JOIN_TIMEOUT)
         if thread.is_alive():
             logger.warning(
-                "Embedding backfill fallback did not stop within %.1fs; keeping "
-                "the thread handle so no concurrent fallback can start.",
+                "Embedding backfill fallback did not stop within %.1fs",
                 _FALLBACK_JOIN_TIMEOUT,
             )
-        else:
-            _fallback_thread = None
+    with _fallback_lock:
+        _fallback_thread = None
+        _fallback_stop_event = None
 
 
 @asynccontextmanager

--- a/tests/test_api/test_admin_embedding_backfill_task.py
+++ b/tests/test_api/test_admin_embedding_backfill_task.py
@@ -1,0 +1,22 @@
+"""embedding_backfill must be a registered admin task in the sleep-cycle (#32)."""
+from __future__ import annotations
+
+from ormah.api import routes_admin
+
+
+def test_embedding_backfill_in_task_registry():
+    assert "embedding_backfill" in routes_admin._TASK_RUNNERS
+    module, func = routes_admin._TASK_RUNNERS["embedding_backfill"]
+    assert module == "ormah.background.embedding_backfill"
+    assert func == "run_embedding_backfill"
+
+
+def test_embedding_backfill_has_description():
+    assert "embedding_backfill" in routes_admin._TASK_DESCRIPTIONS
+
+
+def test_embedding_backfill_in_sleep_cycle_order():
+    order = routes_admin._SLEEP_CYCLE_ORDER
+    assert "embedding_backfill" in order
+    # runs after the index is updated
+    assert order.index("embedding_backfill") > order.index("index_updater")

--- a/tests/test_api/test_admin_embedding_backfill_task.py
+++ b/tests/test_api/test_admin_embedding_backfill_task.py
@@ -20,3 +20,60 @@ def test_embedding_backfill_in_sleep_cycle_order():
     assert "embedding_backfill" in order
     # runs after the index is updated
     assert order.index("embedding_backfill") > order.index("index_updater")
+
+
+def test_run_all_tasks_degraded_returns_503_when_a_task_raises(monkeypatch):
+    """C1/I1: a failed task yields status=degraded AND HTTP 503 (not 200)."""
+    import importlib
+    import json
+    from unittest.mock import MagicMock
+
+    from fastapi.responses import JSONResponse
+
+    import ormah.background.embedding_backfill as ebf
+    from ormah.api import routes_admin
+
+    def _raise(engine):
+        raise RuntimeError("encoder down")
+
+    monkeypatch.setattr(ebf, "run_embedding_backfill", _raise)
+
+    # Stub every other runner so real background code doesn't run with a mock engine.
+    for task_id, (module_path, func_name) in routes_admin._TASK_RUNNERS.items():
+        if task_id != "embedding_backfill":
+            mod = importlib.import_module(module_path)
+            monkeypatch.setattr(mod, func_name, lambda e: None)
+
+    mock_request = MagicMock()
+    mock_request.app.state.engine = MagicMock()
+
+    result = routes_admin.run_all_tasks(mock_request)
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 503
+    body = json.loads(bytes(result.body))
+    assert body["status"] == "degraded"
+    assert body["results"]["embedding_backfill"].startswith("error:")
+
+
+def test_run_all_tasks_completed_returns_dict_when_all_ok(monkeypatch):
+    """Happy path stays a plain dict (HTTP 200) with status=completed."""
+    import importlib
+    from unittest.mock import MagicMock
+
+    from ormah.api import routes_admin
+
+    for task_id, (module_path, func_name) in routes_admin._TASK_RUNNERS.items():
+        mod = importlib.import_module(module_path)
+        monkeypatch.setattr(mod, func_name, lambda e: None)
+
+    mock_request = MagicMock()
+    engine = MagicMock()
+    engine.builder.incremental_update.return_value = (0, 0)
+    mock_request.app.state.engine = engine
+
+    result = routes_admin.run_all_tasks(mock_request)
+
+    assert isinstance(result, dict)
+    assert result["status"] == "completed"
+    assert all(v == "ok" for v in result["results"].values())

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -235,6 +235,42 @@ def test_maintenance_reuses_single_inflight_job(client):
         release.set()
 
 
+def test_health_degraded_when_no_scheduler_and_fallback_failing(monkeypatch):
+    """CH2: with no scheduler, a degraded fallback makes /admin/health degraded."""
+    from unittest.mock import MagicMock
+
+    from ormah import main as _main
+    from ormah.api import routes_admin
+
+    monkeypatch.setattr(_main, "_fallback_degraded", True)
+
+    request = MagicMock()
+    # No job_tracker on app.state -> getattr returns the default (None).
+    request.app.state = MagicMock(spec=[])  # empty spec: no job_tracker, no manager
+
+    result = routes_admin.health(request)
+
+    assert result["status"] == "degraded"
+    assert result["embedding_backfill"].startswith("degraded")
+
+
+def test_health_ok_when_no_scheduler_and_fallback_healthy(monkeypatch):
+    """Inverse: a healthy fallback (flag False) leaves health ok."""
+    from unittest.mock import MagicMock
+
+    from ormah import main as _main
+    from ormah.api import routes_admin
+
+    monkeypatch.setattr(_main, "_fallback_degraded", False)
+
+    request = MagicMock()
+    request.app.state = MagicMock(spec=[])
+
+    result = routes_admin.health(request)
+
+    assert result["status"] == "ok"
+
+
 def test_maintenance_phase2_apply_completes_via_routes(client):
     app = client.app
     original_batches = app.state.engine.get_maintenance_batches

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -332,3 +332,46 @@ def test_maintenance_phase2_apply_completes_via_routes(client):
     finally:
         app.state.engine.get_maintenance_batches = original_batches
         app.state.engine.apply_maintenance_results = original_apply
+
+
+def test_health_degraded_when_scheduler_job_embedding_backfill_failing():
+    """CR2: scheduler present + embedding_backfill last run failed -> health degraded."""
+    from unittest.mock import MagicMock
+
+    from ormah.api import routes_admin
+    from ormah.background.job_tracker import JobTracker
+
+    tracker = JobTracker()
+    tracker.record_failure("embedding_backfill", "encoder down", 12.0)
+
+    request = MagicMock()
+    request.app.state.job_tracker = tracker
+    # no maintenance_manager
+    request.app.state.maintenance_manager = None
+
+    result = routes_admin.health(request)
+
+    assert result["status"] == "degraded"
+    assert "embedding_backfill" in result
+    assert "jobs" in result  # snapshot still attached
+
+
+def test_health_ok_when_scheduler_job_recovered():
+    """A later success after an error leaves health ok."""
+    from unittest.mock import MagicMock
+
+    from ormah.api import routes_admin
+    from ormah.background.job_tracker import JobTracker
+
+    tracker = JobTracker()
+    tracker.record_failure("embedding_backfill", "encoder down", 12.0)
+    time.sleep(0.001)  # ensure success timestamp is strictly later
+    tracker.record_success("embedding_backfill", 8.0)  # recovered
+
+    request = MagicMock()
+    request.app.state.job_tracker = tracker
+    request.app.state.maintenance_manager = None
+
+    result = routes_admin.health(request)
+
+    assert result["status"] == "ok"

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -375,3 +375,37 @@ def test_health_ok_when_scheduler_job_recovered():
     result = routes_admin.health(request)
 
     assert result["status"] == "ok"
+
+
+def test_run_all_records_failure_in_tracker_so_health_degrades():
+    """CRC: a failed task in run-all must persist to the JobTracker so a later
+    GET /admin/health reports degraded (not a stale ok)."""
+    from unittest.mock import MagicMock
+
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from ormah.api.routes_admin import router as admin_router
+    from ormah.background.job_tracker import JobTracker
+
+    class _EngineWhereBackfillRaises:
+        """Minimal engine double: backfill_embeddings raises; other attrs are mocks."""
+
+        def __getattr__(self, name):
+            # builder.incremental_update() and other runner calls go through here
+            return MagicMock(return_value=None)
+
+        def backfill_embeddings(self, *args, **kwargs):
+            raise RuntimeError("encoder down (test double)")
+
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.state.engine = _EngineWhereBackfillRaises()
+    app.state.job_tracker = JobTracker()
+    app.state.maintenance_manager = None
+
+    with TestClient(app) as c:
+        r = c.post("/admin/tasks/run-all")
+        assert r.status_code == 503
+        h = c.get("/admin/health")
+        assert h.json()["status"] == "degraded"

--- a/tests/test_background/test_embedding_backfill.py
+++ b/tests/test_background/test_embedding_backfill.py
@@ -1,7 +1,10 @@
 """Tests for the embedding_backfill reconciliation job (#32)."""
+import threading
+
 import pytest
 from ormah.background.embedding_backfill import run_embedding_backfill
 from ormah.models.node import CreateNodeRequest
+from ormah.engine.memory_engine import _EMBEDDING_SCHEMA_VERSION
 
 
 def test_run_embedding_backfill_closes_gap(engine):
@@ -16,14 +19,34 @@ def test_run_embedding_backfill_closes_gap(engine):
 
 def test_run_embedding_backfill_raises_when_incomplete(engine, monkeypatch):
     monkeypatch.setattr(engine, "backfill_embeddings",
-        lambda: {"mode": "delta", "embedded": 0, "failed": 1, "missing": 1,
-                 "vec_count": 0, "node_count": 1})
+        lambda **_: {"mode": "delta", "embedded": 0, "failed": 1, "missing": 1,
+                     "vec_count": 0, "node_count": 1})
     with pytest.raises(RuntimeError, match="incomplete"):
         run_embedding_backfill(engine)
 
 
 def test_run_embedding_backfill_ok_when_complete(engine, monkeypatch):
     monkeypatch.setattr(engine, "backfill_embeddings",
-        lambda: {"mode": "delta", "embedded": 0, "failed": 0, "missing": 0,
-                 "vec_count": 1, "node_count": 1})
+        lambda **_: {"mode": "delta", "embedded": 0, "failed": 0, "missing": 0,
+                     "vec_count": 1, "node_count": 1})
     run_embedding_backfill(engine)  # must NOT raise
+
+
+def test_run_embedding_backfill_accepts_stop_event(engine):
+    """An interrupted run (stop_event set) leaves missing>0, triggering RuntimeError."""
+    nid, _ = engine.remember(CreateNodeRequest(title="E1", content="event cancel"))
+    # Force a gap so there is work to do.
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    # Ensure delta mode.
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES "
+            "('embedding_schema_version', ?)",
+            (str(_EMBEDDING_SCHEMA_VERSION),),
+        )
+
+    stop = threading.Event()
+    stop.set()  # already cancelled
+    with pytest.raises(RuntimeError, match="incomplete"):
+        run_embedding_backfill(engine, stop_event=stop)

--- a/tests/test_background/test_embedding_backfill.py
+++ b/tests/test_background/test_embedding_backfill.py
@@ -1,0 +1,29 @@
+"""Tests for the embedding_backfill reconciliation job (#32)."""
+import pytest
+from ormah.background.embedding_backfill import run_embedding_backfill
+from ormah.models.node import CreateNodeRequest
+
+
+def test_run_embedding_backfill_closes_gap(engine):
+    nid, _ = engine.remember(CreateNodeRequest(title="Job", content="content"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    run_embedding_backfill(engine)
+    assert engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids WHERE id = ?", (nid,)
+    ).fetchone()[0] == 1
+
+
+def test_run_embedding_backfill_raises_when_incomplete(engine, monkeypatch):
+    monkeypatch.setattr(engine, "backfill_embeddings",
+        lambda: {"mode": "delta", "embedded": 0, "failed": 1, "missing": 1,
+                 "vec_count": 0, "node_count": 1})
+    with pytest.raises(RuntimeError, match="incomplete"):
+        run_embedding_backfill(engine)
+
+
+def test_run_embedding_backfill_ok_when_complete(engine, monkeypatch):
+    monkeypatch.setattr(engine, "backfill_embeddings",
+        lambda: {"mode": "delta", "embedded": 0, "failed": 0, "missing": 0,
+                 "vec_count": 1, "node_count": 1})
+    run_embedding_backfill(engine)  # must NOT raise

--- a/tests/test_background/test_scheduler_embedding_backfill.py
+++ b/tests/test_background/test_scheduler_embedding_backfill.py
@@ -1,6 +1,9 @@
 """The embedding_backfill job must be registered with a post-bind first run (#32)."""
 from __future__ import annotations
 
+import threading
+from unittest.mock import patch
+
 from ormah.background.scheduler import start_scheduler
 
 
@@ -14,3 +17,31 @@ def test_embedding_backfill_job_registered(engine):
         assert job.next_run_time is not None
     finally:
         scheduler.shutdown(wait=False)
+
+
+def test_scheduler_passes_stop_event_to_embedding_backfill(engine):
+    """C2: start_scheduler deve injetar o stop_event no job embedding_backfill."""
+    evt = threading.Event()
+    received_kwargs = {}
+
+    def _fake_run(eng, stop_event=None):
+        received_kwargs["stop_event"] = stop_event
+
+    with patch(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        side_effect=_fake_run,
+    ):
+        scheduler, _tracker = start_scheduler(engine, stop_event=evt)
+        try:
+            job = scheduler.get_job("embedding_backfill")
+            assert job is not None, "job embedding_backfill deve estar registrado"
+            # Executa o job diretamente (sem APScheduler thread pool)
+            job.func()
+        finally:
+            scheduler.shutdown(wait=False)
+
+    assert "stop_event" in received_kwargs, "run_embedding_backfill não foi chamado"
+    assert received_kwargs["stop_event"] is evt, (
+        f"stop_event injetado deve ser o mesmo evento passado a start_scheduler; "
+        f"recebido: {received_kwargs['stop_event']!r}"
+    )

--- a/tests/test_background/test_scheduler_embedding_backfill.py
+++ b/tests/test_background/test_scheduler_embedding_backfill.py
@@ -1,0 +1,16 @@
+"""The embedding_backfill job must be registered with a post-bind first run (#32)."""
+from __future__ import annotations
+
+from ormah.background.scheduler import start_scheduler
+
+
+def test_embedding_backfill_job_registered(engine):
+    scheduler, _tracker = start_scheduler(engine)
+    try:
+        job = scheduler.get_job("embedding_backfill")
+        assert job is not None
+        assert job.name == "Embedding backfill"
+        # next_run_time is set (post-bind first run), not None/deferred
+        assert job.next_run_time is not None
+    finally:
+        scheduler.shutdown(wait=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -284,3 +284,27 @@ def test_consolidation_max_nodes_zero_rejected():
 def test_consolidation_inverted_bounds_rejected():
     with pytest.raises(ValidationError, match="consolidation_max_cluster_nodes"):
         _settings(consolidation_min_cluster_size=3, consolidation_max_cluster_nodes=2)
+
+
+# --- Embedding backfill / vector-store reconciliation (#32) ---
+
+def test_embedding_backfill_settings_defaults():
+    s = _settings()
+    assert s.embedding_backfill_interval_minutes == 60
+    assert s.embedding_index_max_retries == 2
+    assert s.embedding_index_retry_backoff_seconds == 0.5
+
+
+def test_embedding_backfill_interval_rejects_zero():
+    with pytest.raises(ValidationError):
+        _settings(embedding_backfill_interval_minutes=0)
+
+
+def test_embedding_index_max_retries_rejects_negative():
+    with pytest.raises(ValidationError):
+        _settings(embedding_index_max_retries=-1)
+
+
+def test_embedding_index_retry_backoff_rejects_negative():
+    with pytest.raises(ValidationError):
+        _settings(embedding_index_retry_backoff_seconds=-0.1)

--- a/tests/test_engine/test_backfill_embeddings.py
+++ b/tests/test_engine/test_backfill_embeddings.py
@@ -218,7 +218,7 @@ def test_schema_mode_does_not_delete_when_interrupted(engine, monkeypatch):
     # Run backfill with stop_event already set → interrupted=True.
     stop = threading.Event()
     stop.set()
-    result = engine.backfill_embeddings(stop_event=stop)
+    engine.backfill_embeddings(stop_event=stop)
 
     # The stale vector must NOT have been deleted (interrupted guard applied).
     after_count = engine.db.conn.execute(

--- a/tests/test_engine/test_backfill_embeddings.py
+++ b/tests/test_engine/test_backfill_embeddings.py
@@ -1,0 +1,117 @@
+"""Tests for MemoryEngine.backfill_embeddings (delta + schema-bump, no quarantine, #32).
+
+Design (council R2): schema-bump re-embeds all embeddable nodes once, deletes the
+stale vector of any node that fails to encode (so it becomes genuinely missing),
+and advances the version unconditionally after the pass. Delta mode embeds only
+nodes missing from the vector store. A permanently-failing node stays visible in
+``missing`` and is retried every tick -- never dropped, never masked.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from ormah.models.node import CreateNodeRequest
+from ormah.engine.memory_engine import _EMBEDDING_SCHEMA_VERSION
+
+
+def _set_schema_version(engine, version: int) -> None:
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES "
+            "('embedding_schema_version', ?)",
+            (str(version),),
+        )
+
+
+def _stored_version(engine) -> int:
+    return int(engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key='embedding_schema_version'"
+    ).fetchone()["value"])
+
+
+def test_backfill_delta_closes_the_gap(engine):
+    ids = []
+    for i in range(3):
+        nid, _ = engine.remember(CreateNodeRequest(title=f"N{i}", content=f"content {i}"))
+        ids.append(nid)
+    _set_schema_version(engine, _EMBEDDING_SCHEMA_VERSION)  # already current -> delta mode
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (ids[0],))
+
+    result = engine.backfill_embeddings()
+
+    assert result["mode"] == "delta"
+    assert result["missing"] == 0
+    assert engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids WHERE id = ?", (ids[0],)
+    ).fetchone()[0] == 1
+
+
+def test_backfill_delta_is_noop_when_full(engine):
+    engine.remember(CreateNodeRequest(title="Solo", content="content"))
+    _set_schema_version(engine, _EMBEDDING_SCHEMA_VERSION)
+    engine.backfill_embeddings()  # settle any startup-created node
+
+    result = engine.backfill_embeddings()
+
+    assert result["mode"] == "delta"
+    assert result["embedded"] == 0
+
+
+def test_backfill_schema_bump_reembeds_all_and_bumps_version(engine):
+    engine.remember(CreateNodeRequest(title="A", content="alpha"))
+    engine.remember(CreateNodeRequest(title="B", content="beta"))
+    _set_schema_version(engine, 1)
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    result = engine.backfill_embeddings()
+
+    assert result["mode"] == "schema"
+    assert result["missing"] == 0
+    assert _stored_version(engine) == _EMBEDDING_SCHEMA_VERSION
+
+
+def test_schema_bump_poison_node_stays_visible_and_advances_version(engine, monkeypatch):
+    """A node that always fails to encode stays genuinely missing (its stale vector
+    is deleted) and visible in `missing`; the version still advances after the pass,
+    and the next delta run retries it without re-embedding the whole store."""
+    engine.remember(CreateNodeRequest(title="poison", content="POISON payload"))
+    engine.remember(CreateNodeRequest(title="ok1", content="fine one"))
+    engine.remember(CreateNodeRequest(title="ok2", content="fine two"))
+    _set_schema_version(engine, 1)
+
+    dim = engine.settings.embedding_dim
+
+    class _SelectiveEncoder:
+        def __init__(self):
+            self.encode_calls = 0
+
+        def encode(self, text):
+            self.encode_calls += 1
+            if "POISON" in text:
+                raise RuntimeError("poison node")
+            return np.ones(dim, dtype="float32")
+
+    enc = _SelectiveEncoder()
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda settings: enc)
+
+    # Schema bump: poison fails -> its stale vector is deleted -> genuinely missing.
+    r1 = engine.backfill_embeddings()
+    assert r1["mode"] == "schema"
+    assert r1["failed"] == 1
+    assert r1["missing"] == 1
+    assert _stored_version(engine) == _EMBEDDING_SCHEMA_VERSION  # advances unconditionally
+    assert engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids WHERE id = "
+        "(SELECT id FROM nodes WHERE title='poison')"
+    ).fetchone()[0] == 0
+
+    # Delta run: retries ONLY the missing poison node (O(gap)), still fails.
+    calls_after_schema = enc.encode_calls
+    r2 = engine.backfill_embeddings()
+    assert r2["mode"] == "delta"
+    assert r2["embedded"] == 0
+    assert r2["failed"] == 1
+    assert r2["missing"] == 1
+    assert enc.encode_calls == calls_after_schema + 1  # one retry, not a full re-embed

--- a/tests/test_engine/test_backfill_embeddings.py
+++ b/tests/test_engine/test_backfill_embeddings.py
@@ -8,6 +8,8 @@ nodes missing from the vector store. A permanently-failing node stays visible in
 """
 from __future__ import annotations
 
+import threading
+
 import numpy as np
 
 from ormah.models.node import CreateNodeRequest
@@ -115,3 +117,59 @@ def test_schema_bump_poison_node_stays_visible_and_advances_version(engine, monk
     assert r2["failed"] == 1
     assert r2["missing"] == 1
     assert enc.encode_calls == calls_after_schema + 1  # one retry, not a full re-embed
+
+
+# ---------------------------------------------------------------------------
+# Cooperative cancellation via stop_event (Task A — CRA/IA)
+# ---------------------------------------------------------------------------
+
+def test_backfill_stops_before_db_writes_when_event_set(engine):
+    """A stop_event that is already set causes backfill to embed nothing."""
+    engine.remember(CreateNodeRequest(title="C1", content="cancel me one"))
+    engine.remember(CreateNodeRequest(title="C2", content="cancel me two"))
+    # Force delta mode (version already current) and create a gap.
+    _set_schema_version(engine, _EMBEDDING_SCHEMA_VERSION)
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    stop = threading.Event()
+    stop.set()  # already cancelled before the call
+    result = engine.backfill_embeddings(stop_event=stop)
+
+    assert result["embedded"] == 0
+    assert result["missing"] > 0
+
+
+def test_backfill_completes_when_event_not_set(engine):
+    """A stop_event that is never set does not interfere with normal completion."""
+    engine.remember(CreateNodeRequest(title="D1", content="do embed one"))
+    engine.remember(CreateNodeRequest(title="D2", content="do embed two"))
+    _set_schema_version(engine, _EMBEDDING_SCHEMA_VERSION)
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    result = engine.backfill_embeddings(stop_event=threading.Event())  # never set
+
+    assert result["missing"] == 0
+
+
+def test_schema_version_not_advanced_when_interrupted(engine):
+    """An interrupted schema pass must NOT advance embedding_schema_version."""
+    engine.remember(CreateNodeRequest(title="S1", content="schema node one"))
+    _set_schema_version(engine, 1)  # trigger schema mode (stored < current)
+
+    before = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key='embedding_schema_version'"
+    ).fetchone()
+
+    stop = threading.Event()
+    stop.set()
+    engine.backfill_embeddings(stop_event=stop)
+
+    after = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key='embedding_schema_version'"
+    ).fetchone()
+
+    before_val = before["value"] if before else None
+    after_val = after["value"] if after else None
+    assert before_val == after_val

--- a/tests/test_engine/test_backfill_embeddings.py
+++ b/tests/test_engine/test_backfill_embeddings.py
@@ -173,3 +173,58 @@ def test_schema_version_not_advanced_when_interrupted(engine):
     before_val = before["value"] if before else None
     after_val = after["value"] if after else None
     assert before_val == after_val
+
+
+def test_schema_mode_does_not_delete_when_interrupted(engine, monkeypatch):
+    """Fix B: an interrupted schema pass must NOT delete stale vectors.
+
+    The DELETE is guarded by `not interrupted` — consistent with the version-advance
+    guard already in place. A cancel mid-schema stops the encode but must not execute
+    the DELETE that follows it.
+    """
+    # Create a node that will fail encoding (simulates a real encoder error).
+    nid_poison, _ = engine.remember(CreateNodeRequest(title="poison", content="POISON"))
+    engine.remember(CreateNodeRequest(title="ok", content="fine"))
+    # Downgrade schema version so schema mode is triggered.
+    _set_schema_version(engine, 1)
+
+    dim = engine.settings.embedding_dim
+
+    class _FailingEncoder:
+        def encode(self, text):
+            if "POISON" in text:
+                raise RuntimeError("encode failure")
+            return np.ones(dim, dtype="float32")
+
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda s: _FailingEncoder())
+
+    # Ensure the poison node already has a stale vector in the store.
+    # vec0 virtual tables do not support INSERT OR REPLACE — use DELETE + INSERT.
+    import struct
+    stale_vec = struct.pack(f"{dim}f", *[0.5] * dim)
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid_poison,))
+        conn.execute(
+            "INSERT INTO node_vectors (id, embedding) VALUES (?, ?)",
+            (nid_poison, stale_vec),
+        )
+
+    # Confirm the stale vector exists before the interrupted call.
+    before_count = engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors WHERE id = ?", (nid_poison,)
+    ).fetchone()[0]
+    assert before_count == 1, "stale vector should exist before the interrupted call"
+
+    # Run backfill with stop_event already set → interrupted=True.
+    stop = threading.Event()
+    stop.set()
+    result = engine.backfill_embeddings(stop_event=stop)
+
+    # The stale vector must NOT have been deleted (interrupted guard applied).
+    after_count = engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors WHERE id = ?", (nid_poison,)
+    ).fetchone()[0]
+    assert after_count == 1, (
+        "stale vector was deleted despite interrupted=True — "
+        "DELETE must be guarded by `not interrupted`"
+    )

--- a/tests/test_engine/test_embed_node_rows.py
+++ b/tests/test_engine/test_embed_node_rows.py
@@ -1,6 +1,9 @@
 """Tests for MemoryEngine._embed_node_rows (extracted embedding core, #32)."""
 from __future__ import annotations
 
+import numpy as np
+import pytest
+
 from ormah.models.node import CreateNodeRequest
 
 
@@ -45,3 +48,99 @@ def test_embed_node_rows_empty_list_is_noop(engine):
     embedded_ids, failed_ids = engine._embed_node_rows([])
     assert embedded_ids == []
     assert failed_ids == []
+
+
+def test_embed_node_rows_persists_incrementally(engine, monkeypatch):
+    """A hard interrupt mid-encode must leave already-encoded chunks persisted,
+    not lose everything. Simulate the kill with a BaseException on encode #101."""
+    dim = engine.settings.embedding_dim
+    for i in range(150):
+        engine.remember(CreateNodeRequest(title=f"n{i}", content=f"content {i}"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    calls = {"n": 0}
+
+    class _KillAt101:
+        def encode(self, text):
+            calls["n"] += 1
+            if calls["n"] == 101:
+                raise KeyboardInterrupt("hard kill mid-encode")
+            return np.ones(dim, dtype=np.float32)
+
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda s: _KillAt101())
+    rows = engine.db.conn.execute("SELECT id, title, content FROM nodes").fetchall()
+
+    with pytest.raises(KeyboardInterrupt):
+        engine._embed_node_rows(rows)
+
+    persisted = engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids"
+    ).fetchone()[0]
+    assert persisted == 100  # first full chunk landed before the kill
+
+
+def test_embed_node_rows_flushes_pending_on_cooperative_cancel(engine, monkeypatch):
+    """stop_event set mid-run: everything encoded so far is persisted (the final
+    flush runs on the cooperative-cancel path too)."""
+    import threading
+
+    dim = engine.settings.embedding_dim
+    for i in range(120):
+        engine.remember(CreateNodeRequest(title=f"c{i}", content=f"cancel {i}"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    stop = threading.Event()
+    calls = {"n": 0}
+
+    class _StopAt105:
+        def encode(self, text):
+            calls["n"] += 1
+            if calls["n"] == 105:
+                stop.set()  # cancellation arrives after this encode returns
+            return np.ones(dim, dtype=np.float32)
+
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda s: _StopAt105())
+    rows = engine.db.conn.execute("SELECT id, title, content FROM nodes").fetchall()
+
+    embedded_ids, failed_ids = engine._embed_node_rows(rows, stop_event=stop)
+
+    assert len(embedded_ids) == 105  # 100 flushed at the boundary + 5 pending flushed on exit
+    assert failed_ids == []
+    persisted = engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids"
+    ).fetchone()[0]
+    assert persisted == 105
+
+
+def test_persistence_failure_propagates_not_marked_failed(engine, monkeypatch):
+    """An upsert_batch error is a JOB failure, not a per-node encode failure: it
+    must propagate (tracked() records it) and the node must NOT enter failed_ids
+    — a wrong failed_ids entry would get its vector deleted by the schema-mode
+    failed-node cleanup. (council r3, codex high)"""
+    import sqlite3
+
+    dim = engine.settings.embedding_dim
+    nid, _ = engine.remember(CreateNodeRequest(title="pf", content="persist fail"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    class _OkEncoder:
+        def encode(self, text):
+            return np.ones(dim, dtype=np.float32)
+
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda s: _OkEncoder())
+
+    def _boom(self, items):
+        raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(
+        "ormah.embeddings.vector_store.VectorStore.upsert_batch", _boom
+    )
+    rows = engine.db.conn.execute(
+        "SELECT id, title, content FROM nodes WHERE id = ?", (nid,)
+    ).fetchall()
+
+    with pytest.raises(sqlite3.OperationalError):
+        engine._embed_node_rows(rows)

--- a/tests/test_engine/test_embed_node_rows.py
+++ b/tests/test_engine/test_embed_node_rows.py
@@ -118,11 +118,22 @@ def test_persistence_failure_propagates_not_marked_failed(engine, monkeypatch):
     """An upsert_batch error is a JOB failure, not a per-node encode failure: it
     must propagate (tracked() records it) and the node must NOT enter failed_ids
     — a wrong failed_ids entry would get its vector deleted by the schema-mode
-    failed-node cleanup. (council r3, codex high)"""
+    failed-node cleanup. (council r3, codex high)
+
+    Uses >100 nodes so the in-loop chunk-boundary flush actually fires during
+    the loop (with <=100 nodes only the post-loop flush runs, which is
+    structurally outside any try regardless of where the in-loop call sits —
+    that would make this test pass even if _flush() were wrongly moved inside
+    the encode try). Asserts upsert_batch was called exactly once: if the
+    first flush's error were swallowed into failed_ids instead of propagating,
+    the loop would continue and a second (post-loop) flush would call
+    upsert_batch again, catching the exact regression this test guards
+    against."""
     import sqlite3
 
     dim = engine.settings.embedding_dim
-    nid, _ = engine.remember(CreateNodeRequest(title="pf", content="persist fail"))
+    for i in range(101):
+        engine.remember(CreateNodeRequest(title=f"pf{i}", content=f"persist fail {i}"))
     with engine.db.transaction() as conn:
         conn.execute("DELETE FROM node_vectors")
 
@@ -132,15 +143,18 @@ def test_persistence_failure_propagates_not_marked_failed(engine, monkeypatch):
 
     monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda s: _OkEncoder())
 
+    calls = {"n": 0}
+
     def _boom(self, items):
+        calls["n"] += 1
         raise sqlite3.OperationalError("disk I/O error")
 
     monkeypatch.setattr(
         "ormah.embeddings.vector_store.VectorStore.upsert_batch", _boom
     )
-    rows = engine.db.conn.execute(
-        "SELECT id, title, content FROM nodes WHERE id = ?", (nid,)
-    ).fetchall()
+    rows = engine.db.conn.execute("SELECT id, title, content FROM nodes").fetchall()
 
     with pytest.raises(sqlite3.OperationalError):
         engine._embed_node_rows(rows)
+
+    assert calls["n"] == 1  # propagated immediately; no second (post-loop) flush attempt

--- a/tests/test_engine/test_embed_node_rows.py
+++ b/tests/test_engine/test_embed_node_rows.py
@@ -1,0 +1,47 @@
+"""Tests for MemoryEngine._embed_node_rows (extracted embedding core, #32)."""
+from __future__ import annotations
+
+from ormah.models.node import CreateNodeRequest
+
+
+def test_embed_node_rows_returns_embedded_ids(engine):
+    nid, _ = engine.remember(CreateNodeRequest(title="Alpha", content="hello world"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    rows = engine.db.conn.execute(
+        "SELECT id, title, content FROM nodes WHERE id = ?", (nid,)
+    ).fetchall()
+
+    embedded_ids, failed_ids = engine._embed_node_rows(rows)
+
+    assert embedded_ids == [nid]
+    assert failed_ids == []
+    assert engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids WHERE id = ?", (nid,)
+    ).fetchone()[0] == 1
+
+
+def test_embed_node_rows_reports_failed_ids(engine, monkeypatch):
+    nid, _ = engine.remember(CreateNodeRequest(title="Boom", content="payload"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    rows = engine.db.conn.execute(
+        "SELECT id, title, content FROM nodes WHERE id = ?", (nid,)
+    ).fetchall()
+
+    class _DeadEncoder:
+        def encode(self, text):
+            raise RuntimeError("encoder down")
+
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda settings: _DeadEncoder())
+
+    embedded_ids, failed_ids = engine._embed_node_rows(rows)
+
+    assert embedded_ids == []
+    assert failed_ids == [nid]
+
+
+def test_embed_node_rows_empty_list_is_noop(engine):
+    embedded_ids, failed_ids = engine._embed_node_rows([])
+    assert embedded_ids == []
+    assert failed_ids == []

--- a/tests/test_engine/test_embedding_observability.py
+++ b/tests/test_engine/test_embedding_observability.py
@@ -1,0 +1,40 @@
+"""stats() must expose the embedding gap + schema version, and recovery must
+prove out end-to-end via the registered job (#32, council I3)."""
+from __future__ import annotations
+
+from ormah.engine.memory_engine import _EMBEDDING_SCHEMA_VERSION
+from ormah.models.node import CreateNodeRequest
+
+
+def _set_schema_current(engine):
+    with engine.db.transaction() as conn:
+        conn.execute("INSERT OR REPLACE INTO meta (key, value) VALUES "
+                     "('embedding_schema_version', ?)", (str(_EMBEDDING_SCHEMA_VERSION),))
+
+
+def test_stats_exposes_embedding_gap_and_version(engine):
+    nid, _ = engine.remember(CreateNodeRequest(title="x", content="y"))
+    _set_schema_current(engine)
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    s = engine.stats()
+    assert s["embedding_gap"] >= 1
+    assert s["embedding_schema_version"] == _EMBEDDING_SCHEMA_VERSION
+    assert "vec_count" in s
+
+
+def test_e2e_gap_recovers_via_registered_job(engine):
+    from ormah.background.scheduler import start_scheduler
+    from ormah.background.embedding_backfill import run_embedding_backfill
+    nid, _ = engine.remember(CreateNodeRequest(title="recover", content="me"))
+    _set_schema_current(engine)
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    assert engine.stats()["embedding_gap"] >= 1
+    scheduler, _t = start_scheduler(engine)
+    try:
+        assert scheduler.get_job("embedding_backfill") is not None
+        run_embedding_backfill(engine)
+    finally:
+        scheduler.shutdown(wait=False)
+    assert engine.stats()["embedding_gap"] == 0

--- a/tests/test_engine/test_index_embedding_retry.py
+++ b/tests/test_engine/test_index_embedding_retry.py
@@ -1,0 +1,57 @@
+"""Tests for _index_embedding bounded retry (#32)."""
+from __future__ import annotations
+
+from ormah.models.node import CreateNodeRequest
+
+
+class _FlakyEncoder:
+    """Fails `fail_times` then succeeds, returning a fixed-dim vector."""
+    def __init__(self, fail_times, dim):
+        self.fail_times = fail_times
+        self.calls = 0
+        self._dim = dim
+
+    def encode(self, text):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise RuntimeError("transient encoder failure")
+        import numpy as np
+        return np.ones(self._dim, dtype="float32")
+
+
+def test_index_embedding_retries_then_succeeds(engine, monkeypatch):
+    nid, _ = engine.remember(CreateNodeRequest(title="Retry", content="payload"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    node = engine.file_store.load(nid)
+
+    enc = _FlakyEncoder(fail_times=2, dim=engine.settings.embedding_dim)
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda settings: enc)
+    monkeypatch.setattr("time.sleep", lambda s: None)  # no real backoff in tests
+
+    engine._index_embedding(node)  # max_retries default 2 -> 3 attempts total
+
+    assert enc.calls == 3
+    assert engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids WHERE id = ?", (nid,)
+    ).fetchone()[0] == 1
+
+
+def test_index_embedding_gives_up_without_raising(engine, monkeypatch):
+    nid, _ = engine.remember(CreateNodeRequest(title="Down", content="payload"))
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (nid,))
+    node = engine.file_store.load(nid)
+
+    class _DeadEncoder:
+        def encode(self, text):
+            raise RuntimeError("encoder permanently down")
+
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", lambda settings: _DeadEncoder())
+    monkeypatch.setattr("time.sleep", lambda s: None)
+
+    engine._index_embedding(node)  # must NOT raise
+
+    assert engine.db.conn.execute(
+        "SELECT count(*) FROM node_vectors_rowids WHERE id = ?", (nid,)
+    ).fetchone()[0] == 0

--- a/tests/test_engine/test_startup_no_embedding.py
+++ b/tests/test_engine/test_startup_no_embedding.py
@@ -1,0 +1,26 @@
+"""startup() must not embed synchronously anymore (#32)."""
+from __future__ import annotations
+
+from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+
+
+def test_startup_does_not_call_reindex(tmp_memory_dir, monkeypatch):
+    called = {"reindex": False, "embed_rows": False}
+
+    monkeypatch.setattr(
+        MemoryEngine, "_reindex_all_embeddings",
+        lambda self: called.__setitem__("reindex", True),
+    )
+    monkeypatch.setattr(
+        MemoryEngine, "_embed_node_rows",
+        lambda self, nodes: (called.__setitem__("embed_rows", True), ([], []))[1],
+    )
+
+    eng = MemoryEngine(Settings(memory_dir=tmp_memory_dir))
+    eng.startup()
+    try:
+        assert called["reindex"] is False
+        assert called["embed_rows"] is False
+    finally:
+        eng.shutdown()

--- a/tests/test_main_backfill_fallback.py
+++ b/tests/test_main_backfill_fallback.py
@@ -7,6 +7,7 @@ a persistent outage to /admin/health while no scheduler exists.
 """
 from __future__ import annotations
 
+import threading as _threading
 import time as _time
 
 import pytest
@@ -150,8 +151,6 @@ def test_fallback_stops_on_shutdown(monkeypatch):
 # ---------------------------------------------------------------------------
 # Task B — new tests (CRB: atomic singleton, CR1 revert, stop_event forwarding)
 # ---------------------------------------------------------------------------
-
-import threading as _threading
 
 
 class _FakeEngine:

--- a/tests/test_main_backfill_fallback.py
+++ b/tests/test_main_backfill_fallback.py
@@ -1,17 +1,28 @@
-"""Scheduler-independent embedding backfill fallback (#32, council I1).
+"""Scheduler-independent embedding backfill fallback (#32, council C2/CH1/CH2).
 
-The fallback retries with backoff until the gap closes (run_embedding_backfill
-raises while it is incomplete) or the attempt budget is exhausted -- not a single
-one-shot -- so a transient encoder outage at startup doesn't leave vectors
-unhealed until the next restart.
+The fallback retries indefinitely with backoff until the gap closes
+(run_embedding_backfill raises while it is incomplete). Lifecycle is
+controlled by a stop event and a singleton guard; _fallback_degraded exposes
+a persistent outage to /admin/health while no scheduler exists.
 """
 from __future__ import annotations
 
 import time as _time
 
+import pytest
+
 from ormah import main
 
 real_sleep = _time.sleep
+
+
+@pytest.fixture(autouse=True)
+def _reset_fallback_state():
+    main._stop_backfill_fallback()  # tear down any thread a prior test started
+    main._fallback_degraded = False
+    yield
+    main._stop_backfill_fallback()
+    main._fallback_degraded = False
 
 
 def _wait_for(predicate, timeout=2.0):
@@ -43,7 +54,7 @@ def test_fallback_retries_until_success(monkeypatch):
 
     monkeypatch.setattr(
         "ormah.background.embedding_backfill.run_embedding_backfill", _flaky)
-    monkeypatch.setattr("time.sleep", lambda s: real_sleep(0.001))
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
 
     main._start_backfill_fallback(object())
     _wait_for(lambda: len(calls) >= 2)
@@ -51,7 +62,72 @@ def test_fallback_retries_until_success(monkeypatch):
     assert len(calls) == 2  # retried once, then stopped on success
 
 
-def test_fallback_gives_up_after_budget_without_raising(monkeypatch):
+def test_fallback_keeps_retrying_past_old_budget(monkeypatch):
+    """C2: fallback does not give up after 5 attempts — retries until success."""
+    calls = []
+
+    def _mostly_failing(engine):
+        calls.append(engine)
+        if len(calls) <= 6:  # fail more than the old hard budget of 5
+            raise RuntimeError("still incomplete")
+        # 7th call succeeds (returns None)
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        _mostly_failing,
+    )
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    main._start_backfill_fallback(object())
+    _wait_for(lambda: len(calls) >= 7, timeout=3.0)
+    real_sleep(0.05)
+    assert len(calls) == 7  # succeeded on the 7th attempt (past the old budget of 5)
+
+
+def test_fallback_sets_degraded_flag_on_failure_clears_on_success(monkeypatch):
+    """CH2: persistent failure is observable via _fallback_degraded; clears on recovery."""
+    calls = []
+
+    def _flaky(engine):
+        calls.append(engine)
+        if len(calls) < 3:
+            raise RuntimeError("still incomplete")
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill", _flaky)
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    main._start_backfill_fallback(object())
+    # After the first failure, before success, the flag is set.
+    _wait_for(lambda: main._fallback_degraded is True, timeout=2.0)
+    assert main._fallback_degraded is True
+    # On eventual success it clears.
+    _wait_for(lambda: main._fallback_degraded is False and len(calls) >= 3, timeout=2.0)
+    assert main._fallback_degraded is False
+
+
+def test_fallback_is_singleton(monkeypatch):
+    """CH1: a second start while one is alive does not spawn a second thread."""
+    started = []
+
+    def _block_forever(engine):
+        started.append(engine)
+        raise RuntimeError("never closes")  # keeps the loop alive
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill", _block_forever)
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    main._start_backfill_fallback(object())
+    _wait_for(lambda: main._fallback_thread is not None
+              and main._fallback_thread.is_alive(), timeout=2.0)
+    first = main._fallback_thread
+    main._start_backfill_fallback(object())  # second start — must be a no-op
+    assert main._fallback_thread is first  # same thread, not replaced
+
+
+def test_fallback_stops_on_shutdown(monkeypatch):
+    """CH1: _stop_backfill_fallback stops a permanently-failing fallback."""
     calls = []
 
     def _boom(engine):
@@ -60,9 +136,12 @@ def test_fallback_gives_up_after_budget_without_raising(monkeypatch):
 
     monkeypatch.setattr(
         "ormah.background.embedding_backfill.run_embedding_backfill", _boom)
-    monkeypatch.setattr("time.sleep", lambda s: real_sleep(0.001))
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
 
-    main._start_backfill_fallback(object())  # must not raise on the main thread
-    _wait_for(lambda: len(calls) >= main._BACKFILL_FALLBACK_MAX_ATTEMPTS)
-    real_sleep(0.05)
-    assert len(calls) == main._BACKFILL_FALLBACK_MAX_ATTEMPTS  # bounded, then gives up
+    main._start_backfill_fallback(object())
+    _wait_for(lambda: len(calls) >= 1, timeout=2.0)
+    main._stop_backfill_fallback()
+    assert main._fallback_thread is None or not main._fallback_thread.is_alive()
+    settled = len(calls)
+    real_sleep(0.1)
+    assert len(calls) == settled  # no further attempts after stop

--- a/tests/test_main_backfill_fallback.py
+++ b/tests/test_main_backfill_fallback.py
@@ -36,7 +36,7 @@ def test_fallback_runs_backfill_off_thread(monkeypatch):
     calls = []
     monkeypatch.setattr(
         "ormah.background.embedding_backfill.run_embedding_backfill",
-        lambda engine: calls.append(engine),
+        lambda engine, stop_event=None: calls.append(engine),
     )
     sentinel = object()
     main._start_backfill_fallback(sentinel)  # returns immediately (off-thread)
@@ -47,7 +47,7 @@ def test_fallback_runs_backfill_off_thread(monkeypatch):
 def test_fallback_retries_until_success(monkeypatch):
     calls = []
 
-    def _flaky(engine):
+    def _flaky(engine, stop_event=None):
         calls.append(engine)
         if len(calls) < 2:
             raise RuntimeError("still incomplete")
@@ -66,7 +66,7 @@ def test_fallback_keeps_retrying_past_old_budget(monkeypatch):
     """C2: fallback does not give up after 5 attempts — retries until success."""
     calls = []
 
-    def _mostly_failing(engine):
+    def _mostly_failing(engine, stop_event=None):
         calls.append(engine)
         if len(calls) <= 6:  # fail more than the old hard budget of 5
             raise RuntimeError("still incomplete")
@@ -88,7 +88,7 @@ def test_fallback_sets_degraded_flag_on_failure_clears_on_success(monkeypatch):
     """CH2: persistent failure is observable via _fallback_degraded; clears on recovery."""
     calls = []
 
-    def _flaky(engine):
+    def _flaky(engine, stop_event=None):
         calls.append(engine)
         if len(calls) < 3:
             raise RuntimeError("still incomplete")
@@ -110,7 +110,7 @@ def test_fallback_is_singleton(monkeypatch):
     """CH1: a second start while one is alive does not spawn a second thread."""
     started = []
 
-    def _block_forever(engine):
+    def _block_forever(engine, stop_event=None):
         started.append(engine)
         raise RuntimeError("never closes")  # keeps the loop alive
 
@@ -130,7 +130,7 @@ def test_fallback_stops_on_shutdown(monkeypatch):
     """CH1: _stop_backfill_fallback stops a permanently-failing fallback."""
     calls = []
 
-    def _boom(engine):
+    def _boom(engine, stop_event=None):
         calls.append(engine)
         raise RuntimeError("permanently incomplete")
 
@@ -147,31 +147,112 @@ def test_fallback_stops_on_shutdown(monkeypatch):
     assert len(calls) == settled  # no further attempts after stop
 
 
-def test_stop_preserves_handle_when_thread_survives_join(monkeypatch):
-    """CR1: if the runner can't stop within the join timeout, keep the handle
-    so the singleton guard still blocks a second fallback."""
-    import threading
-    release = threading.Event()
-    entered = threading.Event()
+# ---------------------------------------------------------------------------
+# Task B — new tests (CRB: atomic singleton, CR1 revert, stop_event forwarding)
+# ---------------------------------------------------------------------------
 
-    def _stuck(engine):
-        entered.set()
-        release.wait(timeout=5.0)   # ignores stop_event — simulates non-interruptible IO
-        raise RuntimeError("incomplete")
+import threading as _threading
+
+
+class _FakeEngine:
+    """Blocks in backfill_embeddings until stop_event is set or 10s elapses.
+    When stop_event is None (pre-implementation, stop_event not forwarded yet),
+    blocks for the full safety-net duration so the thread stays alive long enough
+    for the concurrent test to count it."""
+
+    def __init__(self):
+        self.entered = _threading.Event()
+        self._internal_block = _threading.Event()
+
+    def backfill_embeddings(self, stop_event=None):
+        self.entered.set()
+        # Use stop_event if provided, otherwise block on internal event (safety net 10s)
+        waiter = stop_event if stop_event is not None else self._internal_block
+        waiter.wait(timeout=10.0)
+        return {"missing": 0}
+
+
+class _QuickEngine:
+    """Completes immediately with no missing nodes."""
+
+    def backfill_embeddings(self, stop_event=None):
+        return {"missing": 0}
+
+
+class _CancellableEngine:
+    """Loops checking stop_event; records whether it received it."""
+
+    def __init__(self):
+        self.entered = _threading.Event()
+        self.saw_stop = False
+
+    def backfill_embeddings(self, stop_event=None):
+        self.entered.set()
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                self.saw_stop = True
+                return {"missing": 0}
+            _threading.Event().wait(timeout=0.01)
+
+
+def _monkeypatch_run_embedding_backfill(monkeypatch):
+    """Patch run_embedding_backfill to delegate to engine.backfill_embeddings(stop_event=...)."""
+    def _fake_run(engine, stop_event=None):
+        result = engine.backfill_embeddings(stop_event=stop_event)
+        if result.get("missing", 0) > 0:
+            raise RuntimeError(f"backfill incomplete: {result['missing']} missing")
 
     monkeypatch.setattr(
-        "ormah.background.embedding_backfill.run_embedding_backfill", _stuck)
-    monkeypatch.setattr(main, "_FALLBACK_JOIN_TIMEOUT", 0.05)
-    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        _fake_run,
+    )
 
-    main._start_backfill_fallback(object())
-    assert entered.wait(timeout=2.0)
-    main._stop_backfill_fallback()              # join times out — thread still in _stuck
-    assert main._fallback_thread is not None    # handle preserved
-    assert main._fallback_thread.is_alive()
-    first = main._fallback_thread
-    main._start_backfill_fallback(object())     # singleton holds → no-op
-    assert main._fallback_thread is first
-    # cleanup so the thread exits and does not leak into the next test
-    release.set()
-    first.join(timeout=2.0)
+
+def test_concurrent_start_creates_single_thread(monkeypatch):
+    """CRB: 8 threads racing _start_backfill_fallback must produce exactly 1 live thread."""
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+    _monkeypatch_run_embedding_backfill(monkeypatch)
+
+    engine = _FakeEngine()
+    barrier = _threading.Barrier(8)
+
+    def racer():
+        barrier.wait()
+        main._start_backfill_fallback(engine)
+
+    threads = [_threading.Thread(target=racer) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    alive = [
+        t for t in _threading.enumerate()
+        if t.name == "embedding-backfill-fallback" and t.is_alive()
+    ]
+    assert len(alive) == 1
+    main._stop_backfill_fallback()
+
+
+def test_stop_clears_handle(monkeypatch):
+    """CR1 reverted: handle is always cleared after stop, even on quick completion."""
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+    _monkeypatch_run_embedding_backfill(monkeypatch)
+
+    main._start_backfill_fallback(_QuickEngine())
+    main._stop_backfill_fallback()
+    assert main._fallback_thread is None
+
+
+def test_stop_cancels_long_backfill_within_join(monkeypatch):
+    """stop_event is forwarded to the engine; handle is cleared; saw_stop is True."""
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+    _monkeypatch_run_embedding_backfill(monkeypatch)
+
+    eng = _CancellableEngine()
+    main._start_backfill_fallback(eng)
+    assert eng.entered.wait(timeout=2.0), "engine never entered backfill"
+    main._stop_backfill_fallback()
+
+    assert main._fallback_thread is None
+    assert eng.saw_stop is True

--- a/tests/test_main_backfill_fallback.py
+++ b/tests/test_main_backfill_fallback.py
@@ -255,3 +255,88 @@ def test_stop_cancels_long_backfill_within_join(monkeypatch):
 
     assert main._fallback_thread is None
     assert eng.saw_stop is True
+
+
+def test_stop_does_not_return_while_backfill_thread_alive(monkeypatch):
+    """M-A: _stop_backfill_fallback must NOT return while the thread is alive.
+
+    Simulates encoder.encode() blocking mid-call (ignores stop_event until
+    the encode finishes). With the old join(timeout=5s) the stop returns after
+    ~5s and the handle is cleared while the thread is still alive — C-A/C-B.
+    With the fix (join without timeout) _stop blocks until the encode releases,
+    guaranteeing the engine is never closed while the thread can still touch the DB.
+
+    Protocol:
+    - `entered` fires when the fake encode begins (thread is alive, inside encode).
+    - `release` blocks the fake encode; setting it simulates the encode finishing.
+    - `_stop_backfill_fallback()` runs in a helper thread; `stopped` fires when it returns.
+    - Assert: stopped does NOT fire within 6s while release is not set  → FAILS on old code
+              (old join(5s) would return after 5s; not stopped.wait(6) would be False).
+    - Release the encode, then assert: stopped fires within 3s, handle is None, thread dead.
+    """
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    entered = _threading.Event()
+    release = _threading.Event()
+
+    def _blocking_run(engine, stop_event=None):
+        entered.set()
+        # Simulate a long encoder.encode() that does NOT check stop_event mid-call.
+        release.wait()
+        # After the blocking encode finishes, honour the stop_event so the loop exits.
+        if stop_event is not None and stop_event.is_set():
+            return {"mode": "delta", "embedded": 0, "failed": 0, "missing": 1,
+                    "vec_count": 0, "node_count": 1}
+        return {"mode": "delta", "embedded": 0, "failed": 0, "missing": 0,
+                "vec_count": 0, "node_count": 1}
+
+    def _fake_run(engine, stop_event=None):
+        result = _blocking_run(engine, stop_event=stop_event)
+        if result.get("missing", 0) > 0:
+            raise RuntimeError(f"backfill incomplete: {result['missing']} missing")
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        _fake_run,
+    )
+
+    main._start_backfill_fallback(object())
+    assert entered.wait(timeout=2.0), "thread never entered the blocking encode"
+
+    # Run _stop in a helper thread so we can observe when it returns.
+    stopped = _threading.Event()
+
+    def _do_stop():
+        main._stop_backfill_fallback()
+        stopped.set()
+
+    stop_thread = _threading.Thread(target=_do_stop, daemon=True)
+    stop_thread.start()
+
+    # CRITICAL assertion: _stop must NOT return while the encode is still blocked.
+    # Old code: join(timeout=5s) returns after ~5s → stopped.wait(6) is True →
+    #           `not stopped.wait(6)` is False → test FAILS on old code.
+    # Fixed code: join() blocks until release → stopped.wait(6) is False →
+    #             `not stopped.wait(6)` is True → test PASSES.
+    assert not stopped.wait(timeout=6), (
+        "_stop_backfill_fallback returned while the encode was still blocking — "
+        "this means join had a timeout and the handle was cleared with the thread alive (C-A/C-B)"
+    )
+
+    # Now release the blocking encode.
+    release.set()
+
+    # _stop must return promptly after the encode finishes.
+    assert stopped.wait(timeout=3), "_stop_backfill_fallback did not return after encode released"
+
+    # Handle must be cleared and thread must be dead.
+    assert main._fallback_thread is None
+    thread_ref = None
+    # Recover thread reference via enumerate to confirm it really died.
+    for t in _threading.enumerate():
+        if t.name == "embedding-backfill-fallback":
+            thread_ref = t
+            break
+    assert thread_ref is None or not thread_ref.is_alive(), (
+        "backfill thread is still alive after _stop_backfill_fallback returned"
+    )

--- a/tests/test_main_backfill_fallback.py
+++ b/tests/test_main_backfill_fallback.py
@@ -145,3 +145,33 @@ def test_fallback_stops_on_shutdown(monkeypatch):
     settled = len(calls)
     real_sleep(0.1)
     assert len(calls) == settled  # no further attempts after stop
+
+
+def test_stop_preserves_handle_when_thread_survives_join(monkeypatch):
+    """CR1: if the runner can't stop within the join timeout, keep the handle
+    so the singleton guard still blocks a second fallback."""
+    import threading
+    release = threading.Event()
+    entered = threading.Event()
+
+    def _stuck(engine):
+        entered.set()
+        release.wait(timeout=5.0)   # ignores stop_event — simulates non-interruptible IO
+        raise RuntimeError("incomplete")
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill", _stuck)
+    monkeypatch.setattr(main, "_FALLBACK_JOIN_TIMEOUT", 0.05)
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    main._start_backfill_fallback(object())
+    assert entered.wait(timeout=2.0)
+    main._stop_backfill_fallback()              # join times out — thread still in _stuck
+    assert main._fallback_thread is not None    # handle preserved
+    assert main._fallback_thread.is_alive()
+    first = main._fallback_thread
+    main._start_backfill_fallback(object())     # singleton holds → no-op
+    assert main._fallback_thread is first
+    # cleanup so the thread exits and does not leak into the next test
+    release.set()
+    first.join(timeout=2.0)

--- a/tests/test_main_backfill_fallback.py
+++ b/tests/test_main_backfill_fallback.py
@@ -1,0 +1,68 @@
+"""Scheduler-independent embedding backfill fallback (#32, council I1).
+
+The fallback retries with backoff until the gap closes (run_embedding_backfill
+raises while it is incomplete) or the attempt budget is exhausted -- not a single
+one-shot -- so a transient encoder outage at startup doesn't leave vectors
+unhealed until the next restart.
+"""
+from __future__ import annotations
+
+import time as _time
+
+from ormah import main
+
+real_sleep = _time.sleep
+
+
+def _wait_for(predicate, timeout=2.0):
+    waited = 0.0
+    while not predicate() and waited < timeout:
+        real_sleep(0.02)
+        waited += 0.02
+
+
+def test_fallback_runs_backfill_off_thread(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        lambda engine: calls.append(engine),
+    )
+    sentinel = object()
+    main._start_backfill_fallback(sentinel)  # returns immediately (off-thread)
+    _wait_for(lambda: len(calls) >= 1)
+    assert calls == [sentinel]
+
+
+def test_fallback_retries_until_success(monkeypatch):
+    calls = []
+
+    def _flaky(engine):
+        calls.append(engine)
+        if len(calls) < 2:
+            raise RuntimeError("still incomplete")
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill", _flaky)
+    monkeypatch.setattr("time.sleep", lambda s: real_sleep(0.001))
+
+    main._start_backfill_fallback(object())
+    _wait_for(lambda: len(calls) >= 2)
+    real_sleep(0.05)  # give a spurious 3rd attempt a chance to (not) happen
+    assert len(calls) == 2  # retried once, then stopped on success
+
+
+def test_fallback_gives_up_after_budget_without_raising(monkeypatch):
+    calls = []
+
+    def _boom(engine):
+        calls.append(engine)
+        raise RuntimeError("permanently incomplete")
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill", _boom)
+    monkeypatch.setattr("time.sleep", lambda s: real_sleep(0.001))
+
+    main._start_backfill_fallback(object())  # must not raise on the main thread
+    _wait_for(lambda: len(calls) >= main._BACKFILL_FALLBACK_MAX_ATTEMPTS)
+    real_sleep(0.05)
+    assert len(calls) == main._BACKFILL_FALLBACK_MAX_ATTEMPTS  # bounded, then gives up

--- a/tests/test_main_backfill_fallback.py
+++ b/tests/test_main_backfill_fallback.py
@@ -257,6 +257,67 @@ def test_stop_cancels_long_backfill_within_join(monkeypatch):
     assert eng.saw_stop is True
 
 
+# ---------------------------------------------------------------------------
+# C1 — bounded join com política pós-timeout
+# ---------------------------------------------------------------------------
+
+
+def test_stop_returns_true_when_thread_survives_timeout(monkeypatch):
+    """C1: se o join expira (encode travado), _stop retorna True e handle é mantido (C-B)."""
+    monkeypatch.setattr(main, "_FALLBACK_JOIN_TIMEOUT", 0.1)
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    release = _threading.Event()
+
+    def _blocking(engine, stop_event=None):
+        # Ignora stop_event mid-call — simula encoder.encode() travado
+        release.wait(timeout=5.0)
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        _blocking,
+    )
+
+    main._start_backfill_fallback(object())
+    # Aguarda o thread entrar no blocking
+    _wait_for(lambda: main._fallback_thread is not None
+              and main._fallback_thread.is_alive(), timeout=2.0)
+
+    result = main._stop_backfill_fallback()
+
+    assert result is True, "_stop deve retornar True quando thread sobrevive ao timeout"
+    assert main._fallback_thread is not None, "handle deve ser mantido (C-B) para bloquear segunda instância"
+
+    # Cleanup: libera o encode e espera o thread morrer
+    release.set()
+    _wait_for(lambda: not main._fallback_thread.is_alive(), timeout=3.0)
+    with main._fallback_lock:
+        main._fallback_thread = None
+        main._fallback_stop_event = None
+
+
+def test_stop_returns_false_when_thread_exits(monkeypatch):
+    """C1: quando o thread sai antes do timeout, _stop retorna False e handle é limpo."""
+    monkeypatch.setattr(main, "_FALLBACK_JOIN_TIMEOUT", 5.0)
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    def _quick(engine, stop_event=None):
+        return  # sai imediatamente ao receber stop_event
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        _quick,
+    )
+
+    main._start_backfill_fallback(object())
+    _wait_for(lambda: main._fallback_thread is not None, timeout=2.0)
+
+    result = main._stop_backfill_fallback()
+
+    assert result is False, "_stop deve retornar False quando thread encerra normalmente"
+    assert main._fallback_thread is None, "handle deve ser limpo quando thread está morto"
+
+
 def test_stop_does_not_return_while_backfill_thread_alive(monkeypatch):
     """M-A: _stop_backfill_fallback must NOT return while the thread is alive.
 

--- a/tests/test_main_lifespan_shutdown.py
+++ b/tests/test_main_lifespan_shutdown.py
@@ -15,6 +15,8 @@ exercise the decision logic via:
   3. An integration-style test that wires `_stop_backfill_fallback` + the
      scheduler bounded block together and asserts engine.shutdown() is NOT
      called when either is alive.
+  4. Per-lifespan stop event (R1): each lifespan execution creates a fresh
+     Event in app.state so a reload cannot rearm an orphan worker.
 """
 from __future__ import annotations
 
@@ -22,6 +24,7 @@ import threading as _threading
 import time as _time
 
 import pytest
+from fastapi import FastAPI
 
 from ormah import main
 
@@ -221,3 +224,101 @@ def test_engine_closed_when_both_exit_cleanly(monkeypatch):
     assert fallback_alive is False
     assert scheduler_alive is False
     assert shutdown_called == [True], "engine.shutdown() must be called when both exit cleanly"
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-lifespan stop event (R1)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_each_lifespan_gets_its_own_stop_event(tmp_path, monkeypatch):
+    """R1: each lifespan execution must create a NEW threading.Event in
+    app.state.lifecycle_stop_event. A reload must never reuse (or clear) the
+    event from a previous lifespan so that orphan workers from a prior,
+    expired shutdown cannot be rearmed.
+
+    We monkeypatch heavy I/O (MemoryEngine, start_scheduler, watchers) so the
+    test is fast and hermetic. The key invariants:
+      - sched_ev1 is not sched_ev2  (distinct object per lifespan execution)
+      - ev1 is sched_ev1 / ev2 is sched_ev2  (app.state holds the same object
+        that was passed to start_scheduler)
+    """
+    import sys
+    import threading
+
+    # --- lightweight fakes ---
+
+    class _FakeEngine:
+        def startup(self): pass
+        def shutdown(self): pass
+
+    class _FakeScheduler:
+        def shutdown(self, wait=True): pass
+
+    class _FakeTracker:
+        pass
+
+    captured_stop_events: list[threading.Event] = []
+
+    def _fake_start_scheduler(engine, stop_event=None):
+        captured_stop_events.append(stop_event)
+        return _FakeScheduler(), _FakeTracker()
+
+    monkeypatch.setattr("ormah.main.MemoryEngine", lambda settings: _FakeEngine())
+    monkeypatch.setattr(
+        "ormah.main.settings",
+        type("S", (), {"port": 8787, "memory_dir": str(tmp_path)})(),
+    )
+    monkeypatch.setattr("ormah.main.MaintenanceManager", lambda *a, **kw: object())
+
+    # Use monkeypatch.setitem so pytest restores sys.modules on teardown,
+    # preventing contamination of later tests (e.g. test_ingest_stores_node_ids).
+    _fake_hippocampus = type(sys)("_fake_hippo")
+    _fake_hippocampus.start_hippocampus = lambda engine: []
+    _fake_hippocampus.stop_hippocampus = lambda obs: None
+    monkeypatch.setitem(sys.modules, "ormah.background.hippocampus", _fake_hippocampus)
+
+    _fake_session_watcher = type(sys)("_fake_sw")
+    _fake_session_watcher.start_session_watcher = lambda engine: []
+    _fake_session_watcher.stop_session_watcher = lambda obs: None
+    monkeypatch.setitem(sys.modules, "ormah.background.session_watcher", _fake_session_watcher)
+
+    _fake_scheduler_mod = type(sys)("_fake_sched")
+    _fake_scheduler_mod.start_scheduler = _fake_start_scheduler
+    monkeypatch.setitem(sys.modules, "ormah.background.scheduler", _fake_scheduler_mod)
+
+    app = FastAPI(lifespan=main.lifespan)
+
+    # --- first lifespan execution ---
+    async with main.lifespan(app):
+        ev1 = app.state.lifecycle_stop_event
+        assert isinstance(ev1, threading.Event), "lifecycle_stop_event must be a threading.Event"
+
+    # --- second lifespan execution (simulates in-process reload) ---
+    async with main.lifespan(app):
+        ev2 = app.state.lifecycle_stop_event
+        assert isinstance(ev2, threading.Event), "lifecycle_stop_event must be a threading.Event"
+
+    # Both lifespans must have passed a stop_event to start_scheduler
+    assert len(captured_stop_events) == 2, (
+        f"Expected 2 captured stop events, got {len(captured_stop_events)}"
+    )
+    sched_ev1, sched_ev2 = captured_stop_events
+
+    # Invariant 1: each lifespan creates a DISTINCT Event — the R1 bug was
+    # reusing (and clear()-ing) a single global Event across lifespans.
+    assert sched_ev1 is not sched_ev2, (
+        "Each lifespan must create a DISTINCT Event; reload must not reuse the old one (R1)"
+    )
+
+    # Invariant 2: app.state holds the same object that was passed to the scheduler
+    assert ev1 is sched_ev1, (
+        "app.state.lifecycle_stop_event must be the exact event passed to start_scheduler"
+    )
+    assert ev2 is sched_ev2, (
+        "app.state.lifecycle_stop_event must be the exact event passed to start_scheduler"
+    )
+
+    # Invariant 3: both events were signalled during their respective shutdowns
+    assert sched_ev1.is_set(), "First lifespan stop event must be set after its shutdown"
+    assert sched_ev2.is_set(), "Second lifespan stop event must be set after its shutdown"

--- a/tests/test_main_lifespan_shutdown.py
+++ b/tests/test_main_lifespan_shutdown.py
@@ -1,0 +1,223 @@
+"""Bounded scheduler shutdown + engine.shutdown() policy (Fix A / Fix D).
+
+Tests the invariant: when the scheduler's shutdown(wait=True) does not
+complete within _SHUTDOWN_TIMEOUT, engine.shutdown() must NOT be called
+(avoids use-after-close). Symmetrically, when scheduler exits in time,
+engine.shutdown() IS called (assuming fallback is not alive).
+
+Design: avoids spinning up a full FastAPI + MemoryEngine for speed. We
+exercise the decision logic via:
+  1. A pure helper `_should_close_engine(fallback_alive, scheduler_alive)`
+     extracted from the lifespan — unit-tests the policy table.
+  2. A direct test that the scheduler-shutdown bounded path sets
+     `scheduler_alive=True` when the scheduler.shutdown() blocks past the
+     timeout (mock scheduler whose shutdown() blocks on an Event).
+  3. An integration-style test that wires `_stop_backfill_fallback` + the
+     scheduler bounded block together and asserts engine.shutdown() is NOT
+     called when either is alive.
+"""
+from __future__ import annotations
+
+import threading as _threading
+import time as _time
+
+import pytest
+
+from ormah import main
+
+real_sleep = _time.sleep
+
+
+@pytest.fixture(autouse=True)
+def _reset_fallback_state():
+    main._stop_backfill_fallback()
+    main._fallback_degraded = False
+    yield
+    main._stop_backfill_fallback()
+    main._fallback_degraded = False
+
+
+def _wait_for(predicate, timeout=2.0):
+    waited = 0.0
+    while not predicate() and waited < timeout:
+        real_sleep(0.02)
+        waited += 0.02
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure policy helper — _should_close_engine
+# ---------------------------------------------------------------------------
+
+def test_should_close_engine_both_alive():
+    assert main._should_close_engine(fallback_alive=True, scheduler_alive=True) is False
+
+
+def test_should_close_engine_fallback_alive():
+    assert main._should_close_engine(fallback_alive=True, scheduler_alive=False) is False
+
+
+def test_should_close_engine_scheduler_alive():
+    assert main._should_close_engine(fallback_alive=False, scheduler_alive=True) is False
+
+
+def test_should_close_engine_neither_alive():
+    assert main._should_close_engine(fallback_alive=False, scheduler_alive=False) is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Bounded scheduler-shutdown: scheduler stuck past timeout → scheduler_alive=True
+# ---------------------------------------------------------------------------
+
+def test_scheduler_shutdown_timeout_sets_scheduler_alive(monkeypatch):
+    """Fix A: scheduler.shutdown(wait=True) that blocks past _SHUTDOWN_TIMEOUT
+    must result in scheduler_alive=True so engine.shutdown() is skipped."""
+    monkeypatch.setattr(main, "_SHUTDOWN_TIMEOUT", 0.1)
+
+    release = _threading.Event()
+
+    class _BlockingScheduler:
+        def shutdown(self, wait=True):
+            # Simulates a job stuck in a non-interruptible encoder.encode()
+            release.wait(timeout=10.0)
+
+    scheduler_alive = main._bounded_scheduler_shutdown(_BlockingScheduler())
+
+    assert scheduler_alive is True, (
+        "scheduler_alive must be True when shutdown() does not complete within _SHUTDOWN_TIMEOUT"
+    )
+    # Cleanup
+    release.set()
+
+
+def test_scheduler_shutdown_completes_within_timeout(monkeypatch):
+    """Fix A: scheduler.shutdown() that completes before timeout → scheduler_alive=False."""
+    monkeypatch.setattr(main, "_SHUTDOWN_TIMEOUT", 5.0)
+
+    class _QuickScheduler:
+        def shutdown(self, wait=True):
+            return  # exits immediately
+
+    scheduler_alive = main._bounded_scheduler_shutdown(_QuickScheduler())
+
+    assert scheduler_alive is False, (
+        "scheduler_alive must be False when shutdown() completes before timeout"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Integration: fallback preso → engine NOT closed
+# ---------------------------------------------------------------------------
+
+def test_engine_not_closed_when_fallback_alive(monkeypatch):
+    """Fix D: when the fallback thread survives the join timeout, engine.shutdown()
+    must NOT be called."""
+    monkeypatch.setattr(main, "_FALLBACK_JOIN_TIMEOUT", 0.1)
+    monkeypatch.setattr(main, "_SHUTDOWN_TIMEOUT", 0.1)
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    release = _threading.Event()
+
+    def _blocking_run(engine, stop_event=None):
+        release.wait(timeout=10.0)
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        _blocking_run,
+    )
+
+    main._start_backfill_fallback(object())
+    _wait_for(lambda: main._fallback_thread is not None
+              and main._fallback_thread.is_alive(), timeout=2.0)
+
+    fallback_alive = main._stop_backfill_fallback()
+
+    shutdown_called = []
+
+    class _FakeEngine:
+        def shutdown(self):
+            shutdown_called.append(True)
+
+    if not main._should_close_engine(fallback_alive=fallback_alive, scheduler_alive=False):
+        pass  # engine.shutdown() deliberately skipped
+    else:
+        _FakeEngine().shutdown()
+
+    assert fallback_alive is True
+    assert shutdown_called == [], "engine.shutdown() must NOT be called when fallback_alive=True"
+
+    # Cleanup
+    release.set()
+    _wait_for(lambda: main._fallback_thread is None
+              or not main._fallback_thread.is_alive(), timeout=3.0)
+    with main._fallback_lock:
+        main._fallback_thread = None
+        main._fallback_stop_event = None
+
+
+def test_engine_not_closed_when_scheduler_alive(monkeypatch):
+    """Fix A: when scheduler shutdown does not complete in time, engine.shutdown()
+    must NOT be called."""
+    monkeypatch.setattr(main, "_SHUTDOWN_TIMEOUT", 0.1)
+
+    release = _threading.Event()
+
+    class _BlockingScheduler:
+        def shutdown(self, wait=True):
+            release.wait(timeout=10.0)
+
+    scheduler_alive = main._bounded_scheduler_shutdown(_BlockingScheduler())
+
+    shutdown_called = []
+
+    class _FakeEngine:
+        def shutdown(self):
+            shutdown_called.append(True)
+
+    if not main._should_close_engine(fallback_alive=False, scheduler_alive=scheduler_alive):
+        pass
+    else:
+        _FakeEngine().shutdown()
+
+    assert scheduler_alive is True
+    assert shutdown_called == [], "engine.shutdown() must NOT be called when scheduler_alive=True"
+
+    release.set()
+
+
+def test_engine_closed_when_both_exit_cleanly(monkeypatch):
+    """Positive path: both fallback and scheduler exit cleanly → engine.shutdown() called."""
+    monkeypatch.setattr(main, "_FALLBACK_JOIN_TIMEOUT", 5.0)
+    monkeypatch.setattr(main, "_SHUTDOWN_TIMEOUT", 5.0)
+    monkeypatch.setattr(main, "_BACKFILL_FALLBACK_BASE_BACKOFF", 0.001)
+
+    def _quick_run(engine, stop_event=None):
+        return  # exits immediately
+
+    monkeypatch.setattr(
+        "ormah.background.embedding_backfill.run_embedding_backfill",
+        _quick_run,
+    )
+
+    main._start_backfill_fallback(object())
+    _wait_for(lambda: main._fallback_thread is not None, timeout=2.0)
+
+    fallback_alive = main._stop_backfill_fallback()
+
+    class _QuickScheduler:
+        def shutdown(self, wait=True):
+            return
+
+    scheduler_alive = main._bounded_scheduler_shutdown(_QuickScheduler())
+
+    shutdown_called = []
+
+    class _FakeEngine:
+        def shutdown(self):
+            shutdown_called.append(True)
+
+    if main._should_close_engine(fallback_alive=fallback_alive, scheduler_alive=scheduler_alive):
+        _FakeEngine().shutdown()
+
+    assert fallback_alive is False
+    assert scheduler_alive is False
+    assert shutdown_called == [True], "engine.shutdown() must be called when both exit cleanly"

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -132,8 +132,17 @@ export function runAdminTask(taskId: string): Promise<{ status: string; task: st
   return post(`/admin/tasks/${taskId}/run`);
 }
 
-export function runAllTasks(): Promise<{ status: string; results: Record<string, string> }> {
-  return post("/admin/tasks/run-all");
+export async function runAllTasks(): Promise<{ status: string; results: Record<string, string> }> {
+  // A 503 with a degraded body is an expected partial-failure signal (C1/I1),
+  // not a transport error — read the body instead of throwing on it.
+  const res = await fetch(`${BASE}/admin/tasks/run-all`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok && res.status !== 503) {
+    throw new Error(`POST /admin/tasks/run-all: ${res.status}`);
+  }
+  return res.json();
 }
 
 export function pauseTask(taskId: string): Promise<{ status: string; task: string }> {

--- a/ui/src/components/AdminPanel.tsx
+++ b/ui/src/components/AdminPanel.tsx
@@ -115,9 +115,17 @@ export default function AdminPanel({ open, onClose, onToast }: Props) {
     setRunningAll(true);
     setLastResult(null);
     try {
-      await runAllTasks();
-      setLastResult({ task: "__all__", ok: true });
-      onToast("Sleep cycle complete", "success");
+      const result = await runAllTasks();
+      if (result.status === "completed") {
+        setLastResult({ task: "__all__", ok: true });
+        onToast("Sleep cycle complete", "success");
+      } else {
+        const failed = Object.entries(result.results)
+          .filter(([, v]) => v.startsWith("error:"))
+          .map(([task]) => task);
+        setLastResult({ task: "__all__", ok: false });
+        onToast(`Sleep cycle degraded — failed: ${failed.join(", ")}`, "error");
+      }
     } catch {
       setLastResult({ task: "__all__", ok: false });
       onToast("Sleep cycle failed", "error");


### PR DESCRIPTION
# fix(embeddings): delta backfill (O(gap)) + continuous reconciliation — closes #32

## TL;DR

A single embeddable node missing its vector used to trigger a **full ~25-min re-embed of every node** on startup, and embed failures were silently swallowed (so the gap never actually closed). This PR replaces that O(n) recovery with an **incremental delta backfill** (O(gap)), moves recovery **off the startup/bind path** into a background job, and makes a missing vector an **honest, observable degraded state** instead of a silent stall. The backfill worker's lifecycle was then hardened across **6 rounds of peer review** (cooperative cancellation, bounded/symmetric shutdown, atomic singleton, per-lifespan state).

---

## 1. The problem (#32)

From the issue: *"a single missing embedding triggers a full ~25-min re-embed of all nodes (swallowed embed failures + O(n) recovery)."*

Concretely, the old behaviour had three compounding faults:

1. **O(n) recovery** — any missing vector caused a re-embed of the **entire** store, not just the gap. On a large store that is ~25 minutes.
2. **Swallowed failures** — an embed failure during recovery was caught and ignored, so the node stayed missing and the next startup re-triggered the whole pass again (a recurring 25-min tax that never converged).
3. **Blocking startup** — recovery ran on the bind path, delaying readiness.

## 2. The fix

| Area | Change |
|------|--------|
| **Delta backfill** | Embed only the embeddable nodes that lack a vector, via an anti-join (`LEFT JOIN node_vectors_rowids … WHERE v.id IS NULL`). Cost is **O(gap)**, not O(n). |
| **Schema-bump path** | A separate full re-embed runs **only** when the embedding-scheme `embedding_schema_version` changes; the version advances **only after a complete pass**, so an interrupted bump re-runs as a bump next time (never marked done prematurely). |
| **Non-blocking startup** | Startup no longer blocks on a full re-embed; recovery moved to the `embedding_backfill` background job (post-bind first run ~10s after start). |
| **Continuous reconciliation** | The job runs on the scheduler; when the scheduler is unavailable, a **scheduler-independent fallback daemon** heals the gap off-thread with capped exponential backoff (never gives up — recovers when a transient encoder outage clears). This satisfies council finding I1 (recovery must not depend on the scheduler). |
| **Honest observability** | `run_embedding_backfill` raises on `missing > 0` instead of swallowing it → `/admin/health` reports `degraded` (both scheduler and no-scheduler paths); `POST /admin/tasks/run-all` returns **HTTP 503** + per-task results and records outcomes in the `JobTracker`; a permanently-failing ("poison") node stays visibly `missing` and is retried each tick rather than masked. |
| **Bounded write retry** | `_index_embedding` gets a small bounded retry to reduce transient gaps on the write path. |
| **Stats** | `engine.stats()` exposes `embedding_gap` and `embedding_schema_version` for diagnostics. |

### Key code files
- `src/ormah/engine/memory_engine.py` — `backfill_embeddings()` (delta + schema-bump), `_embed_node_rows()` (extracted, returns embedded/failed ids; cooperative cancellation), `_missing_embeddable_count()`.
- `src/ormah/background/embedding_backfill.py` — `run_embedding_backfill()` job runner (raises on incomplete).
- `src/ormah/background/scheduler.py` — registers the `embedding_backfill` job (post-bind first run, `max_instances=1`) and forwards a lifecycle stop event.
- `src/ormah/main.py` — lifespan startup/shutdown: scheduler-independent fallback daemon, bounded & symmetric shutdown, per-lifespan stop event.
- `src/ormah/api/routes_admin.py` — `/admin/health` degraded derivation, `run-all` 503 + JobTracker recording.
- `ui/src/api.ts`, `ui/src/components/AdminPanel.tsx` — AdminPanel surfaces a degraded sleep-cycle instead of false success.

---

## 3. Review history — 6 rounds of peer review

This branch was reviewed adversarially across multiple rounds. The severity dropped monotonically each round (2 criticals → 1 → caveat) until the holistic reviewer reached *Approved with caveats*. Findings and how each was resolved:

| Finding | Issue | Resolution | Commit |
|---------|-------|------------|--------|
| **C1/I1** | `run-all` reported success even when a task failed (operability masking) | `run-all` → `status=degraded` + HTTP 503 | `0544283` |
| **C2/CH1/CH2** | Fallback gave up after a fixed budget; no degraded signal without a scheduler | Lifecycle-aware fallback (infinite capped-backoff retry) + `_fallback_degraded` health flag | `f1fceb7` |
| **I2** | UI showed false success on a degraded sleep-cycle | AdminPanel tolerates 503 / names failed tasks | `512e1f2` |
| **CR2** | `/admin/health` stayed `ok` when the scheduler's `embedding_backfill` last run failed | Derive `degraded` from `JobTracker.snapshot()` | `b1f6592` |
| **CRA / IA** | Backfill was non-interruptible → `db.close()` raced a live worker (use-after-close); orphan thread blocked a new fallback | **Cooperative cancellation**: `stop_event` checked between encodes and **before every DB write** | `bb5830f` |
| **CRB** | Singleton `check-then-set` was not atomic | Module `threading.Lock` around check-and-set; reverted the band-aid CR1 (`2062f24`) | `b9b13ab` |
| **CRC** | A failed task in manual `run-all` never persisted to health | `run-all` records `record_success`/`record_failure` in the `JobTracker` | `96525b5` |
| **C-A / C-B** | A timed-out join still cleared the handle and let `engine.shutdown()` run with the worker alive (use-after-close + zombie singleton) | `_stop_backfill_fallback` joins, and the engine is closed only once the worker is confirmed dead | `132f828` |
| **C1/C2 (r4)** | The fix above could hang shutdown forever; the **scheduler** path had no cancellation at all | Forward a lifecycle `stop_event` to the scheduler job; cancel cooperatively on shutdown | `6d54746` |
| **A/B/D (r5)** | Scheduler shutdown still unbounded; schema-mode `DELETE` ignored the interrupt flag; no lifespan integration test | **Bounded, symmetric shutdown** (`_bounded_scheduler_shutdown` + `_should_close_engine`); guard `DELETE` with `not interrupted`; add `test_main_lifespan_shutdown.py` | `b02d98d` |
| **R1 (r6)** | A module-global stop event `clear()` on startup could *rearm* an orphan worker in a same-process reload | **Per-lifespan stop event** in `app.state` (no shared global to clear) | `59b57ba` |

---

## 4. Design decisions (the two that mattered)

**(a) Make the backfill cancellable — not remove the daemon.** When the lifecycle bugs clustered, one option was to delete the fallback daemon entirely (synchronous backfill at startup). It was rejected because it reopens council finding **I1** (continuous, scheduler-independent recovery) and only heals once at boot. Instead the backfill was made **cooperatively cancellable**, which collapses the use-after-close/zombie class while keeping continuous recovery.

**(b) Resolve "corruption vs hang" explicitly with a bounded, fail-safe shutdown.** A non-interruptible `encoder.encode()` means a join can't be instantaneous. Rather than choose between *use-after-close* (close the DB under a live worker) and *infinite hang* (join forever), shutdown now:
- signals the lifecycle stop event,
- **time-bounds** both the fallback join and the scheduler shutdown (`_SHUTDOWN_TIMEOUT`),
- and **skips `engine.shutdown()` entirely if a worker is still in flight** (`_should_close_engine`) — no DB close under a live worker, and no unbounded hang.

A background "finalizer" that closes the engine after the worker eventually exits was **deliberately not added**: it reintroduces an old-engine-vs-new-engine race that is worse than the benign leak it would fix.

---

## 5. Known limitation (documented, accepted)

A single `encoder.encode()` call is **not interruptible** (a fundamental limit; fixing it would require running the encoder in a killable subprocess). Consequence, only in a **same-process reload** (TestClient / `uvicorn --reload` in-process — **not** the production deploy path, which is SIGTERM → process exit → daemon threads die):
- a still-running orphan worker can briefly suppress a replacement fallback for the new engine, or
- the engine connection is left open until process exit (a benign leak).

**No data corruption** in any path, and production (SIGTERM) is unaffected. Tracked as a follow-up rather than blocking this PR.

---

## 6. Testing

- **Full suite green** except 4 pre-existing reds **unrelated** to this PR (present on `main`): `test_config.py::test_llm_provider_defaults_to_none` and `test_setup.py::TestRemoveFastembedCache` ×3.
- New coverage: delta vs schema-bump backfill, poison-node visibility, schema-version-not-advanced-on-interrupt, cooperative cancel before DB writes, atomic singleton under concurrent starts, bounded join (fallback) + bounded scheduler shutdown, `_should_close_engine` policy, per-lifespan stop event, run-all → health degraded, and an end-to-end recovery test.

## 7. Notes for the reviewer
- Rebased cleanly onto `main` (includes #35); no conflicts.
- The diff includes spec/plan docs under `docs/superpowers/` (design + the council review trail) — these are documentation, not runtime code. One unrelated `docs(spec)` commit for the graph-view sigma.js migration (`4174db0`) rode along on this branch; happy to drop it if you'd prefer the PR scoped to code + #32 docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Also closes #109 — the restart-resumable backfill on this branch persists each 100-row chunk as it is encoded (`_embed_node_rows`: `chunk_size = 100`, per-chunk `_flush()` with `upsert_batch` + `wal_checkpoint(TRUNCATE)`), so a mid-encode restart loses at most the current chunk instead of all buffered vectors. Verified: `pytest tests/test_engine/test_embed_node_rows.py` → 6 passed, incl. `test_embed_node_rows_persists_incrementally` and `test_embed_node_rows_flushes_pending_on_cooperative_cancel`.

Closes #109