### PR TITLE
fix(setup): stop clobbering user config (co-tenant hooks + .env comments) (#70)

### DIFF
--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -868,13 +868,34 @@ def _read_env_file() -> dict[str, str]:
 
 
 def _write_env_file(env: dict[str, str]) -> None:
-    """Write env dict to the global config file with secure permissions."""
-    ENV_DIR.mkdir(parents=True, exist_ok=True)
-    lines = []
+    """Write env dict to the global config file, preserving comments and ordering.
+
+    Existing KEY= lines are updated in place; keys absent from `env` are dropped;
+    full-line comments, blank lines, and ordering are kept verbatim; new keys
+    append at end.
+
+    CONTRACT: callers MUST pass the FULL env (from `_read_env_file()`) unless they
+    intentionally want absent keys removed — a partial dict deletes the missing
+    user keys. Non-goal: an inline trailing comment on a key whose VALUE this call
+    rewrites is dropped (full-line comments and untouched keys keep theirs).
+    """
+    original = ENV_PATH.read_text().splitlines() if ENV_PATH.exists() else []
+    seen: set[str] = set()
+    out: list[str] = []
+    for line in original:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#") and "=" in stripped:
+            key = stripped.partition("=")[0].strip()
+            if key in env:
+                out.append(f"{key}={env[key]}")
+                seen.add(key)
+            # key removed by caller -> drop the line
+        else:
+            out.append(line)  # comment / blank / other -> verbatim
     for key, value in env.items():
-        lines.append(f"{key}={value}")
-    ENV_PATH.write_text("\n".join(lines) + "\n")
-    os.chmod(ENV_PATH, 0o600)
+        if key not in seen:
+            out.append(f"{key}={value}")
+    _atomic_write(str(ENV_PATH), "\n".join(out) + "\n", mode=0o600)
 
 
 def generate_server_wrapper(ormah_bin: str) -> Path:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -6,6 +6,7 @@ import contextlib
 import glob
 import json
 import os
+import shlex
 import shutil
 import socket
 import subprocess
@@ -150,6 +151,58 @@ def _merge_json_file(path: str, updates: dict) -> None:
     with open(path, "w") as f:
         json.dump(existing, f, indent=2)
         f.write("\n")
+
+
+def _is_ormah_hook(entry: dict) -> bool:
+    """True when a hook entry is one Ormah installs (argv-aware, not substring).
+
+    Recognizes BOTH install forms:
+      - CLI (ormah setup): `<...>/ormah whisper inject|store`
+      - Plugin wrapper: `<...>/ormah-whisper-inject` | `<...>/ormah-whisper-store`
+        (see integrations/claude-plugin/hooks/hooks.json)
+    A third-party command that merely contains the substring "whisper inject"/
+    "whisper store" is never misclassified. Works for install dedup and uninstall
+    alike, and is resilient to the ormah binary path changing between runs.
+    """
+    try:
+        parts = shlex.split(entry.get("command", ""))
+    except ValueError:
+        return False
+    if not parts:
+        return False
+    name = Path(parts[0]).name
+    if name in ("ormah-whisper-inject", "ormah-whisper-store"):
+        return True  # plugin wrapper form
+    return (
+        len(parts) >= 3
+        and name == "ormah"
+        and parts[1] == "whisper"
+        and parts[2] in ("inject", "store")
+    )  # CLI form
+
+
+def _merge_hooks(existing: dict, ormah_hooks: dict) -> dict:
+    """Merge Ormah hook groups into an existing hooks dict, preserving co-tenants.
+
+    For each event Ormah claims: strip prior Ormah entries (via _is_ormah_hook),
+    keep every third-party hook, then append Ormah's matchers. Events Ormah does
+    not claim are left untouched. Idempotent. Pure (no I/O).
+    """
+    merged = dict(existing)
+    for event, ormah_matchers in ormah_hooks.items():
+        current = merged.get(event)
+        if not isinstance(current, list):
+            current = []
+        cleaned = []
+        for matcher in current:
+            if not isinstance(matcher, dict):
+                cleaned.append(matcher)
+                continue
+            kept = [h for h in matcher.get("hooks", []) if not _is_ormah_hook(h)]
+            if kept:
+                cleaned.append({**matcher, "hooks": kept})
+        merged[event] = cleaned + list(ormah_matchers)
+    return merged
 
 
 def configure_claude_hooks(ormah_bin: str) -> None:
@@ -687,10 +740,6 @@ def _remove_codex_hooks() -> None:
     if not isinstance(hooks_top, dict):
         info("No hooks section — nothing to remove")
         return
-
-    def _is_ormah_hook(entry: dict) -> bool:
-        cmd = entry.get("command", "")
-        return "whisper inject" in cmd or "whisper store" in cmd
 
     changed = False
     to_delete = []
@@ -1241,10 +1290,6 @@ def _remove_claude_hooks() -> None:
     if not isinstance(hooks_top, dict):
         info("No hooks section — nothing to remove")
         return
-
-    def _is_ormah_hook(entry: dict) -> bool:
-        cmd = entry.get("command", "")
-        return "whisper inject" in cmd or "whisper store" in cmd
 
     changed = False
     to_delete = []

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -167,8 +167,11 @@ def _is_ormah_hook(entry: dict) -> bool:
     """
     if not isinstance(entry, dict):
         return False
+    cmd = entry.get("command", "")
+    if not isinstance(cmd, str):
+        return False
     try:
-        parts = shlex.split(entry.get("command", ""))
+        parts = shlex.split(cmd)
     except ValueError:
         return False
     if not parts:
@@ -270,7 +273,11 @@ def _install_hooks(path: str, ormah_hooks: dict) -> bool:
         if value is not None and not isinstance(value, list):
             warn(f"{path} has a non-list '{event}' hooks entry — leaving it unchanged; hooks not configured")
             return False
-    existing["hooks"] = _merge_hooks(current, ormah_hooks)
+    try:
+        existing["hooks"] = _merge_hooks(current, ormah_hooks)
+    except Exception:
+        warn(f"{path} has a malformed hooks structure — leaving it unchanged; hooks not configured")
+        return False
     _atomic_write(path, json.dumps(existing, indent=2) + "\n")
     return True
 

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -255,6 +255,11 @@ def _install_hooks(path: str, ormah_hooks: dict) -> bool:
     elif not isinstance(current, dict):
         warn(f"{path} has a non-object 'hooks' section — leaving it unchanged; hooks not configured")
         return False
+    for event in ormah_hooks:
+        value = current.get(event)
+        if value is not None and not isinstance(value, list):
+            warn(f"{path} has a non-list '{event}' hooks entry — leaving it unchanged; hooks not configured")
+            return False
     existing["hooks"] = _merge_hooks(current, ormah_hooks)
     _atomic_write(path, json.dumps(existing, indent=2) + "\n")
     return True

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -250,8 +250,11 @@ def _install_hooks(path: str, ormah_hooks: dict) -> bool:
             warn(f"{path} is not a JSON object — leaving it unchanged; hooks not configured")
             return False
     current = existing.get("hooks")
-    if not isinstance(current, dict):
+    if current is None:
         current = {}
+    elif not isinstance(current, dict):
+        warn(f"{path} has a non-object 'hooks' section — leaving it unchanged; hooks not configured")
+        return False
     existing["hooks"] = _merge_hooks(current, ormah_hooks)
     _atomic_write(path, json.dumps(existing, indent=2) + "\n")
     return True
@@ -886,7 +889,7 @@ def _write_env_file(env: dict[str, str]) -> None:
         stripped = line.strip()
         if stripped and not stripped.startswith("#") and "=" in stripped:
             key = stripped.partition("=")[0].strip()
-            if key in env:
+            if key in env and key not in seen:
                 out.append(f"{key}={env[key]}")
                 seen.add(key)
             # key removed by caller -> drop the line

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -188,6 +188,10 @@ def _merge_hooks(existing: dict, ormah_hooks: dict) -> dict:
     For each event Ormah claims: strip prior Ormah entries (via _is_ormah_hook),
     keep every third-party hook, then append Ormah's matchers. Events Ormah does
     not claim are left untouched. Idempotent. Pure (no I/O).
+
+    Matcher drop rule: a matcher is dropped only when removing Ormah hooks left it
+    completely empty (i.e. it held *only* Ormah hooks). Matchers with no "hooks" key,
+    an empty hooks list, or hooks that are all third-party are preserved verbatim.
     """
     merged = dict(existing)
     for event, ormah_matchers in ormah_hooks.items():
@@ -199,9 +203,13 @@ def _merge_hooks(existing: dict, ormah_hooks: dict) -> dict:
             if not isinstance(matcher, dict):
                 cleaned.append(matcher)
                 continue
-            kept = [h for h in matcher.get("hooks", []) if not _is_ormah_hook(h)]
-            if kept:
-                cleaned.append({**matcher, "hooks": kept})
+            inner = matcher.get("hooks", [])
+            kept = [h for h in inner if not _is_ormah_hook(h)]
+            if len(kept) == len(inner):
+                cleaned.append(matcher)  # nothing removed -> preserve verbatim
+            elif kept:
+                cleaned.append({**matcher, "hooks": kept})  # removed some, others remain
+            # else: held ONLY Ormah hooks -> drop the now-empty matcher (intentional cleanup)
         merged[event] = cleaned + list(ormah_matchers)
     return merged
 

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -6,18 +6,18 @@ import contextlib
 import glob
 import json
 import os
+import re
 import shlex
-import tempfile
 import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import webbrowser
 from dataclasses import dataclass, field
 from importlib import resources
 from pathlib import Path
 from typing import Callable
-import re
 
 import httpx
 
@@ -407,9 +407,9 @@ def configure_codex_hooks(ormah_bin: str) -> None:
         ],
     }
 
