### PR TITLE
test(db): make thread-local connection test deterministic

### DIFF
--- a/tests/test_index/test_db_concurrency.py
+++ b/tests/test_index/test_db_concurrency.py
@@ -17,21 +17,27 @@ def _init_db(tmp_path):
 
 def test_each_thread_gets_distinct_connection(tmp_path):
     db = _init_db(tmp_path)
-    conns: dict[int, int] = {}
+    conns: list[int | None] = [None] * 4
+    start = threading.Barrier(4)
+    release = threading.Event()
 
-    def grab():
-        conns[threading.get_ident()] = id(db.conn)
+    def grab(index: int):
+        start.wait(timeout=5)
+        conns[index] = id(db.conn)
+        release.wait(timeout=5)
 
-    threads = [threading.Thread(target=grab) for _ in range(4)]
+    threads = [threading.Thread(target=grab, args=(i,)) for i in range(4)]
     for t in threads:
         t.start()
+    release.set()
     for t in threads:
         t.join()
 
     # main thread connection is distinct from every worker's
     main_id = id(db.conn)
-    assert len(set(conns.values())) == 4
-    assert main_id not in conns.values()
+    assert None not in conns
+    assert len(set(conns)) == 4
+    assert main_id not in conns
     db.close()
 
 


### PR DESCRIPTION
## Summary

Fixes the CI flake seen while testing the new release workflow.

The failing test still verifies the same behavior: each live worker thread gets its own SQLite connection, and the main thread has a different connection.

## Why

`test_each_thread_gets_distinct_connection` previously stored worker results in a dict keyed by `threading.get_ident()`. On the GitHub Actions runner, the short-lived worker threads could finish quickly enough for Python to reuse a thread identifier, so four launched threads collapsed into three dict entries:

```text
assert 3 == 4
```

That made the test flaky even though the database behavior under test was still correct.

## Change

- Keep the four worker threads alive concurrently with a `threading.Barrier` and `threading.Event`.
- Store each worker connection ID by stable worker slot index instead of reusable thread identifier.
- Preserve the behavior assertions:
  - all four worker slots produced a connection
  - all four worker connection IDs are distinct
  - the main thread connection ID is distinct from every worker connection

## Verification

- `env UV_CACHE_DIR=/tmp/ormah-uv-cache zsh -lc 'for i in {1..30}; do uv run pytest tests/test_index/test_db_concurrency.py::test_each_thread_gets_distinct_connection -q || exit 1; done'`
- `env UV_CACHE_DIR=/tmp/ormah-uv-cache uv run pytest tests/test_index/test_db_concurrency.py tests/test_packaging.py -q`
- `env UV_CACHE_DIR=/tmp/ormah-uv-cache uv run ruff check tests/test_index/test_db_concurrency.py`
- `git diff --check`
