### PR TITLE
config(background): expose consolidator per-run limits as settings (#89)

### DIFF
--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -26,6 +26,14 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
     max_nodes = s.consolidation_max_cluster_nodes
     threshold = s.consolidation_cluster_threshold
 
+    if max_nodes < min_size:
+        logger.warning(
+            "consolidation_max_cluster_nodes (%d) < consolidation_min_cluster_size (%d); "
+            "no cluster can ever be emitted",
+            max_nodes, min_size,
+        )
+        return []
+
     rows = conn.execute(
         "SELECT id, title, content, space FROM nodes WHERE tier = 'working'"
     ).fetchall()

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -7,20 +7,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-# Maximum number of clusters to consolidate per run.
-_MAX_CLUSTERS_PER_RUN = 10
-
-# Minimum cluster size to justify consolidation.
-_MIN_CLUSTER_SIZE = 2
-
-# Cosine similarity threshold for clustering.
-_CLUSTER_THRESHOLD = 0.6
-
 
 def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
     """Find clusters of similar working-tier nodes for consolidation.
 
-    Returns up to *limit* clusters, each a list of node dicts (max 5 nodes).
+    Returns up to *limit* clusters, each a list of node dicts (max
+    ``engine.settings.consolidation_max_cluster_nodes`` nodes).
     Does NOT call the LLM — pure similarity-based clustering.
     """
     try:
@@ -29,11 +21,15 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
         return []
 
     conn = engine.db.conn
+    s = engine.settings
+    min_size = s.consolidation_min_cluster_size
+    max_nodes = s.consolidation_max_cluster_nodes
+    threshold = s.consolidation_cluster_threshold
 
     rows = conn.execute(
         "SELECT id, title, content, space FROM nodes WHERE tier = 'working'"
     ).fetchall()
-    if len(rows) < _MIN_CLUSTER_SIZE:
+    if len(rows) < min_size:
         return []
 
     try:
@@ -61,12 +57,12 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
         clustered_ids.add(nid)
 
         for match in similar:
-            if len(cluster) >= 5:  # cap at 5 nodes per cluster
+            if len(cluster) >= max_nodes:
                 break
             mid = match["id"]
             if mid == nid or mid in clustered_ids:
                 continue
-            if match["similarity"] < _CLUSTER_THRESHOLD:
+            if match["similarity"] < threshold:
                 continue
             m_row = conn.execute(
                 "SELECT id, title, content, space, tier FROM nodes WHERE id = ?",
@@ -77,7 +73,7 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
             cluster.append(dict(m_row))
             clustered_ids.add(mid)
 
-        if len(cluster) >= _MIN_CLUSTER_SIZE:
+        if len(cluster) >= min_size:
             clusters.append(cluster)
 
     return clusters
@@ -178,7 +174,9 @@ def run_consolidation(engine) -> None:
     if not settings.llm_enabled:
         return
 
-    clusters = _find_consolidation_clusters(engine, limit=_MAX_CLUSTERS_PER_RUN)
+    clusters = _find_consolidation_clusters(
+        engine, limit=settings.consolidation_max_clusters_per_run
+    )
     if not clusters:
         return
 

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -245,6 +245,12 @@ class Settings(BaseSettings):
 
     # Consolidation
     consolidation_interval_minutes: int = 1440
+    # Consolidator per-run limits (#89) — defaults preserve the previous
+    # hardcoded behavior exactly.
+    consolidation_max_clusters_per_run: int = 10
+    consolidation_min_cluster_size: int = 2
+    consolidation_cluster_threshold: float = 0.6
+    consolidation_max_cluster_nodes: int = 5
 
     # Claude-in-the-loop maintenance
     claude_maintenance_enabled: bool = False

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -418,11 +418,40 @@ class Settings(BaseSettings):
         "auto_link_similarity_threshold",
         "auto_merge_threshold",
         "feedback_llm_judge_min_confidence",
+        "consolidation_cluster_threshold",
     )
     @classmethod
     def _threshold_range(cls, v: float) -> float:
+        # `not 0 <= v <= 1` also rejects NaN/inf.
         if not 0 <= v <= 1:
             raise ValueError(f"threshold must be 0–1, got {v}")
+        return v
+
+    @field_validator("consolidation_max_clusters_per_run")
+    @classmethod
+    def _consolidation_max_clusters_non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(f"consolidation_max_clusters_per_run must be >= 0, got {v}")
+        return v
+
+    @field_validator("consolidation_min_cluster_size")
+    @classmethod
+    def _consolidation_min_cluster_size_range(cls, v: int) -> int:
+        if v < 2:
+            raise ValueError(f"consolidation_min_cluster_size must be >= 2, got {v}")
+        return v
+
+    @field_validator("consolidation_max_cluster_nodes")
+    @classmethod
+    def _consolidation_max_cluster_nodes_range(cls, v: int, info) -> int:
+        # Below min_cluster_size, no cluster can ever be emitted; at/above it the
+        # runtime guard still applies. Reject the impossible config up front.
+        min_size = info.data.get("consolidation_min_cluster_size", 2)
+        if v < min_size:
+            raise ValueError(
+                f"consolidation_max_cluster_nodes ({v}) must be >= "
+                f"consolidation_min_cluster_size ({min_size})"
+            )
         return v
 
     @field_validator("activation_decay")

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1539,7 +1539,8 @@ class MemoryEngine:
         batches of candidates (link, conflict, merge, consolidation clusters)
         plus a summary string.  Batch sizes are capped: up to *limit_per_batch*
         pairs for link/conflict/merge (default from settings), up to 4 clusters
-        of max 5 nodes each for consolidation.
+        for consolidation (max nodes per cluster from
+        ``settings.consolidation_max_cluster_nodes``).
         """
         from ormah.background.auto_linker import _find_link_candidates
         from ormah.background.conflict_detector import _find_conflict_candidates

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -157,3 +157,17 @@ def test_run_consolidation_uses_settings_cap(engine, monkeypatch):
     assert seen["limit"] == 3
 
 
+def test_inverted_cluster_bounds_returns_empty_and_warns(consolidation_engine, caplog):
+    from ormah.background.consolidator import _find_consolidation_clusters
+
+    engine, _ids = consolidation_engine
+    engine.settings.consolidation_max_cluster_nodes = 1
+    engine.settings.consolidation_min_cluster_size = 2
+
+    with caplog.at_level("WARNING"):
+        clusters = _find_consolidation_clusters(engine)
+
+    assert clusters == []
+    assert "consolidation_max_cluster_nodes" in caplog.text
+
+

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ormah.config import Settings
 from ormah.models.node import CreateNodeRequest, NodeType, Tier
 
 
@@ -124,5 +125,35 @@ class TestConsolidation:
         from ormah.background.consolidator import run_consolidation
         run_consolidation(engine)
         # Completes without error
+
+
+def test_consolidation_settings_defaults(tmp_path):
+    s = Settings(memory_dir=tmp_path)
+    assert s.consolidation_max_clusters_per_run == 10
+    assert s.consolidation_min_cluster_size == 2
+    assert s.consolidation_cluster_threshold == 0.6
+    assert s.consolidation_max_cluster_nodes == 5
+
+
+def test_consolidation_settings_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORMAH_CONSOLIDATION_MAX_CLUSTERS_PER_RUN", "3")
+    s = Settings(memory_dir=tmp_path)
+    assert s.consolidation_max_clusters_per_run == 3
+
+
+def test_run_consolidation_uses_settings_cap(engine, monkeypatch):
+    from ormah.background import consolidator
+
+    engine.settings.llm_provider = "ollama"
+    engine.settings.consolidation_max_clusters_per_run = 3
+    seen = {}
+
+    def fake_find(eng, limit):
+        seen["limit"] = limit
+        return []
+
+    monkeypatch.setattr(consolidator, "_find_consolidation_clusters", fake_find)
+    consolidator.run_consolidation(engine)
+    assert seen["limit"] == 3
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,3 +221,41 @@ def test_affinity_defaults():
 def test_feedback_llm_judge_min_confidence_range():
     with pytest.raises(ValidationError, match="threshold must be 0"):
         _settings(feedback_llm_judge_min_confidence=1.5)
+
+
+# --- Consolidation limits (#89) ---
+
+def test_consolidation_max_clusters_negative():
+    with pytest.raises(ValidationError, match="consolidation_max_clusters_per_run must be >= 0"):
+        _settings(consolidation_max_clusters_per_run=-1)
+
+
+def test_consolidation_min_cluster_size_below_two():
+    with pytest.raises(ValidationError, match="consolidation_min_cluster_size must be >= 2"):
+        _settings(consolidation_min_cluster_size=1)
+
+
+def test_consolidation_threshold_out_of_range():
+    with pytest.raises(ValidationError, match="threshold must be 0"):
+        _settings(consolidation_cluster_threshold=1.5)
+    with pytest.raises(ValidationError, match="threshold must be 0"):
+        _settings(consolidation_cluster_threshold=-0.1)
+
+
+def test_consolidation_threshold_non_finite():
+    with pytest.raises(ValidationError, match="threshold must be 0"):
+        _settings(consolidation_cluster_threshold=float("nan"))
+    with pytest.raises(ValidationError, match="threshold must be 0"):
+        _settings(consolidation_cluster_threshold=float("inf"))
+
+
+def test_consolidation_max_nodes_zero_rejected():
+    # The destructive misconfig Codex flagged: max_nodes=0 slips past the
+    # runtime guard and emits single-node clusters. Reject it at construction.
+    with pytest.raises(ValidationError, match="consolidation_max_cluster_nodes"):
+        _settings(consolidation_max_cluster_nodes=0)
+
+
+def test_consolidation_inverted_bounds_rejected():
+    with pytest.raises(ValidationError, match="consolidation_max_cluster_nodes"):
+        _settings(consolidation_min_cluster_size=3, consolidation_max_cluster_nodes=2)


### PR DESCRIPTION
Closes #89.

## What

Promotes the four hardcoded consolidator limits to `Settings`
(`ORMAH_CONSOLIDATION_*`), so operators can tune the maintenance
consolidation pass without code changes. **Defaults preserve the previous
behavior exactly.**

| Setting | Default | Was |
|---|---|---|
| `consolidation_max_clusters_per_run` | 10 | `_MAX_CLUSTERS_PER_RUN` |
| `consolidation_min_cluster_size` | 2 | `_MIN_CLUSTER_SIZE` |
| `consolidation_cluster_threshold` | 0.6 | `_CLUSTER_THRESHOLD` |
| `consolidation_max_cluster_nodes` | 5 | hardcoded cap `5` |

## Hardening

Two safety layers on top of the raw settings:

- **Runtime guard** (`consolidator.py`): if `max_cluster_nodes < min_cluster_size`,
  no cluster can ever be emitted — return early with a warning instead of doing
  useless DB/vector work.
- **Config validation** (`config.py`): reject impossible values at construction —
  `max_clusters_per_run >= 0`, `min_cluster_size >= 2`,
  `max_cluster_nodes >= min_cluster_size`, and `cluster_threshold` in `[0, 1]`
  (also rejects NaN/inf). This closes a misconfiguration where
  `min_cluster_size=0` + `max_cluster_nodes=0` slipped past the runtime guard
  (`0 < 0` is false), emitting single-node clusters that `_apply_consolidation`
  would duplicate and archive — silent memory degradation. The runtime guard
  stays as a complementary layer because pydantic does not validate
  post-construction attribute assignment.

## Tests

- `tests/test_background/test_consolidator.py`: defaults, env override, cap
  propagation into `run_consolidation`, inverted-bounds guard.
- `tests/test_config.py`: validation rejects negative / below-min / out-of-range
  / non-finite / inverted-bounds values.

Local run: `ORMAH_LLM_PROVIDER=none pytest tests/test_config.py tests/test_background/test_consolidator.py` — all consolidation tests green; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)