-    _merge_json_file(str(hooks_path), {"hooks": hooks})
-    _enable_codex_feature("hooks", deprecated_feature_names=("codex_hooks",))
-    ok("Codex hooks installed — memories flow before every message")
+    if _install_hooks(str(hooks_path), hooks):
+        _enable_codex_feature("hooks", deprecated_feature_names=("codex_hooks",))
+        ok("Codex hooks installed — memories flow before every message")
 
 
 def _remove_toml_table_block(text: str, table_name: str) -> str:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -165,6 +165,8 @@ def _is_ormah_hook(entry: dict) -> bool:
     "whisper store" is never misclassified. Works for install dedup and uninstall
     alike, and is resilient to the ormah binary path changing between runs.
     """
+    if not isinstance(entry, dict):
+        return False
     try:
         parts = shlex.split(entry.get("command", ""))
     except ValueError:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -219,13 +219,61 @@ def _merge_hooks(existing: dict, ormah_hooks: dict) -> dict:
     return merged
 
 
+def _strip_ormah_hooks(existing: dict) -> tuple[dict, bool]:
+    """Remove Ormah hook entries while preserving every untouched matcher.
+
+    Returns the cleaned hooks mapping and whether any Ormah hook was removed.
+    Missing, empty, or malformed inner ``hooks`` values are preserved verbatim:
+    only a matcher actually changed by removing an Ormah hook may be rewritten
+    or dropped.
+    """
+    cleaned = dict(existing)
+    changed = False
+    for event, matchers in existing.items():
+        if not isinstance(matchers, list):
+            continue
+
+        cleaned_matchers = []
+        event_changed = False
+        for matcher in matchers:
+            if not isinstance(matcher, dict):
+                cleaned_matchers.append(matcher)
+                continue
+
+            inner = matcher.get("hooks")
+            if not isinstance(inner, list):
+                cleaned_matchers.append(matcher)
+                continue
+
+            kept = [hook for hook in inner if not _is_ormah_hook(hook)]
+            if len(kept) == len(inner):
+                cleaned_matchers.append(matcher)
+                continue
+
+            event_changed = True
+            if kept:
+                cleaned_matchers.append({**matcher, "hooks": kept})
+
+        if event_changed:
+            changed = True
+            if cleaned_matchers:
+                cleaned[event] = cleaned_matchers
+            else:
+                cleaned.pop(event, None)
+
+    return cleaned, changed
+
+
 def _atomic_write(path: str, text: str, mode: int | None = None) -> None:
     """Write text to `path` atomically (temp file in the same dir + os.replace).
 
     Prevents a crash mid-write from leaving a truncated/corrupt config — the
     target is either the old bytes or the full new bytes, never a partial file.
