### PR TITLE
chore: release 0.12.3

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.12.2"
+version = "0.12.3"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bump version to 0.12.3 — ships the F10 desktop app backend.

## What's in this release

- **feat**: `GET /agent/stats` — weekly whisper/memory usage counts for the menubar tray
- **feat**: `GET /agent/clients` — detects Claude Code, Claude Desktop, Codex installations
- **feat**: `ormah setup --json` — non-interactive one-click agent wiring for the desktop app
- **feat(ui)**: vertical zoom slider (custom, WebKitGTK-compatible), draggable top bar with in-app window controls
- **feat(desktop)**: Tauri v2 cross-platform app — intro animation, install panel, in-app graph

## Steps after merge

Trigger Actions → Release → `0.12.3` → approve `pypi` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)