### PR TITLE
Add feedback loop for whispered memories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,15 @@ ORMAH_LLM_BASE_URL=http://localhost:11434
 # Maximum seconds to wait for an LLM response before giving up.
 # ORMAH_LLM_TIMEOUT_SECONDS=60
 
+# ── Feedback judge (optional; requires ORMAH_LLM_PROVIDER != none) ────────────
+# Session watcher always records free/local heuristic feedback signals. Enable
+# this to have the configured LLM judge ambiguous transcript turns and promote
+# high-confidence "used" / "irrelevant" verdicts into positive / negative affinity.
+# Cheap JSON-capable models such as llama3.2, gpt-4o-mini, or claude-haiku are
+# typically enough for this classification task.
+# ORMAH_FEEDBACK_LLM_JUDGE_ENABLED=false
+# ORMAH_FEEDBACK_LLM_JUDGE_MIN_CONFIDENCE=0.75
+
 # ── API Keys (only when ORMAH_LLM_PROVIDER=litellm) ──────────────────────────
 #
 # API keys are inherited from your shell environment at daemon startup.

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Ormah supports both deliberate recall and involuntary recall.
 
 When an agent knows it needs something, it can explicitly search memory. But memory should not always wait to be asked. Ormah is built to whisper the right memory at the right time, before the next prompt, so the agent starts with context instead of having to go looking for it.
 