+    If ``path`` is a symlink, atomically replace its resolved target so the link
+    itself remains intact.
     """
-    directory = os.path.dirname(os.path.abspath(path))
+    destination = os.path.realpath(path) if os.path.islink(path) else os.path.abspath(path)
+    directory = os.path.dirname(destination)
     os.makedirs(directory, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=directory)
     try:
@@ -233,7 +281,7 @@ def _atomic_write(path: str, text: str, mode: int | None = None) -> None:
             f.write(text)
         if mode is not None:
             os.chmod(tmp, mode)
-        os.replace(tmp, path)
+        os.replace(tmp, destination)
     except BaseException:
         try:
             os.unlink(tmp)
@@ -818,38 +866,14 @@ def _remove_codex_hooks() -> None:
         info("No hooks section — nothing to remove")
         return
 
-    changed = False
-    to_delete = []
-    for event, matchers in hooks_top.items():
-        if not isinstance(matchers, list):
-            continue
-        new_matchers = []
-        for matcher in matchers:
-            if not isinstance(matcher, dict):
-                new_matchers.append(matcher)
-                continue
-            inner = matcher.get("hooks", [])
-            filtered = [h for h in inner if not _is_ormah_hook(h)]
-            if len(filtered) != len(inner):
-                changed = True
-            if filtered:
-                new_matchers.append({**matcher, "hooks": filtered})
-            else:
-                changed = True
-        if new_matchers:
-            hooks_top[event] = new_matchers
-        else:
-            to_delete.append(event)
-            changed = True
-
-    for key in to_delete:
-        del hooks_top[key]
-    if not hooks_top:
-        del data["hooks"]
-        changed = True
+    cleaned_hooks, changed = _strip_ormah_hooks(hooks_top)
 
     if changed:
-        hooks_path.write_text(json.dumps(data, indent=2) + "\n")
+        if cleaned_hooks:
+            data["hooks"] = cleaned_hooks
+        else:
+            data.pop("hooks", None)
+        _atomic_write(str(hooks_path), json.dumps(data, indent=2) + "\n")
         ok("Removed whisper hooks from ~/.codex/hooks.json")
     else:
         info("No ormah hooks found in hooks.json")
@@ -1389,38 +1413,14 @@ def _remove_claude_hooks() -> None:
         info("No hooks section — nothing to remove")
         return
 
-    changed = False
-    to_delete = []
-    for event, matchers in hooks_top.items():
-        if not isinstance(matchers, list):
-            continue
-        new_matchers = []
-        for matcher in matchers:
-            if not isinstance(matcher, dict):
-                new_matchers.append(matcher)
-                continue
-            inner = matcher.get("hooks", [])
-            filtered = [h for h in inner if not _is_ormah_hook(h)]
-            if len(filtered) != len(inner):
-                changed = True
-            if filtered:
-                new_matchers.append({**matcher, "hooks": filtered})
-            else:
-                changed = True
-        if new_matchers:
-            hooks_top[event] = new_matchers
-        else:
-            to_delete.append(event)
-            changed = True
-
-    for k in to_delete:
-        del hooks_top[k]
-    if not hooks_top:
-        del data["hooks"]
-        changed = True
+    cleaned_hooks, changed = _strip_ormah_hooks(hooks_top)
 
     if changed:
-        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+        if cleaned_hooks:
+            data["hooks"] = cleaned_hooks
+        else:
+            data.pop("hooks", None)
+        _atomic_write(str(settings_path), json.dumps(data, indent=2) + "\n")
         ok("Removed whisper hooks from ~/.claude/settings.json")
     else:
         info("No ormah hooks found in settings.json")

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -7,6 +7,7 @@ import glob
 import json
 import os
 import shlex
+import tempfile
 import shutil
 import socket
 import subprocess
@@ -205,6 +206,57 @@ def _merge_hooks(existing: dict, ormah_hooks: dict) -> dict:
     return merged
 
 
+def _atomic_write(path: str, text: str, mode: int | None = None) -> None:
+    """Write text to `path` atomically (temp file in the same dir + os.replace).
+
+    Prevents a crash mid-write from leaving a truncated/corrupt config — the
+    target is either the old bytes or the full new bytes, never a partial file.
+    """
+    directory = os.path.dirname(os.path.abspath(path))
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        if mode is not None:
+            os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def _install_hooks(path: str, ormah_hooks: dict) -> bool:
+    """Read a JSON hooks config, merge Ormah hooks preserving co-tenants, write back.
+
+    Returns True if the merged config was written, False if it aborted without
+    writing. Fail-closed: if the file exists but does not parse OR does not hold a
+    JSON object, warn and abort (mirrors the uninstall no-op) so a hand-edited
+    config with a transient syntax error is never replaced by a hooks-only file,
+    losing theme/permissions. The write is atomic (no partial-write corruption).
+    """
+    existing: dict = {}
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                existing = json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            warn(f"Could not parse {path} — leaving it unchanged; hooks not configured")
+            return False
+        if not isinstance(existing, dict):
+            warn(f"{path} is not a JSON object — leaving it unchanged; hooks not configured")
+            return False
+    current = existing.get("hooks")
+    if not isinstance(current, dict):
+        current = {}
+    existing["hooks"] = _merge_hooks(current, ormah_hooks)
+    _atomic_write(path, json.dumps(existing, indent=2) + "\n")
+    return True
+
+
 def configure_claude_hooks(ormah_bin: str) -> None:
     """Write Claude Code hook config to global settings using absolute paths."""
     settings_path = os.path.expanduser("~/.claude/settings.json")
@@ -246,8 +298,8 @@ def configure_claude_hooks(ormah_bin: str) -> None:
         }
     ]
 
-    _merge_json_file(settings_path, {"hooks": hooks})
-    ok("Whisper hooks installed \u2014 memories flow before every message")
+    if _install_hooks(settings_path, hooks):
+        ok("Whisper hooks installed \u2014 memories flow before every message")
 
 
 def configure_claude_code_mcp(ormah_bin: str) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2423,6 +2423,46 @@ class TestMergeHooks:
         cmds = [h["command"] for m in merged["UserPromptSubmit"] for h in m["hooks"]]
         assert "/opt/whisper inject-backup run" in cmds
 
+    def test_preserves_matcher_without_hooks_key(self):
+        # matcher dict with no "hooks" key must survive the merge unchanged
+        existing = {"UserPromptSubmit": [{"matcher": "Write"}]}
+        merged = _merge_hooks(existing, self.ORMAH)
+        # user's hooks-less matcher is still present
+        assert {"matcher": "Write"} in merged["UserPromptSubmit"]
+        # ormah's matcher is also appended
+        cmds = [
+            h["command"]
+            for m in merged["UserPromptSubmit"]
+            if isinstance(m, dict)
+            for h in m.get("hooks", [])
+        ]
+        assert "/x/ormah whisper inject" in cmds
+
+    def test_preserves_matcher_with_only_nonormah_hooks(self):
+        # regression guard: a matcher whose hooks are all non-ormah survives unchanged
+        existing = {"UserPromptSubmit": [{"hooks": [{"command": "/bin/other"}]}]}
+        merged = _merge_hooks(existing, self.ORMAH)
+        cmds = [h["command"] for m in merged["UserPromptSubmit"] for h in m.get("hooks", [])]
+        assert "/bin/other" in cmds
+        assert "/x/ormah whisper inject" in cmds
+
+    def test_drops_matcher_emptied_of_only_ormah_hooks(self):
+        # a matcher that held ONLY ormah hooks should be dropped after stripping,
+        # not left as {"hooks": []} — ormah's own fresh matcher is then appended
+        existing = {
+            "UserPromptSubmit": [{"hooks": [{"command": "/x/ormah whisper inject"}]}]
+        }
+        merged = _merge_hooks(existing, self.ORMAH)
+        # exactly one occurrence of the inject command (from ormah's appended matcher)
+        cmds = [h["command"] for m in merged["UserPromptSubmit"] for h in m.get("hooks", [])]
+        assert cmds.count("/x/ormah whisper inject") == 1
+        # no matcher left with an empty hooks list
+        empty_hook_matchers = [
+            m for m in merged["UserPromptSubmit"]
+            if isinstance(m, dict) and m.get("hooks") == []
+        ]
+        assert empty_hook_matchers == []
+
 
 class TestIsOrmahHook:
     def test_matches_real_ormah_hook(self):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -587,6 +587,22 @@ class TestConfigureCodexHooks:
         enable.assert_not_called()
         assert "Codex hooks installed" not in capsys.readouterr().out
 
+    def test_non_list_event_no_false_success(self, tmp_path, capsys):
+        """Non-list value on a claimed event (e.g. Stop) must leave file unchanged."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        hooks_path = codex_dir / "hooks.json"
+        hooks_path.write_text(json.dumps({"hooks": {"Stop": "bad"}}) + "\n")
+        before = hooks_path.read_text()
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path), \
+             patch("ormah.setup._enable_codex_feature") as enable:
+            configure_codex_hooks("/abs/ormah")
+
+        assert hooks_path.read_text() == before
+        enable.assert_not_called()
+        assert "Codex hooks installed" not in capsys.readouterr().out
+
 
 class TestRunSetup:
     def test_server_timeout_exits_nonzero_without_success_summary(self, tmp_path, capsys):
