### PR TITLE
feat(stats): whisper-health metric — surface coverage/precision (follow-up to #40)

### DIFF
--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -19,6 +19,7 @@ from ormah.engine.maintenance_signal import (
     is_maintenance_due_signal,
 )
 from ormah.engine.tier_manager import TierManager
+from ormah.engine.whisper_health import compute_whisper_health
 from ormah.engine.traversal import (
     format_node_with_neighbors,
     format_search_results,
@@ -1070,6 +1071,9 @@ class MemoryEngine:
             "total_nodes": total,
             "by_tier": tier_counts,
             "total_edges": edge_count,
+            "whisper_health": compute_whisper_health(
+                self.db.conn, datetime.now(timezone.utc)
+            ),
         }
 
     # --- Merge operations ---

--- a/src/ormah/engine/whisper_health.py
+++ b/src/ormah/engine/whisper_health.py
@@ -1,0 +1,84 @@
+"""Whisper effectiveness metrics derived from whisper_log + affinity.
+
+Read-only aggregation for the feedback loop closed in #21 — surfaces coverage
+(share of injected memories that drew any feedback) and precision (positive
+share of feedback on injected memories) so whisper effectiveness stops being
+unmeasurable.
+
+Semantics & known limitations (council-reviewed):
+- coverage/precision are LINKED-ONLY: they count affinity rows joined to an
+  injected whisper (whisper_log_id NOT NULL AND was_injected = 1). Legacy
+  pre-#21 rows (whisper_log_id IS NULL) are excluded but surfaced separately as
+  `unlinked_feedback_rows` on `all_time`, so the loss is visible, not silent.
+- the window filters `wl.logged_at`, which production writers always emit via
+  `.isoformat()` (context_builder.py, memory_engine.py) — so lexicographic
+  comparison on that column is safe. `confirmed_at` (written as datetime('now'),
+  a different format) is never compared.
+- KNOWN UNDERCOUNT: if a node was injected then re-logged held-back, feedback
+  attaches to the latest (held-back) whisper_log row and is excluded here. The
+  fix belongs in submit_feedback's attribution (collection side), tracked as a
+  follow-up; this read-only metric reports pessimistically rather than wrong.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta
+
+
+def _window(conn: sqlite3.Connection, since: str | None) -> dict:
+    # Anchor every feedback aggregate in whisper_log via INNER JOIN with
+    # was_injected = 1, so numerator and denominator share one universe. The
+    # window filters wl.logged_at on BOTH sides (single cohort).
+    log_filter = " AND logged_at >= ?" if since else ""
+    join_filter = " AND wl.logged_at >= ?" if since else ""
+    log_params: tuple = (since,) if since else ()
+    join_params: tuple = (since,) if since else ()
+
+    injected = conn.execute(
+        "SELECT COUNT(*) FROM whisper_log WHERE was_injected = 1" + log_filter,
+        log_params,
+    ).fetchone()[0]
+    feedback_rows = conn.execute(
+        "SELECT COUNT(DISTINCT a.whisper_log_id) FROM affinity a "
+        "JOIN whisper_log wl ON wl.id = a.whisper_log_id "
+        "WHERE wl.was_injected = 1" + join_filter,
+        join_params,
+    ).fetchone()[0]
+    pos, neg = conn.execute(
+        "SELECT "
+        "COALESCE(SUM(CASE WHEN a.signal = 1 THEN 1 ELSE 0 END), 0), "
+        "COALESCE(SUM(CASE WHEN a.signal = -1 THEN 1 ELSE 0 END), 0) "
+        "FROM affinity a "
+        "JOIN whisper_log wl ON wl.id = a.whisper_log_id "
+        "WHERE wl.was_injected = 1" + join_filter,
+        join_params,
+    ).fetchone()
+
+    fb_total = pos + neg
+    return {
+        "injected": injected,
+        "feedback_rows": feedback_rows,
+        "coverage": feedback_rows / injected if injected else None,
+        "positive": pos,
+        "negative": neg,
+        "precision": pos / fb_total if fb_total else None,
+    }
+
+
+def compute_whisper_health(conn: sqlite3.Connection, now: datetime) -> dict:
+    """Return whisper coverage/precision over all_time and last_7d windows.
+
+    ``now`` is injected (never ``datetime.now()`` inside the query) so callers
+    and tests are deterministic. See module docstring for the linked-only
+    semantics and known undercount.
+    """
+    since_7d = (now - timedelta(days=7)).isoformat()
+    all_time = _window(conn, None)
+    # Surface legacy/unattributable feedback (whisper_log_id IS NULL) so the
+    # linked-only ratios don't silently hide it. all_time only — the 7d cohort
+    # is injection-anchored and has no NULL side.
+    all_time["unlinked_feedback_rows"] = conn.execute(
+        "SELECT COUNT(*) FROM affinity WHERE whisper_log_id IS NULL"
+    ).fetchone()[0]
+    return {"all_time": all_time, "last_7d": _window(conn, since_7d)}

--- a/src/ormah/engine/whisper_health.py
+++ b/src/ormah/engine/whisper_health.py
@@ -74,11 +74,25 @@ def compute_whisper_health(conn: sqlite3.Connection, now: datetime) -> dict:
     semantics and known undercount.
     """
     since_7d = (now - timedelta(days=7)).isoformat()
-    all_time = _window(conn, None)
-    # Surface legacy/unattributable feedback (whisper_log_id IS NULL) so the
-    # linked-only ratios don't silently hide it. all_time only — the 7d cohort
-    # is injection-anchored and has no NULL side.
-    all_time["unlinked_feedback_rows"] = conn.execute(
-        "SELECT COUNT(*) FROM affinity WHERE whisper_log_id IS NULL"
-    ).fetchone()[0]
-    return {"all_time": all_time, "last_7d": _window(conn, since_7d)}
+    # Read every aggregate under one BEGIN DEFERRED snapshot. Without it, a
+    # concurrent writer (FastAPI handler, session_watcher) inserting an injected
+    # whisper_log + its affinity between the `injected` count and the
+    # `feedback_rows` count could make coverage exceed 100%. The store runs
+    # isolation_level=None (autocommit), so the transaction is opened explicitly;
+    # the in_transaction guard makes this safe to call inside a caller's tx too.
+    own_tx = not conn.in_transaction
+    if own_tx:
+        conn.execute("BEGIN DEFERRED")
+    try:
+        all_time = _window(conn, None)
+        # Surface legacy/unattributable feedback (whisper_log_id IS NULL) so the
+        # linked-only ratios don't silently hide it. all_time only — the 7d
+        # cohort is injection-anchored and has no NULL side.
+        all_time["unlinked_feedback_rows"] = conn.execute(
+            "SELECT COUNT(*) FROM affinity WHERE whisper_log_id IS NULL"
+        ).fetchone()[0]
+        last_7d = _window(conn, since_7d)
+    finally:
+        if own_tx:
+            conn.execute("COMMIT")
+    return {"all_time": all_time, "last_7d": last_7d}

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -69,7 +69,9 @@ def test_recall_not_found(client):
 def test_stats(client):
     resp = client.get("/admin/stats")
     assert resp.status_code == 200
-    assert "total_nodes" in resp.json()
+    body = resp.json()
+    assert "total_nodes" in body
+    assert "whisper_health" in body
 
 
 def test_backup_status_empty_store(client):

--- a/tests/test_whisper_health.py
+++ b/tests/test_whisper_health.py
@@ -68,7 +68,7 @@ def test_mixed_signals_precision():
 
 
 def test_distinct_guards_against_double_count():
-    # In production idx_affinity_node_whisper_log_unique (db.py:234) forbids two
+    # In production idx_affinity_node_whisper_log_unique (schema.sql:126) forbids two
     # affinity rows on one whisper_log_id, so this two-row shape can't occur for
     # real. The minimal schema here omits that index on purpose, to assert the
     # DISTINCT clause is a defensive guard that keeps coverage <= 1.0 regardless.

--- a/tests/test_whisper_health.py
+++ b/tests/test_whisper_health.py
@@ -148,3 +148,45 @@ def test_seven_day_cutoff():
     assert out["last_7d"]["injected"] == 0
     assert out["last_7d"]["coverage"] is None
     assert out["last_7d"]["precision"] is None
+
+
+def test_stats_exposes_whisper_health(engine):
+    out = engine.stats()
+    assert "whisper_health" in out
+    wh = out["whisper_health"]
+    assert set(wh) == {"all_time", "last_7d"}
+    assert set(wh["last_7d"]) == {
+        "injected", "feedback_rows", "coverage",
+        "positive", "negative", "precision",
+    }
+    assert set(wh["all_time"]) == {
+        "injected", "feedback_rows", "coverage",
+        "positive", "negative", "precision", "unlinked_feedback_rows",
+    }
+    assert wh["all_time"]["injected"] == 0
+    assert wh["all_time"]["coverage"] is None
+
+
+def test_stats_whisper_health_seeded(engine):
+    # I2 (council r2): exercise real schema (NOT NULL cols + JOIN), not just empty.
+    from datetime import datetime, timezone
+
+    conn = engine.db.conn
+    conn.execute(
+        "INSERT INTO whisper_log "
+        "(session_id, prompt_hash, prompt_vec, node_id, score, was_injected, logged_at) "
+        "VALUES ('s1', 'h1', X'00', 'n1', 0.5, 1, ?)",
+        (datetime.now(timezone.utc).isoformat(),),
+    )
+    wid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+    conn.execute(
+        "INSERT INTO affinity "
+        "(prompt_vec, node_id, signal, source, confirmed_at, session_id, whisper_log_id) "
+        "VALUES (X'00', 'n1', 1, 'explicit', datetime('now'), 's1', ?)",
+        (wid,),
+    )
+    wh = engine.stats()["whisper_health"]["all_time"]
+    assert wh["injected"] == 1
+    assert wh["feedback_rows"] == 1
+    assert wh["coverage"] == 1.0
+    assert wh["precision"] == 1.0

--- a/tests/test_whisper_health.py
+++ b/tests/test_whisper_health.py
@@ -8,7 +8,9 @@ ISO = NOW.isoformat()
 
 
 def _db() -> sqlite3.Connection:
-    conn = sqlite3.connect(":memory:")
+    # isolation_level=None mirrors the production Database (autocommit; the
+    # whisper-health read opens its own BEGIN DEFERRED snapshot explicitly).
+    conn = sqlite3.connect(":memory:", isolation_level=None)
     conn.row_factory = sqlite3.Row
     conn.execute(
         "CREATE TABLE whisper_log "
@@ -135,6 +137,18 @@ def test_mixed_confirmed_at_format_still_counted():
     out = compute_whisper_health(conn, NOW)["last_7d"]
     assert out["feedback_rows"] == 1
     assert out["coverage"] == 1.0
+
+
+def test_reads_under_snapshot_no_transaction_leak():
+    # Council-PR I1: the aggregates run inside one BEGIN DEFERRED snapshot so a
+    # concurrent insert can't push coverage above 100%. Verify the snapshot is
+    # opened and closed cleanly (no dangling transaction on the connection).
+    conn = _db()
+    _inject(conn, 1)
+    _feedback(conn, 1, 1)
+    out = compute_whisper_health(conn, NOW)["all_time"]
+    assert out["coverage"] == 1.0
+    assert conn.in_transaction is False
 
 
 def test_seven_day_cutoff():

--- a/tests/test_whisper_health.py
+++ b/tests/test_whisper_health.py
@@ -1,0 +1,150 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from ormah.engine.whisper_health import compute_whisper_health
+
+NOW = datetime(2026, 6, 24, tzinfo=timezone.utc)
+ISO = NOW.isoformat()
+
+
+def _db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE whisper_log "
+        "(id INTEGER PRIMARY KEY, was_injected INTEGER, logged_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE affinity "
+        "(whisper_log_id INTEGER, signal INTEGER, confirmed_at TEXT)"
+    )
+    return conn
+
+
+def _inject(conn, wid, when=ISO, injected=1):
+    conn.execute(
+        "INSERT INTO whisper_log (id, was_injected, logged_at) VALUES (?, ?, ?)",
+        (wid, injected, when),
+    )
+
+
+def _feedback(conn, wid, signal, when=ISO):
+    conn.execute(
+        "INSERT INTO affinity (whisper_log_id, signal, confirmed_at) VALUES (?, ?, ?)",
+        (wid, signal, when),
+    )
+
+
+def test_empty_store_ratios_none():
+    out = compute_whisper_health(_db(), NOW)
+    for window in ("all_time", "last_7d"):
+        assert out[window]["coverage"] is None
+        assert out[window]["precision"] is None
+        assert out[window]["injected"] == 0
+    assert out["all_time"]["unlinked_feedback_rows"] == 0
+
+
+def test_injection_without_feedback():
+    conn = _db()
+    _inject(conn, 1)
+    _inject(conn, 2)
+    out = compute_whisper_health(conn, NOW)["all_time"]
+    assert out["injected"] == 2
+    assert out["coverage"] == 0.0
+    assert out["precision"] is None
+
+
+def test_mixed_signals_precision():
+    conn = _db()
+    for wid in (1, 2, 3, 4):
+        _inject(conn, wid)
+    _feedback(conn, 1, 1)
+    _feedback(conn, 2, 1)
+    _feedback(conn, 3, 1)
+    _feedback(conn, 4, -1)
+    out = compute_whisper_health(conn, NOW)["all_time"]
+    assert out["precision"] == 0.75
+    assert out["coverage"] == 1.0
+
+
+def test_distinct_guards_against_double_count():
+    # In production idx_affinity_node_whisper_log_unique (db.py:234) forbids two
+    # affinity rows on one whisper_log_id, so this two-row shape can't occur for
+    # real. The minimal schema here omits that index on purpose, to assert the
+    # DISTINCT clause is a defensive guard that keeps coverage <= 1.0 regardless.
+    conn = _db()
+    _inject(conn, 1)
+    _feedback(conn, 1, 1)
+    _feedback(conn, 1, -1)
+    out = compute_whisper_health(conn, NOW)["all_time"]
+    assert out["feedback_rows"] == 1
+    assert out["coverage"] == 1.0  # not 2.0
+
+
+def test_held_back_candidate_feedback_excluded():
+    # C1: feedback on a was_injected=0 candidate must NOT inflate coverage.
+    conn = _db()
+    _inject(conn, 1, injected=1)
+    _feedback(conn, 1, 1)
+    _inject(conn, 2, injected=0)  # held-back candidate
+    _feedback(conn, 2, 1)         # later converted to affinity
+    out = compute_whisper_health(conn, NOW)["all_time"]
+    assert out["injected"] == 1
+    assert out["feedback_rows"] == 1
+    assert out["coverage"] == 1.0  # not 2.0
+    assert out["positive"] == 1   # held-back signal excluded from precision too
+
+
+def test_legacy_null_whisper_log_id_surfaced_not_counted():
+    # I1 (council r2): pre-#21 affinity rows carry whisper_log_id = NULL. They are
+    # excluded from linked-only coverage/precision but surfaced via
+    # unlinked_feedback_rows so the loss is visible, not silent.
+    conn = _db()
+    _inject(conn, 1)
+    _feedback(conn, 1, 1)
+    conn.execute(
+        "INSERT INTO affinity (whisper_log_id, signal, confirmed_at) "
+        "VALUES (NULL, 1, ?)",
+        (ISO,),
+    )
+    out = compute_whisper_health(conn, NOW)["all_time"]
+    assert out["coverage"] == 1.0            # linked-only, NULL row ignored
+    assert out["positive"] == 1              # NULL row excluded from precision
+    assert out["unlinked_feedback_rows"] == 1  # but counted and exposed
+
+
+def test_last_7d_old_injection_recent_feedback():
+    # I1 (r1): recent feedback for an old injection must not push last_7d above 1.0.
+    conn = _db()
+    old = (NOW - timedelta(days=10)).isoformat()
+    _inject(conn, 1, when=old)
+    _feedback(conn, 1, 1, when=ISO)  # feedback today
+    out = compute_whisper_health(conn, NOW)
+    assert out["all_time"]["coverage"] == 1.0
+    assert out["last_7d"]["injected"] == 0
+    assert out["last_7d"]["feedback_rows"] == 0
+    assert out["last_7d"]["coverage"] is None
+
+
+def test_mixed_confirmed_at_format_still_counted():
+    # I2 (r1): confirmed_at in datetime('now') space-format must not be dropped,
+    # because the window filters wl.logged_at, never confirmed_at.
+    conn = _db()
+    _inject(conn, 1, when=ISO)
+    _feedback(conn, 1, 1, when="2026-06-24 00:00:00")  # space-format, no TZ
+    out = compute_whisper_health(conn, NOW)["last_7d"]
+    assert out["feedback_rows"] == 1
+    assert out["coverage"] == 1.0
+
+
+def test_seven_day_cutoff():
+    conn = _db()
+    old = (NOW - timedelta(days=10)).isoformat()
+    _inject(conn, 1, when=old)
+    _feedback(conn, 1, 1, when=old)
+    out = compute_whisper_health(conn, NOW)
+    assert out["all_time"]["injected"] == 1
+    assert out["all_time"]["coverage"] == 1.0
+    assert out["last_7d"]["injected"] == 0
+    assert out["last_7d"]["coverage"] is None
+    assert out["last_7d"]["precision"] is None


### PR DESCRIPTION
👀 Heads-up before you read the diff: review in progress is welcome — no rush to merge, but flagging early per our process chat on #40.

## What & why

Follow-up to the review on #40: that PR closed the *collection* side of the whisper feedback loop, but whisper effectiveness was still **unmeasurable** — there was no surfaced number to verify the loop moved from the original ~0.7% coverage to something healthy. This PR adds the read/observability side, nothing on collection.

A new read-only `compute_whisper_health(conn, now)` aggregates `whisper_log` + `affinity` and is exposed under a `whisper_health` key in `engine.stats()` — so `GET /admin/stats` and `ormah stats` both surface it for free, and the upcoming Ormah App can plug straight in.

## What it reports

Over two recuts, `all_time` and `last_7d`:

| field | meaning |
|---|---|
| `injected` | `COUNT(*)` whisper_log rows with `was_injected = 1` |
| `feedback_rows` | distinct injected whispers that drew feedback |
| `coverage` | `feedback_rows / injected` (`None` when injected = 0) |
| `positive` / `negative` | signal tallies |
| `precision` | `positive / (positive + negative)` (`None` when no feedback) |
| `unlinked_feedback_rows` | (all_time only) legacy `whisper_log_id IS NULL` feedback, surfaced not hidden |

Raw counts sit beside the ratios so a tiny denominator is never masked; ratios are `None` (never a fake `0.0`) when their denominator is zero.

## Key design decisions

- **Coverage can't exceed 100%.** Every feedback aggregate anchors in `whisper_log` via `JOIN ... AND wl.was_injected = 1`. This keeps numerator and denominator in one universe and excludes feedback on held-back candidates (`was_injected = 0`) and legacy `NULL` rows. `COUNT(DISTINCT whisper_log_id)` collapses multiple per-turn signals.
- **`last_7d` is a single cohort.** Both sides filter `wl.logged_at >= since`, so recent feedback for an old injection can't push coverage past 1.0. As a bonus, `confirmed_at` (written as `datetime('now')`, a different string format than `logged_at`'s `.isoformat()`) is never compared lexicographically.
- **Consistent snapshot.** The aggregate reads run inside one `BEGIN DEFERRED` (guarded by `in_transaction`), so a concurrent writer can't interleave between the `injected` and `feedback_rows` counts and momentarily report coverage > 100%.
- **Legacy feedback is visible, not silent.** Pre-feedback-loop `affinity` rows (`whisper_log_id IS NULL`) are excluded from the linked-only ratios but exposed via `unlinked_feedback_rows`.

## Tests

12 unit/integration tests covering: empty store, no-feedback, mixed signals, the DISTINCT guard, held-back exclusion, legacy-NULL surfacing, the 7-day cohort boundary, the `confirmed_at` format trap, the snapshot/no-transaction-leak, plus a seeded `engine`-fixture integration test on the real schema and an `/admin/stats` presence assert.

## Known limitation / follow-up (out of scope here)

`submit_feedback` resolves the *latest* whisper_log per node without requiring `was_injected = 1`, so feedback on a re-logged held-back row is undercounted by this metric. The fix belongs in attribution (collection side); I'll open a separate issue. A composite `(was_injected, logged_at)` index on `whisper_log` is also a sensible later optimization if `stats()` is hit hard at scale.

Reviewed locally through two adversarial review rounds before opening. Happy to adjust naming or shape to fit the Ormah App's stats surface.