+Whisper feedback can learn from transcript files after they stop changing: a local heuristic records clear usage for free, and an optional LLM judge can classify ambiguous turns into positive, negative, or uncertain retrieval signals.
+
 Read more: [Whisper - Involuntary Recall](https://www.ormah.me/docs/how-ormah-works/whisper), [Search and Ranking](https://www.ormah.me/docs/how-ormah-works/search-and-ranking), [Affinity and Feedback](https://www.ormah.me/docs/operations/affinity-and-feedback)
 
 ### Memory Capture

--- a/docs/09 - Affinity and Feedback.md
+++ b/docs/09 - Affinity and Feedback.md
@@ -20,7 +20,10 @@ applied.
 
 Ormah does not infer negative feedback from silence alone. Session-watcher heuristics may
 record neutral `whisper_unreferenced` signals for observability, but only clear positive
-references are promoted into affinity rows.
+references are promoted into affinity rows. If `feedback_llm_judge_enabled` is on and an
+LLM provider is configured, the session watcher can ask the LLM to judge ambiguous turns;
+only confident `used` / `irrelevant` verdicts are promoted into positive / negative
+affinity.
 
 ## Where Feedback Comes From
 
@@ -93,6 +96,18 @@ heuristics record:
 Only `whisper_referenced` heuristic signals are promoted to `affinity`; unreferenced signals
 remain observational.
 
+If the optional LLM judge is enabled, those ambiguous unreferenced rows are grouped by
+prompt/response and sent to the configured LLM. The judge returns `used`, `irrelevant`, or
+`uncertain` with confidence. Ormah records the judge output in `signals` and promotes only
+high-confidence verdicts:
+
+- `whisper_judged_used` with polarity `+1` becomes positive affinity
+- `whisper_judged_irrelevant` with polarity `-1` becomes negative affinity
+- `whisper_judged_uncertain` with polarity `0` remains observational
+
+Low-confidence judge verdicts are normalized to `whisper_judged_uncertain` so they do not
+change ranking.
+
 That is why the system needs `whisper_log` first: affinity rows are learned from previously logged whisper candidates.
 
 ## Stored Fields
@@ -147,6 +162,8 @@ For each candidate node:
 | `affinity_half_life_days` | `30.0` |
 | `affinity_max_boost` | `0.15` |
 | `affinity_implicit_weight` | `0.8` |
+| `feedback_llm_judge_enabled` | `false` |
+| `feedback_llm_judge_min_confidence` | `0.75` |
 
 ## Math
 
@@ -203,6 +220,9 @@ The review candidate is selected from recent `whisper_log` rows where:
 3. Ormah records a signal tied to the exact `whisper_log` row
 4. trusted positive judgments create an affinity row tied to that same prompt vector
 5. on a future prompt with similar wording, that node can receive a small positive score boost
+
+With the optional LLM judge enabled, a clearly off-topic memory can instead receive a
+trusted negative affinity row when the judge returns a confident `irrelevant` verdict.
 
 ## Code Anchors
 

--- a/docs/09 - Affinity and Feedback.md
+++ b/docs/09 - Affinity and Feedback.md
@@ -1,21 +1,26 @@
 # Affinity and Feedback
 
-Verified against the current repository state on 2026-04-13.
+Verified against the current repository state on 2026-06-13.
 
 Affinity is Ormah's feedback-based score adjustment layer for whisper. It learns whether a memory tends to be useful in prompts similar to the current one.
 
 ## How Feedback Enters the System
 
-Affinity learning is driven by feedback submitted through `submit_feedback(...)`. That feedback can be explicit or implicit.
+Affinity learning is driven by trusted feedback about previously surfaced memories. Feedback
+can arrive through `submit_feedback(...)` or from automatic session-watcher signal mining.
 
 In this system:
 
 - `explicit` feedback means a direct judgment is submitted because the user or agent intentionally marks a memory as useful or not useful
 - `implicit` feedback means the client or agent infers usefulness from the interaction and submits that judgment without the user explicitly rating it
 
-In both cases, Ormah learns through `submit_feedback(...)`; the difference is where the judgment came from, not how it is stored.
+In both explicit and implicit `submit_feedback(...)` cases, Ormah learns through the same
+turn-level affinity table; the difference is where the judgment came from, not how it is
+applied.
 
-Ormah does not currently infer negative feedback from silence alone. Affinity rows are created when `submit_feedback(...)` is called.
+Ormah does not infer negative feedback from silence alone. Session-watcher heuristics may
+record neutral `whisper_unreferenced` signals for observability, but only clear positive
+references are promoted into affinity rows.
 
 ## Where Feedback Comes From
 
@@ -28,7 +33,8 @@ When feedback is submitted:
 1. Ormah resolves the node id against `whisper_log`
 2. it looks up the latest logged prompt vector for that node
 3. it inserts an `affinity` row using that stored prompt context
-4. explicit feedback also marks relevant `review_log` entries as answered
+4. it records a corresponding `signals` ledger row
+5. explicit feedback also marks relevant `review_log` entries as answered
 
 Whispered short ids work here too: the resolver accepts full ids first, then falls back to a unique prefix match against `whisper_log`.
 
@@ -64,7 +70,7 @@ So `whisper_log` is the staging table that says:
 
 > "For this prompt/session, Ormah considered these memories, and here is whether each one was actually injected."
 
-### Step 3: later feedback converts logged candidates into affinity rows
+### Step 3: later feedback or usage detection converts logged candidates into signals
 
 When `submit_feedback(node_id, ...)` is called, Ormah does **not** recompute prompt context. It looks up the most recent `whisper_log` entry for that node and copies:
 
@@ -72,8 +78,20 @@ When `submit_feedback(node_id, ...)` is called, Ormah does **not** recompute pro
 - `prompt_text`
 - `space`
 - `session_id`
+- `whisper_log_id`
 
-into the `affinity` table along with the submitted `signal`.
+into the `affinity` table along with the submitted `signal`. It also appends a
+`feedback_submitted` row to `signals`.
+
+When the transcript watcher processes a normalized transcript, it compares injected `whisper_log` rows
+against the assistant response that followed the matching user prompt. Conservative local
+heuristics record:
+
+- `whisper_referenced` with polarity `+1` when the response clearly cites or reuses the memory
+- `whisper_unreferenced` with polarity `0` when no clear reference is found
+
+Only `whisper_referenced` heuristic signals are promoted to `affinity`; unreferenced signals
+remain observational.
 
 That is why the system needs `whisper_log` first: affinity rows are learned from previously logged whisper candidates.
 
@@ -89,6 +107,22 @@ Current stored affinity rows include:
 - `confirmed_at`
 - `space`
 - `session_id`
+- `whisper_log_id`
+
+Current stored signal rows include:
+
+- `whisper_log_id`
+- `node_id`
+- `signal_type`
+- `polarity`
+- `strength`
+- `source`
+- `session_id`
+- `surface`
+- `space`
+- `prompt_hash`
+- `evidence`
+- `created`
 
 ## How Boost Is Computed
 
@@ -125,7 +159,7 @@ for row in affinity_rows:
         continue
 
     recency = exp(-days_ago * ln(2) / half_life)
-    source_weight = implicit_weight if row.source == "implicit" else 1.0
+    source_weight = 1.0 if row.source == "explicit" else implicit_weight
     weight = sim * recency * source_weight
 
     weighted_sum += row.signal * weight
@@ -151,7 +185,8 @@ It can rescue a borderline candidate or slightly suppress a noisy one, but it is
 
 On the first message of a session, whisper may surface one held-back candidate as a review suggestion. That review block asks the client/agent to call `submit_feedback(...)` later if the relevance can be judged.
 
-This is the current bridge between whisper behavior and future affinity learning.
+This remains one bridge between whisper behavior and future affinity learning. The transcript
+watcher now provides a second bridge by mining completed transcripts for clear memory usage.
 
 The review candidate is selected from recent `whisper_log` rows where:
 
@@ -164,9 +199,10 @@ The review candidate is selected from recent `whisper_log` rows where:
 ## Walkthrough Example
 
 1. whisper surfaces a node during a prompt about database decisions
-2. later, the agent calls `submit_feedback(node_id=..., signal=1, source="implicit")`
-3. Ormah records an affinity row tied to the prompt vector from `whisper_log`
-4. on a future prompt with similar wording, that node can receive a small positive score boost
+2. later, either the agent calls `submit_feedback(...)` or the transcript watcher sees the assistant clearly used that node
+3. Ormah records a signal tied to the exact `whisper_log` row
+4. trusted positive judgments create an affinity row tied to that same prompt vector
+5. on a future prompt with similar wording, that node can receive a small positive score boost
 
 ## Code Anchors
 

--- a/docs/09 - Affinity and Feedback.md
+++ b/docs/09 - Affinity and Feedback.md
@@ -98,7 +98,9 @@ remain observational.
 
 If the optional LLM judge is enabled, those ambiguous unreferenced rows are grouped by
 prompt/response and sent to the configured LLM. The judge returns `used`, `irrelevant`, or
-`uncertain` with confidence. Ormah records the judge output in `signals` and promotes only
+`uncertain` with confidence. For LiteLLM-compatible providers, Ormah first requests a
+compact JSON Schema response and falls back to JSON-object mode if the provider rejects
+schema output. Ormah records the judge output in `signals` and promotes only
 high-confidence verdicts:
 
 - `whisper_judged_used` with polarity `+1` becomes positive affinity

--- a/docs/10 - Hippocampus and Session Watcher.md
+++ b/docs/10 - Hippocampus and Session Watcher.md
@@ -52,21 +52,25 @@ The session watcher ingests normalized agent transcript JSONL files.
 It only starts when:
 
 - `session_watcher_enabled == True`
-- the configured watch dir exists
+- at least one effective watch dir exists
 
 Current defaults:
 
 - `session_watcher_enabled = False`
 - `session_watcher_dir = ~/.claude/projects`
+- existing Codex sessions under `~/.codex/sessions` are also watched when the primary
+  directory is left at the default
 - `session_watcher_debounce_seconds = 60`
 - `session_watcher_min_turns = 5`
 - `session_watcher_lookback_hours = 72`
 - `feedback_llm_judge_enabled = false`
 - `feedback_llm_judge_min_confidence = 0.75`
 
-The current default watch directory remains the historical Claude Code path for compatibility.
-The parser and downstream ingestion path are agent-normalized; adding another client should
-mean adding a transcript source/adapter, not changing memory ingestion or signal mining.
+The primary default watch directory remains the historical Claude Code path for compatibility.
+When that primary is unchanged, the watcher also starts on Codex's default session directory
+if it exists. The parser and downstream ingestion path are agent-normalized; adding another
+client should mean adding a transcript source/adapter, not changing memory ingestion or
+signal mining.
 
 ### What it does
 
@@ -74,7 +78,7 @@ mean adding a transcript source/adapter, not changing memory ingestion or signal
 2. applies first-run lookback filtering
 3. normalizes transcripts into source metadata, turns, and conversation text
 4. skips very short sessions
-5. derives space from the current source's strategy
+5. resolves source-specific session metadata
 6. ingests the conversation through `engine.ingest_conversation(...)`
 7. stores `.session_watcher_state`
 8. starts a real-time observer
@@ -86,6 +90,12 @@ non-references as neutral observations. If `feedback_llm_judge_enabled` is true 
 `used` / `irrelevant` / `uncertain` verdict. Only confident `used` and `irrelevant`
 verdicts affect affinity. The LLM judge requests compact JSON Schema output when the
 configured provider supports it, with a JSON-object fallback for providers that do not.
+
+Claude Code transcript filenames are already the hook session id, and Claude project folders
+encode the project space. Codex rollout filenames can include the hook session id inside a
+longer filename, and the parent directories are usually date folders. For Codex, the watcher
+therefore resolves the session id and space from matching `whisper_log` rows written during
+whisper injection instead of deriving them from the path.
 
 ## Transcript Parser
 

--- a/docs/10 - Hippocampus and Session Watcher.md
+++ b/docs/10 - Hippocampus and Session Watcher.md
@@ -84,7 +84,8 @@ signals. The free/local heuristic path records clear references as positive sign
 non-references as neutral observations. If `feedback_llm_judge_enabled` is true and
 `llm_provider` is not `none`, ambiguous rows are sent to the configured LLM for a
 `used` / `irrelevant` / `uncertain` verdict. Only confident `used` and `irrelevant`
-verdicts affect affinity.
+verdicts affect affinity. The LLM judge requests compact JSON Schema output when the
+configured provider supports it, with a JSON-object fallback for providers that do not.
 
 ## Transcript Parser
 

--- a/docs/10 - Hippocampus and Session Watcher.md
+++ b/docs/10 - Hippocampus and Session Watcher.md
@@ -61,6 +61,8 @@ Current defaults:
 - `session_watcher_debounce_seconds = 60`
 - `session_watcher_min_turns = 5`
 - `session_watcher_lookback_hours = 72`
+- `feedback_llm_judge_enabled = false`
+- `feedback_llm_judge_min_confidence = 0.75`
 
 The current default watch directory remains the historical Claude Code path for compatibility.
 The parser and downstream ingestion path are agent-normalized; adding another client should
@@ -76,6 +78,13 @@ mean adding a transcript source/adapter, not changing memory ingestion or signal
 6. ingests the conversation through `engine.ingest_conversation(...)`
 7. stores `.session_watcher_state`
 8. starts a real-time observer
+
+During transcript processing, the watcher also mines injected whisper rows for feedback
+signals. The free/local heuristic path records clear references as positive signals and
+non-references as neutral observations. If `feedback_llm_judge_enabled` is true and
+`llm_provider` is not `none`, ambiguous rows are sent to the configured LLM for a
+`used` / `irrelevant` / `uncertain` verdict. Only confident `used` and `irrelevant`
+verdicts affect affinity.
 
 ## Transcript Parser
 

--- a/docs/10 - Hippocampus and Session Watcher.md
+++ b/docs/10 - Hippocampus and Session Watcher.md
@@ -5,7 +5,7 @@ Verified against the current repository state on 2026-04-13.
 These are two separate watcher systems:
 
 - **Hippocampus** watches configured markdown directories and ingests changed files
-- **Session watcher** watches transcript directories and ingests completed sessions
+- **Session watcher** watches agent transcript directories and ingests completed sessions
 
 They are separate from the node-store watcher in `src/ormah/store/watcher.py`, which is not started by the app runtime.
 
@@ -45,7 +45,7 @@ Ignored-path filtering is configurable through `hippocampus_ignore_patterns`.
 
 **Code**: `src/ormah/background/session_watcher.py`
 
-The session watcher ingests transcript JSONL files.
+The session watcher ingests normalized agent transcript JSONL files.
 
 ### Startup conditions
 
@@ -62,15 +62,17 @@ Current defaults:
 - `session_watcher_min_turns = 5`
 - `session_watcher_lookback_hours = 72`
 
-The current default watch directory is a concrete Claude Code path, not an auto-detected one.
+The current default watch directory remains the historical Claude Code path for compatibility.
+The parser and downstream ingestion path are agent-normalized; adding another client should
+mean adding a transcript source/adapter, not changing memory ingestion or signal mining.
 
 ### What it does
 
 1. scans for changed `.jsonl` files
 2. applies first-run lookback filtering
-3. parses transcripts into conversation text
+3. normalizes transcripts into source metadata, turns, and conversation text
 4. skips very short sessions
-5. derives space from encoded parent directory names
+5. derives space from the current source's strategy
 6. ingests the conversation through `engine.ingest_conversation(...)`
 7. stores `.session_watcher_state`
 8. starts a real-time observer
@@ -79,9 +81,19 @@ The current default watch directory is a concrete Claude Code path, not an auto-
 
 **Code**: `src/ormah/transcript/parser.py`
 
-The parser now supports **both Claude Code and Codex-style JSONL transcripts**.
+The parser normalizes supported agent transcript formats into a shared result:
 
-That parser support is broader than the session watcher's current default setup: the parser can normalize both formats, while the watcher's default directory and space-decoding logic are still Claude-Code-shaped.
+```python
+TranscriptResult(
+    session_id="...",
+    source="claude_code" | "codex" | "agent_jsonl",
+    turns=[TranscriptTurn(role="user", text="..."), ...],
+    conversation="User: ...\n\nAssistant: ...",
+)
+```
+
+That normalized boundary is what ingestion and signal mining consume. Agent-specific code
+should stay at the discovery/parsing edge.
 
 Supported normalized sources:
 
@@ -122,6 +134,10 @@ Session watcher example:
 4. parent directory name is decoded and the last path segment becomes `ormah`
 5. Ormah ingests the conversation as candidate memories
 6. state is updated so the same file is not reprocessed unnecessarily
+
+For future agents, add a source adapter that finds transcript files, assigns source metadata,
+and provides a space strategy. The rest of the pipeline should continue to consume
+`TranscriptResult`.
 
 ## Code Anchors
 

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -114,7 +114,9 @@ The session watcher always records free/local heuristic feedback signals for inj
 whispers. When `feedback_llm_judge_enabled` is true and `llm_provider != "none"`, it also
 asks the configured LLM to judge ambiguous turns. Confident `used` verdicts become positive
 affinity; confident `irrelevant` verdicts become negative affinity; uncertain or
-low-confidence verdicts remain observational `signals` rows only.
+low-confidence verdicts remain observational `signals` rows only. The judge requests
+compact JSON Schema output when available and falls back to JSON-object mode for providers
+that reject schema output.
 
 ## Search
 

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -103,6 +103,10 @@ Operational note: default-enabled does not mean active without configured watch 
 | `session_watcher_min_turns` | `5` |
 | `session_watcher_lookback_hours` | `72` |
 
+`session_watcher_dir` is the primary watch directory and remains the historical Claude Code
+default. When it is left at the default, Ormah also watches `~/.codex/sessions` if that
+directory exists.
+
 ### Feedback signal mining
 
 | Setting | Default |

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -65,6 +65,10 @@ for manual backup workflows.
 
 Note: setup may persist different values in `.env`. For remote providers, Ormah stores only key policy, such as `ORMAH_LLM_API_KEY_ENV_VAR=ANTHROPIC_API_KEY`; it does not store API key values. `llm_num_predict` maps to Ollama's `options.num_predict` request field.
 
+Cheap JSON-capable models are usually enough for classification-style background jobs such
+as feedback judging. Good starting points are local `llama3.2` through Ollama, or remote
+low-cost models such as `gpt-4o-mini` or Claude Haiku through LiteLLM.
+
 ## Background Intervals
 
 | Setting | Default |
@@ -98,6 +102,19 @@ Operational note: default-enabled does not mean active without configured watch 
 | `session_watcher_debounce_seconds` | `60.0` |
 | `session_watcher_min_turns` | `5` |
 | `session_watcher_lookback_hours` | `72` |
+
+### Feedback signal mining
+
+| Setting | Default |
+|---|---|
+| `feedback_llm_judge_enabled` | `false` |
+| `feedback_llm_judge_min_confidence` | `0.75` |
+
+The session watcher always records free/local heuristic feedback signals for injected
+whispers. When `feedback_llm_judge_enabled` is true and `llm_provider != "none"`, it also
+asks the configured LLM to judge ambiguous turns. Confident `used` verdicts become positive
+affinity; confident `irrelevant` verdicts become negative affinity; uncertain or
+low-confidence verdicts remain observational `signals` rows only.
 
 ## Search
 

--- a/src/ormah/background/llm/base.py
+++ b/src/ormah/background/llm/base.py
@@ -9,10 +9,19 @@ class LLMAdapter(abc.ABC):
     """Interface that all LLM backends must implement."""
 
     @abc.abstractmethod
-    def generate(self, prompt: str, json_mode: bool = True) -> str | None:
+    def generate(
+        self,
+        prompt: str,
+        json_mode: bool = True,
+        *,
+        response_format: dict | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str | None:
         """Send *prompt* to the LLM and return the raw response text.
 
         Returns ``None`` on any failure (timeout, connection error, etc.).
         When *json_mode* is True the adapter should request structured JSON
-        output from the backend (if supported).
+        output from the backend (if supported). *response_format* lets callers
+        provide a provider-specific structured-output schema.
         """

--- a/src/ormah/background/llm/litellm_adapter.py
+++ b/src/ormah/background/llm/litellm_adapter.py
@@ -14,7 +14,15 @@ class LiteLLMAdapter(LLMAdapter):
         self.model = model
         self.timeout = timeout
 
-    def generate(self, prompt: str, json_mode: bool = True) -> str | None:
+    def generate(
+        self,
+        prompt: str,
+        json_mode: bool = True,
+        *,
+        response_format: dict | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str | None:
         try:
             import litellm  # lazy import
         except ImportError:
@@ -29,8 +37,14 @@ class LiteLLMAdapter(LLMAdapter):
             "messages": messages,
             "timeout": self.timeout,
         }
-        if json_mode:
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+        elif json_mode:
             kwargs["response_format"] = {"type": "json_object"}
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
 
         try:
             response = litellm.completion(**kwargs)

--- a/src/ormah/background/llm/ollama_adapter.py
+++ b/src/ormah/background/llm/ollama_adapter.py
@@ -22,8 +22,20 @@ class OllamaAdapter(LLMAdapter):
         self.timeout = timeout
         self.num_predict = num_predict
 
-    def generate(self, prompt: str, json_mode: bool = True) -> str | None:
+    def generate(
+        self,
+        prompt: str,
+        json_mode: bool = True,
+        *,
+        response_format: dict | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> str | None:
         import httpx
+
+        options: dict = {"num_predict": max_tokens or self.num_predict}
+        if temperature is not None:
+            options["temperature"] = temperature
 
         payload: dict = {
             "model": self.model,
@@ -33,9 +45,11 @@ class OllamaAdapter(LLMAdapter):
             # and on large transcripts starve the JSON, yielding empty/truncated
             # extractions. Non-thinking models ignore this flag.
             "think": False,
-            "options": {"num_predict": self.num_predict},
+            "options": options,
         }
-        if json_mode:
+        if response_format and response_format.get("type") == "json_schema":
+            payload["format"] = response_format.get("json_schema", {}).get("schema", "json")
+        elif json_mode:
             payload["format"] = "json"
 
         try:

--- a/src/ormah/background/llm_client.py
+++ b/src/ormah/background/llm_client.py
@@ -32,9 +32,23 @@ def _get_or_create_adapter(settings) -> LLMAdapter | None:
     return _cached_adapter
 
 
-def llm_generate(settings, prompt: str, json_mode: bool = True) -> str | None:
+def llm_generate(
+    settings,
+    prompt: str,
+    json_mode: bool = True,
+    *,
+    response_format: dict | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+) -> str | None:
     """Call configured LLM. Returns raw response text, or None on failure."""
     adapter = _get_or_create_adapter(settings)
     if adapter is None:
         return None
-    return adapter.generate(prompt, json_mode=json_mode)
+    return adapter.generate(
+        prompt,
+        json_mode=json_mode,
+        response_format=response_format,
+        temperature=temperature,
+        max_tokens=max_tokens,
+    )

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -1,10 +1,11 @@
-"""Session watcher — auto-ingest completed Claude Code JSONL transcripts."""
+"""Session watcher — auto-ingest completed agent JSONL transcripts."""
 
 from __future__ import annotations
 
 import hashlib
 import json
 import logging
+import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,17 +15,200 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from ormah.engine.memory_engine import MemoryEngine
+from ormah.text.tokens import distinctive_tokens
+from ormah.transcript.parser import TranscriptResult, TranscriptTurn, parse_transcript
 
 logger = logging.getLogger(__name__)
 
 _STATE_FILENAME = ".session_watcher_state"
 
 
-def _space_from_encoded_dir(dirname: str) -> str | None:
-    """Extract project space from Claude Code's encoded directory name.
+def _normalise_text(text: str) -> str:
+    """Lowercase text and collapse punctuation/whitespace for matching."""
+    cleaned = re.sub(r"[^a-zA-Z0-9]+", " ", text.lower())
+    return " ".join(cleaned.split())
 
-    Claude Code encodes paths like ``-Users-johndoe-Projects-ormah``.
-    The last segment after splitting on ``-`` is the project name.
+
+def _assistant_response_after_prompt(
+    turns: list[TranscriptTurn],
+    prompt_text: str | None,
+) -> str | None:
+    """Return assistant text immediately following the matching user prompt."""
+    if not prompt_text:
+        return None
+
+    wanted = _normalise_text(prompt_text)
+    if not wanted:
+        return None
+
+    for idx, turn in enumerate(turns):
+        if turn.role != "user" or _normalise_text(turn.text) != wanted:
+            continue
+
+        responses: list[str] = []
+        for next_turn in turns[idx + 1:]:
+            if next_turn.role == "user":
+                break
+            if next_turn.role == "assistant":
+                responses.append(next_turn.text)
+        return "\n\n".join(responses) if responses else None
+
+    return None
+
+
+def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
+    """Detect whether an assistant response clearly referenced an injected memory."""
+    response_norm = _normalise_text(response_text)
+    response_tokens = distinctive_tokens(response_text, extra_stop_words={"memory", "ormah"})
+
+    node_id = row["node_id"]
+    short_id = node_id[:8] if node_id else ""
+    if short_id and short_id.lower() in response_text.lower():
+        return True, 1.0, {"match": "node_id", "short_id": short_id}
+
+    title = row["title"] or ""
+    title_tokens = distinctive_tokens(title, extra_stop_words={"memory", "ormah"})
+    title_norm = _normalise_text(title)
+    if len(title_tokens) >= 2 and len(title_norm) >= 12 and title_norm in response_norm:
+        return True, 0.95, {"match": "title", "title": title}
+
+    content = row["content"] or ""
+    for sentence in re.split(r"[\n.!?]+", content):
+        sentence = sentence.strip()
+        if len(sentence) < 24:
+            continue
+        sentence_tokens = distinctive_tokens(sentence, extra_stop_words={"memory", "ormah"})
+        sentence_norm = _normalise_text(sentence)
+        if len(sentence_tokens) >= 4 and sentence_norm in response_norm:
+            return True, 0.9, {"match": "sentence", "text": sentence[:160]}
+
+    node_tokens = distinctive_tokens(
+        f"{title} {content}",
+        extra_stop_words={"memory", "ormah"},
+    )
+    prompt_tokens = distinctive_tokens(row["prompt_text"] or "")
+    candidate_tokens = node_tokens - prompt_tokens
+    overlap = sorted(candidate_tokens & response_tokens)
+    denominator = min(len(candidate_tokens), 12)
+    overlap_ratio = (len(overlap) / denominator) if denominator else 0.0
+    if len(overlap) >= 4 and overlap_ratio >= 0.5:
+        return True, min(0.85, 0.45 + overlap_ratio), {
+            "match": "token_overlap",
+            "overlap": overlap[:12],
+            "overlap_ratio": round(overlap_ratio, 3),
+        }
+
+    return False, 0.0, {
+        "match": "none",
+        "overlap": overlap[:12],
+        "overlap_ratio": round(overlap_ratio, 3),
+    }
+
+
+def _record_whisper_usage_signals(
+    engine: MemoryEngine,
+    transcript: TranscriptResult,
+) -> int:
+    """Mine transcript responses for clear usage of injected whisper memories."""
+    rows = engine.db.conn.execute(
+        """
+        SELECT
+            wl.id, wl.node_id, wl.prompt_text, wl.prompt_hash, wl.prompt_vec,
+            wl.session_id, wl.space, n.title, n.content
+        FROM whisper_log wl
+        JOIN nodes n ON n.id = wl.node_id
+        WHERE wl.session_id = ?
+          AND wl.was_injected = 1
+          AND NOT EXISTS (
+              SELECT 1 FROM signals s
+              WHERE s.whisper_log_id = wl.id
+                AND s.source = 'transcript_watcher_heuristic'
+          )
+        ORDER BY wl.logged_at ASC, wl.id ASC
+        """,
+        (transcript.session_id,),
+    ).fetchall()
+    if not rows:
+        return 0
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    recorded = 0
+    with engine.db.transaction() as conn:
+        for row in rows:
+            response = _assistant_response_after_prompt(transcript.turns, row["prompt_text"])
+            if response is None:
+                continue
+
+            referenced, strength, evidence = _node_usage_evidence(row, response)
+            signal_type = "whisper_referenced" if referenced else "whisper_unreferenced"
+            polarity = 1 if referenced else 0
+            evidence = {
+                **evidence,
+                "detector": "transcript_watcher_heuristic",
+                "response_chars": len(response),
+            }
+            conn.execute(
+                """
+                INSERT INTO signals
+                    (
+                        whisper_log_id, node_id, signal_type, polarity, strength,
+                        source, session_id, agent_id, surface, space, prompt_hash,
+                        evidence, created
+                    )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT DO NOTHING
+                """,
+                (
+                    row["id"],
+                    row["node_id"],
+                    signal_type,
+                    polarity,
+                    strength,
+                    "transcript_watcher_heuristic",
+                    row["session_id"],
+                    transcript.source,
+                    "transcript_watcher",
+                    row["space"],
+                    row["prompt_hash"],
+                    json.dumps(evidence, sort_keys=True),
+                    now_iso,
+                ),
+            )
+            recorded += conn.execute("SELECT changes()").fetchone()[0]
+
+            if referenced:
+                conn.execute(
+                    """
+                    INSERT INTO affinity
+                        (
+                            prompt_vec, prompt_text, node_id, signal, source,
+                            confirmed_at, space, session_id, whisper_log_id
+                        )
+                    VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    (
+                        row["prompt_vec"],
+                        row["prompt_text"],
+                        row["node_id"],
+                        "auto_heuristic",
+                        now_iso,
+                        row["space"],
+                        row["session_id"],
+                        row["id"],
+                    ),
+                )
+
+    return recorded
+
+
+def _space_from_encoded_dir(dirname: str) -> str | None:
+    """Extract project space from an encoded transcript directory name.
+
+    Claude Code uses paths like ``-Users-johndoe-Projects-ormah``.
+    The current compatibility strategy uses the last ``-`` segment as
+    the project name; future transcript sources should provide their
+    own space strategy before reaching the watcher.
     Leading ``-`` is stripped before splitting.
     """
     stripped = dirname.lstrip("-")
@@ -64,8 +248,6 @@ def _ingest_session(
     min_turns: int,
 ) -> bool:
     """Ingest a single JSONL session transcript if changed. Returns True if ingested."""
-    from ormah.transcript.parser import parse_transcript
-
     rel = str(path.relative_to(watch_dir))
 
     try:
@@ -89,12 +271,13 @@ def _ingest_session(
 
     # Detect space from parent directory encoding
     space = _space_from_encoded_dir(path.parent.name)
+    signals_recorded = _record_whisper_usage_signals(engine, result)
 
     try:
         ingested = engine.ingest_conversation(
             content=result.conversation,
             space=space,
-            agent_id="session-watcher",
+            agent_id=result.source,
             extra_tags=["session-transcript"],
         )
         if isinstance(ingested, str):
@@ -112,15 +295,17 @@ def _ingest_session(
         "hash": h,
         "last_ingested": datetime.now(timezone.utc).isoformat(),
         "session_id": result.session_id,
+        "source": result.source,
         "space": space,
         "user_turns": result.user_turn_count,
         "node_ids": prev_node_ids + new_node_ids,
+        "signals_recorded": signals_recorded,
     }
     _save_state(watch_dir, state)
 
     logger.info(
-        "Session watcher ingested %s (%d turns, %d memories extracted)",
-        rel, result.user_turn_count, count,
+        "Session watcher ingested %s (%d turns, %d memories extracted, %d signals recorded)",
+        rel, result.user_turn_count, count, signals_recorded,
     )
     return True
 
@@ -219,7 +404,7 @@ class SessionHandler(FileSystemEventHandler):
 
 
 def start_session_watcher(engine: MemoryEngine) -> list[Observer]:
-    """Start the session watcher for Claude Code transcripts.
+    """Start the session watcher for agent transcript files.
 
     Performs an initial catch-up scan, then starts a real-time watcher.
     Returns list of Observer instances for shutdown.

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -44,14 +44,13 @@ Rules:
 - Use "irrelevant" only when the memory is plainly off-topic for the user's prompt and answer.
 - Prefer "uncertain" when the judgment is ambiguous.
 
-Return strict JSON:
+Return strict JSON matching this shape:
 {
   "verdicts": [
     {
       "whisper_log_id": 123,
       "verdict": "used|irrelevant|uncertain",
-      "confidence": 0.0,
-      "reason": "short concrete reason"
+      "confidence": 0.0
     }
   ]
 }
@@ -185,6 +184,40 @@ def _confidence(raw: object) -> float:
     return max(0.0, min(1.0, value))
 
 
+def _llm_feedback_judge_response_format() -> dict:
+    """Return the compact structured-output schema for whisper feedback judgments."""
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "whisper_feedback_verdicts",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "verdicts": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": False,
+                            "properties": {
+                                "whisper_log_id": {"type": "integer"},
+                                "verdict": {
+                                    "type": "string",
+                                    "enum": ["used", "irrelevant", "uncertain"],
+                                },
+                                "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                            },
+                            "required": ["whisper_log_id", "verdict", "confidence"],
+                        },
+                    },
+                },
+                "required": ["verdicts"],
+            },
+        },
+    }
+
+
 def _feedback_llm_judge_enabled(engine: MemoryEngine) -> bool:
     settings = engine.settings
     return bool(
@@ -225,7 +258,23 @@ def _llm_judge_whisper_usage(
         + json.dumps(payload, ensure_ascii=False, indent=2)
     )
 
-    raw = llm_generate(engine.settings, prompt, json_mode=True)
+    raw = llm_generate(
+        engine.settings,
+        prompt,
+        json_mode=True,
+        response_format=_llm_feedback_judge_response_format(),
+        temperature=0,
+        max_tokens=512,
+    )
+    if raw is None:
+        logger.info("LLM feedback judge schema call failed; falling back to JSON object mode")
+        raw = llm_generate(
+            engine.settings,
+            prompt,
+            json_mode=True,
+            temperature=0,
+            max_tokens=512,
+        )
     if raw is None:
         return {}
 

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -26,6 +26,8 @@ _LLM_JUDGE_SOURCE = "transcript_watcher_llm_judge"
 _HEURISTIC_AFFINITY_SOURCE = "auto_heuristic"
 _LLM_JUDGE_AFFINITY_SOURCE = "auto_llm_judge"
 _FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
+_DEFAULT_SESSION_WATCHER_DIR = Path("~/.claude/projects")
+_CODEX_SESSION_WATCHER_DIR = Path("~/.codex/sessions")
 
 _LLM_FEEDBACK_JUDGE_PROMPT = """\
 You are judging retrieval feedback for Ormah, a memory system.
@@ -568,6 +570,102 @@ def _space_from_encoded_dir(dirname: str) -> str | None:
     return parts[-1] if parts else None
 
 
+def _resolve_transcript_session_id(
+    engine: MemoryEngine,
+    path: Path,
+    parsed_session_id: str,
+    source: str,
+) -> str:
+    """Resolve source-specific transcript filenames back to hook session ids.
+
+    Claude Code transcript filenames are the session id. Codex rollout filenames can embed
+    the hook session id inside a longer filename, so use recent whisper_log rows to recover
+    the id that was used when whispers were injected.
+    """
+    if not parsed_session_id:
+        return parsed_session_id
+
+    exact = engine.db.conn.execute(
+        "SELECT 1 FROM whisper_log WHERE session_id = ? LIMIT 1",
+        (parsed_session_id,),
+    ).fetchone()
+    if exact is not None:
+        return parsed_session_id
+
+    if source != "codex":
+        return parsed_session_id
+
+    row = engine.db.conn.execute(
+        """
+        SELECT session_id
+        FROM whisper_log
+        WHERE session_id IS NOT NULL
+          AND session_id != ''
+          AND length(session_id) >= 6
+          AND ? LIKE '%' || session_id || '%'
+        ORDER BY length(session_id) DESC, logged_at DESC, id DESC
+        LIMIT 1
+        """,
+        (path.name,),
+    ).fetchone()
+    return row["session_id"] if row is not None else parsed_session_id
+
+
+def _space_from_whisper_log(engine: MemoryEngine, session_id: str) -> str | None:
+    """Return the most recent non-empty space logged for a whisper session."""
+    if not session_id:
+        return None
+
+    row = engine.db.conn.execute(
+        """
+        SELECT space
+        FROM whisper_log
+        WHERE session_id = ?
+          AND space IS NOT NULL
+          AND space != ''
+        ORDER BY logged_at DESC, id DESC
+        LIMIT 1
+        """,
+        (session_id,),
+    ).fetchone()
+    return row["space"] if row is not None else None
+
+
+def _space_for_transcript(
+    engine: MemoryEngine,
+    path: Path,
+    result: TranscriptResult,
+) -> str | None:
+    """Choose the project space for a parsed transcript."""
+    logged_space = _space_from_whisper_log(engine, result.session_id)
+    if logged_space:
+        return logged_space
+
+    if result.source == "claude_code":
+        return _space_from_encoded_dir(path.parent.name)
+
+    return None
+
+
+def _expand_watch_dir(path: Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def _session_watch_dirs(settings) -> list[Path]:
+    """Return existing transcript watch directories for the current settings."""
+    primary = _expand_watch_dir(settings.session_watcher_dir)
+    candidates = [primary]
+
+    if primary == _expand_watch_dir(_DEFAULT_SESSION_WATCHER_DIR):
+        candidates.append(_expand_watch_dir(_CODEX_SESSION_WATCHER_DIR))
+
+    watch_dirs: list[Path] = []
+    for candidate in candidates:
+        if candidate.exists() and candidate not in watch_dirs:
+            watch_dirs.append(candidate)
+    return watch_dirs
+
+
 def _file_hash(path: Path) -> str:
     """Return SHA-256 hex digest of a file's contents."""
     return hashlib.sha256(path.read_bytes()).hexdigest()
@@ -619,8 +717,13 @@ def _ingest_session(
     if result.user_turn_count < min_turns:
         return False
 
-    # Detect space from parent directory encoding
-    space = _space_from_encoded_dir(path.parent.name)
+    result.session_id = _resolve_transcript_session_id(
+        engine,
+        path,
+        result.session_id,
+        result.source,
+    )
+    space = _space_for_transcript(engine, path, result)
     signals_recorded = _record_whisper_usage_signals(engine, result)
 
     try:
@@ -763,28 +866,31 @@ def start_session_watcher(engine: MemoryEngine) -> list[Observer]:
     if not s.session_watcher_enabled:
         return []
 
-    watch_dir = Path(s.session_watcher_dir).expanduser().resolve()
-    if not watch_dir.exists():
-        logger.warning("Session watcher dir does not exist: %s", watch_dir)
+    watch_dirs = _session_watch_dirs(s)
+    if not watch_dirs:
+        logger.warning("Session watcher dir does not exist: %s", _expand_watch_dir(s.session_watcher_dir))
         return []
 
-    # Catch-up scan
-    ingested = _scan_sessions(
-        engine, watch_dir, s.session_watcher_min_turns, s.session_watcher_lookback_hours,
-    )
-    if ingested:
-        logger.info("Session watcher catch-up: ingested %d sessions from %s", ingested, watch_dir)
+    observers: list[Observer] = []
+    for watch_dir in watch_dirs:
+        # Catch-up scan
+        ingested = _scan_sessions(
+            engine, watch_dir, s.session_watcher_min_turns, s.session_watcher_lookback_hours,
+        )
+        if ingested:
+            logger.info("Session watcher catch-up: ingested %d sessions from %s", ingested, watch_dir)
 
-    # Start real-time watcher
-    handler = SessionHandler(
-        engine, watch_dir, s.session_watcher_debounce_seconds, s.session_watcher_min_turns,
-    )
-    observer = Observer()
-    observer.schedule(handler, str(watch_dir), recursive=True)
-    observer.start()
-    logger.info("Session watcher started on %s", watch_dir)
+        # Start real-time watcher
+        handler = SessionHandler(
+            engine, watch_dir, s.session_watcher_debounce_seconds, s.session_watcher_min_turns,
+        )
+        observer = Observer()
+        observer.schedule(handler, str(watch_dir), recursive=True)
+        observer.start()
+        observers.append(observer)
+        logger.info("Session watcher started on %s", watch_dir)
 
-    return [observer]
+    return observers
 
 
 def stop_session_watcher(observers: list[Observer]) -> None:

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -21,6 +21,41 @@ from ormah.transcript.parser import TranscriptResult, TranscriptTurn, parse_tran
 logger = logging.getLogger(__name__)
 
 _STATE_FILENAME = ".session_watcher_state"
+_HEURISTIC_SOURCE = "transcript_watcher_heuristic"
+_LLM_JUDGE_SOURCE = "transcript_watcher_llm_judge"
+_HEURISTIC_AFFINITY_SOURCE = "auto_heuristic"
+_LLM_JUDGE_AFFINITY_SOURCE = "auto_llm_judge"
+_FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
+
+_LLM_FEEDBACK_JUDGE_PROMPT = """\
+You are judging retrieval feedback for Ormah, a memory system.
+
+Given a user prompt, the assistant response, and memories that Ormah injected before the
+assistant answered, decide whether each memory was actually useful retrieval context.
+
+Verdicts:
+- "used": the assistant response materially uses, cites, paraphrases, or relies on the memory.
+- "irrelevant": the memory is clearly unrelated/noisy for this prompt and response.
+- "uncertain": there is not enough evidence either way. Silence alone is uncertain, not irrelevant.
+
+Rules:
+- Do not mark a memory "used" just because it shares generic words with the response.
+- Do not mark a memory "irrelevant" just because the assistant omitted it.
+- Use "irrelevant" only when the memory is plainly off-topic for the user's prompt and answer.
+- Prefer "uncertain" when the judgment is ambiguous.
+
+Return strict JSON:
+{
+  "verdicts": [
+    {
+      "whisper_log_id": 123,
+      "verdict": "used|irrelevant|uncertain",
+      "confidence": 0.0,
+      "reason": "short concrete reason"
+    }
+  ]
+}
+"""
 
 
 def _normalise_text(text: str) -> str:
@@ -105,98 +140,364 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
     }
 
 
+def _extract_json(raw: str) -> str:
+    """Extract JSON from an LLM response that may contain fences or prose."""
+    stripped = raw.strip()
+    if stripped.startswith(("{", "[")):
+        return stripped
+
+    match = _FENCE_RE.search(raw)
+    if match:
+        return match.group(1).strip()
+
+    for start_char, end_char in [("{", "}"), ("[", "]")]:
+        start = raw.find(start_char)
+        end = raw.rfind(end_char)
+        if start != -1 and end > start:
+            return raw[start : end + 1]
+
+    return stripped
+
+
+def _normalise_judge_verdict(raw: object) -> str:
+    """Map loose LLM verdict labels to the canonical feedback verdicts."""
+    value = str(raw or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if value in {"used", "useful", "referenced", "positive", "relevant"}:
+        return "used"
+    if value in {
+        "irrelevant",
+        "clearly_irrelevant",
+        "not_useful",
+        "negative",
+        "noisy",
+        "noise",
+    }:
+        return "irrelevant"
+    return "uncertain"
+
+
+def _confidence(raw: object) -> float:
+    """Parse and clamp an LLM confidence value into [0.0, 1.0]."""
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, value))
+
+
+def _feedback_llm_judge_enabled(engine: MemoryEngine) -> bool:
+    settings = engine.settings
+    return bool(
+        getattr(settings, "feedback_llm_judge_enabled", False)
+        and getattr(settings, "llm_enabled", False)
+    )
+
+
+def _llm_judge_whisper_usage(
+    engine: MemoryEngine,
+    prompt_text: str,
+    response_text: str,
+    rows: list,
+) -> dict[int, dict]:
+    """Ask the configured LLM to judge ambiguous whisper usage for one turn."""
+    if not rows:
+        return {}
+
+    from ormah.background.llm_client import llm_generate
+
+    candidates = [
+        {
+            "whisper_log_id": row["id"],
+            "node_id": (row["node_id"] or "")[:8],
+            "title": row["title"] or "",
+            "content": (row["content"] or "")[:1200],
+        }
+        for row in rows
+    ]
+    payload = {
+        "user_prompt": (prompt_text or "")[:2500],
+        "assistant_response": response_text[:5000],
+        "memories": candidates,
+    }
+    prompt = (
+        _LLM_FEEDBACK_JUDGE_PROMPT
+        + "\n\nInput JSON:\n"
+        + json.dumps(payload, ensure_ascii=False, indent=2)
+    )
+
+    raw = llm_generate(engine.settings, prompt, json_mode=True)
+    if raw is None:
+        return {}
+
+    try:
+        parsed = json.loads(_extract_json(raw))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        logger.warning("LLM returned invalid JSON for feedback judgment")
+        return {}
+
+    verdicts = parsed.get("verdicts") if isinstance(parsed, dict) else parsed
+    if not isinstance(verdicts, list):
+        return {}
+
+    judgments: dict[int, dict] = {}
+    valid_ids = {int(row["id"]) for row in rows}
+    for item in verdicts:
+        if not isinstance(item, dict):
+            continue
+        raw_id = item.get("whisper_log_id", item.get("id"))
+        try:
+            whisper_log_id = int(raw_id)
+        except (TypeError, ValueError):
+            continue
+        if whisper_log_id not in valid_ids:
+            continue
+
+        verdict = _normalise_judge_verdict(item.get("verdict"))
+        confidence = _confidence(item.get("confidence"))
+        judgments[whisper_log_id] = {
+            "verdict": verdict,
+            "confidence": confidence,
+            "reason": str(item.get("reason") or "")[:500],
+        }
+
+    return judgments
+
+
+def _insert_usage_signal(
+    conn,
+    row,
+    transcript: TranscriptResult,
+    *,
+    signal_type: str,
+    polarity: int,
+    strength: float,
+    source: str,
+    evidence: dict,
+    created: str,
+) -> int:
+    conn.execute(
+        """
+        INSERT INTO signals
+            (
+                whisper_log_id, node_id, signal_type, polarity, strength,
+                source, session_id, agent_id, surface, space, prompt_hash,
+                evidence, created
+            )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            row["id"],
+            row["node_id"],
+            signal_type,
+            polarity,
+            strength,
+            source,
+            row["session_id"],
+            transcript.source,
+            "transcript_watcher",
+            row["space"],
+            row["prompt_hash"],
+            json.dumps(evidence, sort_keys=True),
+            created,
+        ),
+    )
+    return conn.execute("SELECT changes()").fetchone()[0]
+
+
+def _insert_affinity(
+    conn,
+    row,
+    *,
+    signal: int,
+    source: str,
+    confirmed_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO affinity
+            (
+                prompt_vec, prompt_text, node_id, signal, source,
+                confirmed_at, space, session_id, whisper_log_id
+            )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO NOTHING
+        """,
+        (
+            row["prompt_vec"],
+            row["prompt_text"],
+            row["node_id"],
+            signal,
+            source,
+            confirmed_at,
+            row["space"],
+            row["session_id"],
+            row["id"],
+        ),
+    )
+
+
 def _record_whisper_usage_signals(
     engine: MemoryEngine,
     transcript: TranscriptResult,
 ) -> int:
     """Mine transcript responses for clear usage of injected whisper memories."""