@@ -2525,6 +2541,18 @@ class TestConfigureClaudeHooksMerge:
         with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
             configure_claude_hooks("/abs/ormah")
         assert sp.read_text() == before
+
+    def test_non_list_event_left_unchanged(self, tmp_path, capsys):
+        """Non-list value on a claimed event (nested schema drift) must leave file unchanged."""
+        from ormah.setup import configure_claude_hooks
+
+        sp = tmp_path / "settings.json"
+        sp.write_text(json.dumps({"theme": "dark", "hooks": {"UserPromptSubmit": {"oops": 1}}}) + "\n")
+        before = sp.read_text()
+        with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
+            configure_claude_hooks("/abs/ormah")
+        assert sp.read_text() == before
+        assert "Whisper hooks installed" not in capsys.readouterr().out
 
 
 class TestConfigureCodexHooksMerge:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -25,6 +25,8 @@ from ormah.setup import (
     CODEX_AGENTS_SENTINEL_START,
     CLAUDE_MD_SENTINEL_END,
     CLAUDE_MD_SENTINEL_START,
+    _is_ormah_hook,
+    _merge_hooks,
     _merge_json_file,
     _preload_local_models,
     _print_setup_summary,
@@ -2241,3 +2243,72 @@ class TestStopRunningServer:
             main()
 
         assert exc_info.value.code == 1
+
+
+class TestMergeHooks:
+    ORMAH = {"UserPromptSubmit": [{"hooks": [{"type": "command", "command": "/x/ormah whisper inject"}]}]}
+
+    def test_preserves_cotenant_under_same_event(self):
+        existing = {"UserPromptSubmit": [{"hooks": [{"type": "command", "command": "other-tool"}]}]}
+        merged = _merge_hooks(existing, self.ORMAH)
+        cmds = [h["command"] for m in merged["UserPromptSubmit"] for h in m["hooks"]]
+        assert "other-tool" in cmds
+        assert "/x/ormah whisper inject" in cmds
+
+    def test_idempotent_no_duplicate_ormah(self):
+        once = _merge_hooks({}, self.ORMAH)
+        twice = _merge_hooks(once, self.ORMAH)
+        cmds = [h["command"] for m in twice["UserPromptSubmit"] for h in m["hooks"]]
+        assert cmds.count("/x/ormah whisper inject") == 1
+
+    def test_leaves_unclaimed_events_untouched(self):
+        existing = {"PreToolUse": [{"hooks": [{"type": "command", "command": "rtk hook claude"}]}]}
+        merged = _merge_hooks(existing, self.ORMAH)
+        assert merged["PreToolUse"] == existing["PreToolUse"]
+
+    def test_substring_collision_not_stripped(self):
+        existing = {"UserPromptSubmit": [{"hooks": [
+            {"type": "command", "command": "/opt/whisper inject-backup run"}]}]}
+        merged = _merge_hooks(existing, self.ORMAH)
+        cmds = [h["command"] for m in merged["UserPromptSubmit"] for h in m["hooks"]]
+        assert "/opt/whisper inject-backup run" in cmds
+
+
+class TestIsOrmahHook:
+    def test_matches_real_ormah_hook(self):
+        assert _is_ormah_hook({"command": "/usr/bin/ormah whisper inject"})
+        assert _is_ormah_hook({"command": "/abs/path/ormah whisper store"})
+
+    def test_matches_plugin_wrapper_form(self):
+        assert _is_ormah_hook({"command": "/x/plugin/bin/ormah-whisper-inject"})
+        assert _is_ormah_hook({"command": "/x/plugin/bin/ormah-whisper-store"})
+
+    def test_rejects_substring_collision(self):
+        assert not _is_ormah_hook({"command": "/opt/whisper inject-backup run"})
+        assert not _is_ormah_hook({"command": "tools/whisper store-archive"})
+
+    def test_rejects_malformed_command(self):
+        assert not _is_ormah_hook({"command": ""})
+        assert not _is_ormah_hook({})
+        assert not _is_ormah_hook({"command": "unterminated 'quote"})
+
+
+class TestRemoveClaudeHooksPluginWrapper:
+    def test_removes_plugin_wrapper_hook(self, tmp_path):
+        data = {"hooks": {"UserPromptSubmit": [
+            {"hooks": [{"type": "command", "command": "/x/plugin/bin/ormah-whisper-inject"}]}
+        ]}}
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(json.dumps(data, indent=2) + "\n")
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            _remove_claude_hooks()
+
+        result = json.loads((claude_dir / "settings.json").read_text())
+        cmds = [
+            h["command"]
+            for m in result.get("hooks", {}).get("UserPromptSubmit", [])
+            for h in m["hooks"]
+        ]
+        assert "/x/plugin/bin/ormah-whisper-inject" not in cmds

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -543,7 +543,9 @@ class TestConfigureCodexHooks:
 
         hooks_data = json.loads(hooks_path.read_text())
         assert "UserPromptSubmit" in hooks_data["hooks"]
-        assert hooks_data["hooks"]["Stop"][0]["hooks"][0]["command"] == "/abs/path/ormah whisper store"
+        stop_cmds = [h["command"] for m in hooks_data["hooks"]["Stop"] for h in m["hooks"]]
+        assert "/abs/path/ormah whisper store" in stop_cmds
+        assert "/bin/other" in stop_cmds  # co-tenant preserved
 
 
 class TestRunSetup:
@@ -2393,3 +2395,57 @@ class TestConfigureClaudeHooksMerge:
         with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
             configure_claude_hooks("/abs/ormah")
         assert sp.read_text() == before
+
+
+class TestConfigureCodexHooksMerge:
+    def test_preserves_existing_stop_hook(self, tmp_path):
+        import json
+
+        from ormah.setup import configure_codex_hooks
+
+        codex = tmp_path / ".codex"
+        codex.mkdir()
+        hp = codex / "hooks.json"
+        hp.write_text(
+            json.dumps(
+                {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": "other-stop"}]}]}}
+            )
+        )
+        with patch("ormah.setup.Path.home", return_value=tmp_path), patch(
+            "ormah.setup._enable_codex_feature"
+        ):
+            configure_codex_hooks("/abs/ormah")
+        data = json.loads(hp.read_text())
+        cmds = [h["command"] for m in data["hooks"]["Stop"] for h in m["hooks"]]
+        assert "other-stop" in cmds
+        assert "/abs/ormah whisper store" in cmds
+
+    def test_rerun_does_not_duplicate(self, tmp_path):
+        import json
+
+        from ormah.setup import configure_codex_hooks
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path), patch(
+            "ormah.setup._enable_codex_feature"
+        ):
+            configure_codex_hooks("/abs/ormah")
+            configure_codex_hooks("/abs/ormah")
+        data = json.loads((tmp_path / ".codex" / "hooks.json").read_text())
+        cmds = [h["command"] for m in data["hooks"]["UserPromptSubmit"] for h in m["hooks"]]
+        assert cmds.count("/abs/ormah whisper inject") == 1
+
+    def test_corrupt_hooks_json_no_false_success(self, tmp_path, capsys):
+        from ormah.setup import configure_codex_hooks
+
+        codex = tmp_path / ".codex"
+        codex.mkdir()
+        hp = codex / "hooks.json"
+        hp.write_text("{ BROKEN")
+        before = hp.read_text()
+        with patch("ormah.setup.Path.home", return_value=tmp_path), patch(
+            "ormah.setup._enable_codex_feature"
+        ) as enable:
+            configure_codex_hooks("/abs/ormah")
+        assert hp.read_text() == before  # unchanged
+        enable.assert_not_called()  # feature flag NOT enabled on abort
+        assert "Codex hooks installed" not in capsys.readouterr().out

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2446,6 +2446,17 @@ class TestMergeHooks:
         assert "/bin/other" in cmds
         assert "/x/ormah whisper inject" in cmds
 
+    def test_preserves_malformed_non_dict_hook_entry(self):
+        # a matcher whose hooks list contains a malformed (non-dict) entry must not crash
+        existing = {"UserPromptSubmit": [{"hooks": ["malformed-string-entry"]}]}
+        merged = _merge_hooks(existing, self.ORMAH)  # must NOT raise
+        # the malformed entry is preserved
+        all_hooks = [h for m in merged["UserPromptSubmit"] if isinstance(m, dict) for h in m.get("hooks", [])]
+        assert "malformed-string-entry" in all_hooks
+        # ormah's hook is also appended
+        cmds = [h["command"] for m in merged["UserPromptSubmit"] if isinstance(m, dict) for h in m.get("hooks", []) if isinstance(h, dict)]
+        assert "/x/ormah whisper inject" in cmds
+
     def test_drops_matcher_emptied_of_only_ormah_hooks(self):
         # a matcher that held ONLY ormah hooks should be dropped after stripping,
         # not left as {"hooks": []} — ormah's own fresh matcher is then appended
@@ -2481,6 +2492,12 @@ class TestIsOrmahHook:
         assert not _is_ormah_hook({"command": ""})
         assert not _is_ormah_hook({})
         assert not _is_ormah_hook({"command": "unterminated 'quote"})
+
+    def test_non_dict_entry_returns_false(self):
+        assert _is_ormah_hook("a string") is False
+        assert _is_ormah_hook(123) is False
+        assert _is_ormah_hook(None) is False
+        assert _is_ormah_hook(["list"]) is False
 
 
 class TestRemoveClaudeHooksPluginWrapper:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -255,6 +255,31 @@ class TestConfigureClaudeHooks:
         assert data["allowedTools"] == ["bash"]
         assert "hooks" in data
 
+    def test_non_object_hooks_section_left_unchanged(self, tmp_path, capsys):
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(json.dumps({"theme": "dark", "hooks": []}) + "\n")
+        before = settings_path.read_text()
+
+        with patch("ormah.setup.os.path.expanduser", return_value=str(settings_path)):
+            configure_claude_hooks("/abs/ormah")
+
+        assert settings_path.read_text() == before
+        assert "Whisper hooks installed" not in capsys.readouterr().out
+
+    def test_preserves_top_level_keys(self, tmp_path):
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(
+            json.dumps({"theme": "dark", "permissions": {"allow": ["x"]}}) + "\n"
+        )
+
+        with patch("ormah.setup.os.path.expanduser", return_value=str(settings_path)):
+            configure_claude_hooks("/abs/ormah")
+
+        data = json.loads(settings_path.read_text())
+        assert data["theme"] == "dark"
+        assert data["permissions"] == {"allow": ["x"]}
+        assert "UserPromptSubmit" in data["hooks"]
+
 
 class TestConfigureClaudeCodeMcp:
     def test_writes_mcp_config_to_claude_json(self, tmp_path):
@@ -546,6 +571,21 @@ class TestConfigureCodexHooks:
         stop_cmds = [h["command"] for m in hooks_data["hooks"]["Stop"] for h in m["hooks"]]
         assert "/abs/path/ormah whisper store" in stop_cmds
         assert "/bin/other" in stop_cmds  # co-tenant preserved
+
+    def test_non_object_hooks_section_no_false_success(self, tmp_path, capsys):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        hooks_path = codex_dir / "hooks.json"
+        hooks_path.write_text(json.dumps({"hooks": "bad"}) + "\n")
+        before = hooks_path.read_text()
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path), \
+             patch("ormah.setup._enable_codex_feature") as enable:
+            configure_codex_hooks("/abs/ormah")
+
+        assert hooks_path.read_text() == before
+        enable.assert_not_called()
+        assert "Codex hooks installed" not in capsys.readouterr().out
 
 
 class TestRunSetup:
@@ -959,6 +999,27 @@ class TestWriteEnvPreservation:
         text = env_path.read_text()
         assert "# my ormah config" in text
         assert "ORMAH_LLM_PROVIDER=ollama" in text
+
+    def test_duplicate_keys_collapsed(self, tmp_path):
+        from ormah.setup import _write_env_file
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("DUP=1\nDUP=2\n")
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            _write_env_file({"DUP": "2"})
+        text = env_path.read_text()
+        assert text.count("DUP=") == 1
+        assert "DUP=2" in text
+
+    def test_existing_file_mode_forced_to_600(self, tmp_path):
+        from ormah.setup import _write_env_file
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("A=1\n")
+        env_path.chmod(0o644)
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            _write_env_file({"A": "1"})
+        assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
 
 
 # --- Server wrapper tests ---

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2246,7 +2246,9 @@ class TestStopRunningServer:
 
 
 class TestMergeHooks:
-    ORMAH = {"UserPromptSubmit": [{"hooks": [{"type": "command", "command": "/x/ormah whisper inject"}]}]}
+    ORMAH = {
+        "UserPromptSubmit": [{"hooks": [{"type": "command", "command": "/x/ormah whisper inject"}]}]
+    }
 
     def test_preserves_cotenant_under_same_event(self):
         existing = {"UserPromptSubmit": [{"hooks": [{"type": "command", "command": "other-tool"}]}]}
