### PR TITLE
fix(session-watcher): never ingest subagent transcripts (follow-up to #34)

### DIFF
--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -562,6 +562,15 @@ def _record_whisper_usage_signals(
     return recorded
 
 
+def _is_subagent_transcript(path: Path) -> bool:
+    """True for subagent transcripts (Claude Code writes them under ``<uuid>/subagents/``).
+
+    These are internal agent scratch, not user-facing sessions — ingesting them balloons
+    the store with low-value granular memories under a junk ``subagents`` space.
+    """
+    return path.parent.name == "subagents"
+
+
 def _space_from_encoded_dir(dirname: str) -> str | None:
     """Extract project space from an encoded transcript directory name.
 
@@ -706,6 +715,8 @@ def _ingest_session(
     on_defer_active=None,
 ) -> bool:
     """Ingest a single JSONL session transcript if changed. Returns True if ingested."""
+    if _is_subagent_transcript(path):
+        return False
     rel = str(path.relative_to(watch_dir))
 
     try:
@@ -948,11 +959,15 @@ class SessionHandler(FileSystemEventHandler):
 
     def on_created(self, event):
         if not event.is_directory and event.src_path.endswith(".jsonl"):
-            self._schedule_ingest(Path(event.src_path))
+            path = Path(event.src_path)
+            if not _is_subagent_transcript(path):
+                self._schedule_ingest(path)
 
     def on_modified(self, event):
         if not event.is_directory and event.src_path.endswith(".jsonl"):
-            self._schedule_ingest(Path(event.src_path))
+            path = Path(event.src_path)
+            if not _is_subagent_transcript(path):
+                self._schedule_ingest(path)
 
 
 def start_session_watcher(engine: MemoryEngine) -> list[Observer]:

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -566,9 +566,10 @@ def _is_subagent_transcript(path: Path) -> bool:
     """True for subagent transcripts (Claude Code writes them under ``<uuid>/subagents/``).
 
     These are internal agent scratch, not user-facing sessions — ingesting them balloons
-    the store with low-value granular memories under a junk ``subagents`` space.
+    the store with low-value granular memories under a junk ``subagents`` space. Matches a
+    ``subagents`` segment at any depth so nested layouts are covered too.
     """
-    return path.parent.name == "subagents"
+    return "subagents" in path.parts
 
 
 def _space_from_encoded_dir(dirname: str) -> str | None:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -1178,7 +1178,10 @@ def _discover_transcripts() -> list[tuple[Path, str | None]]:
 
     Returns list of (path, space_name) tuples.
     """
-    from ormah.background.session_watcher import _space_from_encoded_dir
+    from ormah.background.session_watcher import (
+        _is_subagent_transcript,
+        _space_from_encoded_dir,
+    )
 
     projects_dir = Path.home() / ".claude" / "projects"
     if not projects_dir.exists():
@@ -1186,6 +1189,8 @@ def _discover_transcripts() -> list[tuple[Path, str | None]]:
 
     transcripts: list[tuple[Path, str | None, float]] = []
     for jsonl_file in projects_dir.rglob("*.jsonl"):
+        if _is_subagent_transcript(jsonl_file):
+            continue  # internal agent scratch — never backfill (see session_watcher)
         try:
             mtime = jsonl_file.stat().st_mtime
         except OSError:

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -197,7 +197,8 @@ def test_scan_skips_subagents_keeps_primary(engine, tmp_path):
 
     assert ingested == 1
     state = _load_state(watch_dir)
-    assert "subagents" not in str(list(state.keys()))
+    sub_rel = str((sub_dir / "agent-deadbeef.jsonl").relative_to(watch_dir))
+    assert sub_rel not in state
 
 
 def test_ingest_codex_session_resolves_rollout_session_id_and_space(engine, tmp_path):

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -163,6 +163,43 @@ def test_ingest_session_basic(engine, tmp_path):
     assert len(entry["node_ids"]) == 1
 
 
+def test_subagent_transcript_is_not_ingested(engine, tmp_path):
+    """Subagent transcripts (<uuid>/subagents/agent-*.jsonl) are internal agent scratch.
+
+    They must never be ingested as memories, even with turns above min_turns — otherwise
+    every Task-tool spawn balloons the store with low-value granular memories.
+    """
+    watch_dir = tmp_path / "projects"
+    sub_dir = watch_dir / "-Users-alice-Code-myproject" / "abc123" / "subagents"
+    sub_dir.mkdir(parents=True)
+    jsonl = sub_dir / "agent-deadbeef.jsonl"
+    _make_jsonl(jsonl, user_turns=6)  # well above min_turns
+
+    state = {}
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        result = _ingest_session(engine, jsonl, state, watch_dir, min_turns=5)
+
+    assert result is False
+    assert state == {}
+
+
+def test_scan_skips_subagents_keeps_primary(engine, tmp_path):
+    """A scan ingests the primary session transcript but skips sibling subagent transcripts."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    sub_dir = project_dir / "abc123" / "subagents"
+    sub_dir.mkdir(parents=True)
+    _make_jsonl(project_dir / "abc123.jsonl", user_turns=6)
+    _make_jsonl(sub_dir / "agent-deadbeef.jsonl", user_turns=6)
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        ingested = _scan_sessions(engine, watch_dir, min_turns=5, lookback_hours=9999)
+
+    assert ingested == 1
+    state = _load_state(watch_dir)
+    assert "subagents" not in str(list(state.keys()))
+
+
 def test_ingest_codex_session_resolves_rollout_session_id_and_space(engine, tmp_path):
     """Codex rollout filenames are matched back to the whisper_log hook session id."""
     watch_dir = tmp_path / ".codex" / "sessions"

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -26,6 +26,7 @@ from ormah.setup import (
     CLAUDE_MD_SENTINEL_END,
     CLAUDE_MD_SENTINEL_START,
     _atomic_write,
+    _discover_transcripts,
     _is_ormah_hook,
     _merge_hooks,
     _merge_json_file,
@@ -56,6 +57,25 @@ from ormah.setup import (
     run_setup,
     run_uninstall,
 )
+
+
+class TestDiscoverTranscripts:
+    def test_skips_subagent_transcripts(self, tmp_path):
+        """Backfill discovery must not surface subagent scratch transcripts."""
+        projects = tmp_path / ".claude" / "projects"
+        primary = projects / "-Users-alice-Code-myproject" / "abc123.jsonl"
+        subagent = projects / "-Users-alice-Code-myproject" / "abc123" / "subagents" / "agent-x.jsonl"
+        primary.parent.mkdir(parents=True)
+        subagent.parent.mkdir(parents=True)
+        primary.write_text("{}\n")
+        subagent.write_text("{}\n")
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            found = _discover_transcripts()
+
+        paths = [p for p, _ in found]
+        assert primary in paths
+        assert subagent not in paths
 
 
 # --- server_manager tests ---


### PR DESCRIPTION
## Problem

After #34 merged, the session watcher started ballooning the store with
low-value memories pulled from **subagent (Task-tool) transcripts**.

Claude Code writes subagent transcripts under
`~/.claude/projects/<project>/<uuid>/subagents/agent-*.jsonl`. The
watcher's recursive `rglob("*.jsonl")` + recursive observer have always
captured these, but two things made it surface now:

- The `min_turns` gate is bypassed for **idle** files (a finished short
  session is flushed so it isn't stranded — `_ingest_session`). Subagent
  transcripts idle within seconds with only 1–2 turns.
- #34's safe-payload / completion-signal turn closing made those short
  subagent transcripts produce a valid closed payload.

Net effect on one heavy multi-agent afternoon: **580+ nodes** created in
a junk `space="subagents"` (derived from `path.parent.name`). This is not
duplication — embeddings show ~0 semantic overlap — it is over-ingestion
of internal agent scratch that was never meant to be a user session.

## Fix

- Add `_is_subagent_transcript(path)` — true when a `subagents` segment
  appears anywhere in the path (`"subagents" in path.parts`), covering
  nested layouts.
- Skip such transcripts at the single ingest chokepoint
  (`_ingest_session`, covering both the catch-up scan and the realtime
  event path) plus the live `on_created`/`on_modified` handlers to avoid
  pointless debounce timers.
- Apply the same predicate in `setup.py::_discover_transcripts`, so the
  `ormah setup` backfill never offers/ingests subagent transcripts
  either (sibling caller).

## Tests

- `test_subagent_transcript_is_not_ingested` — direct ingest skipped
  even with turns above `min_turns`.
- `test_scan_skips_subagents_keeps_primary` — scan ingests the primary
  session transcript but not its sibling subagent transcripts.
- `test_skips_subagent_transcripts` (setup) — backfill discovery
  excludes subagent transcripts.

43 passed locally; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)