+    llm_judge_enabled = _feedback_llm_judge_enabled(engine)
     rows = engine.db.conn.execute(
         """
         SELECT
             wl.id, wl.node_id, wl.prompt_text, wl.prompt_hash, wl.prompt_vec,
-            wl.session_id, wl.space, n.title, n.content
+            wl.session_id, wl.space, n.title, n.content,
+            (
+                SELECT s.polarity FROM signals s
+                WHERE s.whisper_log_id = wl.id
+                  AND s.source = ?
+                ORDER BY s.id DESC
+                LIMIT 1
+            ) AS heuristic_polarity,
+            EXISTS (
+                SELECT 1 FROM signals s
+                WHERE s.whisper_log_id = wl.id
+                  AND s.source = ?
+            ) AS has_llm_judge
         FROM whisper_log wl
         JOIN nodes n ON n.id = wl.node_id
         WHERE wl.session_id = ?
           AND wl.was_injected = 1
-          AND NOT EXISTS (
-              SELECT 1 FROM signals s
-              WHERE s.whisper_log_id = wl.id
-                AND s.source = 'transcript_watcher_heuristic'
-          )
         ORDER BY wl.logged_at ASC, wl.id ASC
         """,
-        (transcript.session_id,),
+        (_HEURISTIC_SOURCE, _LLM_JUDGE_SOURCE, transcript.session_id),
     ).fetchall()
     if not rows:
         return 0
 
     now_iso = datetime.now(timezone.utc).isoformat()
     recorded = 0
