### PR TITLE
perf(background): reuse stored vectors for maintenance probe nodes (#88)

### DIFF
--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -172,7 +172,7 @@ def _find_link_candidates(engine, limit: int = 8) -> list[dict]:
     """
     try:
         from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore
+        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
         settings = engine.settings
         encoder = get_encoder(settings)
@@ -195,7 +195,7 @@ def _find_link_candidates(engine, limit: int = 8) -> list[dict]:
             if not text:
                 continue
 
-            query_vec = encoder.encode(text)
+            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
             similar = vec_store.search(query_vec, limit=6)
 
             for match in similar:
@@ -308,7 +308,6 @@ def run_auto_linker(engine) -> None:
     """Incrementally link nodes with seq above the watermark; advance only past
     fully-resolved nodes."""
     try:
-        from ormah.embeddings.encoder import get_encoder
         from ormah.embeddings.vector_store import VectorStore
 
         settings = engine.settings
@@ -316,7 +315,6 @@ def run_auto_linker(engine) -> None:
             logger.debug("Auto-linker skipped: LLM not enabled")
             return
 
-        encoder = get_encoder(settings)
         vec_store = VectorStore(engine.db)
         conn = engine.db.conn
         threshold = settings.auto_link_similarity_threshold
@@ -335,7 +333,8 @@ def run_auto_linker(engine) -> None:
 
             node_resolved = True
             text = f"{node['title'] or ''} {node['content']}".strip()
-            if text and vec_store.get(node["id"]) is None:
+            node_vec = vec_store.get(node["id"]) if text else None
+            if text and node_vec is None:
                 # Node has no vector yet (e.g. node_vectors wiped mid full_rebuild,
                 # before _reindex_all_embeddings restores them). search() would return no
                 # candidates and the watermark would advance past a node never actually
@@ -346,7 +345,7 @@ def run_auto_linker(engine) -> None:
                 # permanently-unembeddable node ever stalls the cursor in practice.
                 node_resolved = False
             elif text:
-                query_vec = encoder.encode(text)
+                query_vec = node_vec
                 similar = vec_store.search(query_vec, limit=6)
 
                 for match in similar:

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -195,7 +195,14 @@ def _find_link_candidates(engine, limit: int = 8) -> list[dict]:
             if not text:
                 continue
 
-            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
+            query_vec = stored_or_encoded(
+                vec_store,
+                encoder,
+                node["id"],
+                node["title"],
+                node["content"],
+                settings.embedding_max_content_chars,
+            )
             similar = vec_store.search(query_vec, limit=6)
 
             for match in similar:

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -141,7 +141,14 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
             if not text:
                 continue
 
-            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
+            query_vec = stored_or_encoded(
+                vec_store,
+                encoder,
+                node["id"],
+                node["title"],
+                node["content"],
+                settings.embedding_max_content_chars,
+            )
             similar = vec_store.search(query_vec, limit=15)
 
             for match in similar:

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -111,7 +111,7 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
     """
     try:
         from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore
+        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
         settings = engine.settings
         encoder = get_encoder(settings)
@@ -141,7 +141,7 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
             if not text:
                 continue
 
-            query_vec = encoder.encode(text)
+            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
             similar = vec_store.search(query_vec, limit=15)
 
             for match in similar:

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -164,7 +164,14 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
             if not text:
                 continue
 
-            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
+            query_vec = stored_or_encoded(
+                vec_store,
+                encoder,
+                node["id"],
+                node["title"],
+                node["content"],
+                settings.embedding_max_content_chars,
+            )
             similar = vec_store.search(query_vec, limit=6)
 
             for match in similar:
@@ -263,7 +270,14 @@ def run_duplicate_detection(engine) -> None:
             if not text:
                 continue
 
-            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
+            query_vec = stored_or_encoded(
+                vec_store,
+                encoder,
+                node["id"],
+                node["title"],
+                node["content"],
+                settings.embedding_max_content_chars,
+            )
             # Fetch more candidates since we use a lower embedding pre-filter
             similar = vec_store.search(query_vec, limit=6)
 

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -143,7 +143,7 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
     """
     try:
         from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore
+        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
         settings = engine.settings
         encoder = get_encoder(settings)
@@ -164,7 +164,7 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
             if not text:
                 continue
 
-            query_vec = encoder.encode(text)
+            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
             similar = vec_store.search(query_vec, limit=6)
 
             for match in similar:
@@ -240,7 +240,7 @@ def run_duplicate_detection(engine) -> None:
     """
     try:
         from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore
+        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
         settings = engine.settings
         encoder = get_encoder(settings)
@@ -263,7 +263,7 @@ def run_duplicate_detection(engine) -> None:
             if not text:
                 continue
 
-            query_vec = encoder.encode(text)
+            query_vec = stored_or_encoded(vec_store, encoder, node["id"], text)
             # Fetch more candidates since we use a lower embedding pre-filter
             similar = vec_store.search(query_vec, limit=6)
 

--- a/src/ormah/embeddings/text.py
+++ b/src/ormah/embeddings/text.py
@@ -1,0 +1,15 @@
+"""Canonical probe text for embeddings.
+
+Single source of truth: every vector in ``node_vectors`` and every maintenance
+probe must be built from this function, or KNN compares vectors of different
+texts.
+"""
+
+from __future__ import annotations
+
+
+def embedding_text(title: str | None, content: str, max_content_chars: int = 512) -> str:
+    """Build text for embedding. Truncates content to avoid topic averaging in long docs."""
+    prefix = title or ""
+    truncated = content[:max_content_chars]
+    return f"{prefix} {truncated}".strip()

--- a/src/ormah/embeddings/vector_store.py
+++ b/src/ormah/embeddings/vector_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import struct
 from typing import TYPE_CHECKING, Any
 
@@ -9,6 +10,8 @@ import numpy as np
 
 if TYPE_CHECKING:
     from ormah.index.db import Database
+
+logger = logging.getLogger(__name__)
 
 
 def _serialize_f32(vec: np.ndarray) -> bytes:
@@ -88,3 +91,15 @@ class VectorStore:
     def count(self) -> int:
         row = self.db.conn.execute("SELECT COUNT(*) FROM node_vectors").fetchone()
         return row[0] if row else 0
+
+
+def stored_or_encoded(vec_store: VectorStore, encoder, node_id: str, text: str) -> np.ndarray:
+    """Return the stored embedding for *node_id*; re-encode *text* only if missing.
+
+    A miss should not happen after embedding backfill — warn so operators see it.
+    """
+    vec = vec_store.get(node_id)
+    if vec is not None:
+        return vec
+    logger.warning("node_vectors has no embedding for %s; re-encoding probe text", node_id[:8])
+    return encoder.encode(text)

--- a/src/ormah/embeddings/vector_store.py
+++ b/src/ormah/embeddings/vector_store.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from ormah.embeddings.text import embedding_text
+
 if TYPE_CHECKING:
     from ormah.index.db import Database
 
@@ -93,8 +95,19 @@ class VectorStore:
         return row[0] if row else 0
 
 
-def stored_or_encoded(vec_store: VectorStore, encoder, node_id: str, text: str) -> np.ndarray:
-    """Return the stored embedding for *node_id*; re-encode *text* only if missing.
+def stored_or_encoded(
+    vec_store: VectorStore,
+    encoder,
+    node_id: str,
+    title: str | None,
+    content: str,
+    max_content_chars: int,
+) -> np.ndarray:
+    """Return the stored embedding for *node_id*, re-encoding only if it is missing.
+
+    The fallback rebuilds the probe through ``embedding_text`` so it matches the
+    truncation the corpus vectors were built with — encoding the raw full content
+    here would compare a full-content probe against a truncated corpus.
 
     A miss should not happen after embedding backfill — warn so operators see it.
     """
@@ -102,4 +115,4 @@ def stored_or_encoded(vec_store: VectorStore, encoder, node_id: str, text: str) 
     if vec is not None:
         return vec
     logger.warning("node_vectors has no embedding for %s; re-encoding probe text", node_id[:8])
-    return encoder.encode(text)
+    return encoder.encode(embedding_text(title, content, max_content_chars))

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from ormah.config import Settings
+from ormah.embeddings.text import embedding_text as _embedding_text
 from ormah.engine.context_builder import ContextBuilder
 from ormah.engine.maintenance_signal import (
     MAINTENANCE_DUE_SIGNAL,
@@ -57,13 +58,6 @@ def _generate_title(content: str, max_chars: int = 60) -> str:
     # Truncate at last word boundary within max_chars
     truncated = first_line[:max_chars].rsplit(" ", 1)[0]
     return truncated + "…" if truncated else first_line[:max_chars]
-
-
-def _embedding_text(title: str | None, content: str, max_content_chars: int = 512) -> str:
-    """Build text for embedding. Truncates content to avoid topic averaging in long docs."""
-    prefix = title or ""
-    truncated = content[:max_content_chars]
-    return f"{prefix} {truncated}".strip()
 
 
 # Edge type factors for spreading activation scoring.

--- a/tests/test_background/test_reuse_stored_vectors.py
+++ b/tests/test_background/test_reuse_stored_vectors.py
@@ -2,6 +2,7 @@
 import re
 import numpy as np
 
+from ormah.embeddings.text import embedding_text
 from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
 
@@ -21,9 +22,11 @@ class _CountingEncoder:
     def __init__(self, dim):
         self.dim = dim
         self.calls = 0
+        self.seen: str | None = None
 
     def encode(self, text):
         self.calls += 1
+        self.seen = text
         return np.ones(self.dim, dtype=np.float32)
 
 
@@ -33,7 +36,7 @@ def test_stored_or_encoded_prefers_stored_vector(db):
     dim = _vec_dim(db)
     stored = np.full(dim, 0.5, dtype=np.float32)
     store.upsert("node-1", stored)
-    out = stored_or_encoded(store, _ExplodingEncoder(), "node-1", "some text")
+    out = stored_or_encoded(store, _ExplodingEncoder(), "node-1", "Title", "some text", 512)
     assert np.allclose(out, stored)
 
 
@@ -42,10 +45,26 @@ def test_stored_or_encoded_falls_back_and_warns(db, caplog):
     store = VectorStore(db)
     enc = _CountingEncoder(_vec_dim(db))
     with caplog.at_level("WARNING"):
-        out = stored_or_encoded(store, enc, "missing-node", "some text")
+        out = stored_or_encoded(store, enc, "missing-node", "Title", "some text", 512)
     assert enc.calls == 1
     assert out.shape == (enc.dim,)
     assert any("re-encoding" in r.message for r in caplog.records)
+
+
+def test_fallback_encodes_same_truncated_text_as_the_corpus(db):
+    """A miss must probe with _embedding_text semantics, not the raw full content.
+
+    Corpus vectors come from embedding_text(title, content[:max_chars]). Encoding the
+    untruncated probe here would compare a full-content vector against a truncated
+    corpus — the very probe/corpus asymmetry this helper exists to remove.
+    """
+    db.init_vec_table(dim=8)
+    store = VectorStore(db)
+    enc = _CountingEncoder(_vec_dim(db))
+    long_content = "a" * 600
+    stored_or_encoded(store, enc, "missing-node", "Title", long_content, 512)
+    assert enc.seen == embedding_text("Title", long_content, 512)
+    assert enc.seen == "Title " + "a" * 512
 
 
 def test_find_link_candidates_does_not_reencode(engine, monkeypatch, caplog):

--- a/tests/test_background/test_reuse_stored_vectors.py
+++ b/tests/test_background/test_reuse_stored_vectors.py
@@ -1,0 +1,94 @@
+"""Issue #88: pairwise jobs must reuse stored vectors, not re-encode probes."""
+import re
+import numpy as np
+import pytest
+
+from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
+
+
+def _vec_dim(db) -> int:
+    sql = db.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name='node_vectors'"
+    ).fetchone()[0]
+    return int(re.search(r"float\[(\d+)\]", sql, re.IGNORECASE).group(1))
+
+
+class _ExplodingEncoder:
+    def encode(self, text):
+        raise AssertionError("encoder.encode must not run when a stored vector exists")
+
+
+class _CountingEncoder:
+    def __init__(self, dim):
+        self.dim = dim
+        self.calls = 0
+
+    def encode(self, text):
+        self.calls += 1
+        return np.ones(self.dim, dtype=np.float32)
+
+
+def test_stored_or_encoded_prefers_stored_vector(db):
+    db.init_vec_table(dim=8)
+    store = VectorStore(db)
+    dim = _vec_dim(db)
+    stored = np.full(dim, 0.5, dtype=np.float32)
+    store.upsert("node-1", stored)
+    out = stored_or_encoded(store, _ExplodingEncoder(), "node-1", "some text")
+    assert np.allclose(out, stored)
+
+
+def test_stored_or_encoded_falls_back_and_warns(db, caplog):
+    db.init_vec_table(dim=8)
+    store = VectorStore(db)
+    enc = _CountingEncoder(_vec_dim(db))
+    with caplog.at_level("WARNING"):
+        out = stored_or_encoded(store, enc, "missing-node", "some text")
+    assert enc.calls == 1
+    assert out.shape == (enc.dim,)
+    assert any("re-encoding" in r.message for r in caplog.records)
+
+
+def test_find_link_candidates_does_not_reencode(engine, monkeypatch, caplog):
+    from ormah.background import auto_linker
+    from ormah.models.node import CreateNodeRequest
+
+    for i in range(2):
+        engine.remember(CreateNodeRequest(content=f"same fact repeated {i}", title="same fact"))
+    monkeypatch.setattr(
+        "ormah.embeddings.encoder.get_encoder", lambda s: _ExplodingEncoder()
+    )
+    # must not raise: every probe vector already sits in node_vectors
+    with caplog.at_level("WARNING"):
+        auto_linker._find_link_candidates(engine, limit=4)
+    assert not [r for r in caplog.records if "failed" in r.message]
+
+
+def test_find_merge_candidates_does_not_reencode(engine, monkeypatch, caplog):
+    from ormah.background import duplicate_merger
+    from ormah.models.node import CreateNodeRequest
+
+    for i in range(2):
+        engine.remember(CreateNodeRequest(content=f"same fact repeated {i}", title="same fact"))
+    monkeypatch.setattr(
+        "ormah.embeddings.encoder.get_encoder", lambda s: _ExplodingEncoder()
+    )
+    with caplog.at_level("WARNING"):
+        duplicate_merger._find_merge_candidates(engine, limit=4)
+    assert not [r for r in caplog.records if "failed" in r.message]
+
+
+def test_find_conflict_candidates_does_not_reencode(engine, monkeypatch, caplog):
+    from ormah.background import conflict_detector
+    from ormah.models.node import CreateNodeRequest
+
+    for i in range(2):
+        engine.remember(CreateNodeRequest(
+            content=f"same fact repeated {i}", title="same fact", type="preference"
+        ))
+    monkeypatch.setattr(
+        "ormah.embeddings.encoder.get_encoder", lambda s: _ExplodingEncoder()
+    )
+    with caplog.at_level("WARNING"):
+        conflict_detector._find_conflict_candidates(engine, limit=4)
+    assert not [r for r in caplog.records if "failed" in r.message]

