### PR TITLE
ci(release): add manual PyPI release workflow

### DIFF
--- a/.github/release/verify_release_versions.py
+++ b/.github/release/verify_release_versions.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Verify release versions before publishing."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+RELEASE_VERSION_RE = re.compile(r"^[0-9]+(?:\.[0-9]+){2}(?:[A-Za-z0-9.+_-]+)?$")
+PLUGIN_MANIFEST = Path("integrations/claude-plugin/.claude-plugin/plugin.json")
+
+
+def _read_project_version(root: Path) -> str:
+    pyproject_path = root / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    return str(pyproject["project"]["version"])
+
+
+def _read_plugin_version(root: Path) -> str:
+    manifest_path = root / PLUGIN_MANIFEST
+    with manifest_path.open() as handle:
+        manifest = json.load(handle)
+    return str(manifest["version"])
+
+
+def verify_release_versions(requested_version: str, root: Path) -> str:
+    root = root.resolve()
+    requested_version = requested_version.strip()
+
+    if requested_version.startswith("v"):
+        raise ValueError("Release version should not include the leading 'v'. Use 0.12.0.")
+
+    if not RELEASE_VERSION_RE.fullmatch(requested_version):
+        raise ValueError(
+            "Release version must look like 0.12.0 and must not contain whitespace."
+        )
+
+    project_version = _read_project_version(root)
+    plugin_version = _read_plugin_version(root)
+
+    if requested_version != project_version:
+        raise ValueError(
+            f"Requested release version {requested_version} does not match "
+            f"pyproject.toml version {project_version}."
+        )
+
+    if plugin_version != project_version:
+        raise ValueError(
+            f"Claude plugin manifest version {plugin_version} does not match "
+            f"pyproject.toml version {project_version}."
+        )
+
+    return project_version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Release version without a leading v, e.g. 0.12.0")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root. Defaults to the parent of .github/.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        version = verify_release_versions(args.version, args.root)
+    except (KeyError, OSError, ValueError, json.JSONDecodeError, tomllib.TOMLDecodeError) as exc:
+        print(f"Release version verification failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Release version verified: {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,185 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version from pyproject.toml, e.g. 0.12.0
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  RELEASE_ALLOWED_ACTOR: r-spade
+
+jobs:
+  build:
+    name: Test and build wheel
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.release-version.outputs.version }}
+      tag: ${{ steps.release-version.outputs.tag }}
+    env:
+      ORMAH_LLM_PROVIDER: none
+    steps:
+      - name: Check release actor
+        env:
+          RELEASE_ACTOR: ${{ github.actor }}
+        run: |
+          if [ "$RELEASE_ACTOR" != "$RELEASE_ALLOWED_ACTOR" ]; then
+            echo "::error::Only $RELEASE_ALLOWED_ACTOR can run the release workflow."
+            exit 1
+          fi
+
+      - name: Check release branch
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::Run releases from the main branch."
+            exit 1
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Verify release versions
+        id: release-version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          python .github/release/verify_release_versions.py "$RELEASE_VERSION"
+          printf 'version=%s\n' "$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'tag=v%s\n' "$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build UI
+        working-directory: ui
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build wheel
+        run: uv build --wheel --out-dir dist
+
+      - name: Verify wheel-only release artifact
+        run: |
+          shopt -s nullglob
+          wheels=(dist/*.whl)
+          sdists=(dist/*.tar.gz dist/*.zip)
+
+          if [ "${#wheels[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly one wheel in dist/."
+            exit 1
+          fi
+
+          if [ "${#sdists[@]}" -ne 0 ]; then
+            echo "::error::Release workflow should publish wheels only."
+            exit 1
+          fi
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ormah-wheel
+          path: dist/*.whl
+          if-no-files-found: error
+
+  publish:
+    name: Publish and create release
+    runs-on: ubuntu-latest
+    needs: build
+    environment: pypi
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ormah-wheel
+          path: dist
+
+      - name: Validate release tag
+        env:
+          RELEASE_TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          git fetch --tags origin
+
+          if git rev-parse --verify --quiet "$RELEASE_TAG" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tag_sha" != "$GITHUB_SHA" ]; then
+              echo "::error::$RELEASE_TAG already points to $tag_sha, not $GITHUB_SHA."
+              exit 1
+            fi
+
+            echo "$RELEASE_TAG already exists on this commit."
+          fi
+
+      - name: Publish wheel to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          print-hash: true
+
+      - name: Create and push tag
+        env:
+          RELEASE_TAG: ${{ needs.build.outputs.tag }}
+        run: |
+          git fetch --tags origin
+
+          if git rev-parse --verify --quiet "$RELEASE_TAG" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tag_sha" != "$GITHUB_SHA" ]; then
+              echo "::error::$RELEASE_TAG already points to $tag_sha, not $GITHUB_SHA."
+              exit 1
+            fi
+
+            echo "$RELEASE_TAG already exists on this commit."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG" "$GITHUB_SHA"
+          git push origin "$RELEASE_TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.build.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "GitHub release $RELEASE_TAG already exists."
+            exit 0
+          fi
+
+          gh release create "$RELEASE_TAG" \
+            --title "Ormah $RELEASE_VERSION" \
+            --generate-notes \
+            dist/*.whl

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean: ## Remove build artifacts
 logs: ## Tail the server logs (if running in background)
 	@echo "Server runs with stdout logging. Use 'make server' in foreground to see logs."
 
-release: ## Build and publish the wheel to PyPI (fresh UI build, no sdist upload)
+release: ## Local fallback: build and publish the wheel to PyPI (fresh UI build, no sdist upload)
 	rm -rf dist/
 	cd ui && npm ci && npm run build
 	uv build --wheel --out-dir dist

--- a/README.md
+++ b/README.md
@@ -173,6 +173,35 @@ make install
 uv run pytest
 ```
 
+## Release Process
+
+Releases are published through the manual GitHub Actions `Release` workflow. The workflow
+is guarded so only the GitHub login listed in `RELEASE_ALLOWED_ACTOR` can run the release
+path.
+
+Before running the workflow:
+
+1. Bump `pyproject.toml`.
+2. Bump `integrations/claude-plugin/.claude-plugin/plugin.json` to the same version.
+3. Merge the release PR to `main`.
+
+Then open GitHub Actions, run `Release` from `main`, and enter the version without the
+leading `v`, for example `0.12.0`.
+
+The workflow verifies that the requested version matches `pyproject.toml`, verifies that
+the Claude plugin manifest has the same version, runs the Python test suite with
+`ORMAH_LLM_PROVIDER=none`, builds the UI, builds one wheel, publishes that wheel to PyPI,
+creates `v<version>`, and creates the GitHub Release with generated notes.
+
+PyPI publishing uses Trusted Publishing. No long-lived PyPI token is stored in the repo,
+local `.env`, or developer machines. The PyPI project should trust this repository,
+`.github/workflows/release.yml`, and the `pypi` GitHub environment.
+
+Protect the `pypi` GitHub environment with the release manager as the required reviewer.
+Do not enable prevent-self-review unless a second reviewer is intentionally required for
+every release. If Trusted Publishing is not configured yet, use a project-scoped PyPI API
+token only as a temporary environment-scoped GitHub Actions secret.
+
 ## License
 
 MIT

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import builtins
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -28,6 +31,88 @@ class TestBuildMetadata:
         assert "src/ormah" in included
         assert "ui" in included
         assert "install.sh" in included
+
+
+class TestReleaseVersionVerification:
+    def _write_release_files(self, root: Path, project_version: str, plugin_version: str):
+        (root / "integrations/claude-plugin/.claude-plugin").mkdir(parents=True)
+        (root / "pyproject.toml").write_text(
+            "\n".join(
+                [
+                    "[project]",
+                    'name = "ormah"',
+                    f'version = "{project_version}"',
+                    "",
+                ]
+            )
+        )
+        (root / "integrations/claude-plugin/.claude-plugin/plugin.json").write_text(
+            json.dumps({"name": "ormah", "version": plugin_version})
+        )
+
+    def _run_verifier(self, root: Path, version: str) -> subprocess.CompletedProcess[str]:
+        repo_root = Path(__file__).resolve().parents[1]
+        return subprocess.run(
+            [
+                sys.executable,
+                str(repo_root / ".github/release/verify_release_versions.py"),
+                version,
+                "--root",
+                str(root),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_accepts_matching_project_and_plugin_versions(self, tmp_path):
+        self._write_release_files(tmp_path, project_version="1.2.3", plugin_version="1.2.3")
+
+        result = self._run_verifier(tmp_path, "1.2.3")
+
+        assert result.returncode == 0
+        assert "Release version verified: 1.2.3" in result.stdout
+
+    def test_rejects_requested_version_mismatch(self, tmp_path):
+        self._write_release_files(tmp_path, project_version="1.2.3", plugin_version="1.2.3")
+
+        result = self._run_verifier(tmp_path, "1.2.4")
+
+        assert result.returncode == 1
+        assert "does not match pyproject.toml version 1.2.3" in result.stderr
+
+    def test_rejects_plugin_manifest_mismatch(self, tmp_path):
+        self._write_release_files(tmp_path, project_version="1.2.3", plugin_version="1.2.2")
+
+        result = self._run_verifier(tmp_path, "1.2.3")
+
+        assert result.returncode == 1
+        assert "Claude plugin manifest version 1.2.2 does not match" in result.stderr
+
+    def test_rejects_leading_v_release_version(self, tmp_path):
+        self._write_release_files(tmp_path, project_version="1.2.3", plugin_version="1.2.3")
+
+        result = self._run_verifier(tmp_path, "v1.2.3")
+
+        assert result.returncode == 1
+        assert "should not include the leading 'v'" in result.stderr
+
+
+class TestReleaseWorkflow:
+    def test_manual_release_workflow_publishes_wheel_with_trusted_publishing(self):
+        root = Path(__file__).resolve().parents[1]
+        workflow = (root / ".github/workflows/release.yml").read_text()
+
+        assert "workflow_dispatch:" in workflow
+        assert "RELEASE_ALLOWED_ACTOR: r-spade" in workflow
+        assert "Only $RELEASE_ALLOWED_ACTOR can run the release workflow" in workflow
+        assert "python .github/release/verify_release_versions.py" in workflow
+        assert "uv run pytest" in workflow
+        assert "npm run build" in workflow
+        assert "uv build --wheel --out-dir dist" in workflow
+        assert "pypa/gh-action-pypi-publish@release/v1" in workflow
+        assert "id-token: write" in workflow
+        assert "gh release create" in workflow
 
 
 class TestEvalCliFallback:


### PR DESCRIPTION
## Summary

Closes #44.

Adds a manual GitHub Actions release workflow so Ormah releases are repeatable from GitHub instead of depending on one local machine.

The workflow:

- runs only through `workflow_dispatch`
- requires a version input like `0.12.0`
- refuses to run from anything other than `main`
- refuses to continue unless the triggering GitHub actor matches `RELEASE_ALLOWED_ACTOR`
- verifies that the requested version matches `pyproject.toml`
- verifies that the Claude plugin manifest version matches the project version
- runs the Python test suite with `ORMAH_LLM_PROVIDER=none`
- installs UI dependencies and builds the UI before packaging
- builds exactly one wheel with `uv build --wheel`
- uploads the wheel as a workflow artifact
- publishes the wheel to PyPI through Trusted Publishing
- validates that `v<version>` does not already point at another commit
- creates and pushes `v<version>` after PyPI publish succeeds
- creates the GitHub Release with generated notes and attaches the wheel

## Why

The `0.12.0` release worked, but it involved local version edits, local tests, local UI and wheel builds, local PyPI credentials, a manual tag, and a manual GitHub Release. That is easy to get wrong and hard to audit.

This moves the risky part of the release into a reviewed workflow. The only manual release action after a version PR is merged should be: run the `Release` workflow from `main` and enter the version.

## Release Authorization

GitHub does not give us a clean per-workflow UI permission that says only one repo collaborator can click `Run workflow`. So the workflow now enforces this in code as the first step:

- `RELEASE_ALLOWED_ACTOR: r-spade`
- `${{ github.actor }}` must match that actor
- unauthorized runs fail before checkout, tests, builds, PyPI publish, tag creation, or GitHub release creation

The `publish` job also uses the `pypi` GitHub environment. That environment should be protected with the release manager as required reviewer. Do not enable prevent-self-review unless we intentionally want a second release approver every time.

## PyPI Credentials

The committed workflow does not store or read a PyPI token.

It uses PyPI Trusted Publishing via `pypa/gh-action-pypi-publish@release/v1` with job-level `id-token: write`. PyPI should be configured to trust:

- repository: `r-spade/ormah`
- workflow: `.github/workflows/release.yml`
- environment: `pypi`

If Trusted Publishing is not configured yet, a project-scoped PyPI API token can be used as a temporary GitHub environment secret, but that fallback is intentionally not baked into the workflow.

## Version Guard

I added `.github/release/verify_release_versions.py` rather than embedding the checks directly in YAML. That gives us a small reusable preflight with tests for:

- matching project and plugin versions
- requested version mismatch
- plugin manifest mismatch
- accidentally entering `v1.2.3` instead of `1.2.3`

## Docs

The README now documents the release process, the release actor guard, the `pypi` environment protection, and the fact that Trusted Publishing means no long-lived PyPI token is stored in the repo, local `.env`, or developer machines.

## Verification

- `uv run pytest tests/test_packaging.py -q`
- `uv run ruff check .github/release/verify_release_versions.py tests/test_packaging.py`
- `npm ci`
- `npm run build`
- `env UV_CACHE_DIR=/tmp/ormah-uv-cache uv build --wheel --out-dir /tmp/ormah-release-workflow-dist`

I also attempted the full pytest suite locally with an isolated temporary home. The sandboxed run reached the test body but then stopped producing output for several minutes, so I terminated that local process rather than leaving it running. The new release workflow itself will run the full suite in CI before publishing.