-    with engine.db.transaction() as conn:
-        for row in rows:
-            response = _assistant_response_after_prompt(transcript.turns, row["prompt_text"])
-            if response is None:
-                continue
 
+    heuristic_records: list[dict] = []
+    llm_groups: dict[tuple[str, str], list] = {}
+    response_cache: dict[str, str | None] = {}
+    for row in rows:
+        prompt_text = row["prompt_text"] or ""
+        if prompt_text not in response_cache:
+            response_cache[prompt_text] = _assistant_response_after_prompt(
+                transcript.turns,
+                prompt_text,
+            )
+        response = response_cache[prompt_text]
+        if response is None:
+            continue
+
+        heuristic_polarity = row["heuristic_polarity"]
+        has_heuristic = heuristic_polarity is not None
+        has_llm_judge = bool(row["has_llm_judge"])
+
+        referenced = False
+        if not has_heuristic:
             referenced, strength, evidence = _node_usage_evidence(row, response)
             signal_type = "whisper_referenced" if referenced else "whisper_unreferenced"
             polarity = 1 if referenced else 0
-            evidence = {
-                **evidence,
-                "detector": "transcript_watcher_heuristic",
-                "response_chars": len(response),
-            }
-            conn.execute(
-                """
-                INSERT INTO signals
-                    (
-                        whisper_log_id, node_id, signal_type, polarity, strength,
-                        source, session_id, agent_id, surface, space, prompt_hash,
-                        evidence, created
-                    )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT DO NOTHING
-                """,
-                (
-                    row["id"],
-                    row["node_id"],
-                    signal_type,
-                    polarity,
-                    strength,
-                    "transcript_watcher_heuristic",
-                    row["session_id"],
-                    transcript.source,
-                    "transcript_watcher",
-                    row["space"],
-                    row["prompt_hash"],
-                    json.dumps(evidence, sort_keys=True),
-                    now_iso,
-                ),
-            )
-            recorded += conn.execute("SELECT changes()").fetchone()[0]
+            heuristic_records.append({
+                "row": row,
+                "signal_type": signal_type,
+                "polarity": polarity,
+                "strength": strength,
+                "evidence": {
+                    **evidence,
+                    "detector": _HEURISTIC_SOURCE,
+                    "response_chars": len(response),
+                },
+            })
+        else:
+            referenced = int(heuristic_polarity) == 1
 