@@ -2312,3 +2314,82 @@ class TestRemoveClaudeHooksPluginWrapper:
             for h in m["hooks"]
         ]
         assert "/x/plugin/bin/ormah-whisper-inject" not in cmds
+
+
+class TestConfigureClaudeHooksMerge:
+    def test_preserves_existing_userpromptsubmit_hook(self, tmp_path):
+        from ormah.setup import configure_claude_hooks
+        import json
+
+        sp = tmp_path / "settings.json"
+        sp.write_text(
+            json.dumps(
+                {"hooks": {"UserPromptSubmit": [{"hooks": [{"type": "command", "command": "other-tool"}]}]}}
+            )
+        )
+        with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
+            configure_claude_hooks("/abs/ormah")
+        data = json.loads(sp.read_text())
+        cmds = [h["command"] for m in data["hooks"]["UserPromptSubmit"] for h in m["hooks"]]
+        assert "other-tool" in cmds
+        assert "/abs/ormah whisper inject" in cmds
+
+    def test_rerun_does_not_duplicate(self, tmp_path):
+        from ormah.setup import configure_claude_hooks
+        import json
+
+        sp = tmp_path / "settings.json"
+        with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
+            configure_claude_hooks("/abs/ormah")
+            configure_claude_hooks("/abs/ormah")
+        data = json.loads(sp.read_text())
+        cmds = [h["command"] for m in data["hooks"]["UserPromptSubmit"] for h in m["hooks"]]
+        assert cmds.count("/abs/ormah whisper inject") == 1
+
+    def test_preserves_existing_precompact_and_sessionend(self, tmp_path):
+        from ormah.setup import configure_claude_hooks
+        import json
+
+        sp = tmp_path / "settings.json"
+        sp.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreCompact": [
+                            {"hooks": [{"type": "command", "command": "other-precompact"}]}
+                        ],
+                        "SessionEnd": [
+                            {"hooks": [{"type": "command", "command": "other-sessionend"}]}
+                        ],
+                    }
+                }
+            )
+        )
+        with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
+            configure_claude_hooks("/abs/ormah")
+        data = json.loads(sp.read_text())
+        pre = [h["command"] for m in data["hooks"]["PreCompact"] for h in m["hooks"]]
+        end = [h["command"] for m in data["hooks"]["SessionEnd"] for h in m["hooks"]]
+        assert "other-precompact" in pre and "/abs/ormah whisper store" in pre
+        assert "other-sessionend" in end and "/abs/ormah whisper store" in end
+
+    def test_corrupt_json_left_unchanged_and_no_false_success(self, tmp_path, capsys):
+        from ormah.setup import configure_claude_hooks
+
+        sp = tmp_path / "settings.json"
+        sp.write_text('{ "theme": "dark", BROKEN')
+        before = sp.read_text()
+        with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
+            configure_claude_hooks("/abs/ormah")
+        assert sp.read_text() == before
+        assert "Whisper hooks installed" not in capsys.readouterr().out
+
+    def test_non_object_json_left_unchanged(self, tmp_path):
+        from ormah.setup import configure_claude_hooks
+
+        sp = tmp_path / "settings.json"
+        sp.write_text('["not", "an", "object"]')
+        before = sp.read_text()
+        with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
+            configure_claude_hooks("/abs/ormah")
+        assert sp.read_text() == before

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -25,6 +25,7 @@ from ormah.setup import (
     CODEX_AGENTS_SENTINEL_START,
     CLAUDE_MD_SENTINEL_END,
     CLAUDE_MD_SENTINEL_START,
+    _atomic_write,
     _is_ormah_hook,
     _merge_hooks,
     _merge_json_file,
@@ -39,6 +40,7 @@ from ormah.setup import (
     _remove_claude_md_block,
     _remove_fastembed_cache,
     _remove_mcp_from_json,
+    _strip_ormah_hooks,
     _write_env_file,
     configure_claude_hooks,
     configure_claude_code_mcp,
@@ -949,6 +951,20 @@ class TestEnvFile:
 
 
 class TestWriteEnvPreservation:
+    def test_atomic_write_preserves_relative_symlink(self, tmp_path):
+        target = tmp_path / "managed.env"
+        target.write_text("A=old\n")
+        target.chmod(0o644)
+        link = tmp_path / ".env"
+        link.symlink_to(target.name)
+
+        _atomic_write(str(link), "A=new\n", mode=0o600)
+
+        assert link.is_symlink()
+        assert link.read_text() == "A=new\n"
+        assert target.read_text() == "A=new\n"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
     def test_preserves_comments_and_manual_key(self, tmp_path):
         from ormah.setup import _write_env_file
 
@@ -1662,6 +1678,30 @@ class TestRemoveClaudeHooks:
         assert len(hooks) == 1
         assert hooks[0]["command"] == "/usr/bin/other-tool run"
 
+    def test_preserves_untouched_empty_and_missing_hooks_matchers(self, tmp_path):
+        data = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"matcher": "empty", "hooks": []},
+                    {"hooks": [{"command": "/usr/bin/ormah whisper inject"}]},
+                ],
+                "PreToolUse": [{"matcher": "Write"}],
+            }
+        }
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        settings_path = claude_dir / "settings.json"
+        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            _remove_claude_hooks()
+
+        result = json.loads(settings_path.read_text())
+        assert result["hooks"] == {
+            "UserPromptSubmit": [{"matcher": "empty", "hooks": []}],
+            "PreToolUse": [{"matcher": "Write"}],
+        }
+
     def test_no_settings_file_is_noop(self, tmp_path, capsys):
         claude_dir = tmp_path / ".claude"
         claude_dir.mkdir()
