### PR TITLE
chore: release 0.13.2

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.13.1"
+version = "0.13.2"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the Python package version to 0.13.2
- keep the Claude plugin manifest in sync
- release the setup config-preservation fix from #71

## Verification

- release version verifier passed for 0.13.2
- full test suite: 1059 passed, 1 deselected

After merge, the manual Release workflow will publish the wheel to PyPI and create tag v0.13.2 plus the GitHub release.