-            if referenced:
-                conn.execute(
-                    """
-                    INSERT INTO affinity
-                        (
-                            prompt_vec, prompt_text, node_id, signal, source,
-                            confirmed_at, space, session_id, whisper_log_id
-                        )
-                    VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?)
-                    ON CONFLICT DO NOTHING
-                    """,
-                    (
-                        row["prompt_vec"],
-                        row["prompt_text"],
-                        row["node_id"],
-                        "auto_heuristic",
-                        now_iso,
-                        row["space"],
-                        row["session_id"],
-                        row["id"],
-                    ),
+        if llm_judge_enabled and not has_llm_judge and not referenced:
+            llm_groups.setdefault((prompt_text, response), []).append(row)
+
+    with engine.db.transaction() as conn:
+        for record in heuristic_records:
+            row = record["row"]
+            recorded += _insert_usage_signal(
+                conn,
+                row,
+                transcript,
+                signal_type=record["signal_type"],
+                polarity=record["polarity"],
+                strength=record["strength"],
+                source=_HEURISTIC_SOURCE,
+                evidence=record["evidence"],
+                created=now_iso,
+            )
+            if record["polarity"] == 1:
+                _insert_affinity(
+                    conn,
+                    row,
+                    signal=1,
+                    source=_HEURISTIC_AFFINITY_SOURCE,
+                    confirmed_at=now_iso,
+                )
+
+    if not llm_groups:
+        return recorded
+
+    judge_records: list[dict] = []
+    min_confidence = getattr(engine.settings, "feedback_llm_judge_min_confidence", 0.75)
+    for (prompt_text, response), group_rows in llm_groups.items():
+        judgments = _llm_judge_whisper_usage(engine, prompt_text, response, group_rows)
+        for row in group_rows:
+            judgment = judgments.get(int(row["id"]))
+            if judgment is None:
+                continue
+
+            verdict = judgment["verdict"]
+            confidence = judgment["confidence"]
+            promoted = confidence >= min_confidence and verdict in {"used", "irrelevant"}
+            polarity = 0
+            signal_type = "whisper_judged_uncertain"
+            if promoted and verdict == "used":
+                polarity = 1
+                signal_type = "whisper_judged_used"
+            elif promoted and verdict == "irrelevant":
+                polarity = -1
+                signal_type = "whisper_judged_irrelevant"
+
+            judge_records.append({
+                "row": row,
+                "signal_type": signal_type,
+                "polarity": polarity,
+                "strength": confidence,
+                "evidence": {
+                    "detector": _LLM_JUDGE_SOURCE,
+                    "verdict": verdict,
+                    "confidence": confidence,
+                    "min_confidence": min_confidence,
+                    "reason": judgment["reason"],
+                    "promoted": promoted,
+                    "response_chars": len(response),
+                },
+            })
+
+    with engine.db.transaction() as conn:
+        for record in judge_records:
+            row = record["row"]
+            recorded += _insert_usage_signal(
+                conn,
+                row,
+                transcript,
+                signal_type=record["signal_type"],
+                polarity=record["polarity"],
+                strength=record["strength"],
+                source=_LLM_JUDGE_SOURCE,
+                evidence=record["evidence"],
+                created=now_iso,
+            )
+            if record["polarity"] in (1, -1):
+                _insert_affinity(
+                    conn,
+                    row,
+                    signal=record["polarity"],
+                    source=_LLM_JUDGE_AFFINITY_SOURCE,
+                    confirmed_at=now_iso,
                 )
 
     return recorded

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
     hippocampus_enabled: bool = True
     hippocampus_ignore_patterns: list[str] = []
 
-    # Session watcher (auto-ingest Claude Code transcripts)
+    # Session watcher (auto-ingest agent transcripts; default path is Claude Code)
     session_watcher_enabled: bool = False
     session_watcher_dir: Path = Path("~/.claude/projects")
     session_watcher_debounce_seconds: float = 60.0

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -180,6 +180,8 @@ class Settings(BaseSettings):
     affinity_max_boost: float = 0.15
     affinity_implicit_weight: float = 0.8
     whisper_exploration_enabled: bool = True
+    feedback_llm_judge_enabled: bool = False
+    feedback_llm_judge_min_confidence: float = 0.75
 
     # Space prioritization
     space_boost_global: float = 1.0
@@ -352,7 +354,12 @@ class Settings(BaseSettings):
             raise ValueError(f"rrf_min_spread_ratio must be 0–1, got {v}")
         return v
 
-    @field_validator("similarity_threshold", "auto_link_similarity_threshold", "auto_merge_threshold")
+    @field_validator(
+        "similarity_threshold",
+        "auto_link_similarity_threshold",
+        "auto_merge_threshold",
+        "feedback_llm_judge_min_confidence",
+    )
     @classmethod
     def _threshold_range(cls, v: float) -> float:
         if not 0 <= v <= 1:

--- a/src/ormah/engine/affinity.py
+++ b/src/ormah/engine/affinity.py
@@ -99,7 +99,7 @@ def compute_affinity_boost(
         days_ago = (now_utc - confirmed_dt).total_seconds() / 86400.0
         recency = math.exp(-days_ago * ln2 / half_life)
 
-        source_w = implicit_w if row["source"] == "implicit" else 1.0
+        source_w = 1.0 if row["source"] == "explicit" else implicit_w
         weight = sim * recency * source_w
 
         signal = int(row["signal"])

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
 from ormah.index.graph import GraphIndex
+from ormah.text.tokens import distinctive_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -32,21 +33,6 @@ _REVIEW_FRAMING = (
     "this won't be surfaced again for 14 days."
 )
 
-_TOPIC_STOP_WORDS = frozenset({
-    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
-    "have", "has", "had", "do", "does", "did", "will", "would", "could",
-    "should", "may", "might", "shall", "can", "need", "dare", "ought",
-    "i", "me", "my", "we", "our", "you", "your", "he", "she", "it",
-    "they", "them", "this", "that", "these", "those", "am", "not", "no",
-    "nor", "so", "if", "or", "and", "but", "for", "of", "to", "in",
-    "on", "at", "by", "with", "from", "as", "into", "about", "what",
-    "which", "who", "whom", "when", "where", "why", "how", "all", "any",
-    "each", "every", "both", "few", "more", "most", "other", "some",
-    "such", "than", "too", "very", "just", "because", "also", "let",
-    "lets", "please", "explain", "implemented", "build", "design", "new",
-    "feature", "component", "page", "work", "working", "user",
-})
-
 def _truncate_at_word_boundary(text: str, max_len: int = 300) -> str:
     """Return *text* truncated to *max_len* characters at a word boundary."""
     if len(text) <= max_len:
@@ -66,8 +52,7 @@ def _prompt_log_snippet(text: str, max_len: int = 80) -> str:
 
 def _topic_tokens(text: str) -> set[str]:
     """Extract meaningful topical tokens from text."""
-    tokens = {tok.lower() for tok in re.findall(r"\b[a-zA-Z][a-zA-Z0-9_-]{2,}\b", text)}
-    return {tok for tok in tokens if tok not in _TOPIC_STOP_WORDS}
+    return distinctive_tokens(text)
 def _has_topical_overlap(prompt_tokens: set[str], node: dict) -> bool:
     """Return True when prompt tokens overlap node title/content tokens."""
     if not prompt_tokens:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -37,6 +37,7 @@ from ormah.models.node import (
     UpdateNodeRequest,
 )
 from ormah.store.file_store import FileStore
+from ormah.text.tokens import STOP_WORDS
 
 logger = logging.getLogger(__name__)
 
@@ -549,21 +550,12 @@ class MemoryEngine:
         )
         return format_node_with_neighbors(node, edges, neighbors)
 
-    # Stop words for detecting "pure temporal" queries (no topical signal).
-    _STOP_WORDS = frozenset({
-        "what", "did", "we", "do", "i", "you", "the", "a", "is", "are",
-        "was", "were", "have", "has", "had", "been", "be", "will", "would",
-        "could", "should", "can", "may", "might", "shall", "on", "in", "at",
-        "to", "for", "of", "with", "by", "from", "up", "about", "into",
-        "through", "during", "before", "after", "above", "below", "between",
-        "out", "off", "over", "under", "again", "further", "then", "once",
-        "here", "there", "when", "where", "why", "how", "all", "each",
-        "every", "both", "few", "more", "most", "other", "some", "such",
-        "no", "not", "only", "own", "same", "so", "than", "too", "very",
-        "just", "because", "as", "until", "while", "and", "but", "or",
-        "nor", "if", "that", "which", "who", "whom", "this", "these",
-        "those", "am", "an", "any", "work", "worked", "working",
-        "me", "my", "our", "us", "show", "tell", "give", "get",
+    # Additional command-like words for detecting "pure temporal" queries.
+    _STOP_WORDS = STOP_WORDS | frozenset({
+        "after", "again", "above", "below", "between", "during", "further",
+        "get", "give", "here", "me", "once", "only", "out", "own", "same",
+        "show", "tell", "then", "through", "under", "until", "up", "us",
+        "while", "work", "worked", "working",
     })
 
     def recall_search_structured(
@@ -2022,7 +2014,7 @@ class MemoryEngine:
             SELECT node_id
             FROM whisper_log
             WHERE node_id = ?
-            ORDER BY logged_at DESC
+            ORDER BY logged_at DESC, id DESC
             LIMIT 1
             """,
             (node_id,),
@@ -2064,10 +2056,10 @@ class MemoryEngine:
 
         row = self.db.conn.execute(
             """
-            SELECT prompt_vec, prompt_text, session_id, space
+            SELECT id, prompt_vec, prompt_text, prompt_hash, session_id, space
             FROM whisper_log
             WHERE node_id = ?
-            ORDER BY logged_at DESC
+            ORDER BY logged_at DESC, id DESC
             LIMIT 1
             """,
             (resolved_node_id,),
@@ -2078,18 +2070,65 @@ class MemoryEngine:
 
         prompt_vec = row["prompt_vec"]
         prompt_text = row["prompt_text"]
+        prompt_hash = row["prompt_hash"]
         session_id = row["session_id"]
         space = row["space"]
+        whisper_log_id = row["id"]
 
         with self.db.transaction() as conn:
             conn.execute(
                 """
                 INSERT INTO affinity
-                    (prompt_vec, prompt_text, node_id, signal, source, confirmed_at, space, session_id)
-                VALUES (?, ?, ?, ?, ?, datetime('now'), ?, ?)
-                ON CONFLICT (node_id, session_id) DO NOTHING
+                    (
+                        prompt_vec, prompt_text, node_id, signal, source,
+                        confirmed_at, space, session_id, whisper_log_id
+                    )
+                VALUES (?, ?, ?, ?, ?, datetime('now'), ?, ?, ?)
+                ON CONFLICT DO NOTHING
                 """,
-                (prompt_vec, prompt_text, resolved_node_id, signal, source, space, session_id),
+                (
+                    prompt_vec,
+                    prompt_text,
+                    resolved_node_id,
+                    signal,
+                    source,
+                    space,
+                    session_id,
+                    whisper_log_id,
+                ),
+            )
+            if source == "explicit":
+                conn.execute(
+                    """
+                    UPDATE affinity
+                    SET signal = ?, source = ?, confirmed_at = datetime('now')
+                    WHERE node_id = ? AND whisper_log_id = ?
+                    """,
+                    (signal, source, resolved_node_id, whisper_log_id),
+                )
+            conn.execute(
+                """
+                INSERT INTO signals
+                    (
+                        whisper_log_id, node_id, signal_type, polarity, strength,
+                        source, session_id, surface, space, prompt_hash, evidence, created
+                    )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+                ON CONFLICT DO NOTHING
+                """,
+                (
+                    whisper_log_id,
+                    resolved_node_id,
+                    "feedback_submitted",
+                    signal,
+                    1.0,
+                    source,
+                    session_id,
+                    "submit_feedback",
+                    space,
+                    prompt_hash,
+                    json.dumps({"source": source}),
+                ),
             )
             if source != "implicit":
                 conn.execute(

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -150,26 +150,8 @@ class Database:
                     "CREATE INDEX IF NOT EXISTS idx_whisper_log_logged ON whisper_log(logged_at)"
                 )
 
-            if "affinity" not in existing_tables:
-                conn.execute(
-                    """
-                    CREATE TABLE IF NOT EXISTS affinity (
-                        id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                        prompt_vec   BLOB NOT NULL,
-                        prompt_text  TEXT,
-                        node_id      TEXT NOT NULL,
-                        signal       INTEGER NOT NULL,
-                        source       TEXT NOT NULL DEFAULT 'explicit',
-                        confirmed_at TEXT NOT NULL,
-                        space        TEXT,
-                        session_id   TEXT NOT NULL,
-                        UNIQUE (node_id, session_id)
-                    )
-                    """
-                )
-                conn.execute(
-                    "CREATE INDEX IF NOT EXISTS idx_affinity_node ON affinity(node_id)"
-                )
+            self._migrate_affinity_schema(conn, existing_tables)
+            self._ensure_signals_schema(conn)
 
             if "review_log" not in existing_tables:
                 conn.execute(
@@ -189,6 +171,119 @@ class Database:
 
         # Migrate FTS table to porter stemmer if needed
         self._migrate_fts_tokenizer()
+
+    def _create_affinity_table(self, conn: sqlite3.Connection, table: str = "affinity") -> None:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                prompt_vec     BLOB NOT NULL,
+                prompt_text    TEXT,
+                node_id        TEXT NOT NULL,
+                signal         INTEGER NOT NULL,
+                source         TEXT NOT NULL DEFAULT 'explicit',
+                confirmed_at   TEXT NOT NULL,
+                space          TEXT,
+                session_id     TEXT NOT NULL,
+                whisper_log_id INTEGER REFERENCES whisper_log(id) ON DELETE SET NULL
+            )
+            """
+        )
+
+    def _ensure_affinity_indexes(self, conn: sqlite3.Connection) -> None:
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_affinity_node ON affinity(node_id)")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_affinity_whisper_log "
+            "ON affinity(whisper_log_id)"
+        )
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_affinity_node_whisper_log_unique
+            ON affinity(node_id, whisper_log_id)
+            WHERE whisper_log_id IS NOT NULL
+            """
+        )
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_affinity_node_session_legacy_unique
+            ON affinity(node_id, session_id)
+            WHERE whisper_log_id IS NULL
+            """
+        )
+
+    def _migrate_affinity_schema(
+        self,
+        conn: sqlite3.Connection,
+        existing_tables: set[str],
+    ) -> None:
+        if "affinity" not in existing_tables:
+            self._create_affinity_table(conn)
+            self._ensure_affinity_indexes(conn)
+            return
+
+        cols = [row[1] for row in conn.execute("PRAGMA table_info(affinity)").fetchall()]
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='affinity'"
+        ).fetchone()
+        create_sql = (row[0] or "").lower() if row else ""
+        has_session_unique = "unique (node_id, session_id)" in create_sql
+
+        if "whisper_log_id" not in cols or has_session_unique:
+            logger.info("Migrating affinity table to turn-level whisper_log_id keys")
+            conn.execute("DROP TABLE IF EXISTS affinity_new")
+            self._create_affinity_table(conn, "affinity_new")
+            conn.execute(
+                """
+                INSERT INTO affinity_new
+                    (
+                        id, prompt_vec, prompt_text, node_id, signal, source,
+                        confirmed_at, space, session_id, whisper_log_id
+                    )
+                SELECT
+                    id, prompt_vec, prompt_text, node_id, signal, source,
+                    confirmed_at, space, session_id, NULL
+                FROM affinity
+                """
+            )
+            conn.execute("DROP TABLE affinity")
+            conn.execute("ALTER TABLE affinity_new RENAME TO affinity")
+
+        self._ensure_affinity_indexes(conn)
+
+    def _ensure_signals_schema(self, conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS signals (
+                id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                whisper_log_id INTEGER REFERENCES whisper_log(id) ON DELETE SET NULL,
+                node_id        TEXT NOT NULL,
+                signal_type    TEXT NOT NULL,
+                polarity       INTEGER NOT NULL,
+                strength       REAL NOT NULL DEFAULT 1.0,
+                source         TEXT NOT NULL,
+                session_id     TEXT,
+                agent_id       TEXT,
+                surface        TEXT,
+                space          TEXT,
+                prompt_hash    TEXT,
+                evidence       TEXT,
+                created        TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_signals_node ON signals(node_id)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_signals_session ON signals(session_id)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_signals_created ON signals(created)")
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_signals_whisper_log ON signals(whisper_log_id)"
+        )
+        conn.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_signals_whisper_type_source_unique
+            ON signals(whisper_log_id, signal_type, source)
+            WHERE whisper_log_id IS NOT NULL
+            """
+        )
 
     def _migrate_fts_tokenizer(self) -> None:
         """Recreate FTS table with porter stemmer if it uses the old tokenizer."""

--- a/src/ormah/index/graph.py
+++ b/src/ormah/index/graph.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from ormah.index.db import Database
 
+from ormah.text.tokens import IDENTITY_TOKENS, STOP_WORDS
+
 logger = logging.getLogger(__name__)
 
 
@@ -201,20 +203,8 @@ class GraphIndex:
         return [dict(r) for r in rows]
 
 
-_STOP_WORDS = frozenset({
-    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
-    "have", "has", "had", "do", "does", "did", "will", "would", "could",
-    "should", "may", "might", "shall", "can", "need", "dare", "ought",
-    "user", "i", "me", "my", "we", "our", "you", "your", "he", "she", "it",
-    "they", "them", "this", "that", "these", "those", "am", "not", "no",
-    "nor", "so", "if", "or", "and", "but", "for", "of", "to", "in",
-    "on", "at", "by", "with", "from", "as", "into", "about", "what",
-    "which", "who", "whom", "when", "where", "why", "how", "all", "any",
-    "each", "every", "both", "few", "more", "most", "other", "some",
-    "such", "than", "too", "very", "just", "because", "also",
-})
-
-_IDENTITY_TOKENS = frozenset({"user", "i", "me", "my", "we", "our", "you", "your"})
+_STOP_WORDS = STOP_WORDS
+_IDENTITY_TOKENS = IDENTITY_TOKENS
 
 
 def _sanitize_fts_query(query: str) -> list[str]:

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -119,9 +119,40 @@ CREATE TABLE IF NOT EXISTS affinity (
     confirmed_at TEXT NOT NULL,
     space        TEXT,
     session_id   TEXT NOT NULL,
-    UNIQUE (node_id, session_id)
+    whisper_log_id INTEGER REFERENCES whisper_log(id) ON DELETE SET NULL
 );
 CREATE INDEX IF NOT EXISTS idx_affinity_node ON affinity(node_id);
+CREATE INDEX IF NOT EXISTS idx_affinity_whisper_log ON affinity(whisper_log_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_affinity_node_whisper_log_unique
+    ON affinity(node_id, whisper_log_id)
+    WHERE whisper_log_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_affinity_node_session_legacy_unique
+    ON affinity(node_id, session_id)
+    WHERE whisper_log_id IS NULL;
+
+CREATE TABLE IF NOT EXISTS signals (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    whisper_log_id INTEGER REFERENCES whisper_log(id) ON DELETE SET NULL,
+    node_id        TEXT NOT NULL,
+    signal_type    TEXT NOT NULL,
+    polarity       INTEGER NOT NULL,
+    strength       REAL NOT NULL DEFAULT 1.0,
+    source         TEXT NOT NULL,
+    session_id     TEXT,
+    agent_id       TEXT,
+    surface        TEXT,
+    space          TEXT,
+    prompt_hash    TEXT,
+    evidence       TEXT,
+    created        TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_signals_node ON signals(node_id);
+CREATE INDEX IF NOT EXISTS idx_signals_session ON signals(session_id);
+CREATE INDEX IF NOT EXISTS idx_signals_created ON signals(created);
+CREATE INDEX IF NOT EXISTS idx_signals_whisper_log ON signals(whisper_log_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_signals_whisper_type_source_unique
+    ON signals(whisper_log_id, signal_type, source)
+    WHERE whisper_log_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS review_log (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -79,7 +79,7 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Hippocampus watchers not started: %s", e)
 
-    # Start session watcher for Claude Code transcripts
+    # Start session watcher for agent transcripts
     try:
         from ormah.background.session_watcher import start_session_watcher, stop_session_watcher
 

--- a/src/ormah/text/__init__.py
+++ b/src/ormah/text/__init__.py
@@ -1,0 +1,2 @@
+"""Shared text processing helpers."""
+

--- a/src/ormah/text/tokens.py
+++ b/src/ormah/text/tokens.py
@@ -1,0 +1,39 @@
+"""Shared lightweight tokenisation helpers."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+STOP_WORDS = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "shall", "can", "need", "dare", "ought",
+    "user", "i", "me", "my", "we", "our", "you", "your", "he", "she", "it",
+    "they", "them", "this", "that", "these", "those", "am", "not", "no",
+    "nor", "so", "if", "or", "and", "but", "for", "of", "to", "in",
+    "on", "at", "by", "with", "from", "as", "into", "about", "what",
+    "which", "who", "whom", "when", "where", "why", "how", "all", "any",
+    "each", "every", "both", "few", "more", "most", "other", "some",
+    "such", "than", "too", "very", "just", "because", "also",
+})
+
+IDENTITY_TOKENS = frozenset({"user", "i", "me", "my", "we", "our", "you", "your"})
+
+_TOKEN_RE = re.compile(r"\b[a-zA-Z][a-zA-Z0-9_-]{2,}\b")
+
+
+def distinctive_tokens(
+    text: str,
+    *,
+    extra_stop_words: Iterable[str] = (),
+    min_len: int = 3,
+) -> set[str]:
+    """Return lowercased content-bearing tokens from free text."""
+    stop_words = STOP_WORDS | {word.lower() for word in extra_stop_words}
+    return {
+        token
+        for token in (match.group(0).lower() for match in _TOKEN_RE.finditer(text))
+        if len(token) >= min_len and token not in stop_words
+    }
+