--- a/tests/test_background/test_reuse_stored_vectors.py
+++ b/tests/test_background/test_reuse_stored_vectors.py
@@ -1,7 +1,6 @@
 """Issue #88: pairwise jobs must reuse stored vectors, not re-encode probes."""
 import re
 import numpy as np
-import pytest
 
 from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 


### PR DESCRIPTION
Closes #88.

## What

The pairwise maintenance jobs (`auto_linker`, `duplicate_merger`, `conflict_detector`) re-encoded each probe node on every run, even though its embedding already sits in `node_vectors`. They now read the stored vector.

- `stored_or_encoded(...)` returns the stored embedding, re-encoding only on a miss (with a warning — a miss should not happen after backfill).
- `run_auto_linker` reuses the vector it already fetched for its fail-closed watermark check, so the encoder is no longer constructed there at all.
- New `ormah/embeddings/text.py` holds `embedding_text` as the **single source of truth** for probe text. It could not live in `encoder.py` or `vector_store.py`: both import numpy, and `memory_engine` deliberately keeps numpy off its startup import path.

## Behaviour change (intended)

Probe and corpus now speak the same language. Corpus vectors were always built from `embedding_text`, which truncates content to `embedding_max_content_chars` (512); the old probes encoded `title + full content`. For nodes with content longer than 512 chars, **similarity scores change** — the two sides of the KNN were previously misaligned, and this PR aligns them. That realignment is the point of #88, not a side effect.

