### PR TITLE
feat(agents): modular agent registry, per-agent connect/disconnect, desktop app v0.3.0

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.12.4"
+version = "0.13.0"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Introduces a fully modular agent registry so new AI tool integrations can be added with a single entry — no changes needed anywhere else. Replaces the one-shot \"Wire Agents\" tray action with a proper Agents panel in the main UI, and ships the ormah desktop app as v0.3.0.

### Backend
- **Agent registry** (`AGENT_REGISTRY`): data-driven list of `AgentDescriptor` entries, each with `detect_fn`, `is_wired_fn`, `wire_fn`, `unwire_fn`. Adding a new agent (Cursor, Windsurf, Gemini CLI…) = one registry entry, zero other changes.
- **`_find_binary()`**: replaces `shutil.which` with fallbacks for nvm, mise, Homebrew, `~/.local/bin` — fixes Claude Code not being detected when ormah is launched from the system tray (GUI apps don't inherit shell PATH).
- **Improved `_*_is_wired()`**: parses JSON/TOML and checks specific keys (`mcpServers.ormah`, hook commands containing `ormah whisper`) instead of a loose substring scan.
- **New API endpoints**:
  - `GET /agent/clients` → `AgentInfo[]` list (was flat dict — breaking shape change)
  - `POST /agent/setup/{agent_id}` — wire one agent
  - `DELETE /agent/setup/{agent_id}` — unwire one agent (removes hooks, MCP, CLAUDE.md/AGENTS.md blocks)
- **`run_setup_json()`** now iterates `AGENT_REGISTRY.wire_fn` — single source of truth, no more duplicated wire step lists.
- **`wire_agent()`** guards against platform-unavailable agents.

### UI
- **Agents panel**: click `agents` in the top bar — side panel slides in showing each agent with status (`connected` / `not wired` / `not installed` / `n/a on this OS`) and per-row Connect / Disconnect buttons.
- **Settings panel**: now has a consistent header with title and × close button.
- **Side panels**: fully opaque solid background (no more bleed-through to the graph).
- **Desktop app alignment**: panels start below the floating action buttons (`top: 80px`) via `.ormah-desktop` class on `<html>`.
- Keyboard shortcut numbers removed from top bar buttons.

### Desktop app (v0.3.0 → v0.3.1)
- Tray: \"Wire Agents\" menu item removed; agents managed from the main UI.
- Tauri app version bumped from `0.1.0` to `0.3.0` to match the release tag.

### Version
- `pyproject.toml` and `plugin.json` bumped to `0.13.0`.
- 916 tests passing.

## Test plan
- [ ] `make test` passes
- [ ] `GET /agent/clients` returns list of `AgentInfo` objects
- [ ] `POST /agent/setup/claude_code` wires Claude Code; `DELETE` unwires it cleanly
- [ ] Agents panel opens/closes, shows correct status per agent, Connect/Disconnect work
- [ ] Settings panel has header and close button, all panels fully opaque
- [ ] Desktop app: panels aligned below floating buttons; tray has no Wire Agents item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Kh34fa1fHQiX4vNUnyRJN