--- a/src/ormah/transcript/parser.py
+++ b/src/ormah/transcript/parser.py
@@ -1,18 +1,26 @@
-"""Parse Claude Code and Codex JSONL session transcripts into clean conversation text."""
+"""Normalize supported agent JSONL transcripts into conversation text and turns."""
 
 from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class TranscriptTurn:
+    """One normalized text-bearing conversation turn."""
+
+    role: str
+    text: str
+
+
 @dataclass
 class TranscriptResult:
-    """Result of parsing a supported agent JSONL transcript."""
+    """Result of parsing a supported agent transcript."""
 
     conversation: str  # "User: ...\n\nAssistant: ...\n\n..."
     user_turn_count: int  # User messages with actual text (not tool_result)
@@ -20,6 +28,8 @@ class TranscriptResult:
     cleaned_chars: int  # After stripping
     session_id: str  # From filename stem (UUID)
     end_offset: int = 0  # Byte position after last line read
+    turns: list[TranscriptTurn] = field(default_factory=list)
+    source: str = "agent_jsonl"
 
 
 def _extract_user_text(content) -> str | None:
@@ -90,6 +100,16 @@ def _coerce_entry(entry: dict) -> tuple[str | None, object | None]:
     return None, None
 
 
+def _source_for_entry(entry: dict) -> str | None:
+    """Return the agent/source label implied by a supported transcript record."""
+    entry_type = entry.get("type")
+    if entry_type in ("user", "assistant"):
+        return "claude_code"
+    if entry_type == "response_item":
+        return "codex"
+    return None
+
+
 def _is_bootstrap_user_text(text: str) -> bool:
     """Return True when text is client/bootstrap context, not a real user turn."""
     stripped = text.strip()
@@ -131,6 +151,13 @@ def extract_user_prompts(path: Path, start_offset: int = 0) -> list[str]:
     return prompts
 
 