@@ -1805,6 +1845,29 @@ class TestRemoveCodexHooks:
         result = json.loads(hooks_path.read_text())
         assert result["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"] == "/usr/bin/other-tool run"
         assert "Stop" not in result["hooks"]
+
+    def test_preserves_untouched_empty_and_missing_hooks_matchers(self, tmp_path):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        hooks_path = codex_dir / "hooks.json"
+        hooks_path.write_text(json.dumps({
+            "hooks": {
+                "Stop": [
+                    {"matcher": "empty", "hooks": []},
+                    {"hooks": [{"command": "/usr/bin/ormah whisper store"}]},
+                ],
+                "PreToolUse": [{"matcher": "Write"}],
+            }
+        }, indent=2) + "\n")
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            _remove_codex_hooks()
+
+        result = json.loads(hooks_path.read_text())
+        assert result["hooks"] == {
+            "Stop": [{"matcher": "empty", "hooks": []}],
+            "PreToolUse": [{"matcher": "Write"}],
+        }
 
     def test_noop_when_missing(self, tmp_path):
         with patch("ormah.setup.Path.home", return_value=tmp_path):
@@ -2486,6 +2549,44 @@ class TestMergeHooks:
             if isinstance(m, dict) and m.get("hooks") == []
         ]
         assert empty_hook_matchers == []
+
+
+class TestStripOrmahHooks:
+    def test_preserves_malformed_inner_hooks_verbatim(self):
+        existing = {
+            "UserPromptSubmit": [
+                {"hooks": 5},
+                {"hooks": "not-a-list"},
+                {"matcher": "missing"},
+            ]
+        }
+
+        cleaned, changed = _strip_ormah_hooks(existing)
+
+        assert changed is False
+        assert cleaned == existing
+
+    def test_removes_ormah_hook_without_rewriting_untouched_matchers(self):
+        untouched = {"matcher": "empty", "hooks": []}
+        existing = {
+            "UserPromptSubmit": [
+                untouched,
+                {
+                    "hooks": [
+                        {"command": "/x/ormah whisper inject"},
+                        {"command": "/bin/other"},
+                    ]
+                },
+            ]
+        }
+
+        cleaned, changed = _strip_ormah_hooks(existing)
+
+        assert changed is True
+        assert cleaned["UserPromptSubmit"] == [
+            untouched,
+            {"hooks": [{"command": "/bin/other"}]},
+        ]
 
 
 class TestIsOrmahHook:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -892,6 +892,75 @@ class TestEnvFile:
         assert file_mode == 0o600
 
 
+class TestWriteEnvPreservation:
+    def test_preserves_comments_and_manual_key(self, tmp_path):
+        from ormah.setup import _write_env_file
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("# header comment\nMANUAL_KEY=keep\n\nORMAH_X=old\n")
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            _write_env_file({"MANUAL_KEY": "keep", "ORMAH_X": "new"})
+        text = env_path.read_text()
+        assert "# header comment" in text
+        assert "MANUAL_KEY=keep" in text
+        assert "ORMAH_X=new" in text
+        assert "ORMAH_X=old" not in text
+
+    def test_removed_key_dropped_comments_kept(self, tmp_path):
+        from ormah.setup import _write_env_file
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("# keep me\nDROP=1\nKEEP=2\n")
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            _write_env_file({"KEEP": "2"})
+        text = env_path.read_text()
+        assert "# keep me" in text
+        assert "KEEP=2" in text
+        assert "DROP" not in text
+
+    def test_new_key_appended(self, tmp_path):
+        from ormah.setup import _write_env_file
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("# c\nA=1\n")
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            _write_env_file({"A": "1", "B": "2"})
+        lines = [ln for ln in env_path.read_text().splitlines() if ln.strip()]
+        assert lines[-1] == "B=2"
+        assert "# c" in env_path.read_text()
+
+    def test_nonexistent_file_writes_dict_order(self, tmp_path):
+        from ormah.setup import _write_env_file
+
+        env_path = tmp_path / ".env"
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            _write_env_file({"A": "1", "B": "2"})
+        assert env_path.read_text() == "A=1\nB=2\n"
+
+    def test_untouched_key_with_inline_comment_preserved(self, tmp_path):
+        from ormah.setup import _read_env_file, _write_env_file
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("MANUAL=val  # keep this note\n")
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            env = _read_env_file()
+            _write_env_file(env)
+        assert "# keep this note" in env_path.read_text()
+
+    def test_configure_llm_flow_preserves_block_comment(self, tmp_path):
+        from ormah.setup import _read_env_file, _write_env_file
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("# my ormah config\nORMAH_LLM_PROVIDER=none\n")
+        with patch("ormah.setup.ENV_PATH", env_path), patch("ormah.setup.ENV_DIR", tmp_path):
+            env = _read_env_file()
+            env["ORMAH_LLM_PROVIDER"] = "ollama"
+            _write_env_file(env)
+        text = env_path.read_text()
+        assert "# my ormah config" in text
+        assert "ORMAH_LLM_PROVIDER=ollama" in text
+
+
 # --- Server wrapper tests ---
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2457,6 +2457,19 @@ class TestMergeHooks:
         cmds = [h["command"] for m in merged["UserPromptSubmit"] if isinstance(m, dict) for h in m.get("hooks", []) if isinstance(h, dict)]
         assert "/x/ormah whisper inject" in cmds
 
