### PR TITLE
refactor(stats): consolidate stats API

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -18,7 +18,7 @@ product:
 ```
 Tauri shell (Rust, src-tauri/)
   ├─ tray.rs      tray icon + title (counter) + dropdown menu
-  ├─ stats.rs     polls GET /agent/stats every 60s → tray title
+  ├─ stats.rs     polls GET /stats every 60s → tray title
   ├─ sidecar.rs   checks ormah on PATH; if absent, runs bundled uv to install it
   └─ commands.rs  setup_agents (ormah setup --json), open graph, onboarding marker
        ↓ installs (first launch only)
@@ -100,5 +100,5 @@ Also set `plugins.updater.pubkey` in `tauri.conf.json` and
 
 ## Backend coverage
 
-- `GET /agent/stats` — `tests/test_api/test_stats.py`
+- `GET /stats` — `tests/test_api/test_stats.py`
 - `GET /agent/clients` + `ormah setup --json` — `tests/test_setup_json.py`

--- a/desktop/src-tauri/src/stats.rs
+++ b/desktop/src-tauri/src/stats.rs
@@ -1,4 +1,4 @@
-//! Poll the bundled server's `/agent/stats` and surface the counter.
+//! Poll the bundled server's `/stats` and surface the counter.
 
 use std::time::Duration;
 
@@ -7,10 +7,14 @@ use tauri::{menu::MenuItem, tray::TrayIcon, AppHandle, Runtime};
 
 use crate::commands::base_url;
 
-/// Mirror of the JSON returned by `GET /agent/stats`. Unknown fields
-/// (window_days, generated_at) are ignored by serde.
+/// Mirror of the JSON returned by `GET /stats`. Unknown fields are ignored by serde.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stats {
+    pub usage: UsageStats,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageStats {
     pub whispers_used_this_week: i64,
     pub whispers_used_total: i64,
     pub memories_this_week: i64,
@@ -28,7 +32,7 @@ fn fmt_num(n: i64) -> String {
 }
 
 pub async fn fetch() -> Result<Stats, reqwest::Error> {
-    let url = format!("{}/agent/stats", base_url());
+    let url = format!("{}/stats", base_url());
     reqwest::Client::new()
         .get(url)
         .timeout(Duration::from_secs(5))
@@ -63,15 +67,16 @@ pub fn spawn_poller<R: Runtime>(
 
             if running {
                 if let Ok(s) = fetch().await {
-                    let _ = tray.set_title(Some(s.whispers_used_this_week.to_string()));
+                    let usage = s.usage;
+                    let _ = tray.set_title(Some(usage.whispers_used_this_week.to_string()));
                     let _ = week_item.set_text(format!(
                         "{} whispers this week",
-                        s.whispers_used_this_week
+                        usage.whispers_used_this_week
                     ));
                     let _ = total_item.set_text(format!(
                         "{}  all-time  ·  {}  memories",
-                        fmt_num(s.whispers_used_total),
-                        fmt_num(s.memories_total)
+                        fmt_num(usage.whispers_used_total),
+                        fmt_num(usage.memories_total)
                     ));
                 }
             } else {

--- a/desktop/src-tauri/src/tray.rs
+++ b/desktop/src-tauri/src/tray.rs
@@ -111,7 +111,7 @@ pub fn build(app: &App) -> tauri::Result<()> {
         })
         .build(app)?;
 
-    // Poll /agent/stats + health every 60s; updates tray title, menu counters,
+    // Poll /stats + health every 60s; updates tray title, menu counters,
     // and server status items.
     stats::spawn_poller(
         handle.clone(),

--- a/src/ormah/adapters/cli_adapter.py
+++ b/src/ormah/adapters/cli_adapter.py
@@ -208,18 +208,17 @@ def cmd_outdated(args):
 def cmd_stats(args):
     def call():
         with _client() as c:
-            r = c.get("/admin/stats")
+            r = c.get("/stats")
             r.raise_for_status()
             data = r.json()
-            u = c.get("/agent/stats")
-            u.raise_for_status()
-            usage = u.json()
+            usage = data.get("usage", {})
+            store = data.get("store", {})
             if args.json:
-                print(json.dumps({**data, "usage": usage}, indent=2))
+                print(json.dumps(data, indent=2))
             else:
-                total = data.get("total_nodes", 0)
-                edges = data.get("total_edges", 0)
-                by_tier = data.get("by_tier", {})
+                total = store.get("total_nodes", 0)
+                edges = store.get("total_edges", 0)
+                by_tier = store.get("by_tier", {})
                 week = usage.get("whispers_used_this_week", 0)
                 used_total = usage.get("whispers_used_total", 0)
                 print(f"Whispers used: {week} this week  ({used_total} total)")

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -109,12 +109,6 @@ def health(request: Request):
     return result
 
 
-@router.get("/stats")
-def stats(request: Request):
-    engine = request.app.state.engine
-    return engine.stats()
-
-
 @router.get("/maintenance-status")
 def maintenance_status(request: Request):
     manager = getattr(request.app.state, "maintenance_manager", None)

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -250,22 +250,6 @@ def unwire_one(agent_id: str):
         raise HTTPException(status_code=404, detail=str(exc))
 
 
-@router.get("/stats")
-def get_stats(
-    request: Request,
-    days: int | None = Query(
-        None,
-        ge=1,
-        le=365,
-        description="Rolling window in days for the *_this_week counts. "
-        "Omit to use the fixed current calendar week (Mon-Sun UTC).",
-    ),
-):
-    """Ambient usage counts for the menubar/CLI surface (F09 counter)."""
-    engine = request.app.state.engine
-    return engine.get_stats(days=days)
-
-
 @router.get("/insights")
 def get_insights(request: Request):
     """Get belief evolutions and conflicting ideas detected by the system."""

--- a/src/ormah/api/routes_stats.py
+++ b/src/ormah/api/routes_stats.py
@@ -1,0 +1,25 @@
+"""Canonical stats API route."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query, Request
+
+router = APIRouter(tags=["stats"])
+
+
+@router.get("/stats")
+def stats(
+    request: Request,
+    days: int | None = Query(
+        None,
+        ge=1,
+        le=365,
+        description=(
+            "Rolling window in days for usage counters. Omit to use the fixed "
+            "current calendar week (Mon-Sun UTC)."
+        ),
+    ),
+):
+    """Canonical stats payload for tray, CLI, UI, and diagnostics."""
+    engine = request.app.state.engine
+    return engine.stats(days=days)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1062,18 +1062,79 @@ class MemoryEngine:
         except Exception as e:
             logger.warning("Failed to reindex embeddings: %s", e)
 
-    def stats(self) -> dict:
-        """Get memory store statistics."""
+    def _usage_stats(
+        self,
+        now: datetime,
+        days: int | None = None,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Return tray-facing usage counters and their window metadata."""
+        conn = self.db.conn
+        if days is None:
+            window_days = now.weekday() + 1  # days elapsed in this calendar week
+            cutoff = (now - timedelta(days=now.weekday())).replace(
+                hour=0, minute=0, second=0, microsecond=0
+            ).isoformat()
+            window_kind = "calendar_week"
+        else:
+            window_days = days
+            cutoff = (now - timedelta(days=days)).isoformat()
+            window_kind = "rolling"
+
+        used_key = "session_id || '|' || prompt_hash || '|' || logged_at"
+        whispers_total = conn.execute(
+            f"SELECT COUNT(DISTINCT {used_key}) FROM whisper_log WHERE was_injected = 1"
+        ).fetchone()[0]
+        whispers_window = conn.execute(
+            f"SELECT COUNT(DISTINCT {used_key}) FROM whisper_log "
+            "WHERE was_injected = 1 AND logged_at >= ?",
+            (cutoff,),
+        ).fetchone()[0]
+
+        # Exclude system-seeded bootstrap nodes (e.g. the "Self" node) so a
+        # fresh install honestly reads zero memories in the tray.
+        not_system = "source NOT LIKE 'system:%'"
+        memories_total = conn.execute(
+            f"SELECT COUNT(*) FROM nodes WHERE {not_system}"
+        ).fetchone()[0]
+        memories_window = conn.execute(
+            f"SELECT COUNT(*) FROM nodes WHERE {not_system} AND created >= ?", (cutoff,)
+        ).fetchone()[0]
+
+        usage = {
+            "whispers_used_this_week": whispers_window,
+            "whispers_used_total": whispers_total,
+            "memories_this_week": memories_window,
+            "memories_total": memories_total,
+        }
+        window = {
+            "kind": window_kind,
+            "days": window_days,
+            "cutoff": cutoff,
+        }
+        return usage, window
+
+    def stats(self, days: int | None = None) -> dict[str, Any]:
+        """Return the canonical stats payload for tray, CLI, UI, and diagnostics."""
+        now = datetime.now(timezone.utc)
         tier_counts = self.graph.count_by_tier()
         total = sum(tier_counts.values())
         edge_count = self.db.conn.execute("SELECT COUNT(*) FROM edges").fetchone()[0]
-        return {
+        store = {
             "total_nodes": total,
             "by_tier": tier_counts,
             "total_edges": edge_count,
-            "whisper_health": compute_whisper_health(
-                self.db.conn, datetime.now(timezone.utc)
-            ),
+        }
+        usage, window = self._usage_stats(now, days=days)
+        whisper_health = compute_whisper_health(self.db.conn, now)
+
+        return {
+            "generated_at": now.isoformat(),
+            "window": window,
+            "usage": usage,
+            "store": store,
+            "whisper": {
+                "feedback_health": whisper_health,
+            },
         }
 
     # --- Merge operations ---
@@ -2148,66 +2209,6 @@ class MemoryEngine:
                 )
 
         return f"Feedback recorded for node {resolved_node_id[:8]}..."
-
-    def get_stats(self, days: int | None = None) -> dict[str, Any]:
-        """Return ambient usage counts for the menubar/CLI surface (F09/F10).
-
-        A "whisper used" is a single whisper call that actually injected at
-        least one memory. ``whisper_log`` writes one row per candidate sharing
-        the same ``logged_at`` per call, so distinct used calls are counted by
-        the ``(session_id, prompt_hash, logged_at)`` triple where
-        ``was_injected = 1``. Memory counts come straight from ``nodes``.
-
-        With ``days=None`` (the default, used by the tray/CLI), the "week"
-        window is the fixed current calendar week (Mon 00:00 UTC) so the count
-        only ever increases within a week and resets once on Monday — it never
-        drifts down mid-week the way a rolling N-day window would. Passing an
-        explicit ``days`` opts into a rolling N-day window ending now instead,
-        for ad-hoc/custom-range queries.
-
-        ISO-8601 UTC timestamps compare correctly lexicographically, so the
-        window is a simple string ``>=`` against a Python-computed cutoff — no
-        SQLite date math, no timezone surprises.
-        """
-        conn = self.db.conn
-        now = datetime.now(timezone.utc)
-        if days is None:
-            window_days = now.weekday() + 1  # days elapsed in this calendar week
-            cutoff = (now - timedelta(days=now.weekday())).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            ).isoformat()
-        else:
-            window_days = days
-            cutoff = (now - timedelta(days=days)).isoformat()
-
-        used_key = "session_id || '|' || prompt_hash || '|' || logged_at"
-        whispers_total = conn.execute(
-            f"SELECT COUNT(DISTINCT {used_key}) FROM whisper_log WHERE was_injected = 1"
-        ).fetchone()[0]
-        whispers_week = conn.execute(
-            f"SELECT COUNT(DISTINCT {used_key}) FROM whisper_log "
-            "WHERE was_injected = 1 AND logged_at >= ?",
-            (cutoff,),
-        ).fetchone()[0]
-
-        # Exclude system-seeded bootstrap nodes (e.g. the "Self" node) so a
-        # fresh install honestly reads zero memories.
-        not_system = "source NOT LIKE 'system:%'"
-        memories_total = conn.execute(
-            f"SELECT COUNT(*) FROM nodes WHERE {not_system}"
-        ).fetchone()[0]
-        memories_week = conn.execute(
-            f"SELECT COUNT(*) FROM nodes WHERE {not_system} AND created >= ?", (cutoff,)
-        ).fetchone()[0]
-
-        return {
-            "whispers_used_this_week": whispers_week,
-            "whispers_used_total": whispers_total,
-            "memories_this_week": memories_week,
-            "memories_total": memories_total,
-            "window_days": window_days,
-            "generated_at": datetime.now(timezone.utc).isoformat(),
-        }
 
     def _is_duplicate_memory(self, content: str) -> bool:
         """Check if a very similar memory already exists using vector search."""

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -16,6 +16,7 @@ from ormah.api.middleware import AgentMiddleware
 from ormah.api.routes_admin import router as admin_router
 from ormah.api.routes_agent import router as agent_router
 from ormah.api.routes_ingest import router as ingest_router
+from ormah.api.routes_stats import router as stats_router
 from ormah.api.routes_ui import router as ui_router
 from ormah.background.maintenance_manager import MaintenanceManager
 from ormah.config import settings
@@ -30,7 +31,7 @@ setup_logging(
 )
 logger = logging.getLogger(__name__)
 
-_RESERVED_API_PREFIXES = {"agent", "admin", "ingest", "ui"}
+_RESERVED_API_PREFIXES = {"agent", "admin", "ingest", "stats", "ui"}
 _LOCAL_CORS_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$"
 
 
@@ -124,6 +125,7 @@ app.add_middleware(AgentMiddleware)
 
 app.include_router(agent_router)
 app.include_router(admin_router)
+app.include_router(stats_router)
 app.include_router(ui_router)
 app.include_router(ingest_router)
 

--- a/tests/test_adapters/test_cli_adapter.py
+++ b/tests/test_adapters/test_cli_adapter.py
@@ -355,10 +355,15 @@ def test_outdated_no_reason(monkeypatch):
 def test_stats_text(monkeypatch):
     def handler(request):
         url = str(request.url)
-        if "/admin/stats" in url:
-            return _mock_response({"total_nodes": 42, "by_tier": {"core": 5, "working": 30, "archival": 7}, "total_edges": 18})
-        if "/agent/stats" in url:
-            return _mock_response({"whispers_used_this_week": 7, "whispers_used_total": 42})
+        if "/stats" in url:
+            return _mock_response({
+                "store": {
+                    "total_nodes": 42,
+                    "by_tier": {"core": 5, "working": 30, "archival": 7},
+                    "total_edges": 18,
+                },
+                "usage": {"whispers_used_this_week": 7, "whispers_used_total": 42},
+            })
         return _mock_response({}, status_code=404)
 
     transport = httpx.MockTransport(handler)
@@ -377,10 +382,15 @@ def test_stats_text(monkeypatch):
 def test_stats_json(monkeypatch):
     def handler(request):
         url = str(request.url)
-        if "/admin/stats" in url:
-            return _mock_response({"total_nodes": 42, "by_tier": {"core": 5}, "total_edges": 18})
-        if "/agent/stats" in url:
-            return _mock_response({"whispers_used_this_week": 3, "whispers_used_total": 10})
+        if "/stats" in url:
+            return _mock_response({
+                "store": {
+                    "total_nodes": 42,
+                    "by_tier": {"core": 5},
+                    "total_edges": 18,
+                },
+                "usage": {"whispers_used_this_week": 3, "whispers_used_total": 10},
+            })
         return _mock_response({}, status_code=404)
 
     transport = httpx.MockTransport(handler)
@@ -391,7 +401,7 @@ def test_stats_json(monkeypatch):
     code, out, err = _run_cli(["stats", "--json"], monkeypatch)
     assert code == 0
     parsed = json.loads(out)
-    assert parsed["total_nodes"] == 42
+    assert parsed["store"]["total_nodes"] == 42
     assert parsed["usage"]["whispers_used_this_week"] == 3
 
 

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from ormah.api.routes_admin import router as admin_router
 from ormah.api.routes_agent import router as agent_router
+from ormah.api.routes_stats import router as stats_router
 from ormah.api.routes_ui import router as ui_router
 from ormah.background.maintenance_manager import MaintenanceManager
 from ormah.config import Settings
@@ -26,6 +27,7 @@ def client(tmp_memory_dir):
     test_app = FastAPI()
     test_app.include_router(agent_router)
     test_app.include_router(admin_router)
+    test_app.include_router(stats_router)
     test_app.include_router(ui_router)
     test_app.state.engine = engine
     test_app.state.maintenance_manager = MaintenanceManager(engine)
@@ -67,11 +69,14 @@ def test_recall_not_found(client):
 
 
 def test_stats(client):
-    resp = client.get("/admin/stats")
+    resp = client.get("/stats")
     assert resp.status_code == 200
     body = resp.json()
-    assert "total_nodes" in body
-    assert "whisper_health" in body
+    assert "total_nodes" in body["store"]
+    assert "feedback_health" in body["whisper"]
+
+    assert client.get("/admin/stats").status_code == 404
+    assert client.get("/agent/stats").status_code == 404
 
 
 def test_backup_status_empty_store(client):
@@ -182,7 +187,7 @@ def test_maintenance_runs_in_background_and_stats_stay_available(client):
         assert resp.json()["status"] == "running_phase1"
         assert started.wait(timeout=1)
 
-        stats = client.get("/admin/stats")
+        stats = client.get("/stats")
         assert stats.status_code == 200
 
         release.set()

--- a/tests/test_api/test_stats.py
+++ b/tests/test_api/test_stats.py
@@ -1,4 +1,4 @@
-"""Tests for the /agent/stats counter endpoint (F09/F10)."""
+"""Tests for the canonical /stats endpoint."""
 
 from datetime import datetime, timedelta, timezone
 
@@ -6,7 +6,9 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from ormah.api.routes_admin import router as admin_router
 from ormah.api.routes_agent import router as agent_router
+from ormah.api.routes_stats import router as stats_router
 from ormah.config import Settings
 from ormah.engine.memory_engine import MemoryEngine
 
@@ -19,6 +21,8 @@ def stats_setup(tmp_memory_dir):
 
     test_app = FastAPI()
     test_app.include_router(agent_router)
+    test_app.include_router(admin_router)
+    test_app.include_router(stats_router)
     test_app.state.engine = engine
 
     with TestClient(test_app) as c:
@@ -48,26 +52,34 @@ def _remember(client, content="A fact about the user."):
 
 def test_stats_empty(stats_setup):
     client, _ = stats_setup
-    resp = client.get("/agent/stats")
+    resp = client.get("/stats")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["whispers_used_total"] == 0
-    assert data["whispers_used_this_week"] == 0
-    assert data["memories_total"] == 0
-    assert data["memories_this_week"] == 0
-    # window_days is days elapsed in the current calendar week (1-7), not a
+    assert data["usage"]["whispers_used_total"] == 0
+    assert data["usage"]["whispers_used_this_week"] == 0
+    assert data["usage"]["memories_total"] == 0
+    assert data["usage"]["memories_this_week"] == 0
+    assert data["store"]["total_nodes"] >= 1
+    assert "feedback_health" in data["whisper"]
+    # window.days is days elapsed in the current calendar week (1-7), not a
     # fixed rolling-window size, since the default is now a fixed Mon-Sun week.
-    assert 1 <= data["window_days"] <= 7
+    assert 1 <= data["window"]["days"] <= 7
     assert "generated_at" in data
+
+
+def test_old_stats_routes_removed(stats_setup):
+    client, _ = stats_setup
+    assert client.get("/agent/stats").status_code == 404
+    assert client.get("/admin/stats").status_code == 404
 
 
 def test_memories_counted(stats_setup):
     client, _ = stats_setup
     _remember(client, "Fact one.")
     _remember(client, "Fact two.")
-    data = client.get("/agent/stats").json()
-    assert data["memories_total"] == 2
-    assert data["memories_this_week"] == 2
+    data = client.get("/stats").json()
+    assert data["usage"]["memories_total"] == 2
+    assert data["usage"]["memories_this_week"] == 2
 
 
 def test_whispers_used_counts_distinct_calls(stats_setup):
@@ -80,9 +92,9 @@ def test_whispers_used_counts_distinct_calls(stats_setup):
     # Two candidates from a single whisper call, both injected.
     _log_whisper(engine, node_id="n1", was_injected=1, logged_at=now)
     _log_whisper(engine, node_id="n2", was_injected=1, logged_at=now)
-    data = client.get("/agent/stats").json()
-    assert data["whispers_used_total"] == 1
-    assert data["whispers_used_this_week"] == 1
+    data = client.get("/stats").json()
+    assert data["usage"]["whispers_used_total"] == 1
+    assert data["usage"]["whispers_used_this_week"] == 1
 
 
 def test_non_injected_whispers_excluded(stats_setup):
@@ -90,8 +102,8 @@ def test_non_injected_whispers_excluded(stats_setup):
     client, engine = stats_setup
     now = datetime.now(timezone.utc).isoformat()
     _log_whisper(engine, node_id="n1", was_injected=0, logged_at=now, prompt="p1")
-    data = client.get("/agent/stats").json()
-    assert data["whispers_used_total"] == 0
+    data = client.get("/stats").json()
+    assert data["usage"]["whispers_used_total"] == 0
 
 
 def test_weekly_window_excludes_old(stats_setup):
@@ -100,9 +112,9 @@ def test_weekly_window_excludes_old(stats_setup):
     old = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
     _log_whisper(engine, node_id="n1", was_injected=1, logged_at=recent, prompt="recent")
     _log_whisper(engine, node_id="n2", was_injected=1, logged_at=old, prompt="old")
-    data = client.get("/agent/stats").json()
-    assert data["whispers_used_total"] == 2
-    assert data["whispers_used_this_week"] == 1
+    data = client.get("/stats").json()
+    assert data["usage"]["whispers_used_total"] == 2
+    assert data["usage"]["whispers_used_this_week"] == 1
 
 
 def test_clients_endpoint(stats_setup, monkeypatch):
@@ -129,7 +141,7 @@ def test_custom_window(stats_setup):
     old = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
     _log_whisper(engine, node_id="n1", was_injected=1, logged_at=old, prompt="old")
     # default 7d window excludes it; 30d window includes it
-    assert client.get("/agent/stats").json()["whispers_used_this_week"] == 0
-    data = client.get("/agent/stats", params={"days": 30}).json()
-    assert data["whispers_used_this_week"] == 1
-    assert data["window_days"] == 30
+    assert client.get("/stats").json()["usage"]["whispers_used_this_week"] == 0
+    data = client.get("/stats", params={"days": 30}).json()
+    assert data["usage"]["whispers_used_this_week"] == 1
+    assert data["window"]["days"] == 30

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -229,7 +229,7 @@ def test_stats(engine):
 
     stats = engine.stats()
     # +1 for the self node created on startup
-    assert stats["total_nodes"] == 2
+    assert stats["store"]["total_nodes"] == 2
 
 
 def test_warmup_reranker_marks_unavailable_when_cache_missing(settings):

--- a/tests/test_whisper_health.py
+++ b/tests/test_whisper_health.py
@@ -166,8 +166,8 @@ def test_seven_day_cutoff():
 
 def test_stats_exposes_whisper_health(engine):
     out = engine.stats()
-    assert "whisper_health" in out
-    wh = out["whisper_health"]
+    assert "feedback_health" in out["whisper"]
+    wh = out["whisper"]["feedback_health"]
     assert set(wh) == {"all_time", "last_7d"}
     assert set(wh["last_7d"]) == {
         "injected", "feedback_rows", "coverage",
@@ -199,7 +199,7 @@ def test_stats_whisper_health_seeded(engine):
         "VALUES (X'00', 'n1', 1, 'explicit', datetime('now'), 's1', ?)",
         (wid,),
     )
-    wh = engine.stats()["whisper_health"]["all_time"]
+    wh = engine.stats()["whisper"]["feedback_health"]["all_time"]
     assert wh["injected"] == 1
     assert wh["feedback_rows"] == 1
     assert wh["coverage"] == 1.0

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -52,7 +52,7 @@ export function fetchInsights(): Promise<InsightsData> {
 }
 
 export function fetchStats(): Promise<Record<string, unknown>> {
-  return get("/admin/stats");
+  return get("/stats");
 }
 
 export interface AdminTask {


### PR DESCRIPTION
## Summary

- Add canonical `GET /stats` for tray, CLI, UI, and diagnostics.
- Remove the old stats routes: `/agent/stats` and `/admin/stats`.
- Return one clean nested stats payload from `MemoryEngine.stats()`.
- Move desktop tray, CLI, and web UI callers to `GET /stats`.

## Response Shape

```json
{
  "generated_at": "2026-07-07T11:30:00+00:00",
  "window": {
    "kind": "calendar_week",
    "days": 2,
    "cutoff": "2026-07-06T00:00:00+00:00"
  },
  "usage": {
    "whispers_used_this_week": 3,
    "whispers_used_total": 42,
    "memories_this_week": 2,
    "memories_total": 18
  },
  "store": {
    "total_nodes": 19,
    "by_tier": {
      "core": 1,
      "working": 18,
      "archival": 0
    },
    "total_edges": 6
  },
  "whisper": {
    "feedback_health": {
      "all_time": {
        "injected": 10,
        "feedback_rows": 4,
        "coverage": 0.4,
        "positive": 3,
        "negative": 1,
        "precision": 0.75,
        "unlinked_feedback_rows": 0
      },
      "last_7d": {
        "injected": 5,
        "feedback_rows": 2,
        "coverage": 0.4,
        "positive": 2,
        "negative": 0,
        "precision": 1.0
      }
    }
  }
}
```

When `days` is omitted, `usage` uses the current calendar week window. Passing `?days=N` switches the usage window to a rolling N-day window. Andre's `whisper.feedback_health.last_7d` remains a fixed 7-day health window by design.

## Compatibility

This intentionally removes the old stats API routes. New source clients are updated in this PR:

- desktop tray polls `/stats` and reads `usage`.
- `ormah stats` calls `/stats` once and reads `usage` + `store`.
- web UI stats fetcher calls `/stats`.

Older desktop app builds that still poll `/agent/stats` will need to be updated alongside the newer server.

## Verification

- Live smoke: started the changed server on `127.0.0.1`, verified `GET /stats`, verified `/agent/stats` and `/admin/stats` return `404`, and verified `ormah stats --json` against that server.
- `uv run pytest tests/test_api/test_stats.py tests/test_api/test_routes.py tests/test_adapters/test_cli_adapter.py tests/test_whisper_health.py tests/test_engine/test_memory_engine.py::test_stats -q`
- `uv run ruff check src/ormah/engine/memory_engine.py src/ormah/api/routes_stats.py src/ormah/api/routes_agent.py src/ormah/api/routes_admin.py src/ormah/main.py src/ormah/adapters/cli_adapter.py tests/test_api/test_stats.py tests/test_api/test_routes.py tests/test_adapters/test_cli_adapter.py tests/test_whisper_health.py tests/test_engine/test_memory_engine.py`
- `npm run build` in `ui/`
- `npm --prefix desktop/ui install`
- `npm run build` in `desktop/ui/`
- `cargo check` in `desktop/src-tauri/`

For `cargo check`, I used a temporary ignored `desktop/src-tauri/binaries/uv-x86_64-unknown-linux-gnu` placeholder so Tauri's build script could resolve the expected sidecar path.
