### PR TITLE
Release 0.12.0

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.11.0"
+version = "0.12.0"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Prepare Ormah `0.12.0`.

This release includes the merged feedback-loop work from #40:

- transcript watcher mines completed agent transcripts for whisper usage
- clear heuristic positives write positive affinity
- optional LLM judge can classify ambiguous rows
- schema-first structured output for feedback judge calls
- Codex rollout transcript metadata is resolved back to `whisper_log`

## Version Updates

- `pyproject.toml`: `0.11.0` -> `0.12.0`
- `integrations/claude-plugin/.claude-plugin/plugin.json`: `0.11.0` -> `0.12.0`

## Verification

- `uv run pytest tests/test_setup.py::TestClaudePluginManifest::test_plugin_manifest_version_matches_project_version -q`: passed
- `ORMAH_LLM_PROVIDER=none uv run pytest -q`: `933 passed, 1 deselected, 1 warning`