+def _conversation_from_turns(turns: list[TranscriptTurn]) -> str:
+    return "\n\n".join(
+        f"{turn.role.title()}: {turn.text}"
+        for turn in turns
+    )
+
+
 def parse_transcript(path: Path, start_offset: int = 0) -> TranscriptResult:
     """Parse a supported JSONL transcript into cleaned conversation text.
 
@@ -145,8 +172,9 @@ def parse_transcript(path: Path, start_offset: int = 0) -> TranscriptResult:
     path = Path(path)
     total_chars = path.stat().st_size
 
-    turns: list[str] = []
+    turns: list[TranscriptTurn] = []
     user_turn_count = 0
+    source = "agent_jsonl"
 
     with open(path) as f:
         if start_offset > 0:
@@ -161,6 +189,10 @@ def parse_transcript(path: Path, start_offset: int = 0) -> TranscriptResult:
             except (json.JSONDecodeError, ValueError):
                 continue
 
+            entry_source = _source_for_entry(entry)
+            if source == "agent_jsonl" and entry_source is not None:
+                source = entry_source
+
             entry_type, content = _coerce_entry(entry)
             if entry_type not in ("user", "assistant"):
                 continue
@@ -170,17 +202,17 @@ def parse_transcript(path: Path, start_offset: int = 0) -> TranscriptResult:
             if entry_type == "user":
                 text = _extract_user_text(content)
                 if text and not _is_bootstrap_user_text(text):
-                    turns.append(f"User: {text}")
+                    turns.append(TranscriptTurn(role="user", text=text))
                     user_turn_count += 1
 
             elif entry_type == "assistant":
                 text = _extract_assistant_text(content)
                 if text:
-                    turns.append(f"Assistant: {text}")
+                    turns.append(TranscriptTurn(role="assistant", text=text))
 
         end_offset = f.tell()
 
-    conversation = "\n\n".join(turns)
+    conversation = _conversation_from_turns(turns)
     return TranscriptResult(
         conversation=conversation,
         user_turn_count=user_turn_count,
@@ -188,4 +220,6 @@ def parse_transcript(path: Path, start_offset: int = 0) -> TranscriptResult:
         cleaned_chars=len(conversation),
         session_id=path.stem,
         end_offset=end_offset,
+        turns=turns,
+        source=source,
     )

--- a/tests/test_background/test_llm_adapters.py
+++ b/tests/test_background/test_llm_adapters.py
@@ -86,6 +86,37 @@ def test_litellm_adapter_success():
     assert call_kwargs["response_format"] == {"type": "json_object"}
 
 
+def test_litellm_adapter_structured_response_options():
+    adapter = LiteLLMAdapter(model="nvidia_nim/meta/llama-4-maverick-17b-128e-instruct")
+    mock_choice = MagicMock()
+    mock_choice.message.content = '{"result": "ok"}'
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test_schema",
+            "schema": {"type": "object", "properties": {}, "additionalProperties": False},
+        },
+    }
+
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = mock_response
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        result = adapter.generate(
+            "test prompt",
+            response_format=response_format,
+            temperature=0,
+            max_tokens=512,
+        )
+
+    assert result == '{"result": "ok"}'
+    call_kwargs = mock_litellm.completion.call_args[1]
+    assert call_kwargs["response_format"] == response_format
+    assert call_kwargs["temperature"] == 0
+    assert call_kwargs["max_tokens"] == 512
+
+
 def test_litellm_adapter_failure():
     adapter = LiteLLMAdapter(model="claude-sonnet-4-20250514")
 

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -264,10 +264,16 @@ def test_llm_judge_promotes_used_verdict(engine, tmp_path):
             "reason": "The answer endorses the injected deployment guidance.",
         }]
     })
-    with patch(_LLM_PATCH, return_value=llm_response):
+    with patch(_LLM_PATCH, return_value=llm_response) as mock_llm:
         recorded = _record_whisper_usage_signals(engine, transcript)
 
     assert recorded == 2
+    call_kwargs = mock_llm.call_args.kwargs
+    assert call_kwargs["response_format"]["type"] == "json_schema"
+    assert call_kwargs["response_format"]["json_schema"]["name"] == "whisper_feedback_verdicts"
+    assert call_kwargs["temperature"] == 0
+    assert call_kwargs["max_tokens"] == 512
+
     judge_signal = engine.db.conn.execute(
         "SELECT * FROM signals WHERE whisper_log_id = ? "
         "AND source = 'transcript_watcher_llm_judge'",
@@ -284,6 +290,60 @@ def test_llm_judge_promotes_used_verdict(engine, tmp_path):
     assert affinity is not None
     assert affinity["signal"] == 1
     assert affinity["source"] == "auto_llm_judge"
+
+
+def test_llm_judge_falls_back_to_json_object_mode(engine, tmp_path):
+    """Providers that reject JSON Schema can still use the JSON-object fallback."""
+    prompt = "How should we solve feedback collection?"
+    response = "We should first fix the database uniqueness key."
+    transcript_path = tmp_path / "judge-schema-fallback-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Graph rendering should use level of detail for large datasets.",
+        type="fact",
+        title="Large graph rendering performance",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="judge-schema-fallback-session",
+        prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "irrelevant",
+            "confidence": 0.91,
+        }]
+    })
+    mock_llm = MagicMock(side_effect=[None, llm_response])
+    with patch(_LLM_PATCH, mock_llm):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 2
+    assert mock_llm.call_count == 2
+    first_kwargs = mock_llm.call_args_list[0].kwargs
+    second_kwargs = mock_llm.call_args_list[1].kwargs
+    assert first_kwargs["response_format"]["type"] == "json_schema"
+    assert first_kwargs["temperature"] == 0
+    assert first_kwargs["max_tokens"] == 512
+    assert "response_format" not in second_kwargs
+    assert second_kwargs["json_mode"] is True
+    assert second_kwargs["temperature"] == 0
+    assert second_kwargs["max_tokens"] == 512
+
+    judge_signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ? "
+        "AND source = 'transcript_watcher_llm_judge'",
+        (whisper_log_id,),
+    ).fetchone()
+    assert judge_signal is not None
+    assert judge_signal["signal_type"] == "whisper_judged_irrelevant"
 
 
 def test_llm_judge_promotes_irrelevant_verdict_as_negative(engine, tmp_path):

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -70,19 +70,42 @@ def _write_turn_jsonl(path: Path, prompt: str, response: str) -> None:
     path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
 
 
+def _write_codex_turn_jsonl(path: Path, prompt: str, response: str) -> None:
+    lines = [
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt}],
+            },
+        },
+        {
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": response}],
+            },
+        },
+    ]
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+
+
 def _insert_injected_whisper_log(
     engine: MemoryEngine,
     *,
     node_id: str,
     session_id: str,
     prompt: str,
+    space: str = "myproject",
 ) -> int:
     cursor = engine.db.conn.execute(
         "INSERT INTO whisper_log "
         "(session_id, space, prompt_hash, prompt_text, prompt_vec, node_id, score, "
         "was_injected, logged_at) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))",
-        (session_id, "myproject", "hash-abc", prompt, b"\x00" * 4, node_id, 0.9, 1),
+        (session_id, space, "hash-abc", prompt, b"\x00" * 4, node_id, 0.9, 1),
     )
     engine.db.conn.commit()
     return cursor.lastrowid
@@ -125,6 +148,70 @@ def test_ingest_session_basic(engine, tmp_path):
     assert entry["space"] == "myproject"
     assert entry["user_turns"] == 6
     assert len(entry["node_ids"]) == 1
+
+
+def test_ingest_codex_session_resolves_rollout_session_id_and_space(engine, tmp_path):
+    """Codex rollout filenames are matched back to the whisper_log hook session id."""
+    watch_dir = tmp_path / ".codex" / "sessions"
+    transcript_dir = watch_dir / "2026" / "06" / "24"
+    transcript_dir.mkdir(parents=True)
+    jsonl = transcript_dir / "rollout-2026-06-24T12-00-00-sess-456.jsonl"
+
+    prompt = "Why is the Codex watcher less polished?"
+    response = (
+        "The Codex watcher should resolve rollout filenames through whisper_log session ids "
+        "instead of trusting the transcript filename stem."
+    )
+    _write_codex_turn_jsonl(jsonl, prompt, response)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Codex watcher rollout filenames should be resolved through whisper_log session ids.",
+        type="fact",
+        title="Codex watcher session id resolution",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="sess-456",
+        prompt=prompt,
+        space="ormah",
+    )
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+
+    rel = str(jsonl.relative_to(watch_dir))
+    entry = state[rel]
+    assert entry["session_id"] == "sess-456"
+    assert entry["source"] == "codex"
+    assert entry["space"] == "ormah"
+    assert entry["signals_recorded"] == 1
+
+    signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert signal is not None
+    assert signal["session_id"] == "sess-456"
+    assert signal["agent_id"] == "codex"
+    assert signal["polarity"] == 1
+
+
+def test_ingest_codex_session_without_whisper_log_does_not_infer_date_space(engine, tmp_path):
+    """Codex date folders are storage layout, not project space."""
+    watch_dir = tmp_path / ".codex" / "sessions"
+    transcript_dir = watch_dir / "2026" / "06" / "24"
+    transcript_dir.mkdir(parents=True)
+    jsonl = transcript_dir / "rollout-2026-06-24T12-00-00-no-log.jsonl"
+    _write_codex_turn_jsonl(jsonl, "Prompt with enough content", "Response with enough content")
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+
+    entry = state[str(jsonl.relative_to(watch_dir))]
+    assert entry["source"] == "codex"
+    assert entry["space"] is None
 
 
 def test_record_whisper_usage_signal_promotes_clear_reference(engine, tmp_path):
@@ -637,6 +724,31 @@ def test_lifecycle_start_stop(engine, tmp_path):
     # Give observer thread a moment to stop
     time.sleep(0.1)
     assert not observers[0].is_alive()
+
+
+def test_lifecycle_includes_codex_sessions_when_using_default_agent_dir(
+    engine,
+    tmp_path,
+    monkeypatch,
+):
+    """Default watcher setup starts observers for existing Claude and Codex session dirs."""
+    home = tmp_path / "home"
+    claude_dir = home / ".claude" / "projects"
+    codex_dir = home / ".codex" / "sessions"
+    claude_dir.mkdir(parents=True)
+    codex_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    engine.settings.session_watcher_enabled = True
+    engine.settings.session_watcher_dir = Path("~/.claude/projects")
+    engine.settings.session_watcher_debounce_seconds = 10.0
+
+    observers = start_session_watcher(engine)
+    try:
+        assert len(observers) == 2
+        assert all(observer.is_alive() for observer in observers)
+    finally:
+        stop_session_watcher(observers)
 
 
 # --- Test 8: Disabled returns empty ---

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1,4 +1,4 @@
-"""Tests for the session watcher — auto-ingestion of Claude Code transcripts."""
+"""Tests for the transcript watcher — auto-ingestion of agent transcripts."""
 
 from __future__ import annotations
 
@@ -13,14 +13,16 @@ from ormah.background.session_watcher import (
     SessionHandler,
     _ingest_session,
     _load_state,
+    _record_whisper_usage_signals,
     _save_state,
     _scan_sessions,
     _space_from_encoded_dir,
     start_session_watcher,
     stop_session_watcher,
 )
-from ormah.config import Settings
 from ormah.engine.memory_engine import MemoryEngine
+from ormah.models.node import CreateNodeRequest
+from ormah.transcript.parser import parse_transcript
 
 _LLM_PATCH = "ormah.background.llm_client.llm_generate"
 
@@ -49,6 +51,41 @@ def _make_jsonl(path: Path, user_turns: int = 6) -> None:
             ]},
         }))
     path.write_text("\n".join(lines) + "\n")
+
+
+def _write_turn_jsonl(path: Path, prompt: str, response: str) -> None:
+    lines = [
+        {
+            "type": "user",
+            "message": {"role": "user", "content": prompt},
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": response}],
+            },
+        },
+    ]
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+
+
+def _insert_injected_whisper_log(
+    engine: MemoryEngine,
+    *,
+    node_id: str,
+    session_id: str,
+    prompt: str,
+) -> int:
+    cursor = engine.db.conn.execute(
+        "INSERT INTO whisper_log "
+        "(session_id, space, prompt_hash, prompt_text, prompt_vec, node_id, score, "
+        "was_injected, logged_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))",
+        (session_id, "myproject", "hash-abc", prompt, b"\x00" * 4, node_id, 0.9, 1),
+    )
+    engine.db.conn.commit()
+    return cursor.lastrowid
 
 
 # --- Test 1: Space detection from encoded directory names ---
@@ -84,9 +121,88 @@ def test_ingest_session_basic(engine, tmp_path):
     assert rel in state
     entry = state[rel]
     assert entry["session_id"] == "abc123"
+    assert entry["source"] == "claude_code"
     assert entry["space"] == "myproject"
     assert entry["user_turns"] == 6
     assert len(entry["node_ids"]) == 1
+
+
+def test_record_whisper_usage_signal_promotes_clear_reference(engine, tmp_path):
+    """Clear references in an assistant response create a signal and affinity row."""
+    prompt = "How should we solve feedback collection?"
+    response = "The right fix is the transcript watcher mines feedback usage approach."
+    transcript_path = tmp_path / "usage-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="The transcript watcher mines feedback usage from completed transcripts.",
+        type="fact",
+        title="Transcript watcher mines feedback usage",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="usage-session",
+        prompt=prompt,
+    )
+
+    recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 1
+    signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert signal is not None
+    assert signal["signal_type"] == "whisper_referenced"
+    assert signal["polarity"] == 1
+    assert signal["source"] == "transcript_watcher_heuristic"
+    assert signal["surface"] == "transcript_watcher"
+    assert signal["agent_id"] == "claude_code"
+
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert affinity is not None
+    assert affinity["node_id"] == node_id
+    assert affinity["signal"] == 1
+    assert affinity["source"] == "auto_heuristic"
+
+
+def test_record_whisper_usage_signal_keeps_unreferenced_neutral(engine, tmp_path):
+    """Unreferenced whispers are observable but do not become negative affinity."""
+    prompt = "How should we solve feedback collection?"
+    response = "We should first fix the database uniqueness key."
+    transcript_path = tmp_path / "neutral-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Graph rendering should use level of detail for large datasets.",
+        type="fact",
+        title="Large graph rendering performance",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="neutral-session",
+        prompt=prompt,
+    )
+
+    recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 1
+    signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert signal is not None
+    assert signal["signal_type"] == "whisper_unreferenced"
+    assert signal["polarity"] == 0
+
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert affinity is None
 
 
 # --- Test 3: Min turns filter ---

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -203,6 +203,264 @@ def test_record_whisper_usage_signal_keeps_unreferenced_neutral(engine, tmp_path
         "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)
     ).fetchone()
     assert affinity is None
+
+
+def test_llm_judge_disabled_by_default(engine, tmp_path):
+    """The transcript watcher does not call the LLM unless the judge is enabled."""
+    prompt = "How should we solve feedback collection?"
+    response = "We should first fix the database uniqueness key."
+    transcript_path = tmp_path / "judge-disabled-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Graph rendering should use level of detail for large datasets.",
+        type="fact",
+        title="Large graph rendering performance",
+    ))
+    _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="judge-disabled-session",
+        prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+
+    mock_llm = MagicMock(return_value=json.dumps({"verdicts": []}))
+    with patch(_LLM_PATCH, mock_llm):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 1
+    mock_llm.assert_not_called()
+
+
+def test_llm_judge_promotes_used_verdict(engine, tmp_path):
+    """A confident LLM 'used' verdict creates positive affinity for an ambiguous row."""
+    prompt = "What deployment marker should we use?"
+    response = "That guidance is the right one for the rollout."
+    transcript_path = tmp_path / "judge-used-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Use blue deployment markers when rollback plans need quick visual checks.",
+        type="fact",
+        title="Blue deployment rollback marker",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="judge-used-session",
+        prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "used",
+            "confidence": 0.88,
+            "reason": "The answer endorses the injected deployment guidance.",
+        }]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 2
+    judge_signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ? "
+        "AND source = 'transcript_watcher_llm_judge'",
+        (whisper_log_id,),
+    ).fetchone()
+    assert judge_signal is not None
+    assert judge_signal["signal_type"] == "whisper_judged_used"
+    assert judge_signal["polarity"] == 1
+    assert judge_signal["strength"] == 0.88
+
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert affinity is not None
+    assert affinity["signal"] == 1
+    assert affinity["source"] == "auto_llm_judge"
+
+
+def test_llm_judge_promotes_irrelevant_verdict_as_negative(engine, tmp_path):
+    """A confident LLM irrelevant verdict is the automatic negative-feedback path."""
+    prompt = "How should we solve feedback collection?"
+    response = "We should first fix the database uniqueness key."
+    transcript_path = tmp_path / "judge-negative-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Graph rendering should use level of detail for large datasets.",
+        type="fact",
+        title="Large graph rendering performance",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="judge-negative-session",
+        prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "irrelevant",
+            "confidence": 0.91,
+            "reason": "The memory is about graph UI rendering, not feedback schema work.",
+        }]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 2
+    judge_signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ? "
+        "AND source = 'transcript_watcher_llm_judge'",
+        (whisper_log_id,),
+    ).fetchone()
+    assert judge_signal is not None
+    assert judge_signal["signal_type"] == "whisper_judged_irrelevant"
+    assert judge_signal["polarity"] == -1
+
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert affinity is not None
+    assert affinity["signal"] == -1
+    assert affinity["source"] == "auto_llm_judge"
+
+
+def test_llm_judge_low_confidence_records_uncertain_without_affinity(engine, tmp_path):
+    """Low-confidence LLM verdicts remain observable but do not affect ranking."""
+    prompt = "How should we solve feedback collection?"
+    response = "We should first fix the database uniqueness key."
+    transcript_path = tmp_path / "judge-low-confidence-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Graph rendering should use level of detail for large datasets.",
+        type="fact",
+        title="Large graph rendering performance",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="judge-low-confidence-session",
+        prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "irrelevant",
+            "confidence": 0.4,
+            "reason": "Maybe unrelated, but confidence is low.",
+        }]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 2
+    judge_signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ? "
+        "AND source = 'transcript_watcher_llm_judge'",
+        (whisper_log_id,),
+    ).fetchone()
+    assert judge_signal is not None
+    assert judge_signal["signal_type"] == "whisper_judged_uncertain"
+    assert judge_signal["polarity"] == 0
+
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert affinity is None
+
+
+def test_llm_judge_skips_clear_heuristic_positive(engine, tmp_path):
+    """The optional judge does not spend an LLM call on clear heuristic positives."""
+    prompt = "How should we solve feedback collection?"
+    response = "The right fix is the transcript watcher mines feedback usage approach."
+    transcript_path = tmp_path / "judge-skip-positive-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="The transcript watcher mines feedback usage from completed transcripts.",
+        type="fact",
+        title="Transcript watcher mines feedback usage",
+    ))
+    _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="judge-skip-positive-session",
+        prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    mock_llm = MagicMock(return_value=json.dumps({"verdicts": []}))
+    with patch(_LLM_PATCH, mock_llm):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 1
+    mock_llm.assert_not_called()
+
+
+def test_llm_judge_is_idempotent(engine, tmp_path):
+    """Once a judge signal exists, the same whisper row is not judged again."""
+    prompt = "How should we solve feedback collection?"
+    response = "We should first fix the database uniqueness key."
+    transcript_path = tmp_path / "judge-idempotent-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Graph rendering should use level of detail for large datasets.",
+        type="fact",
+        title="Large graph rendering performance",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine,
+        node_id=node_id,
+        session_id="judge-idempotent-session",
+        prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    mock_llm = MagicMock(return_value=json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "irrelevant",
+            "confidence": 0.91,
+            "reason": "The memory is about graph UI rendering.",
+        }]
+    }))
+    with patch(_LLM_PATCH, mock_llm):
+        assert _record_whisper_usage_signals(engine, transcript) == 2
+        assert _record_whisper_usage_signals(engine, transcript) == 0
+
+    assert mock_llm.call_count == 1
+    signal_count = engine.db.conn.execute(
+        "SELECT COUNT(*) AS count FROM signals WHERE whisper_log_id = ?",
+        (whisper_log_id,),
+    ).fetchone()["count"]
+    affinity_count = engine.db.conn.execute(
+        "SELECT COUNT(*) AS count FROM affinity WHERE whisper_log_id = ?",
+        (whisper_log_id,),
+    ).fetchone()["count"]
+    assert signal_count == 2
+    assert affinity_count == 1
 
 
 # --- Test 3: Min turns filter ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -214,3 +214,10 @@ def test_affinity_defaults():
     assert s.affinity_max_boost == 0.15
     assert s.affinity_implicit_weight == 0.8
     assert s.whisper_exploration_enabled is True
+    assert s.feedback_llm_judge_enabled is False
+    assert s.feedback_llm_judge_min_confidence == 0.75
+
+
+def test_feedback_llm_judge_min_confidence_range():
+    with pytest.raises(ValidationError, match="threshold must be 0"):
+        _settings(feedback_llm_judge_min_confidence=1.5)

--- a/tests/test_engine/test_submit_feedback.py
+++ b/tests/test_engine/test_submit_feedback.py
@@ -17,14 +17,16 @@ def _insert_whisper_log(
     node_id: str,
     session_id: str = "sess-abc",
     space: str = "myspace",
-) -> None:
-    conn.execute(
+    prompt_text: str = "how does auth work",
+) -> int:
+    cursor = conn.execute(
         "INSERT INTO whisper_log "
         "(node_id, score, session_id, space, prompt_text, prompt_vec, prompt_hash, was_injected, logged_at) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))",
-        (node_id, 0.48, session_id, space, "how does auth work", b"", "hash-abc", 0),
+        (node_id, 0.48, session_id, space, prompt_text, b"", "hash-abc", 0),
     )
     conn.commit()
+    return cursor.lastrowid
 
 
 def _insert_review_log(conn, node_id: str, session_id: str = "sess-abc") -> int:
@@ -71,6 +73,22 @@ class TestSubmitFeedbackBasic:
         assert row is not None
         assert row["source"] == "implicit"
 
+    def test_feedback_records_signal_row(self, engine):
+        node_id = "node-signal-001"
+        whisper_log_id = _insert_whisper_log(engine.db.conn, node_id)
+
+        engine.submit_feedback(node_id, 1, "explicit")
+
+        row = engine.db.conn.execute(
+            "SELECT * FROM signals WHERE node_id = ?", (node_id,)
+        ).fetchone()
+        assert row is not None
+        assert row["whisper_log_id"] == whisper_log_id
+        assert row["signal_type"] == "feedback_submitted"
+        assert row["polarity"] == 1
+        assert row["source"] == "explicit"
+        assert row["surface"] == "submit_feedback"
+
     def test_short_id_feedback_resolves_full_whisper_log_node_id(self, engine):
         node_id = "72a9ea26-1111-2222-3333-444444444444"
         _insert_whisper_log(engine.db.conn, node_id)
@@ -103,6 +121,30 @@ class TestSubmitFeedbackBasic:
             "SELECT * FROM affinity WHERE node_id = ?", (node_id,)
         ).fetchall()
         assert len(rows) == 1
+
+    def test_same_node_same_session_can_record_distinct_whisper_events(self, engine):
+        node_id = "node-turn-level-001"
+        _insert_whisper_log(
+            engine.db.conn,
+            node_id,
+            session_id="sess-1",
+            prompt_text="first prompt",
+        )
+        engine.submit_feedback(node_id, 1, "explicit")
+        _insert_whisper_log(
+            engine.db.conn,
+            node_id,
+            session_id="sess-1",
+            prompt_text="second prompt",
+        )
+        engine.submit_feedback(node_id, 1, "explicit")
+
+        rows = engine.db.conn.execute(
+            "SELECT whisper_log_id FROM affinity WHERE node_id = ? ORDER BY id",
+            (node_id,),
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0]["whisper_log_id"] != rows[1]["whisper_log_id"]
 
     def test_explicit_updates_review_log(self, engine):
         node_id = "node-review-001"

--- a/tests/test_index/test_feedback_schema.py
+++ b/tests/test_index/test_feedback_schema.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sqlite3
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -78,30 +77,92 @@ def test_affinity_columns(db):
         "confirmed_at",
         "space",
         "session_id",
+        "whisper_log_id",
     ]:
         assert expected in cols, f"Missing column '{expected}' in affinity"
 
 
-def test_affinity_unique_constraint(db):
-    """UNIQUE (node_id, session_id) should reject duplicate inserts."""
+def test_affinity_unique_constraint_is_per_whisper_log(db):
+    """Feedback is capped per whisper event, not per whole session."""
     import datetime
 
     now = datetime.datetime.now(datetime.UTC).isoformat()
-    db.conn.execute(
-        "INSERT INTO affinity (prompt_vec, node_id, signal, source, confirmed_at, session_id) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
-        (b"\x00" * 4, "node-1", 1, "explicit", now, "sess-1"),
+    cursor = db.conn.execute(
+        "INSERT INTO whisper_log "
+        "(session_id, space, prompt_hash, prompt_text, prompt_vec, node_id, score, "
+        "was_injected, logged_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("sess-1", "space", "hash-1", "prompt one", b"\x00" * 4, "node-1", 0.8, 1, now),
     )
+    first_whisper_log_id = cursor.lastrowid
+    cursor = db.conn.execute(
+        "INSERT INTO whisper_log "
+        "(session_id, space, prompt_hash, prompt_text, prompt_vec, node_id, score, "
+        "was_injected, logged_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("sess-1", "space", "hash-2", "prompt two", b"\x00" * 4, "node-1", 0.8, 1, now),
+    )
+    second_whisper_log_id = cursor.lastrowid
+
+    db.conn.execute(
+        "INSERT INTO affinity "
+        "(prompt_vec, node_id, signal, source, confirmed_at, session_id, whisper_log_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (b"\x00" * 4, "node-1", 1, "explicit", now, "sess-1", first_whisper_log_id),
+    )
+    db.conn.execute(
+        "INSERT INTO affinity "
+        "(prompt_vec, node_id, signal, source, confirmed_at, session_id, whisper_log_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (b"\x00" * 4, "node-1", 1, "explicit", now, "sess-1", second_whisper_log_id),
+    )
+
     with pytest.raises(sqlite3.IntegrityError):
         db.conn.execute(
-            "INSERT INTO affinity (prompt_vec, node_id, signal, source, confirmed_at, session_id) "
-            "VALUES (?, ?, ?, ?, ?, ?)",
-            (b"\x00" * 4, "node-1", 1, "explicit", now, "sess-1"),
+            "INSERT INTO affinity "
+            "(prompt_vec, node_id, signal, source, confirmed_at, session_id, whisper_log_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (b"\x00" * 4, "node-1", 1, "explicit", now, "sess-1", first_whisper_log_id),
         )
 
 
 def test_affinity_index(db):
     assert _index_exists(db, "idx_affinity_node")
+    assert _index_exists(db, "idx_affinity_whisper_log")
+    assert _index_exists(db, "idx_affinity_node_whisper_log_unique")
+
+
+def test_signals_table_exists(db):
+    assert _table_exists(db, "signals")
+
+
+def test_signals_columns(db):
+    cols = _table_columns(db, "signals")
+    for expected in [
+        "id",
+        "whisper_log_id",
+        "node_id",
+        "signal_type",
+        "polarity",
+        "strength",
+        "source",
+        "session_id",
+        "agent_id",
+        "surface",
+        "space",
+        "prompt_hash",
+        "evidence",
+        "created",
+    ]:
+        assert expected in cols, f"Missing column '{expected}' in signals"
+
+
+def test_signals_indexes(db):
+    assert _index_exists(db, "idx_signals_node")
+    assert _index_exists(db, "idx_signals_session")
+    assert _index_exists(db, "idx_signals_created")
+    assert _index_exists(db, "idx_signals_whisper_log")
+    assert _index_exists(db, "idx_signals_whisper_type_source_unique")
 
 
 def test_review_log_table_exists(db):
@@ -132,6 +193,7 @@ def _make_db_without_new_tables(tmp_path: Path) -> Database:
     database.conn.executescript(
         "DROP TABLE IF EXISTS whisper_log;"
         "DROP TABLE IF EXISTS affinity;"
+        "DROP TABLE IF EXISTS signals;"
         "DROP TABLE IF EXISTS review_log;"
     )
     return database
@@ -161,6 +223,14 @@ def test_migrate_creates_review_log(tmp_path):
     db.close()
 
 
+def test_migrate_creates_signals(tmp_path):
+    db = _make_db_without_new_tables(tmp_path)
+    assert not _table_exists(db, "signals")
+    db._migrate()
+    assert _table_exists(db, "signals")
+    db.close()
+
+
 def test_migrate_is_idempotent(tmp_path):
     """Calling _migrate() on an already-migrated DB must not raise."""
     db = _make_db_without_new_tables(tmp_path)
@@ -168,5 +238,6 @@ def test_migrate_is_idempotent(tmp_path):
     db._migrate()  # second call should be a no-op
     assert _table_exists(db, "whisper_log")
     assert _table_exists(db, "affinity")
+    assert _table_exists(db, "signals")
     assert _table_exists(db, "review_log")
     db.close()

--- a/tests/test_transcript/test_parser.py
+++ b/tests/test_transcript/test_parser.py
@@ -1,4 +1,4 @@
-"""Tests for the Claude Code JSONL transcript parser."""
+"""Tests for agent JSONL transcript normalization."""
 
 from __future__ import annotations
 
@@ -36,6 +36,11 @@ class TestParseTranscript:
         assert "Assistant: Hi! How can I help?" in result.conversation
         assert "tool_use" not in result.conversation
         assert result.user_turn_count == 1
+        assert result.source == "claude_code"
+        assert [(turn.role, turn.text) for turn in result.turns] == [
+            ("user", "Hello there"),
+            ("assistant", "Hi! How can I help?"),
+        ]
 
     def test_user_raw_string_content(self, tmp_path):
         lines = [
@@ -237,6 +242,11 @@ class TestParseTranscript:
         assert "User: How does whisper work?" in result.conversation
         assert "Assistant: It injects relevant memory context." in result.conversation
         assert result.user_turn_count == 1
+        assert result.source == "codex"
+        assert [(turn.role, turn.text) for turn in result.turns] == [
+            ("user", "How does whisper work?"),
+            ("assistant", "It injects relevant memory context."),
+        ]
 
     def test_codex_bootstrap_user_message_skipped(self, tmp_path):
         lines = [


### PR DESCRIPTION
## Context

Closes #21.

The issue was that Ormah had an affinity system, but the feedback loop was effectively open-ended: `submit_feedback(...)` could write useful signal, but there was no automatic trigger that converted normal agent sessions into feedback. In practice, most whispered memories were surfaced, used or ignored by the assistant, and then forgotten by the learning loop unless someone explicitly submitted feedback.

This PR closes that loop for watched agent transcript files after they stop changing for the
configured debounce window, while keeping the default behavior conservative. It is not tied
to a first-class "session closed" event from the agent.

## What Changed

### 1. Transcript watcher now records whisper usage signals

When the session watcher processes a debounced transcript file, it looks up injected `whisper_log` rows for that session and compares each logged user prompt with the assistant response that followed it.

It now records signal rows such as:

- `whisper_referenced`
- `whisper_unreferenced`
- `whisper_judged_used`
- `whisper_judged_irrelevant`
- `whisper_judged_uncertain`

Why this is needed:

The signals ledger gives us a durable audit trail before changing affinity. That matters because not every observation should immediately affect ranking. For example, "assistant did not visibly mention the memory" is useful telemetry, but it is not safe negative feedback by itself.

### 2. Local heuristics provide the free baseline

The heuristic path looks only for clear positive evidence that the assistant used a memory. It checks for:

- short node id references
- title phrase matches
- copied or paraphrased memory sentences
- distinctive token overlap after subtracting tokens already present in the user prompt

Why this is justified:

This gives Ormah a zero-cost local path for obvious positive references. It also avoids the dangerous case: inferring negative feedback from silence. If the assistant did not mention a memory, the memory might still have helped frame the answer, so the heuristic only writes neutral observations for non-references.

### 3. Affinity writes are tied back to `whisper_log`

Promoted feedback writes affinity rows with the original prompt context from `whisper_log`, including:

- `prompt_vec`
- `prompt_text`
- `space`
- `session_id`
- `whisper_log_id`

Why this is needed:

Affinity is only meaningful relative to the prompt that caused the memory to be surfaced. Storing feedback against `whisper_log_id` keeps the learning turn-level rather than treating a memory as globally good or bad.

### 4. Optional LLM judge handles ambiguous cases

The LLM judge is disabled by default. When enabled, it only receives rows that were not clear heuristic positives.

Config:

```bash
ORMAH_FEEDBACK_LLM_JUDGE_ENABLED=true
ORMAH_FEEDBACK_LLM_JUDGE_MIN_CONFIDENCE=0.75
ORMAH_LLM_PROVIDER=litellm
ORMAH_LLM_MODEL=<model>
```

The judge returns:

- `used`
- `irrelevant`
- `uncertain`

High-confidence `used` becomes positive affinity. High-confidence `irrelevant` becomes negative affinity. `uncertain` and low-confidence outputs remain neutral signal rows only.

Why this is justified:

Negative feedback is higher risk than positive feedback. The LLM judge has access to the user prompt, assistant response, and injected memory content, so it can make a better judgment than the local heuristic about whether a memory was truly off-topic. Even then, the result is gated by `feedback_llm_judge_min_confidence`.

### 5. Judge calls use schema-first structured output

The feedback judge now requests compact JSON Schema structured output:

```json
{
  "verdicts": [
    {
      "whisper_log_id": 123,
      "verdict": "used",
      "confidence": 0.9
    }
  ]
}
```

Runtime call parameters:

- `response_format`: JSON Schema when supported
- `temperature=0`
- `max_tokens=512`
- fallback to JSON-object mode if schema output is rejected

Why this is justified:

The judge is part of a background feedback pipeline, so malformed output should be rare and recoverable. The schema removes free-form fields from the required output and keeps the result small. The fallback preserves compatibility with providers that support JSON mode but not JSON Schema.

### 6. Codex watcher setup now uses source-specific metadata

Claude Code transcript support was more polished because its transcript filename is already the hook session id, and its parent directory encodes the project path. Codex uses a different layout: session files can live under date folders such as `~/.codex/sessions/2026/06/24`, and rollout filenames can contain the hook session id inside a longer filename.

This PR now handles that explicitly:

- when `session_watcher_dir` is left at the default Claude path, Ormah also watches `~/.codex/sessions` if it exists
- Codex rollout filenames are resolved back to the hook `session_id` by matching existing `whisper_log` rows
- Codex transcript space comes from the matching `whisper_log.space`, not from date folders
- Claude behavior remains unchanged: Claude filenames still work directly, and Claude project folders still provide the fallback space

Why this is justified:

The feedback loop depends on joining transcript turns back to the exact `whisper_log.session_id` written during whisper injection. Without this, Codex transcripts can parse successfully but fail to produce feedback for the injected memories, or they can be ingested under a bogus space such as a date segment.

## Working Example

Suppose the user asks:

> Where does someone set `feedback_llm_judge`, which LLM is used, and what happens to heuristics?

Ormah injects three memories:

| `whisper_log_id` | Memory | Expected outcome |
|---:|---|---|
| `101` | LLM judge config: enabled by `ORMAH_FEEDBACK_LLM_JUDGE_ENABLED`, uses `llm_provider` / `llm_model`, heuristics remain the baseline | Useful |
| `102` | Graph view color cleanup notes | Irrelevant |
| `103` | NVIDIA service key storage details | Ambiguous |

The assistant answers:

> Set `ORMAH_FEEDBACK_LLM_JUDGE_ENABLED=true`. The judge uses the configured `ORMAH_LLM_PROVIDER` and `ORMAH_LLM_MODEL`. Heuristics still run first as the free local baseline.

After the transcript file stops changing for the debounce window and is processed:

1. Memory `101` has clear evidence in the response.
   - Signal: `whisper_referenced`
   - Affinity: positive `auto_heuristic`
   - LLM judge: skipped for this row

2. Memory `102` has no heuristic positive evidence.
   - Signal: `whisper_unreferenced`
   - If the LLM judge is enabled, the judge sees the prompt, answer, and graph-memory content.
   - Likely judge output:

```json
{
  "verdicts": [
    {
      "whisper_log_id": 102,
      "verdict": "irrelevant",
      "confidence": 0.96
    }
  ]
}
```

   - Signal: `whisper_judged_irrelevant`
   - Affinity: negative `auto_llm_judge`

3. Memory `103` is related to setup but not clearly used by the answer.
   - Signal: `whisper_unreferenced`
   - Likely LLM verdict: `uncertain`
   - Affinity: no change

So the system learns from the observed turn without treating every omitted memory as bad.

## When This Actually Works

The feedback loop becomes active when all of these are true:

1. The user has a version of Ormah with this PR installed and the Ormah server is running.
2. Whisper injection is active for the agent, so `ormah whisper inject` is called on user prompts.
3. The whisper call has a `session_id`, so surfaced memories are written to `whisper_log` for that session.
4. `session_watcher_enabled=true`.
5. At least one effective watched transcript directory exists and receives JSONL transcript files.
6. The transcript file stops changing for `session_watcher_debounce_seconds`, default `60`.
7. The transcript has at least `session_watcher_min_turns`, default `5`.

Then the benefit appears automatically on later similar prompts.

Concrete flow:

1. User asks something in Claude Code, Codex, or another hooked client.
2. `ormah whisper inject` retrieves memories and injects some into context.
3. Ormah logs those injected memories in `whisper_log` with the current prompt, prompt vector, session id, space, and node id.
4. The assistant answers.
5. The transcript file is updated.
6. Session watcher sees the file change, waits for the debounce window, parses it, and finds the assistant response after that prompt.
7. It compares the injected memories against the response.
8. If a memory was clearly used, it records a positive signal and positive affinity.
9. If LLM judge is enabled, ambiguous non-positive rows can be judged as `used`, `irrelevant`, or `uncertain`.
10. Next time a similar prompt comes in, affinity can boost useful memories and suppress confidently irrelevant ones.

For a normal user, the minimal config for the free/local benefit is:

```bash
ORMAH_SESSION_WATCHER_ENABLED=true
ORMAH_SESSION_WATCHER_DIR=~/.claude/projects
```

With the default watcher directory, Ormah watches the Claude Code transcript directory and also watches `~/.codex/sessions` if that Codex directory exists. If a user wants a custom transcript location instead, they can point `ORMAH_SESSION_WATCHER_DIR` directly at it.

For the LLM negative/ambiguous path:

```bash
ORMAH_FEEDBACK_LLM_JUDGE_ENABLED=true
ORMAH_FEEDBACK_LLM_JUDGE_MIN_CONFIDENCE=0.75
ORMAH_LLM_PROVIDER=litellm
ORMAH_LLM_MODEL=nvidia_nim/meta/llama-4-maverick-17b-128e-instruct
```

## Before / After

Before this PR:

- `whisper_log` recorded surfaced memories
- affinity only learned when explicit feedback was submitted
- most normal sessions produced no learning signal
- Codex transcripts could parse but still miss feedback mining when rollout filenames did not equal the hook session id

After this PR:

- debounced transcript files produce observable feedback signals
- clear positive references can improve future ranking for similar prompts
- confident LLM judgments can add positive or negative affinity
- ambiguous/low-confidence cases stay neutral
- automatic negative feedback is only created by explicit feedback or the LLM judge, never by local silence heuristics
- Codex rollout transcripts can be joined back to `whisper_log` and ingested under the correct space

## Model Notes

I ran a local live-model matrix for the LLM judge task. The eval harness is intentionally not included in this PR, but the useful ordering from the broader 15-judgment check was:

1. `nvidia_nim/meta/llama-4-maverick-17b-128e-instruct`
2. `nvidia_nim/qwen/qwen3-next-80b-a3b-instruct`
3. `nvidia_nim/z-ai/glm-5.1`
4. `nvidia_nim/deepseek-ai/deepseek-v4-pro`
5. `nvidia_nim/meta/llama-3.3-70b-instruct`
6. `nvidia_nim/meta/llama-3.1-70b-instruct`

The main differentiator was ambiguous-case handling. The top models handled clear positive and clear negative examples well.

## Verification

- Focused Ruff on touched Python files: passed
- Focused pytest for session watcher: `27 passed`
- Transcript parser tests: `19 passed`
- Codex rollout hook path test: passed
- Full pytest with clean LLM baseline, excluding the local untracked eval guard: `935 passed, 1 deselected, 1 warning`
- Live NVIDIA NIM smoke through the runtime judge path using `llama-4-maverick`: passed

## Review Focus

@AndreLFSMartins, it would be very useful to get your eyes on this and appreciate your help in making Ormah better.

I would especially appreciate review on:

- whether the boundary between neutral signal and affinity promotion is conservative enough
- whether the LLM judge should remain disabled by default
- whether the schema/fallback behavior is the right compatibility tradeoff
- whether `feedback_llm_judge_min_confidence=0.75` is a reasonable default
- whether the Codex watcher metadata handling is the right way to keep client-specific transcript layout at the watcher boundary