+    def test_non_string_command_preserved(self):
+        # a hook with a non-string command is neither Ormah nor crash-worthy —
+        # it must be preserved and the merge must succeed
+        existing = {"UserPromptSubmit": [{"hooks": [{"command": 123}]}]}
+        merged = _merge_hooks(existing, self.ORMAH)  # must not raise
+        preserved = [
+            h
+            for m in merged["UserPromptSubmit"]
+            if isinstance(m, dict)
+            for h in m.get("hooks", [])
+        ]
+        assert {"command": 123} in preserved
+
     def test_drops_matcher_emptied_of_only_ormah_hooks(self):
         # a matcher that held ONLY ormah hooks should be dropped after stripping,
         # not left as {"hooks": []} — ormah's own fresh matcher is then appended
@@ -2476,6 +2489,11 @@ class TestMergeHooks:
 
 
 class TestIsOrmahHook:
+    def test_non_string_command_returns_false(self):
+        assert _is_ormah_hook({"command": 123}) is False
+        assert _is_ormah_hook({"command": ["a", "b"]}) is False
+        assert _is_ormah_hook({"command": {"x": 1}}) is False
+
     def test_matches_real_ormah_hook(self):
         assert _is_ormah_hook({"command": "/usr/bin/ormah whisper inject"})
         assert _is_ormah_hook({"command": "/abs/path/ormah whisper store"})
@@ -2605,6 +2623,17 @@ class TestConfigureClaudeHooksMerge:
 
         sp = tmp_path / "settings.json"
         sp.write_text(json.dumps({"theme": "dark", "hooks": {"UserPromptSubmit": {"oops": 1}}}) + "\n")
+        before = sp.read_text()
+        with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
+            configure_claude_hooks("/abs/ormah")
+        assert sp.read_text() == before
+        assert "Whisper hooks installed" not in capsys.readouterr().out
+
+    def test_uniterable_matcher_hooks_fail_closed(self, tmp_path, capsys):
+        """A non-iterable 'hooks' value inside a matcher triggers the backstop:
+        file is left unchanged, no success message printed."""
+        sp = tmp_path / "settings.json"
+        sp.write_text(json.dumps({"hooks": {"UserPromptSubmit": [{"hooks": 5}]}}) + "\n")
         before = sp.read_text()
         with patch("ormah.setup.os.path.expanduser", return_value=str(sp)):
             configure_claude_hooks("/abs/ormah")


### PR DESCRIPTION
## Summary

Fixes #70 — `ormah setup` overwrote pre-existing, user-owned content in external config files instead of surgically merging only Ormah's own entries.

Two root causes:

- **Hooks (`~/.claude/settings.json`, `~/.codex/hooks.json`):** `_merge_json_file` did a one-level merge that *replaced the whole list* under each hook event, wiping any third-party (co-tenant) hook registered under the same event (`UserPromptSubmit` / `PreCompact` / `SessionEnd` / `Stop`).
- **`.env` (`~/.config/ormah/.env`):** `_write_env_file` rebuilt the file from a dict, destroying all comments, blank lines, and ordering on every write.

## What changed

- **`_is_ormah_hook`** is now a single module-level, **argv-aware** predicate (was duplicated and substring-based). It recognizes both the CLI form (`…/ormah whisper inject|store`) and the plugin wrapper form (`…/ormah-whisper-inject|-store`), so a third-party command that merely *contains* the substring is no longer misclassified. It is **total** — never raises on malformed input. Reused by both install and uninstall.
- **`_merge_hooks`** (new, pure): strips only Ormah's own hook entries per claimed event, preserves every co-tenant hook, appends Ormah's, and leaves unclaimed events untouched. Idempotent. Only drops a matcher it actually emptied by removing Ormah hooks; never drops a matcher it didn't modify.
- **`_install_hooks`** (new): the shared, **fail-closed** install path used by both `configure_claude_hooks` and `configure_codex_hooks`. It refuses to write (warns, returns `False`) when the config is unparseable, not a JSON object, has a non-object `hooks` section, or has a non-list value under a claimed event — and a `try/except` backstop guarantees it never crashes setup nor partial-writes on any other malformed structure. The success message (and, for Codex, the feature-flag enable) is gated on an actual write.
- **`_atomic_write`** (new): temp file in the same dir + `os.replace`, with `chmod` applied before replace — no partial-write corruption, and the `.env` `0600` permission is preserved.
- **`_write_env_file`** rewritten to preserve comments, blank lines, and ordering: existing `KEY=` lines are updated in place, keys absent from the dict are dropped, new keys appended, and the file written atomically with `0600`.

`_merge_json_file` is retained — it is still correct for the `mcpServers` callers (keyed by server name, not a list to merge).

## Known behavior (intentional)

- `_atomic_write` uses `os.replace`, which swaps the inode. A config file that is a symlink/hardlink to another location is detached after the first write — standard atomic-write trade-off, fine for these config paths.
- A `.env` hand-edited with duplicate `KEY=` lines is collapsed to one line on the next write.
- An inline trailing comment on a key whose *value* Ormah rewrites is dropped; full-line comments and untouched keys keep theirs.

## Test plan

- `tests/test_setup.py` / `tests/test_setup_json.py`: added coverage for co-tenant preservation (all claimed events), idempotent re-runs, fail-closed on corrupt / non-object / non-list-event / non-iterable-hooks config (file byte-unchanged, no false "installed" message, Codex feature flag not enabled), malformed/non-dict/non-string-command hook entries preserved without crashing, `.env` comment/order preservation, duplicate-key collapse, and `0600` preserved on replace.
- Full suite green except 9 pre-existing, environment-specific failures unrelated to this change (real `claude`/`codex` MCP subprocesses + fastembed cache dir).
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
