### PR TITLE
chore: release 0.12.2

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.12.1"
+version = "0.12.2"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bump version to 0.12.2 — patch release for the schema migration crash fix (#55).

## What's in this release

- **fix(db):** startup crash on pre-feedback databases — `no such column: whisper_log_id` (#55). Affected all installs that existed before the 0.12.0 transcript-feedback feature shipped.

## Steps after merge

Trigger Actions → Release → `0.12.2` → approve `pypi` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)