### PR TITLE
fix(db): repair startup crash on pre-feedback DBs (no such column: whisper_log_id)

### DIFF
--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -122,13 +122,13 @@ CREATE TABLE IF NOT EXISTS affinity (
     whisper_log_id INTEGER REFERENCES whisper_log(id) ON DELETE SET NULL
 );
 CREATE INDEX IF NOT EXISTS idx_affinity_node ON affinity(node_id);
-CREATE INDEX IF NOT EXISTS idx_affinity_whisper_log ON affinity(whisper_log_id);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_affinity_node_whisper_log_unique
-    ON affinity(node_id, whisper_log_id)
-    WHERE whisper_log_id IS NOT NULL;
-CREATE UNIQUE INDEX IF NOT EXISTS idx_affinity_node_session_legacy_unique
-    ON affinity(node_id, session_id)
-    WHERE whisper_log_id IS NULL;
+-- Indexes on affinity.whisper_log_id are created by the migration code
+-- (_ensure_affinity_indexes), NOT here. On a pre-feedback DB the affinity table
+-- already exists without whisper_log_id, so "CREATE TABLE IF NOT EXISTS affinity"
+-- above is a no-op and the column is missing. executescript() runs this file
+-- before _migrate() adds the column, so creating these indexes here would crash
+-- with "no such column: whisper_log_id". _migrate_affinity_schema() rebuilds the
+-- legacy table and then creates these indexes, which is the correct ordering.
 
 CREATE TABLE IF NOT EXISTS signals (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/test_index/test_feedback_schema.py
+++ b/tests/test_index/test_feedback_schema.py
@@ -240,4 +240,71 @@ def test_migrate_is_idempotent(tmp_path):
     assert _table_exists(db, "affinity")
     assert _table_exists(db, "signals")
     assert _table_exists(db, "review_log")
+
+
+# ---------------------------------------------------------------------------
+# Regression: a *pre-feedback* DB whose affinity table still has the legacy
+# schema (no whisper_log_id, UNIQUE(node_id, session_id)) must survive the full
+# init_schema() path. The earlier migration tests drop the affinity table
+# entirely and call _migrate() directly, so they never exercised executescript()
+# running schema.sql against a pre-existing legacy affinity table -- which is
+# exactly what crashed in 0.12.0/0.12.1 with "no such column: whisper_log_id".
+# ---------------------------------------------------------------------------
+
+_LEGACY_AFFINITY_DDL = """
+CREATE TABLE affinity (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    prompt_vec   BLOB NOT NULL,
+    prompt_text  TEXT,
+    node_id      TEXT NOT NULL,
+    signal       INTEGER NOT NULL,
+    source       TEXT NOT NULL DEFAULT 'explicit',
+    confirmed_at TEXT NOT NULL,
+    space        TEXT,
+    session_id   TEXT NOT NULL,
+    UNIQUE (node_id, session_id)
+);
+CREATE INDEX idx_affinity_node ON affinity(node_id);
+"""
+
+
+def _make_legacy_affinity_db(tmp_path: Path) -> Path:
+    """Build a DB with the pre-feedback affinity table and a seed row, without
+    any of the new feedback tables/columns."""
+    path = tmp_path / "index.db"
+    conn = sqlite3.connect(path)
+    conn.executescript(_LEGACY_AFFINITY_DDL)
+    conn.execute(
+        "INSERT INTO affinity "
+        "(prompt_vec, prompt_text, node_id, signal, source, confirmed_at, "
+        " space, session_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (b"\x00", "hi", "node-1", 1, "explicit", "2026-01-01T00:00:00Z",
+         "proj", "sess-1"),
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_init_schema_migrates_legacy_affinity_table(tmp_path):
+    """Full init_schema() on a legacy affinity table must not raise and must
+    add whisper_log_id, create the signals table, and preserve existing rows."""
+    path = _make_legacy_affinity_db(tmp_path)
+
+    db = Database(path)
+    db.init_schema()  # regression: this used to raise OperationalError
+
+    assert "whisper_log_id" in _table_columns(db, "affinity")
+    assert _table_exists(db, "signals")
+    assert _index_exists(db, "idx_affinity_whisper_log")
+    assert _index_exists(db, "idx_affinity_node_whisper_log_unique")
+    # existing data survives the table rebuild
+    rows = db.conn.execute("SELECT node_id, session_id FROM affinity").fetchall()
+    assert [tuple(r) for r in rows] == [("node-1", "sess-1")]
+
+    # idempotent: a second init_schema() on the now-migrated DB is a no-op
+    db.init_schema()
+    assert "whisper_log_id" in _table_columns(db, "affinity")
+    db.close()
     db.close()


### PR DESCRIPTION
## Problem

0.12.0/0.12.1 **crash on startup** for any database created *before* the transcript-feedback feature, with:

```
sqlite3.OperationalError: no such column: whisper_log_id
```

This bricks existing installs the moment they update (the server crash-loops; the desktop app shows only the intro).

## Root cause

`schema.sql` is run via `executescript()` **before** `_migrate()`. On a pre-feedback DB the `affinity` table already exists with the legacy schema (no `whisper_log_id`), so `CREATE TABLE IF NOT EXISTS affinity` is a no-op and the column is never added. The next statement — `CREATE INDEX ... ON affinity(whisper_log_id)` — then runs against the old table and throws. The migration that *would* add the column (`_migrate_affinity_schema`) never gets to run.

Fresh DBs were fine (table born with the column), which is why it slipped through.

## Fix

- Remove the `affinity.whisper_log_id` indexes from `schema.sql`. They are already created idempotently by `_ensure_affinity_indexes` (called from `_migrate_affinity_schema`), which runs **after** the column is guaranteed to exist. The `signals` block stays — it's a brand-new table and can't fail on legacy DBs.
- Add a regression test that builds a **legacy affinity table** and runs the full `init_schema()` path. The existing migration tests dropped `affinity` entirely and called `_migrate()` directly, so they never exercised the real failing path.

## Verification

- New regression test fails on the unfixed schema with the exact `no such column: whisper_log_id` error, passes with the fix.
- Tested against a copy of a real legacy DB: migrates cleanly, `whisper_log_id` + `signals` created, all 235 affinity rows preserved, idempotent on re-run.
- Full suite: 969 passed (1 pre-existing env-leak failure in `test_config.py`, unrelated).
- Verified end-to-end: reinstalled locally, restarted the server — it now starts and serves on a previously-crashing real DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)