### PR TITLE
fix(session-watcher): disk-truth reconcile safety net for dropped transcripts (#59)

### DIFF
--- a/scripts/diag/fsevents_monitor.py
+++ b/scripts/diag/fsevents_monitor.py
@@ -79,6 +79,10 @@ def poll_disk_truth(root: Path, seen: set[str], lock: threading.Lock,
             advanced = key not in last_mtimes or m > last_mtimes[key]
             last_mtimes[key] = m
             if advanced and key not in events_this_window:
+                # A write landing between the swap-and-clear above and this rglob can show a
+                # one-off spurious LEAK (its event arrives next window). A *real* leak (e.g. an
+                # on_moved/atomic-replace the production handler ignores) repeats EVERY window —
+                # so trust a path that leaks repeatedly, not a lone hit.
                 leaks.append(key)
         if leaks:
             log.warning("LEAK %d file(s) advanced on disk with NO fsevent this window:", len(leaks))

--- a/scripts/diag/fsevents_monitor.py
+++ b/scripts/diag/fsevents_monitor.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Standalone FSEvents leak monitor (diagnostic for r-spade/ormah#59).
+
+Proves WHY the session-watcher's live path misses some transcripts, WITHOUT touching
+production code. Run it alongside the server across a sleep/wake cycle and a heavy day,
+then read the log. It:
+  1. Logs every watchdog event by TYPE (created/modified/MOVED/deleted). The production
+     handler implements only on_created/on_modified — a transcript written via
+     rename/atomic-replace arrives as on_moved and is missed deterministically.
+  2. Enables watchdog's FSEvents DEBUG line: the raw native flags per event
+     (is_coalesced / must_scan_subdirs / *_dropped) — the kernel saying it dropped events.
+  3. Every --poll seconds, diffs disk truth vs. events: files whose mtime advanced but for
+     which NO event fired in the window = the leaks.
+
+Usage:
+  uv run --with watchdog python scripts/diag/fsevents_monitor.py \
+      --dir ~/.claude/projects --poll 30 --log /tmp/fsevents_monitor.log
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import threading
+import time
+from pathlib import Path
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+log = logging.getLogger("fsevents_monitor")
+
+
+class LoggingHandler(FileSystemEventHandler):
+    def __init__(self, seen: set[str], lock: threading.Lock) -> None:
+        self._seen = seen
+        self._lock = lock
+
+    def _record(self, kind: str, path: str) -> None:
+        if not path.endswith(".jsonl"):
+            return
+        with self._lock:
+            self._seen.add(path)
+        log.info("EVENT %-9s %s", kind, path)
+
+    def on_created(self, event):
+        if not event.is_directory:
+            self._record("created", event.src_path)
+
+    def on_modified(self, event):
+        if not event.is_directory:
+            self._record("modified", event.src_path)
+
+    def on_moved(self, event):
+        # The production handler does NOT implement this — a leak if it fires for .jsonl.
+        if not event.is_directory:
+            self._record("MOVED", getattr(event, "dest_path", event.src_path))
+
+    def on_deleted(self, event):
+        if not event.is_directory:
+            self._record("deleted", event.src_path)
+
+
+def poll_disk_truth(root: Path, seen: set[str], lock: threading.Lock,
+                    interval: float, stop: threading.Event) -> None:
+    last_mtimes: dict[str, float] = {}
+    while not stop.wait(interval):
+        with lock:
+            events_this_window = set(seen)
+            seen.clear()
+        leaks = []
+        for f in root.rglob("*.jsonl"):
+            if "subagents" in f.parts:
+                continue
+            try:
+                m = f.stat().st_mtime
+            except OSError:
+                continue
+            key = str(f)
+            advanced = key not in last_mtimes or m > last_mtimes[key]
+            last_mtimes[key] = m
+            if advanced and key not in events_this_window:
+                leaks.append(key)
+        if leaks:
+            log.warning("LEAK %d file(s) advanced on disk with NO fsevent this window:", len(leaks))
+            for k in leaks:
+                log.warning("  LEAK %s", k)
+        else:
+            log.info("poll ok: every advanced file had an event")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dir", default="~/.claude/projects")
+    ap.add_argument("--poll", type=float, default=30.0)
+    ap.add_argument("--log", default="/tmp/fsevents_monitor.log")
+    ap.add_argument("--duration", type=float, default=0.0, help="seconds; 0 = until Ctrl-C")
+    args = ap.parse_args()
+
+    logging.basicConfig(
+        filename=args.log, level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    logging.getLogger().addHandler(logging.StreamHandler())
+    # Raw native FSEvents flags (is_coalesced / must_scan_subdirs / *_dropped):
+    logging.getLogger("watchdog.observers.fsevents").setLevel(logging.DEBUG)
+
+    root = Path(args.dir).expanduser().resolve()
+    seen: set[str] = set()
+    lock = threading.Lock()
+    stop = threading.Event()
+
+    observer = Observer()
+    observer.schedule(LoggingHandler(seen, lock), str(root), recursive=True)
+    observer.start()
+    log.info("fsevents_monitor watching %s (poll=%ss, log=%s)", root, args.poll, args.log)
+
+    poller = threading.Thread(
+        target=poll_disk_truth, args=(root, seen, lock, args.poll, stop), daemon=True,
+    )
+    poller.start()
+
+    deadline = time.time() + args.duration if args.duration else None
+    try:
+        while True:
+            time.sleep(5)
+            log.info("observer.is_alive=%s", observer.is_alive())
+            if deadline and time.time() >= deadline:
+                break
+    except KeyboardInterrupt:
+        pass
+    finally:
+        stop.set()
+        observer.stop()
+        observer.join(timeout=5)
+        log.info("fsevents_monitor stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -160,3 +160,28 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
     scheduler.start()
     logger.info("Background scheduler started with %d jobs", len(scheduler.get_jobs()))
     return scheduler, tracker
+
+
+def register_session_reconcile_job(scheduler, tracker, watches, interval_minutes: int) -> None:
+    """Register the session-watcher reconcile job on an already-started scheduler.
+
+    Registered after the watchers start (they do not exist when start_scheduler runs), so the job
+    can reach the live handlers/observers. ``coalesce=True`` + a full-interval misfire grace mean a
+    slightly-long tick is never silently dropped; reconcile re-scans disk each run, so a coalesced
+    tick loses no work. No-op when there are no watchers.
+    """
+    if not watches:
+        return
+    from ormah.background.session_watcher import run_session_reconcile
+
+    scheduler.add_job(
+        tracked(tracker, "session_reconcile", run_session_reconcile, watches),
+        "interval",
+        minutes=interval_minutes,
+        id="session_reconcile",
+        name="Session reconcile",
+        max_instances=1,
+        coalesce=True,
+        misfire_grace_time=max(_MISFIRE_GRACE, interval_minutes * 60),
+    )
+    logger.info("Session reconcile job registered (every %d min)", interval_minutes)

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -979,6 +979,48 @@ class SessionHandler(FileSystemEventHandler):
             self._schedule_ingest(path)
         return bool(ingested)
 
+    def reconcile(self) -> int:
+        """Disk-truth safety net: ingest transcripts the live FSEvents path dropped.
+
+        Mechanism-agnostic and cheap: a stat-only scan finds files that still need work —
+        never-seen (within lookback) or a state cursor not at EOF — then routes up to
+        ``session_watcher_reconcile_max_per_tick`` of them through ``self._do_ingest`` (the
+        single state owner, so no clobber / no double-ingest). A file with a pending or failed
+        tail (``end_offset != size``) is re-checked every tick until fully consumed, so a
+        transient ingest failure never strands it. Returns transcripts recovered.
+        """
+        cutoff = time.time() - (self.lookback_hours * 3600) if self.lookback_hours > 0 else 0
+        cap = self.engine.settings.session_watcher_reconcile_max_per_tick
+        candidates: list[Path] = []
+        for jsonl_file in sorted(self.watch_dir.rglob("*.jsonl")):
+            if _is_subagent_transcript(jsonl_file):
+                continue
+            try:
+                st = jsonl_file.stat()
+            except OSError:
+                continue
+            rel = str(jsonl_file.relative_to(self.watch_dir))
+            entry = self._state.get(rel)
+            if entry is None:
+                # Never-seen: lookback cutoff applies (mirrors _scan_sessions).
+                if cutoff > 0 and st.st_mtime < cutoff:
+                    continue
+                candidates.append(jsonl_file)
+            elif entry.get("end_offset", 0) != st.st_size:
+                # Seen but the cursor is not at EOF: pending/failed tail (or a rewrite).
+                candidates.append(jsonl_file)
+            # else: fully consumed -> skip cheaply (no hash, no _do_ingest).
+        recovered = 0
+        for jsonl_file in candidates[:cap]:
+            if self._do_ingest(jsonl_file):
+                recovered += 1
+        if recovered:
+            logger.info(
+                "Session watcher reconcile recovered %d transcript(s) the live path missed",
+                recovered,
+            )
+        return recovered
+
     def on_created(self, event):
         if not event.is_directory and event.src_path.endswith(".jsonl"):
             path = Path(event.src_path)

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -9,6 +9,7 @@ import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from threading import Lock, Timer
 
@@ -20,6 +21,14 @@ from ormah.text.tokens import distinctive_tokens
 from ormah.transcript.parser import TranscriptResult, TranscriptTurn, parse_transcript
 
 logger = logging.getLogger(__name__)
+
+
+class IngestResult(Enum):
+    """Why an ingest attempt did/didn't commit, so reconcile parks only files that cannot
+    progress (corrupt / frozen safe boundary) and never parks transient external failures."""
+    OK = "ok"                    # committed new content
+    NO_PROGRESS = "no_progress"  # nothing new at the safe boundary, or unparseable (file's fault) -> park-eligible
+    TRANSIENT = "transient"      # external failure (engine error) or defer -> retry, never park
 
 _STATE_FILENAME = ".session_watcher_state"
 MAX_RECONCILE_RETRIES = 3
@@ -723,22 +732,31 @@ def _ingest_session(
     idle_threshold: float = 30.0,
     on_defer_active=None,
     state_lock=None,
-) -> bool:
-    """Ingest a single JSONL session transcript if changed. Returns True if ingested."""
+) -> IngestResult:
+    """Ingest a single JSONL session transcript if changed.
+
+    Returns:
+        IngestResult.OK         — new content was committed.
+        IngestResult.NO_PROGRESS — nothing to commit at the safe boundary (file is frozen,
+                                   corrupt, or already fully consumed) — park-eligible by
+                                   reconcile after MAX_RECONCILE_RETRIES at the same size.
+        IngestResult.TRANSIENT  — external failure (engine error, in-flight defer, or
+                                   in-flight skip); never increments the park counter.
+    """
     if _is_subagent_transcript(path):
-        return False
+        return IngestResult.NO_PROGRESS
     rel = str(path.relative_to(watch_dir))
 
     try:
         h = _file_hash(path)
     except OSError as e:
         logger.warning("Cannot read %s: %s", path, e)
-        return False
+        return IngestResult.TRANSIENT
     try:
         size = path.stat().st_size
     except OSError as e:
         logger.warning("Cannot stat %s: %s", path, e)
-        return False
+        return IngestResult.TRANSIENT
 
     # Incremental: only parse the turns appended since the last ingest.
     existing = state.get(rel)
@@ -747,7 +765,7 @@ def _ingest_session(
     # offset behind EOF means a pending tail or a legacy mid-response cursor still to process,
     # which must be re-parsed (so recovery can run) even when the hash is unchanged.
     if existing and existing.get("hash") == h and prev_offset >= size:
-        return False
+        return IngestResult.NO_PROGRESS
     if prev_offset > size:
         prev_offset = 0  # file shrank (compaction/rewrite) -> re-ingest whole
 
@@ -762,7 +780,7 @@ def _ingest_session(
             result = parse_transcript(path, start_offset=0)
     except Exception as e:
         logger.warning("Session transcript parse error for %s: %s", path, e)
-        return False
+        return IngestResult.NO_PROGRESS
 
     # Commit only the "safe" payload — the closed boundary, content proven complete by a
     # terminal stop_reason (Claude Code), a Codex task_complete event, or a following user
@@ -789,13 +807,14 @@ def _ingest_session(
         # schedule a retry so the turn is committed once it completes.
         if not is_idle and result.end_offset > prev_offset and on_defer_active is not None:
             on_defer_active()
-        return False
+            return IngestResult.TRANSIENT  # will grow; retry, never park
+        return IngestResult.NO_PROGRESS   # idle/frozen safe boundary -> park-eligible
 
     # Short tail on an active session — defer until more turns close or the session idles.
     if not is_idle and payload_users < min_turns:
         if on_defer_active is not None:
             on_defer_active()  # schedule a retry so the tail is not lost
-        return False
+        return IngestResult.TRANSIENT
 
     result.session_id = _resolve_transcript_session_id(
         engine,
@@ -815,11 +834,11 @@ def _ingest_session(
         )
         if isinstance(ingested, str):
             logger.warning("Session watcher ingestion failed for %s: %s", path, ingested)
-            return False
+            return IngestResult.TRANSIENT
         count = len(ingested) if isinstance(ingested, list) else 0
     except Exception as e:
         logger.warning("Session watcher ingestion error for %s: %s", path, e)
-        return False
+        return IngestResult.TRANSIENT
 
     new_node_ids = [m["node_id"] for m in ingested] if isinstance(ingested, list) else []
     # prev_offset == 0 means a fresh/whole re-ingest; don't carry stale cumulative
@@ -851,7 +870,7 @@ def _ingest_session(
         "Session watcher ingested %s (%d new turns, %d memories extracted, %d signals recorded)",
         rel, payload_users, count, signals_recorded,
     )
-    return True
+    return IngestResult.OK
 
 
 def _scan_sessions(
@@ -883,7 +902,7 @@ def _scan_sessions(
         if rel not in state and lookback_hours < 0:
             continue
 
-        if _ingest_session(engine, jsonl_file, state, watch_dir, min_turns):
+        if _ingest_session(engine, jsonl_file, state, watch_dir, min_turns) == IngestResult.OK:
             ingested += 1
 
     # Clean stale state entries for deleted files
@@ -951,8 +970,8 @@ class SessionHandler(FileSystemEventHandler):
             self._timers[key] = timer
             timer.start()
 
-    def _do_ingest(self, path: Path) -> bool:
-        """Ingest the session (after debounce, retry, or reconcile). Returns True if ingested.
+    def _do_ingest(self, path: Path) -> IngestResult:
+        """Ingest the session (after debounce, retry, or reconcile). Returns IngestResult.
 
         The heavy work (parse/LLM/DB) runs lock-free; only the state read-modify-write
         serializes via ``self._state_lock`` (passed into ``_ingest_session``), so a backlog
@@ -963,11 +982,11 @@ class SessionHandler(FileSystemEventHandler):
             self._timers.pop(key, None)
             if key in self._ingesting:
                 self._pending.add(key)
-                return False
+                return IngestResult.TRANSIENT
             self._ingesting.add(key)
-        ingested = False
+        result = IngestResult.NO_PROGRESS
         try:
-            ingested = _ingest_session(
+            result = _ingest_session(
                 self.engine, path, self._state, self.watch_dir, self.min_turns,
                 idle_threshold=self.idle_threshold,
                 on_defer_active=lambda: self._schedule_retry(path),
@@ -980,7 +999,7 @@ class SessionHandler(FileSystemEventHandler):
                 self._pending.discard(key)
         if rerun:
             self._schedule_ingest(path)
-        return bool(ingested)
+        return result
 
     def reconcile(self) -> int:
         """Disk-truth safety net: ingest transcripts the live FSEvents path dropped.
@@ -1031,13 +1050,15 @@ class SessionHandler(FileSystemEventHandler):
                 size = jsonl_file.stat().st_size
             except OSError:
                 continue
-            if self._do_ingest(jsonl_file):
+            result = self._do_ingest(jsonl_file)
+            if result == IngestResult.OK:
                 recovered += 1
-                self._reconcile_attempts.pop(rel, None)  # progress -> reset
-            else:
+                self._reconcile_attempts.pop(rel, None)
+            elif result == IngestResult.NO_PROGRESS:
                 prev = self._reconcile_attempts.get(rel)
                 count = prev[1] + 1 if (prev is not None and prev[0] == size) else 1
                 self._reconcile_attempts[rel] = (size, count)
+            # TRANSIENT: leave _reconcile_attempts untouched -> retried next tick, never parked
         if recovered:
             logger.info(
                 "Session watcher reconcile recovered %d transcript(s) the live path missed",

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -1012,10 +1012,15 @@ class SessionHandler(FileSystemEventHandler):
         ``MAX_RECONCILE_RETRIES`` attempts per size so an abandoned in-flight tail is not
         re-hashed forever — so a transient ingest failure never strands it. Returns
         transcripts recovered.
+
+        Candidates are sorted most-recently-modified first so freshly dropped transcripts are
+        recovered soonest. A per-tick wall-clock budget
+        (``session_watcher_reconcile_max_seconds``) caps scheduler-thread occupancy: remaining
+        candidates are picked up on the next tick.
         """
         cutoff = time.time() - (self.lookback_hours * 3600) if self.lookback_hours > 0 else 0
         cap = self.engine.settings.session_watcher_reconcile_max_per_tick
-        candidates: list[Path] = []
+        candidates: list[tuple[float, Path]] = []
         for jsonl_file in sorted(self.watch_dir.rglob("*.jsonl")):
             if _is_subagent_transcript(jsonl_file):
                 continue
@@ -1026,7 +1031,9 @@ class SessionHandler(FileSystemEventHandler):
             rel = str(jsonl_file.relative_to(self.watch_dir))
             entry = self._state.get(rel)
             if entry is None:
-                # Never-seen: lookback cutoff applies (mirrors _scan_sessions).
+                # Never-seen: mirror _scan_sessions catch-up rules.
+                if self.lookback_hours < 0:
+                    continue  # catch-up disabled -> skip never-seen files
                 if cutoff > 0 and st.st_mtime < cutoff:
                     continue
             elif entry.get("end_offset", 0) == st.st_size:
@@ -1042,9 +1049,15 @@ class SessionHandler(FileSystemEventHandler):
             if attempt is not None and attempt[0] == st.st_size \
                     and attempt[1] >= MAX_RECONCILE_RETRIES:
                 continue
-            candidates.append(jsonl_file)
+            candidates.append((st.st_mtime, jsonl_file))
+        # Most-recently-modified first: freshly dropped transcripts recovered soonest.
+        candidates.sort(key=lambda t: t[0], reverse=True)
         recovered = 0
-        for jsonl_file in candidates[:cap]:
+        budget = self.engine.settings.session_watcher_reconcile_max_seconds
+        start = time.time()
+        for _mtime, jsonl_file in candidates[:cap]:
+            if time.time() - start >= budget:
+                break  # yield scheduler thread; remaining picked up next tick
             rel = str(jsonl_file.relative_to(self.watch_dir))
             try:
                 size = jsonl_file.stat().st_size

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -720,6 +720,7 @@ def _ingest_session(
     min_turns: int,
     idle_threshold: float = 30.0,
     on_defer_active=None,
+    state_lock=None,
 ) -> bool:
     """Ingest a single JSONL session transcript if changed. Returns True if ingested."""
     if _is_subagent_transcript(path):
@@ -825,7 +826,7 @@ def _ingest_session(
     prev_node_ids = existing.get("node_ids", []) if carry else []
     prev_turns = existing.get("user_turns", 0) if carry else 0
 
-    state[rel] = {
+    entry = {
         "hash": h,
         "end_offset": payload_offset,
         "last_ingested": datetime.now(timezone.utc).isoformat(),
@@ -836,7 +837,13 @@ def _ingest_session(
         "node_ids": prev_node_ids + new_node_ids,
         "signals_recorded": signals_recorded,
     }
-    _save_state(watch_dir, state)
+    if state_lock is not None:
+        with state_lock:
+            state[rel] = entry
+            _save_state(watch_dir, state)
+    else:
+        state[rel] = entry
+        _save_state(watch_dir, state)
 
     logger.info(
         "Session watcher ingested %s (%d new turns, %d memories extracted, %d signals recorded)",
@@ -900,17 +907,20 @@ class SessionHandler(FileSystemEventHandler):
         debounce_seconds: float,
         min_turns: int,
         idle_threshold: float = 30.0,
+        lookback_hours: int = 72,
     ) -> None:
         self.engine = engine
         self.watch_dir = watch_dir
         self.debounce_seconds = debounce_seconds
         self.min_turns = min_turns
         self.idle_threshold = idle_threshold
+        self.lookback_hours = lookback_hours
         self._state = _load_state(watch_dir)
         self._timers: dict[str, Timer] = {}
         self._ingesting: set[str] = set()
         self._pending: set[str] = set()
         self._lock = Lock()
+        self._state_lock = Lock()
 
     def _schedule_ingest(self, path: Path) -> None:
         """Schedule a debounced ingestion for the given file."""
@@ -938,23 +948,27 @@ class SessionHandler(FileSystemEventHandler):
             self._timers[key] = timer
             timer.start()
 
-    def _do_ingest(self, path: Path) -> None:
-        """Actually ingest the session (called after debounce or retry)."""
+    def _do_ingest(self, path: Path) -> bool:
+        """Ingest the session (after debounce, retry, or reconcile). Returns True if ingested.
+
+        The heavy work (parse/LLM/DB) runs lock-free; only the state read-modify-write
+        serializes via ``self._state_lock`` (passed into ``_ingest_session``), so a backlog
+        reconcile never blocks the live fast path.
+        """
         key = str(path)
         with self._lock:
             self._timers.pop(key, None)
             if key in self._ingesting:
-                # An ingest for this path is already running and has already parsed
-                # its slice; mark the path so the new content is re-ingested once it
-                # finishes, instead of dropping this event.
                 self._pending.add(key)
-                return
+                return False
             self._ingesting.add(key)
+        ingested = False
         try:
-            _ingest_session(
+            ingested = _ingest_session(
                 self.engine, path, self._state, self.watch_dir, self.min_turns,
                 idle_threshold=self.idle_threshold,
                 on_defer_active=lambda: self._schedule_retry(path),
+                state_lock=self._state_lock,
             )
         finally:
             with self._lock:
@@ -962,7 +976,8 @@ class SessionHandler(FileSystemEventHandler):
                 rerun = key in self._pending
                 self._pending.discard(key)
         if rerun:
-            self._schedule_ingest(path)  # re-process content that arrived mid-ingest
+            self._schedule_ingest(path)
+        return bool(ingested)
 
     def on_created(self, event):
         if not event.is_directory and event.src_path.endswith(".jsonl"):

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock, Timer
@@ -1058,11 +1059,19 @@ class SessionHandler(FileSystemEventHandler):
                 self._schedule_ingest(path)
 
 
-def start_session_watcher(engine: MemoryEngine) -> list[Observer]:
+@dataclass
+class SessionWatch:
+    """A live watcher: its directory, handler, and (swappable) Observer."""
+    watch_dir: Path
+    handler: SessionHandler
+    observer: Observer
+
+
+def start_session_watcher(engine: MemoryEngine) -> list[SessionWatch]:
     """Start the session watcher for agent transcript files.
 
     Performs an initial catch-up scan, then starts a real-time watcher.
-    Returns list of Observer instances for shutdown.
+    Returns list of SessionWatch for shutdown and reconcile.
     """
     s = engine.settings
     if not s.session_watcher_enabled:
@@ -1073,34 +1082,62 @@ def start_session_watcher(engine: MemoryEngine) -> list[Observer]:
         logger.warning("Session watcher dir does not exist: %s", _expand_watch_dir(s.session_watcher_dir))
         return []
 
-    observers: list[Observer] = []
+    watches: list[SessionWatch] = []
     for watch_dir in watch_dirs:
-        # Catch-up scan
         ingested = _scan_sessions(
             engine, watch_dir, s.session_watcher_min_turns, s.session_watcher_lookback_hours,
         )
         if ingested:
             logger.info("Session watcher catch-up: ingested %d sessions from %s", ingested, watch_dir)
 
-        # Start real-time watcher
         handler = SessionHandler(
             engine, watch_dir, s.session_watcher_debounce_seconds, s.session_watcher_min_turns,
-            s.session_watcher_idle_threshold,
+            s.session_watcher_idle_threshold, s.session_watcher_lookback_hours,
         )
         observer = Observer()
         observer.schedule(handler, str(watch_dir), recursive=True)
         observer.start()
-        observers.append(observer)
+        watches.append(SessionWatch(watch_dir=watch_dir, handler=handler, observer=observer))
         logger.info("Session watcher started on %s", watch_dir)
 
-    return observers
+    return watches
 
 
-def stop_session_watcher(observers: list[Observer]) -> None:
+def stop_session_watcher(watches: list[SessionWatch]) -> None:
     """Stop and join all session watcher observers."""
-    for observer in observers:
-        observer.stop()
-    for observer in observers:
-        observer.join(timeout=5)
-    if observers:
+    for w in watches:
+        w.observer.stop()
+    for w in watches:
+        w.observer.join(timeout=5)
+    if watches:
         logger.info("Session watcher stopped")
+
+
+def run_session_reconcile(watches: list[SessionWatch]) -> int:
+    """Periodic safety net: recreate any dead Observer, then reconcile each watcher.
+
+    Recreating the Observer keeps the fast path alive going forward; the reconcile scan recovers
+    anything the live path dropped (Observer death OR FSEvents coalescing). Returns total recovered.
+    """
+    total = 0
+    for w in watches:
+        try:
+            alive = w.observer.is_alive()
+        except Exception:
+            alive = False
+        if not alive:
+            logger.warning("Session watcher Observer not alive for %s; recreating", w.watch_dir)
+            try:
+                w.observer.stop()
+                w.observer.join(timeout=5)
+            except Exception:
+                pass
+            try:
+                observer = Observer()
+                observer.schedule(w.handler, str(w.watch_dir), recursive=True)
+                observer.start()
+                w.observer = observer
+            except Exception as e:
+                logger.warning("Failed to recreate Observer for %s: %s", w.watch_dir, e)
+        total += w.handler.reconcile()
+    return total

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -1010,21 +1010,20 @@ class SessionHandler(FileSystemEventHandler):
                 # Never-seen: lookback cutoff applies (mirrors _scan_sessions).
                 if cutoff > 0 and st.st_mtime < cutoff:
                     continue
-                candidates.append(jsonl_file)
-            elif entry.get("end_offset", 0) != st.st_size:
-                # Seen but the cursor is not at EOF: pending/failed tail (or a rewrite).
-                # Bounded retry: a tail whose safe boundary never advances (abandoned
-                # in-flight response) is retried a few times then parked until its size
-                # changes, so it is not re-hashed every tick forever (which would starve
-                # genuinely-new dropped sessions from the per-tick budget). A transient
-                # ingest failure still retries, because the size is unchanged and the
-                # attempt count has not yet hit the cap.
-                attempt = self._reconcile_attempts.get(rel)
-                if attempt is not None and attempt[0] == st.st_size \
-                        and attempt[1] >= MAX_RECONCILE_RETRIES:
-                    continue
-                candidates.append(jsonl_file)
-            # else: fully consumed -> skip cheaply (no hash, no _do_ingest).
+            elif entry.get("end_offset", 0) == st.st_size:
+                # Fully consumed -> skip cheaply (no hash, no _do_ingest).
+                continue
+            # else: seen with cursor not at EOF -> pending/failed tail (or a rewrite).
+            # Bounded retry applies to BOTH never-seen and seen-pending files: a file attempted
+            # MAX_RECONCILE_RETRIES times at the same size without progress (a corrupt transcript,
+            # a session that died before any turn closed, or a persistent ingest failure) is parked
+            # until its size changes, so a cluster of stuck files cannot consume the per-tick budget
+            # every tick and starve a genuinely-ingestible transcript.
+            attempt = self._reconcile_attempts.get(rel)
+            if attempt is not None and attempt[0] == st.st_size \
+                    and attempt[1] >= MAX_RECONCILE_RETRIES:
+                continue
+            candidates.append(jsonl_file)
         recovered = 0
         for jsonl_file in candidates[:cap]:
             rel = str(jsonl_file.relative_to(self.watch_dir))

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -21,6 +21,7 @@ from ormah.transcript.parser import TranscriptResult, TranscriptTurn, parse_tran
 logger = logging.getLogger(__name__)
 
 _STATE_FILENAME = ".session_watcher_state"
+MAX_RECONCILE_RETRIES = 3
 _HEURISTIC_SOURCE = "transcript_watcher_heuristic"
 _LLM_JUDGE_SOURCE = "transcript_watcher_llm_judge"
 _HEURISTIC_AFFINITY_SOURCE = "auto_heuristic"
@@ -921,6 +922,7 @@ class SessionHandler(FileSystemEventHandler):
         self._pending: set[str] = set()
         self._lock = Lock()
         self._state_lock = Lock()
+        self._reconcile_attempts: dict[str, tuple[int, int]] = {}  # rel -> (size_at_attempt, no_progress_count)
 
     def _schedule_ingest(self, path: Path) -> None:
         """Schedule a debounced ingestion for the given file."""
@@ -1008,12 +1010,32 @@ class SessionHandler(FileSystemEventHandler):
                 candidates.append(jsonl_file)
             elif entry.get("end_offset", 0) != st.st_size:
                 # Seen but the cursor is not at EOF: pending/failed tail (or a rewrite).
+                # Bounded retry: a tail whose safe boundary never advances (abandoned
+                # in-flight response) is retried a few times then parked until its size
+                # changes, so it is not re-hashed every tick forever (which would starve
+                # genuinely-new dropped sessions from the per-tick budget). A transient
+                # ingest failure still retries, because the size is unchanged and the
+                # attempt count has not yet hit the cap.
+                attempt = self._reconcile_attempts.get(rel)
+                if attempt is not None and attempt[0] == st.st_size \
+                        and attempt[1] >= MAX_RECONCILE_RETRIES:
+                    continue
                 candidates.append(jsonl_file)
             # else: fully consumed -> skip cheaply (no hash, no _do_ingest).
         recovered = 0
         for jsonl_file in candidates[:cap]:
+            rel = str(jsonl_file.relative_to(self.watch_dir))
+            try:
+                size = jsonl_file.stat().st_size
+            except OSError:
+                continue
             if self._do_ingest(jsonl_file):
                 recovered += 1
+                self._reconcile_attempts.pop(rel, None)  # progress -> reset
+            else:
+                prev = self._reconcile_attempts.get(rel)
+                count = prev[1] + 1 if (prev is not None and prev[0] == size) else 1
+                self._reconcile_attempts[rel] = (size, count)
         if recovered:
             logger.info(
                 "Session watcher reconcile recovered %d transcript(s) the live path missed",

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -988,8 +988,10 @@ class SessionHandler(FileSystemEventHandler):
         never-seen (within lookback) or a state cursor not at EOF — then routes up to
         ``session_watcher_reconcile_max_per_tick`` of them through ``self._do_ingest`` (the
         single state owner, so no clobber / no double-ingest). A file with a pending or failed
-        tail (``end_offset != size``) is re-checked every tick until fully consumed, so a
-        transient ingest failure never strands it. Returns transcripts recovered.
+        tail (``end_offset != size``) is retried each tick — bounded to
+        ``MAX_RECONCILE_RETRIES`` attempts per size so an abandoned in-flight tail is not
+        re-hashed forever — so a transient ingest failure never strands it. Returns
+        transcripts recovered.
         """
         cutoff = time.time() - (self.lookback_hours * 3600) if self.lookback_hours > 0 else 0
         cap = self.engine.settings.session_watcher_reconcile_max_per_tick

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -942,7 +942,8 @@ class SessionHandler(FileSystemEventHandler):
         self._pending: set[str] = set()
         self._lock = Lock()
         self._state_lock = Lock()
-        self._reconcile_attempts: dict[str, tuple[int, int]] = {}  # rel -> (size_at_attempt, no_progress_count)
+        self._reconcile_attempts: dict[str, tuple[int, int, int]] = {}  # rel -> (size, mtime_ns, no_progress_count)
+        self._reconcile_transient: dict[str, tuple[int, int, int]] = {}  # rel -> (size, mtime_ns, count)
 
     def _schedule_ingest(self, path: Path) -> None:
         """Schedule a debounced ingestion for the given file."""
@@ -1017,6 +1018,13 @@ class SessionHandler(FileSystemEventHandler):
         recovered soonest. A per-tick wall-clock budget
         (``session_watcher_reconcile_max_seconds``) caps scheduler-thread occupancy: remaining
         candidates are picked up on the next tick.
+
+        The park key for NO_PROGRESS is ``(size, mtime_ns)``: a same-size content rewrite
+        (e.g. a repaired JSONL line) changes the mtime_ns, producing a new token that un-parks
+        the file immediately without waiting for a process restart.  Persistently-TRANSIENT files
+        (external failures that repeat at the same token) are deprioritized — sorted behind
+        fresh candidates — rather than parked, so they keep being retried but cannot monopolize
+        the per-tick cap and starve valid candidates.
         """
         cutoff = time.time() - (self.lookback_hours * 3600) if self.lookback_hours > 0 else 0
         cap = self.engine.settings.session_watcher_reconcile_max_per_tick
@@ -1040,38 +1048,49 @@ class SessionHandler(FileSystemEventHandler):
                 # Fully consumed -> skip cheaply (no hash, no _do_ingest).
                 continue
             # else: seen with cursor not at EOF -> pending/failed tail (or a rewrite).
-            # Bounded retry applies to BOTH never-seen and seen-pending files: a file attempted
-            # MAX_RECONCILE_RETRIES times at the same size without progress (a corrupt transcript,
-            # a session that died before any turn closed, or a persistent ingest failure) is parked
-            # until its size changes, so a cluster of stuck files cannot consume the per-tick budget
-            # every tick and starve a genuinely-ingestible transcript.
-            attempt = self._reconcile_attempts.get(rel)
-            if attempt is not None and attempt[0] == st.st_size \
-                    and attempt[1] >= MAX_RECONCILE_RETRIES:
-                continue
-            candidates.append((st.st_mtime, jsonl_file))
-        # Most-recently-modified first: freshly dropped transcripts recovered soonest.
-        candidates.sort(key=lambda t: t[0], reverse=True)
+            token = (st.st_size, st.st_mtime_ns)
+            # H1: park NO_PROGRESS by (size, mtime_ns) — a same-size content rewrite (new mtime)
+            # changes the token and un-parks the file, so a recoverable tail is never stranded.
+            park = self._reconcile_attempts.get(rel)
+            if park is not None and (park[0], park[1]) == token and park[2] >= MAX_RECONCILE_RETRIES:
+                continue  # parked at this exact content; skip until the content (token) changes
+            # H2: deprioritize (never park) a file that keeps failing TRANSIENT at this token, so a
+            # cluster of deterministically-failing files can't monopolize the per-tick cap and
+            # starve valid candidates. Deprioritized files still get retried — just behind fresh ones.
+            tr = self._reconcile_transient.get(rel)
+            deprioritized = (
+                tr is not None and (tr[0], tr[1]) == token and tr[2] >= MAX_RECONCILE_RETRIES
+            )
+            candidates.append((deprioritized, st.st_mtime, jsonl_file))
+        # Non-deprioritized first, then most-recently-modified first within each group.
+        candidates.sort(key=lambda t: (t[0], -t[1]))
         recovered = 0
         budget = self.engine.settings.session_watcher_reconcile_max_seconds
         start = time.time()
-        for _mtime, jsonl_file in candidates[:cap]:
+        for _dep, _mtime, jsonl_file in candidates[:cap]:
             if time.time() - start >= budget:
                 break  # yield scheduler thread; remaining picked up next tick
             rel = str(jsonl_file.relative_to(self.watch_dir))
             try:
-                size = jsonl_file.stat().st_size
+                st2 = jsonl_file.stat()
             except OSError:
                 continue
+            size, mtime_ns = st2.st_size, st2.st_mtime_ns
             result = self._do_ingest(jsonl_file)
             if result == IngestResult.OK:
                 recovered += 1
                 self._reconcile_attempts.pop(rel, None)
+                self._reconcile_transient.pop(rel, None)
             elif result == IngestResult.NO_PROGRESS:
                 prev = self._reconcile_attempts.get(rel)
-                count = prev[1] + 1 if (prev is not None and prev[0] == size) else 1
-                self._reconcile_attempts[rel] = (size, count)
-            # TRANSIENT: leave _reconcile_attempts untouched -> retried next tick, never parked
+                count = prev[2] + 1 if (prev is not None and (prev[0], prev[1]) == (size, mtime_ns)) else 1
+                self._reconcile_attempts[rel] = (size, mtime_ns, count)
+                self._reconcile_transient.pop(rel, None)
+            else:  # TRANSIENT — never park; count toward deprioritization at this token
+                prev = self._reconcile_transient.get(rel)
+                count = prev[2] + 1 if (prev is not None and (prev[0], prev[1]) == (size, mtime_ns)) else 1
+                self._reconcile_transient[rel] = (size, mtime_ns, count)
+                self._reconcile_attempts.pop(rel, None)
         if recovered:
             logger.info(
                 "Session watcher reconcile recovered %d transcript(s) the live path missed",

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -1130,8 +1130,8 @@ def run_session_reconcile(watches: list[SessionWatch]) -> int:
             try:
                 w.observer.stop()
                 w.observer.join(timeout=5)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Stopping dead Observer for %s failed: %s", w.watch_dir, e)
             try:
                 observer = Observer()
                 observer.schedule(w.handler, str(w.watch_dir), recursive=True)

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -1046,6 +1046,12 @@ class SessionHandler(FileSystemEventHandler):
                     continue
             elif entry.get("end_offset", 0) == st.st_size:
                 # Fully consumed -> skip cheaply (no hash, no _do_ingest).
+                # ponytail: known limitation (council-pr H1') — a same-size rewrite that PRESERVES
+                # mtime_ns (utime / cp --preserve, or an in-place repair restoring the timestamp)
+                # is invisible here and in the park check below. Closing it means hashing every
+                # consumed file each tick, reintroducing the O(n) scan cost flagged earlier; the
+                # Claude/Codex transcript workload is append-only (rewrites grow the file), so this
+                # pattern does not occur in practice. Upgrade path: content-hash token if it ever does.
                 continue
             # else: seen with cursor not at EOF -> pending/failed tail (or a rewrite).
             token = (st.st_size, st.st_mtime_ns)
@@ -1062,8 +1068,10 @@ class SessionHandler(FileSystemEventHandler):
                 tr is not None and (tr[0], tr[1]) == token and tr[2] >= MAX_RECONCILE_RETRIES
             )
             candidates.append((deprioritized, st.st_mtime, jsonl_file))
-        # Non-deprioritized first, then most-recently-modified first within each group.
-        candidates.sort(key=lambda t: (t[0], -t[1]))
+        # Non-deprioritized first (newest-first, so freshly dropped transcripts recover soonest),
+        # then deprioritized (oldest-first FIFO, so a long-failing transient that just became
+        # recoverable is retried before newer deprioritized peers — no intra-group starvation).
+        candidates.sort(key=lambda t: (t[0], t[1] if t[0] else -t[1]))
         recovered = 0
         budget = self.engine.settings.session_watcher_reconcile_max_seconds
         start = time.time()

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -78,6 +78,8 @@ class Settings(BaseSettings):
     session_watcher_min_turns: int = 5
     session_watcher_lookback_hours: int = 72
     session_watcher_idle_threshold: float = 30.0
+    session_watcher_reconcile_interval_minutes: int = 5
+    session_watcher_reconcile_max_per_tick: int = 50
 
     # Tier limits
     core_memory_cap: int = 50
@@ -385,6 +387,24 @@ class Settings(BaseSettings):
     def _session_watcher_debounce_min(cls, v: float) -> float:
         if v < 10.0:
             raise ValueError(f"session_watcher_debounce_seconds must be >= 10.0, got {v}")
+        return v
+
+    @field_validator("session_watcher_reconcile_interval_minutes")
+    @classmethod
+    def _session_watcher_reconcile_min(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(
+                f"session_watcher_reconcile_interval_minutes must be >= 1, got {v}"
+            )
+        return v
+
+    @field_validator("session_watcher_reconcile_max_per_tick")
+    @classmethod
+    def _session_watcher_reconcile_cap_min(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(
+                f"session_watcher_reconcile_max_per_tick must be >= 1, got {v}"
+            )
         return v
 
     @field_validator("decay_interval_hours")

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -80,6 +80,7 @@ class Settings(BaseSettings):
     session_watcher_idle_threshold: float = 30.0
     session_watcher_reconcile_interval_minutes: int = 5
     session_watcher_reconcile_max_per_tick: int = 50
+    session_watcher_reconcile_max_seconds: float = 30.0
 
     # Tier limits
     core_memory_cap: int = 50
@@ -404,6 +405,15 @@ class Settings(BaseSettings):
         if v < 1:
             raise ValueError(
                 f"session_watcher_reconcile_max_per_tick must be >= 1, got {v}"
+            )
+        return v
+
+    @field_validator("session_watcher_reconcile_max_seconds")
+    @classmethod
+    def _session_watcher_reconcile_max_seconds_positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError(
+                f"session_watcher_reconcile_max_seconds must be > 0, got {v}"
             )
         return v
 

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -97,6 +97,14 @@ async def lifespan(app: FastAPI):
 
     yield
 
+    # Stop the reconcile job before stopping the watchers, so a tick landing in the
+    # shutdown window cannot recreate an Observer that nothing then stops (thread/FD leak).
+    if hasattr(app.state, "scheduler"):
+        try:
+            app.state.scheduler.remove_job("session_reconcile")
+        except Exception:
+            pass
+
     # Shutdown — stop session watcher first
     if hasattr(app.state, "session_watcher_observers"):
         stop_session_watcher(app.state.session_watcher_observers)

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -97,8 +97,12 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    # Stop the reconcile job before stopping the watchers, so a tick landing in the
-    # shutdown window cannot recreate an Observer that nothing then stops (thread/FD leak).
+    # Unschedule the reconcile job before stopping the watchers, to shrink the window where
+    # a tick recreates an Observer that nothing then stops. remove_job() only cancels future
+    # triggers, not an already-running tick, so a single in-flight tick can still recreate one
+    # Observer; that leaked daemon thread dies with the process (same tradeoff as the engine
+    # connection below). Fully closing it would require shutting the scheduler down before the
+    # watchers, which the bind-sensitive shutdown order avoids.
     if hasattr(app.state, "scheduler"):
         try:
             app.state.scheduler.remove_job("session_reconcile")

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -84,8 +84,14 @@ async def lifespan(app: FastAPI):
     try:
         from ormah.background.session_watcher import start_session_watcher, stop_session_watcher
 
-        session_observers = start_session_watcher(engine)
-        app.state.session_watcher_observers = session_observers
+        session_watches = start_session_watcher(engine)
+        app.state.session_watcher_observers = session_watches
+        if hasattr(app.state, "scheduler"):
+            from ormah.background.scheduler import register_session_reconcile_job
+            register_session_reconcile_job(
+                app.state.scheduler, app.state.job_tracker, session_watches,
+                engine.settings.session_watcher_reconcile_interval_minutes,
+            )
     except Exception as e:
         logger.warning("Session watcher not started: %s", e)
 

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1606,3 +1606,24 @@ def test_run_session_reconcile_recreates_dead_observer(engine, tmp_path):
     new_obs.start.assert_called_once()
     assert watch.observer is new_obs
     assert total == 0  # empty dir, nothing to recover
+
+
+def test_run_session_reconcile_runs_reconcile_even_when_recreate_fails(engine, tmp_path):
+    """If recreating a dead Observer raises, the reconcile scan still runs (safety-net guarantee)."""
+    from ormah.background.session_watcher import SessionWatch, run_session_reconcile
+
+    watch_dir = tmp_path / "projects"
+    watch_dir.mkdir(parents=True)
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    handler.reconcile = MagicMock(return_value=0)
+
+    dead = MagicMock()
+    dead.is_alive.return_value = False
+    watch = SessionWatch(watch_dir=watch_dir, handler=handler, observer=dead)
+
+    with patch("ormah.background.session_watcher.Observer", side_effect=RuntimeError("boom")):
+        total = run_session_reconcile([watch])
+
+    handler.reconcile.assert_called_once()  # safety net ran despite recreate failure
+    assert total == 0
+    assert watch.observer is dead            # failed recreate leaves the (dead) ref; next tick retries

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ormah.background.session_watcher import (
+    IngestResult,
     SessionHandler,
     _ingest_session,
     _load_state,
@@ -152,7 +153,7 @@ def test_ingest_session_basic(engine, tmp_path):
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
         result = _ingest_session(engine, jsonl, state, watch_dir, min_turns=5)
 
-    assert result is True
+    assert result == IngestResult.OK
     rel = str(jsonl.relative_to(watch_dir))
     assert rel in state
     entry = state[rel]
@@ -179,7 +180,7 @@ def test_subagent_transcript_is_not_ingested(engine, tmp_path):
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
         result = _ingest_session(engine, jsonl, state, watch_dir, min_turns=5)
 
-    assert result is False
+    assert result == IngestResult.NO_PROGRESS
     assert state == {}
 
 
@@ -231,7 +232,7 @@ def test_ingest_codex_session_resolves_rollout_session_id_and_space(engine, tmp_
 
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) == IngestResult.OK
 
     rel = str(jsonl.relative_to(watch_dir))
     entry = state[rel]
@@ -260,7 +261,7 @@ def test_ingest_codex_session_without_whisper_log_does_not_infer_date_space(engi
 
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) == IngestResult.OK
 
     entry = state[str(jsonl.relative_to(watch_dir))]
     assert entry["source"] == "codex"
@@ -677,7 +678,9 @@ def test_min_turns_filter(engine, tmp_path):
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
         result = _ingest_session(engine, jsonl, state, watch_dir, min_turns=5)
 
-    assert result is False
+    # A fresh (active) file below min_turns fires a defer → TRANSIENT (will retry).
+    # An idle file below min_turns with no closed boundary → NO_PROGRESS (frozen content).
+    assert result != IngestResult.OK
     assert str(jsonl.relative_to(watch_dir)) not in state
 
 
@@ -693,8 +696,8 @@ def test_unchanged_session_skipped(engine, tmp_path):
 
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is False
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.NO_PROGRESS
 
 
 # --- Test 5: Scan respects lookback ---
@@ -869,12 +872,12 @@ def test_incremental_only_new_turns(engine, tmp_path):
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
          patch.object(engine, "ingest_conversation", side_effect=capture):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
         first_offset = state[str(jsonl.relative_to(watch_dir))]["end_offset"]
         assert first_offset > 0
 
         _make_jsonl(jsonl, user_turns=12)  # identical first 6 turns + 6 appended
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
 
     assert "User message 0 " not in captured[1]
     assert "User message 6 " in captured[1]
@@ -902,11 +905,11 @@ def test_incremental_defers_small_append(engine, tmp_path):
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
          patch.object(engine, "ingest_conversation", side_effect=counting):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
         saved = dict(state[str(jsonl.relative_to(watch_dir))])
 
-        _make_jsonl(jsonl, user_turns=8)  # only 2 new turns < min_turns
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is False
+        _make_jsonl(jsonl, user_turns=8)  # only 2 new turns < min_turns, file still active → TRANSIENT defer
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.TRANSIENT
 
     assert calls == 1
     assert state[str(jsonl.relative_to(watch_dir))] == saved
@@ -932,10 +935,10 @@ def test_shrink_resets_cursor(engine, tmp_path):
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
          patch.object(engine, "ingest_conversation", side_effect=capture):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
 
         _make_jsonl(jsonl, user_turns=5)  # smaller file → size < stored end_offset
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
 
     assert "User message 0 " in captured[1]
 
@@ -1015,7 +1018,7 @@ def test_inflight_multirecord_response_not_split(engine, tmp_path):
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
          patch.object(engine, "ingest_conversation", side_effect=capture):
         # Every pair is terminal -> all committed; the cursor sits after the last one.
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
         cursor1 = state[rel]["end_offset"]
 
         # New turn: prompt + a FIRST assistant record still in flight (tool_use). The
@@ -1023,13 +1026,13 @@ def test_inflight_multirecord_response_not_split(engine, tmp_path):
         # into the middle of the response.
         _append_user(jsonl, 6)
         _append_assistant(jsonl, 6, stop_reason="tool_use")
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is False
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) != IngestResult.OK
         assert state[rel]["end_offset"] == cursor1
 
         # The response completes with a terminal record: prompt + BOTH assistant records
         # commit together — never split.
         _append_assistant(jsonl, 6, stop_reason="end_turn")
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) == IngestResult.OK
 
     committed = captured[-1]
     assert "User message 6 " in committed
@@ -1061,7 +1064,7 @@ def test_codex_multirecord_turn_committed_whole_via_task_complete(engine, tmp_pa
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
          patch.object(engine, "ingest_conversation", side_effect=capture):
         # Fresh/active: the two task_complete turns commit whole; the in-flight one waits.
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) == IngestResult.OK
 
     committed = captured[-1]
     assert committed.count("Assistant response 0 part ") == 3  # turn 0 not split
@@ -1105,7 +1108,7 @@ def test_legacy_mid_response_cursor_recovered(engine, tmp_path):
 
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
          patch.object(engine, "ingest_conversation", side_effect=capture):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) == IngestResult.OK
 
     committed = captured[-1]
     assert "Prompt with the memory detail" in committed   # prompt recovered
@@ -1117,7 +1120,7 @@ def test_legacy_mid_response_cursor_recovered(engine, tmp_path):
     # second pass on the unchanged file skips without re-recovering.
     assert state[rel]["end_offset"] == jsonl.stat().st_size
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is False
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) == IngestResult.NO_PROGRESS
 
 
 def test_codex_inflight_turn_not_split_on_idle(engine, tmp_path):
@@ -1132,7 +1135,7 @@ def test_codex_inflight_turn_not_split_on_idle(engine, tmp_path):
     _append_codex_turn(jsonl, 0, records=2, complete=True)
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1) == IngestResult.OK
     cursor = state[rel]["end_offset"]
 
     # In-flight multi-record turn, file now idle. The turn has no closure signal, so it is
@@ -1142,7 +1145,7 @@ def test_codex_inflight_turn_not_split_on_idle(engine, tmp_path):
     os.utime(jsonl, (now, now - 120))
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
         assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=1,
-                               idle_threshold=30) is False
+                               idle_threshold=30) == IngestResult.NO_PROGRESS
     assert state[rel]["end_offset"] == cursor
 
 
@@ -1174,7 +1177,7 @@ def test_idle_tail_with_dangling_user_no_duplicate(engine, tmp_path):
          patch.object(engine, "ingest_conversation", side_effect=capture):
         assert _ingest_session(
             engine, jsonl, state, watch_dir, min_turns=5, idle_threshold=30
-        ) is True
+        ) == IngestResult.OK
         assert "User message 8 " not in captured[-1]
 
         _append_assistant(jsonl, 8)
@@ -1182,7 +1185,7 @@ def test_idle_tail_with_dangling_user_no_duplicate(engine, tmp_path):
         os.utime(jsonl, (now2, now2 - 120))
         assert _ingest_session(
             engine, jsonl, state, watch_dir, min_turns=1, idle_threshold=30
-        ) is True
+        ) == IngestResult.OK
 
     joined = "\n".join(captured)
     assert joined.count("User message 8 ") == 1
@@ -1216,7 +1219,7 @@ def test_session_tail_idle_ingested(engine, tmp_path):
          patch.object(engine, "ingest_conversation", side_effect=counting):
         assert _ingest_session(
             engine, jsonl, state, watch_dir, min_turns=5, idle_threshold=30
-        ) is True
+        ) == IngestResult.OK
     assert calls == 1
 
 
@@ -1381,13 +1384,13 @@ def test_shrink_resets_node_ids(engine, tmp_path):
     _make_jsonl(jsonl, user_turns=10)
     state = {}
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
     first_nodes = list(state[rel]["node_ids"])
     assert first_nodes  # first ingest produced at least one node
 
     _make_jsonl(jsonl, user_turns=5)  # smaller file → size < stored end_offset → full re-ingest
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) is True
+        assert _ingest_session(engine, jsonl, state, watch_dir, min_turns=5) == IngestResult.OK
 
     # Full re-ingest (prev_offset reset to 0): stale node_ids must not be concatenated,
     # so the stored provenance carries no duplicates.
@@ -1395,8 +1398,8 @@ def test_shrink_resets_node_ids(engine, tmp_path):
     assert len(nodes) == len(set(nodes))
 
 
-def test_do_ingest_returns_true_when_it_ingests(engine, tmp_path):
-    """_do_ingest reports whether it ingested, so reconcile can count recoveries."""
+def test_do_ingest_returns_ok_when_it_ingests(engine, tmp_path):
+    """_do_ingest reports IngestResult so reconcile can count recoveries and triage failures."""
     watch_dir = tmp_path / "projects"
     project_dir = watch_dir / "-Users-alice-Code-myproject"
     project_dir.mkdir(parents=True)
@@ -1406,8 +1409,8 @@ def test_do_ingest_returns_true_when_it_ingests(engine, tmp_path):
 
     handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
-        assert handler._do_ingest(jsonl) is True
-        assert handler._do_ingest(jsonl) is False  # nothing new the second time
+        assert handler._do_ingest(jsonl) == IngestResult.OK
+        assert handler._do_ingest(jsonl) == IngestResult.NO_PROGRESS  # nothing new the second time
 
 
 def test_reconcile_ingests_file_the_live_path_missed(engine, tmp_path):
@@ -1504,7 +1507,7 @@ def test_reconcile_retries_seen_file_when_first_do_ingest_fails(engine, tmp_path
     def flaky(*a, **k):
         calls["n"] += 1
         if calls["n"] == 1:
-            return False                      # transient failure on the first reconcile
+            return IngestResult.TRANSIENT     # transient failure on the first reconcile
         return real(*a, **k)
 
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
@@ -1575,7 +1578,7 @@ def test_reconcile_bounds_retries_for_abandoned_inflight_tail(engine, tmp_path):
 
     def noop(path):
         calls["n"] += 1
-        return False  # never makes progress (size + safe boundary frozen)
+        return IngestResult.NO_PROGRESS  # never makes progress (size + safe boundary frozen)
 
     handler._do_ingest = noop
     for _ in range(8):
@@ -1656,3 +1659,35 @@ def test_reconcile_does_not_starve_valid_file_behind_stuck_never_seen_files(engi
                 break
 
     assert rel_valid in handler._state                # reached, not starved
+
+
+def test_reconcile_never_parks_transient_failures(engine, tmp_path):
+    """A TRANSIENT _do_ingest result must never increment _reconcile_attempts — the file
+    is retried every tick indefinitely, never parked (unlike NO_PROGRESS which parks after
+    MAX_RECONCILE_RETRIES attempts at the same file size)."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    rel = str(jsonl.relative_to(watch_dir))
+    # Seed state: seen file with a pending tail (cursor behind EOF).
+    handler._state[rel] = {"hash": "stale", "end_offset": 0, "node_ids": [], "user_turns": 0}
+
+    ingest_calls = {"n": 0}
+
+    def always_transient(path):
+        ingest_calls["n"] += 1
+        return IngestResult.TRANSIENT
+
+    handler._do_ingest = always_transient
+    for _ in range(6):
+        handler.reconcile()
+
+    # Must have been attempted every single tick — never parked.
+    assert ingest_calls["n"] == 6
+    # And _reconcile_attempts must not have accumulated a count for this file.
+    assert handler._reconcile_attempts.get(rel) is None

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -770,13 +770,13 @@ def test_lifecycle_start_stop(engine, tmp_path):
     observers = start_session_watcher(engine)
     try:
         assert len(observers) == 1
-        assert observers[0].is_alive()
+        assert observers[0].observer.is_alive()
     finally:
         stop_session_watcher(observers)
 
     # Give observer thread a moment to stop
     time.sleep(0.1)
-    assert not observers[0].is_alive()
+    assert not observers[0].observer.is_alive()
 
 
 def test_lifecycle_includes_codex_sessions_when_using_default_agent_dir(
@@ -799,7 +799,7 @@ def test_lifecycle_includes_codex_sessions_when_using_default_agent_dir(
     observers = start_session_watcher(engine)
     try:
         assert len(observers) == 2
-        assert all(observer.is_alive() for observer in observers)
+        assert all(w.observer.is_alive() for w in observers)
     finally:
         stop_session_watcher(observers)
 
@@ -1582,3 +1582,27 @@ def test_reconcile_bounds_retries_for_abandoned_inflight_tail(engine, tmp_path):
         handler.reconcile()
 
     assert calls["n"] == MAX_RECONCILE_RETRIES  # bounded, not 8
+
+
+def test_run_session_reconcile_recreates_dead_observer(engine, tmp_path):
+    """A dead Observer is stopped/joined and recreated; reconcile still runs."""
+    from ormah.background.session_watcher import SessionWatch, run_session_reconcile
+
+    watch_dir = tmp_path / "projects"
+    watch_dir.mkdir(parents=True)
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+
+    dead = MagicMock()
+    dead.is_alive.return_value = False
+    watch = SessionWatch(watch_dir=watch_dir, handler=handler, observer=dead)
+
+    with patch("ormah.background.session_watcher.Observer") as MockObserver:
+        new_obs = MockObserver.return_value
+        total = run_session_reconcile([watch])
+
+    dead.stop.assert_called_once()        # old observer cleaned up before recreate
+    dead.join.assert_called_once()
+    new_obs.schedule.assert_called_once()
+    new_obs.start.assert_called_once()
+    assert watch.observer is new_obs
+    assert total == 0  # empty dir, nothing to recover

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1693,6 +1693,124 @@ def test_reconcile_never_parks_transient_failures(engine, tmp_path):
     assert handler._reconcile_attempts.get(rel) is None
 
 
+# --- Council-PR H1/H2: change-token park key + TRANSIENT deprioritization ---
+
+def test_reconcile_unparks_after_same_size_content_change(engine, tmp_path):
+    """H1: a same-byte-size content rewrite (new mtime) un-parks a NO_PROGRESS file.
+
+    If a parked file's content is repaired but byte length is unchanged, the mtime_ns
+    changes. The new (size, mtime_ns) token differs from the parked token, so the file
+    is un-parked and _do_ingest is called again on the next tick.
+    """
+    from ormah.background.session_watcher import MAX_RECONCILE_RETRIES
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    rel = str(jsonl.relative_to(watch_dir))
+    # Seed state: seen file with a pending tail (cursor behind EOF).
+    handler._state[rel] = {"hash": "stale", "end_offset": 0, "node_ids": [], "user_turns": 0}
+
+    ingest_calls = {"n": 0}
+
+    def always_no_progress(path):
+        ingest_calls["n"] += 1
+        return IngestResult.NO_PROGRESS
+
+    handler._do_ingest = always_no_progress
+
+    # Drive reconcile MAX_RECONCILE_RETRIES times to park the file.
+    for _ in range(MAX_RECONCILE_RETRIES):
+        handler.reconcile()
+    assert ingest_calls["n"] == MAX_RECONCILE_RETRIES
+
+    # File is now parked: further reconcile calls must NOT call _do_ingest.
+    handler.reconcile()
+    assert ingest_calls["n"] == MAX_RECONCILE_RETRIES  # count did not increase → parked
+
+    # Rewrite with identical byte size but a bumped mtime (content changed, size unchanged).
+    original_size = jsonl.stat().st_size
+    content = jsonl.read_bytes()
+    jsonl.write_bytes(content)  # same bytes = same size; write bumps mtime_ns
+    assert jsonl.stat().st_size == original_size  # size unchanged — regression guard
+
+    # Now reconcile must call _do_ingest again (token changed → un-parked).
+    handler.reconcile()
+    assert ingest_calls["n"] == MAX_RECONCILE_RETRIES + 1
+
+
+def test_reconcile_deprioritizes_persistent_transient_behind_valid(engine, tmp_path):
+    """H2: files that keep returning TRANSIENT are deprioritized, not starved-out, so an
+    older valid file is still ingested within a bounded number of ticks.
+
+    Setup: cap=2 newest files → always TRANSIENT; 1 older file → returns OK.
+    After TRANSIENT files cross MAX_RECONCILE_RETRIES ticks at their token, they sort
+    behind the valid file and the valid file is ingested.
+    """
+    from ormah.background.session_watcher import MAX_RECONCILE_RETRIES
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+
+    cap = 2
+    engine.settings.session_watcher_reconcile_max_per_tick = cap
+
+    now = time.time()
+
+    # Two newest TRANSIENT files.
+    transient_files = []
+    for i in range(cap):
+        p = project_dir / f"new-{i:03d}.jsonl"
+        _make_jsonl(p, user_turns=6)
+        mtime = now - i  # newest first (decreasing by 1s)
+        os.utime(p, (mtime, mtime))
+        transient_files.append(p)
+
+    # One older valid file.
+    valid = project_dir / "old-valid.jsonl"
+    _make_jsonl(valid, user_turns=6)
+    old_mtime = now - 1000  # clearly older
+    os.utime(valid, (old_mtime, old_mtime))
+    rel_valid = str(valid.relative_to(watch_dir))
+
+    # Seed all as seen with a pending tail.
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    for p in transient_files + [valid]:
+        rel = str(p.relative_to(watch_dir))
+        handler._state[rel] = {"hash": "x", "end_offset": 0, "node_ids": [], "user_turns": 0}
+
+    transient_paths = {str(p) for p in transient_files}
+    valid_path = str(valid)
+    ingested_paths: list[str] = []
+
+    def selective_ingest(path):
+        ingested_paths.append(str(path))
+        if str(path) in transient_paths:
+            return IngestResult.TRANSIENT
+        return IngestResult.OK
+
+    handler._do_ingest = selective_ingest
+
+    # Run enough ticks for TRANSIENT files to cross MAX_RECONCILE_RETRIES at their token
+    # and become deprioritized, then for the valid file to be picked up.
+    max_ticks = MAX_RECONCILE_RETRIES + 3
+    for _ in range(max_ticks):
+        handler.reconcile()
+        if valid_path in ingested_paths:
+            break
+
+    assert valid_path in ingested_paths, (
+        f"Valid file was never ingested after {max_ticks} ticks — it was starved. "
+        f"ingested_paths={ingested_paths}"
+    )
+
+
 # --- Council-PR F2/F3: per-tick time budget + lookback<0 never-seen guard ---
 
 def test_reconcile_respects_per_tick_time_budget(engine, tmp_path):

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1810,6 +1810,51 @@ def test_reconcile_deprioritizes_persistent_transient_behind_valid(engine, tmp_p
     )
 
 
+def test_reconcile_deprioritized_transients_retried_oldest_first(engine, tmp_path):
+    """H2': among already-deprioritized TRANSIENT files, the OLDEST is retried first (FIFO).
+
+    Non-deprioritized candidates sort newest-first (fresh drops recover soonest), but within the
+    deprioritized group oldest-first avoids a long-failing transient that just became recoverable
+    being starved behind newer deprioritized peers.
+    """
+    from ormah.background.session_watcher import MAX_RECONCILE_RETRIES
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    now = time.time()
+
+    older = project_dir / "older.jsonl"
+    newer = project_dir / "newer.jsonl"
+    _make_jsonl(older, user_turns=6)
+    _make_jsonl(newer, user_turns=6)
+    os.utime(older, (now - 1000, now - 1000))
+    os.utime(newer, (now - 1, now - 1))
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    handler.engine.settings.session_watcher_reconcile_max_per_tick = 1  # one slot per tick
+
+    # Seed both as seen-pending AND already deprioritized at their current token.
+    for p in (older, newer):
+        rel = str(p.relative_to(watch_dir))
+        st = p.stat()
+        handler._state[rel] = {"hash": "x", "end_offset": 0, "node_ids": [], "user_turns": 0}
+        handler._reconcile_transient[rel] = (st.st_size, st.st_mtime_ns, MAX_RECONCILE_RETRIES)
+
+    calls: list[str] = []
+
+    def record_ingest(path):
+        calls.append(str(path))
+        return IngestResult.TRANSIENT
+
+    handler._do_ingest = record_ingest
+    handler.reconcile()  # cap=1 -> only the first-sorted deprioritized candidate runs
+
+    assert calls == [str(older)], (
+        f"Oldest deprioritized file should be retried first (FIFO), got {calls}"
+    )
+
+
 # --- Council-PR F2/F3: per-tick time budget + lookback<0 never-seen guard ---
 
 def test_reconcile_respects_per_tick_time_budget(engine, tmp_path):

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1393,3 +1393,18 @@ def test_shrink_resets_node_ids(engine, tmp_path):
     # so the stored provenance carries no duplicates.
     nodes = state[rel]["node_ids"]
     assert len(nodes) == len(set(nodes))
+
+
+def test_do_ingest_returns_true_when_it_ingests(engine, tmp_path):
+    """_do_ingest reports whether it ingested, so reconcile can count recoveries."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        assert handler._do_ingest(jsonl) is True
+        assert handler._do_ingest(jsonl) is False  # nothing new the second time

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1691,3 +1691,75 @@ def test_reconcile_never_parks_transient_failures(engine, tmp_path):
     assert ingest_calls["n"] == 6
     # And _reconcile_attempts must not have accumulated a count for this file.
     assert handler._reconcile_attempts.get(rel) is None
+
+
+# --- Council-PR F2/F3: per-tick time budget + lookback<0 never-seen guard ---
+
+def test_reconcile_respects_per_tick_time_budget(engine, tmp_path):
+    """The per-tick wall-clock budget causes an early break, so not all candidates are processed
+    in one reconcile() call even when count < max_per_tick."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+
+    # Three seen files with a pending tail (end_offset=0, size>0) — all are reconcile candidates.
+    files = []
+    for i in range(3):
+        p = project_dir / f"session-{i:02d}.jsonl"
+        _make_jsonl(p, user_turns=6)
+        _mark_idle(p)
+        files.append(p)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    handler.engine.settings.session_watcher_reconcile_max_seconds = 30.0
+
+    # Seed all files as seen-but-pending (cursor at 0, size > 0).
+    for p in files:
+        rel = str(p.relative_to(watch_dir))
+        handler._state[rel] = {"hash": "stale", "end_offset": 0, "node_ids": [], "user_turns": 0}
+
+    ingest_calls = []
+
+    def counting_ingest(path):
+        ingest_calls.append(path)
+        return IngestResult.OK
+
+    handler._do_ingest = counting_ingest
+
+    # time.time() calls inside reconcile(): cutoff calc, start=, loop check×N.
+    # Sequence: 0.0 (cutoff), 0.0 (start), 0.0 (loop check 1 → no break), 9999.0 (loop check 2 → break).
+    time_seq = iter([0.0, 0.0, 0.0, 9999.0])
+    with patch("ormah.background.session_watcher.time.time", side_effect=lambda: next(time_seq)):
+        handler.reconcile()
+
+    # Budget broke after 1 — fewer than all 3 candidates were processed.
+    assert len(ingest_calls) == 1
+
+
+def test_reconcile_skips_never_seen_when_lookback_negative(engine, tmp_path):
+    """When lookback_hours < 0 (catch-up disabled), never-seen files must be skipped in
+    reconcile() — mirroring the _scan_sessions rule."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    # lookback_hours=-1 means no catch-up: never-seen files must be skipped.
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, lookback_hours=-1)
+    rel = str(jsonl.relative_to(watch_dir))
+    assert rel not in handler._state  # never seen
+
+    ingest_calls = []
+
+    def counting_ingest(path):
+        ingest_calls.append(path)
+        return IngestResult.OK
+
+    handler._do_ingest = counting_ingest
+    recovered = handler.reconcile()
+
+    assert recovered == 0
+    assert ingest_calls == []
+    assert rel not in handler._state

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1552,3 +1552,33 @@ def test_reconcile_while_live_ingesting_defers_then_retries(engine, tmp_path):
     handler._pending.discard(str(jsonl))
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
         assert handler.reconcile() == 1               # not poisoned -> retried and recovered
+
+
+def test_reconcile_bounds_retries_for_abandoned_inflight_tail(engine, tmp_path):
+    """A seen tail that never converges (always no-op) is retried a bounded number of
+    times, not re-attempted (re-hashed) every tick forever."""
+    from ormah.background.session_watcher import MAX_RECONCILE_RETRIES
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    rel = str(jsonl.relative_to(watch_dir))
+    # Seen file stuck below EOF that never makes progress (abandoned in-flight tail).
+    handler._state[rel] = {"hash": "x", "end_offset": 1, "node_ids": [], "user_turns": 0}
+
+    calls = {"n": 0}
+
+    def noop(path):
+        calls["n"] += 1
+        return False  # never makes progress (size + safe boundary frozen)
+
+    handler._do_ingest = noop
+    for _ in range(8):
+        handler.reconcile()
+
+    assert calls["n"] == MAX_RECONCILE_RETRIES  # bounded, not 8

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1408,3 +1408,147 @@ def test_do_ingest_returns_true_when_it_ingests(engine, tmp_path):
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
         assert handler._do_ingest(jsonl) is True
         assert handler._do_ingest(jsonl) is False  # nothing new the second time
+
+
+def test_reconcile_ingests_file_the_live_path_missed(engine, tmp_path):
+    """A changed, idle transcript whose fsevent never reached the handler is recovered."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    rel = str(jsonl.relative_to(watch_dir))
+    assert rel not in handler._state  # simulate the dropped event: handler never saw it
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        recovered = handler.reconcile()
+
+    assert recovered == 1
+    assert rel in handler._state
+    assert handler._state[rel]["user_turns"] == 6
+
+
+def test_reconcile_skips_fully_consumed_file_on_second_pass(engine, tmp_path):
+    """A second reconcile does not re-ingest a file already consumed to EOF (cheap skip)."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        assert handler.reconcile() == 1
+        assert handler.reconcile() == 0
+
+
+def test_reconcile_does_not_reingest_what_live_path_already_took(engine, tmp_path):
+    """reconcile shares handler state, so a file ingested live is not re-ingested."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        handler._do_ingest(jsonl)                      # live path ingests it
+        rel = str(jsonl.relative_to(watch_dir))
+        node_count = len(handler._state[rel]["node_ids"])
+        recovered = handler.reconcile()
+
+    assert recovered == 0
+    assert len(handler._state[rel]["node_ids"]) == node_count
+
+
+def test_reconcile_logs_recovery_heartbeat(engine, tmp_path, caplog):
+    """reconcile emits the functional heartbeat when it recovers >0 transcripts."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        with caplog.at_level("INFO", logger="ormah.background.session_watcher"):
+            handler.reconcile()
+    assert any("reconcile recovered" in r.message for r in caplog.records)
+
+
+# --- Adversarial regressions for the two HIGH council findings ---
+
+def test_reconcile_retries_seen_file_when_first_do_ingest_fails(engine, tmp_path):
+    """A transient ingest failure must NOT strand a seen file: the next tick retries it."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    # Seed state as a seen file with a pending tail (cursor behind EOF).
+    rel = str(jsonl.relative_to(watch_dir))
+    handler._state[rel] = {"hash": "stale", "end_offset": 0, "node_ids": [], "user_turns": 0}
+
+    calls = {"n": 0}
+    real = _ingest_session
+
+    def flaky(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return False                      # transient failure on the first reconcile
+        return real(*a, **k)
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE), \
+            patch("ormah.background.session_watcher._ingest_session", side_effect=flaky):
+        assert handler.reconcile() == 0       # first tick: ingest "fails"
+        assert handler.reconcile() == 1       # second tick retries (not skipped) and recovers
+
+
+def test_reconcile_recovers_partial_tail_without_mtime_change(engine, tmp_path):
+    """A grown tail with an UNCHANGED mtime is still recovered (cursor != size, not mtime)."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        assert handler.reconcile() == 1               # consumes the first 6 turns
+        old_mtime = jsonl.stat().st_mtime
+        _make_jsonl(jsonl, user_turns=12)             # append 6 more (size grows)
+        os.utime(jsonl, (old_mtime, old_mtime))       # mtime unchanged on purpose
+        recovered = handler.reconcile()
+
+    assert recovered == 1                             # picked up via end_offset != size
+
+
+def test_reconcile_while_live_ingesting_defers_then_retries(engine, tmp_path):
+    """If the live path owns the path mid-ingest, reconcile defers, then retries next tick."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    _make_jsonl(jsonl, user_turns=6)
+    _mark_idle(jsonl)
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    handler._ingesting.add(str(jsonl))                # simulate live path mid-ingest
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        assert handler.reconcile() == 0               # deferred: live path owns it
+
+    handler._ingesting.discard(str(jsonl))            # live path finished without ingesting
+    handler._pending.discard(str(jsonl))
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        assert handler.reconcile() == 1               # not poisoned -> retried and recovered

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1626,4 +1626,33 @@ def test_run_session_reconcile_runs_reconcile_even_when_recreate_fails(engine, t
 
     handler.reconcile.assert_called_once()  # safety net ran despite recreate failure
     assert total == 0
-    assert watch.observer is dead            # failed recreate leaves the (dead) ref; next tick retries
+
+
+def test_reconcile_does_not_starve_valid_file_behind_stuck_never_seen_files(engine, tmp_path):
+    """>cap never-seen files that never ingest must not starve a later valid transcript:
+    they get parked after MAX_RECONCILE_RETRIES, freeing the per-tick budget for the valid one."""
+    from ormah.background.session_watcher import MAX_RECONCILE_RETRIES
+
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+
+    cap = engine.settings.session_watcher_reconcile_max_per_tick
+    for i in range(cap):                              # sort BEFORE 'zz-valid' below
+        p = project_dir / f"00stuck-{i:03d}.jsonl"
+        p.write_text("not a valid transcript line\n")  # ingests nothing -> stays never-seen
+        _mark_idle(p)
+
+    valid = project_dir / "zz-valid.jsonl"            # sorts AFTER all stuck files
+    _make_jsonl(valid, user_turns=6)
+    _mark_idle(valid)
+    rel_valid = str(valid.relative_to(watch_dir))
+
+    handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
+        for _ in range(MAX_RECONCILE_RETRIES + 2):    # let the stuck files exhaust their budget
+            handler.reconcile()
+            if rel_valid in handler._state:
+                break
+
+    assert rel_valid in handler._state                # reached, not starved

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -678,9 +678,9 @@ def test_min_turns_filter(engine, tmp_path):
     with patch(_LLM_PATCH, return_value=_LLM_RESPONSE):
         result = _ingest_session(engine, jsonl, state, watch_dir, min_turns=5)
 
-    # A fresh (active) file below min_turns fires a defer → TRANSIENT (will retry).
-    # An idle file below min_turns with no closed boundary → NO_PROGRESS (frozen content).
-    assert result != IngestResult.OK
+    # A fresh (active, not idle) file below min_turns hits the short-tail branch and
+    # defers → TRANSIENT (retry until it grows past min_turns or the session idles).
+    assert result == IngestResult.TRANSIENT
     assert str(jsonl.relative_to(watch_dir)) not in state
 
 
@@ -1726,10 +1726,13 @@ def test_reconcile_respects_per_tick_time_budget(engine, tmp_path):
 
     handler._do_ingest = counting_ingest
 
-    # time.time() calls inside reconcile(): cutoff calc, start=, loop check×N.
-    # Sequence: 0.0 (cutoff), 0.0 (start), 0.0 (loop check 1 → no break), 9999.0 (loop check 2 → break).
-    time_seq = iter([0.0, 0.0, 0.0, 9999.0])
-    with patch("ormah.background.session_watcher.time.time", side_effect=lambda: next(time_seq)):
+    # Tie the clock to real progress instead of an exact call count: time stays at 0.0
+    # until the first file is ingested, then jumps past the 30s budget so the next
+    # loop-check breaks. Robust to any extra time.time() calls reconcile() may add.
+    def fake_time():
+        return 9999.0 if ingest_calls else 0.0
+
+    with patch("ormah.background.session_watcher.time.time", side_effect=fake_time):
         handler.reconcile()
 
     # Budget broke after 1 — fewer than all 3 candidates were processed.

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1777,7 +1777,6 @@ def test_reconcile_deprioritizes_persistent_transient_behind_valid(engine, tmp_p
     _make_jsonl(valid, user_turns=6)
     old_mtime = now - 1000  # clearly older
     os.utime(valid, (old_mtime, old_mtime))
-    rel_valid = str(valid.relative_to(watch_dir))
 
     # Seed all as seen with a pending tail.
     handler = SessionHandler(engine, watch_dir, 60.0, 5, 30.0, 9999)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -284,3 +284,23 @@ def test_consolidation_max_nodes_zero_rejected():
 def test_consolidation_inverted_bounds_rejected():
     with pytest.raises(ValidationError, match="consolidation_max_cluster_nodes"):
         _settings(consolidation_min_cluster_size=3, consolidation_max_cluster_nodes=2)
+
+
+# --- Session watcher reconcile (#34) ---
+
+def test_reconcile_interval_default_is_five():
+    assert _settings().session_watcher_reconcile_interval_minutes == 5
+
+
+def test_reconcile_interval_must_be_positive():
+    with pytest.raises(ValidationError):
+        _settings(session_watcher_reconcile_interval_minutes=0)
+
+
+def test_reconcile_cap_default_is_fifty():
+    assert _settings().session_watcher_reconcile_max_per_tick == 50
+
+
+def test_reconcile_cap_must_be_positive():
+    with pytest.raises(ValidationError):
+        _settings(session_watcher_reconcile_max_per_tick=0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -304,3 +304,19 @@ def test_reconcile_cap_default_is_fifty():
 def test_reconcile_cap_must_be_positive():
     with pytest.raises(ValidationError):
         _settings(session_watcher_reconcile_max_per_tick=0)
+
+
+# --- Session watcher per-tick time budget (council-pr F2) ---
+
+def test_reconcile_max_seconds_default():
+    assert _settings().session_watcher_reconcile_max_seconds == 30.0
+
+
+def test_reconcile_max_seconds_rejects_zero():
+    with pytest.raises(ValidationError, match="session_watcher_reconcile_max_seconds must be > 0"):
+        _settings(session_watcher_reconcile_max_seconds=0)
+
+
+def test_reconcile_max_seconds_rejects_negative():
+    with pytest.raises(ValidationError, match="session_watcher_reconcile_max_seconds must be > 0"):
+        _settings(session_watcher_reconcile_max_seconds=-1.0)


### PR DESCRIPTION
## Summary

Fixes #59 — the session-watcher's live FSEvents path intermittently drops a fraction of transcripts (whole sessions + held-back tails), recoverable only by a restart's catch-up, and anything past the 72h lookback is lost permanently.

Adds a mechanism-agnostic safety net on top of the existing live path:

- **`SessionHandler.reconcile()`** — a stat-only disk-truth scan that re-ingests transcripts the live path missed (candidate = never-seen within lookback, or a state cursor not at EOF). Routes through the existing `_do_ingest` (single state owner → no clobber / no double-ingest).
- **Periodic scheduler job + Observer supervision** — runs reconcile every 5 min (configurable), recreating a dead Observer (`is_alive()`) first; heartbeat log on recovery.
- **Tri-state `IngestResult`** (OK / NO_PROGRESS / TRANSIENT) — reconcile parks only files whose *content* can't progress (corrupt / frozen safe boundary), never transient external (LLM/DB) failures.
- **Park/retry keyed on a `(size, mtime_ns)` change-token** — a same-size content rewrite un-parks; persistently-TRANSIENT files are *deprioritized* (oldest-first FIFO, never hard-parked) so they can't monopolize the per-tick cap and starve valid candidates.
- **Per-tick wall-clock budget + mtime-priority** — bounds scheduler-thread occupancy; freshly-dropped transcripts recovered soonest.
- **Narrow `_state_lock`** — serializes only the state write, leaving parse/LLM/DB lock-free so reconcile never starves the live path.
- **Standalone `scripts/diag/fsevents_monitor.py`** — proves *why* FSEvents misses events (logs event types incl. `on_moved`, raw native flags, disk-truth vs events) without touching production.

## Review

Peer-reviewed via a 3-round adversarial council (cursor + codex). Findings F1/F2/F3 and H1/H2 fixed and re-confirmed. H1' (a same-size rewrite that *preserves* `mtime_ns`) is accepted as a documented known limitation — closing it would reintroduce O(n)-per-tick hashing for a pattern that doesn't occur in append-only transcript workloads (see the code comment at the fully-consumed skip in `session_watcher.py`).

## Stacked on #57

This branch is stacked on #57 (`fix/exclude-subagent-transcripts`) — `reconcile()` reuses `_is_subagent_transcript`. Until #57 merges, this PR's diff includes #57's commits; they drop automatically once #57 lands.

## Test plan

- [ ] `pytest tests/test_background/test_session_watcher.py tests/test_config.py` — 60 reconcile/watcher tests (tri-state, park/un-park, deprioritize FIFO, per-tick budget, lookback<0, Observer recreate) + config validators
- [ ] Run `scripts/diag/fsevents_monitor.py` across a sleep/wake cycle to confirm the leak mechanism

## Deferred follow-ups (non-blocking)

- Same-size `mtime_ns`-preserved rewrite (above)
- `rglob` incremental index (scan scale)
- `on_moved` live handler (gated on fsevents_monitor evidence)
- Non-atomic DB+cursor dup-on-crash (pre-existing; dedup jobs are the backstop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