## Review

Reviewed by the Dev Council (Cursor + Codex, 1 round, 0 criticals).

The adversarial focus was exactly the question above: *do the stored vectors embed the same probe text the removed `encoder.encode` used?* They do not — by design, per the paragraph above. Codex read that divergence as a regression and recommended reverting to full-content semantics; that was rejected, because the old probe was the misaligned side.

The one defect the review found that this PR had genuinely introduced (raised by Cursor) is fixed in b972a37: `stored_or_encoded`'s **fallback** re-encoded the caller's raw, untruncated probe text, comparing a full-content probe against a truncated corpus — reintroducing the exact asymmetry the helper exists to remove, in the one path it exists to serve. The fallback now rebuilds the probe through `embedding_text`.

Note that `duplicate_merger` still builds its own untruncated `text` for `_token_overlap` — truncating it there would have silently changed the composite duplicate score.

## Verification

- `pytest tests/` → `1163 passed, 11 failed`. The 11 failures reproduce identically on a clean worktree of the base commit (`98ca398`) with none of these changes applied: they are environment-dependent (`~/.config/ormah/.env`, real MCP client config, fastembed cache), not a regression.
- `ruff check src/ tests/` → clean.

## Follow-ups (not in this PR)

- `mark_outdated` mutates `content` and calls `index_single`, which preserves the vector (`keep_vectors=True`), without re-embedding. It is the only content mutator that does not re-embed (`update` and `execute_merge` both do). Low severity: the `[Outdated: reason]` suffix only reaches the embedding for nodes under 512 chars.
- `_index_embedding` swallows encode failures and leaves the previous vector in place — a *stale* vector, invisible to the `vec_count < node_count` check. Documented as a comment on #32; see also #38, which implements that issue's delta backfill and retry, and which also touches `memory_engine.py` (currently CONFLICTING with main).
- The new regression tests cover the `_find_*_candidates` paths; `run_auto_linker` and `run_duplicate_detection` are not yet mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
