### PR TITLE
feat(background): batch K pairs per LLM call in sleep-cycle maintenance jobs (#87)

### DIFF
--- a/eval/maintenance/cli.py
+++ b/eval/maintenance/cli.py
@@ -1,0 +1,43 @@
+"""CLI: python -m eval.maintenance.cli {mine|run|report} ...
+
+Local A/B eval gate for #87. Mines auto-link candidate pairs from a production
+store (read-only), runs them through the single and batched paths, and reports
+whether the batched verdicts agree with the single ones (gate for raising K).
+Only the aggregate report is safe to share — never the mined pairs.jsonl.
+"""
+import argparse
+import json
+import sys
+
+from eval.maintenance import miner, report, runner
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(prog="eval.maintenance")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    m = sub.add_parser("mine")
+    m.add_argument("--db", required=True)
+    m.add_argument("--out", default="eval/maintenance/corpus/pairs.jsonl")
+    m.add_argument("-n", type=int, default=100)
+    r = sub.add_parser("run")
+    r.add_argument("--pairs", required=True)
+    r.add_argument("--mode", choices=["single", "batched"], required=True)
+    r.add_argument("--k", type=int, default=10)
+    r.add_argument("--out", required=True)
+    g = sub.add_parser("report")
+    g.add_argument("--single", required=True)
+    g.add_argument("--batched", required=True)
+    a = p.parse_args()
+    if a.cmd == "mine":
+        print(f"mined {miner.mine_pairs(a.db, a.out, a.n)} pairs -> {a.out}")
+    elif a.cmd == "run":
+        runner.run(a.pairs, a.mode, a.k, a.out)
+    else:
+        res = report.agreement(json.load(open(a.single)), json.load(open(a.batched)))
+        print(json.dumps(res, indent=2))
+        return 0 if res["gate_pass"] else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/eval/maintenance/corpus/.gitignore
+++ b/eval/maintenance/corpus/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/eval/maintenance/miner.py
+++ b/eval/maintenance/miner.py
@@ -1,0 +1,68 @@
+"""Mine auto-link candidate pairs from a production store, read-only (#87 eval).
+
+Pairs are sampled across similarity bands so the A/B corpus exercises the whole
+decision surface, not just obvious matches. The mined file contains PERSONAL
+memory content and must NEVER be committed (see corpus/.gitignore) — only the
+aggregate agreement metrics leave the machine.
+"""
+from __future__ import annotations
+
+import json
+import random
+import sqlite3
+from pathlib import Path  # noqa: F401 -- convenient for callers building paths
+
+import sqlite_vec
+
+BANDS = [(0.65, 0.75), (0.75, 0.85), (0.85, 1.01)]
+
+
+def _connect_ro(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    return conn
+
+
+def mine_pairs(db_path: str, out_path: str, n: int = 100, seed: int = 42) -> int:
+    conn = _connect_ro(db_path)
+    rng = random.Random(seed)
+    nodes = conn.execute("SELECT id, title, content, type, space FROM nodes").fetchall()
+    rng.shuffle(nodes)
+    per_band = n // len(BANDS)
+    got = {b: 0 for b in BANDS}
+    seen: set[tuple[str, str]] = set()
+    out = open(out_path, "w", encoding="utf-8")
+    written = 0
+    for node in nodes:
+        if written >= n:
+            break
+        vec = conn.execute("SELECT embedding FROM node_vectors WHERE id = ?",
+                           (node["id"],)).fetchone()
+        if vec is None:
+            continue
+        for row in conn.execute(
+                "SELECT id, distance FROM node_vectors WHERE embedding MATCH ? "
+                "ORDER BY distance LIMIT 6", (vec[0],)):
+            sim = 1.0 - (row["distance"] ** 2 / 2.0)
+            key = tuple(sorted([node["id"], row["id"]]))
+            band = next((b for b in BANDS if b[0] <= sim < b[1]), None)
+            if row["id"] == node["id"] or key in seen or band is None or got[band] >= per_band + 5:
+                continue
+            other = conn.execute(
+                "SELECT id, title, content, type, space FROM nodes WHERE id = ?",
+                (row["id"],)).fetchone()
+            if other is None:
+                continue
+            seen.add(key)
+            got[band] += 1
+            out.write(json.dumps({
+                "pair_id": f"{key[0][:8]}-{key[1][:8]}", "similarity": round(sim, 3),
+                "node_a": {k: node[k] for k in node.keys()},
+                "node_b": {k: other[k] for k in other.keys()},
+            }) + "\n")
+            written += 1
+    out.close()
+    return written

--- a/eval/maintenance/report.py
+++ b/eval/maintenance/report.py
@@ -1,0 +1,31 @@
+"""Agreement metrics for the single-vs-batched maintenance eval (#87 gate).
+
+Gate (issue #87): before raising K anywhere, batched verdicts must agree with
+single-call verdicts on the mined pairs — overall agreement >= 0.90 and
+"none"->edge flips <= 0.10. Passing authorizes raising ONE job's per-call K,
+and only for the schema whose corpus was mined (council C3).
+"""
+from __future__ import annotations
+
+GATE_MIN_AGREEMENT = 0.90
+GATE_MAX_NONE_TO_EDGE = 0.10
+
+
+def agreement(single: dict[str, str], batched: dict[str, str]) -> dict:
+    keys = sorted(set(single) & set(batched))
+    n = len(keys)
+    agree = sum(1 for k in keys if single[k] == batched[k])
+    none_keys = [k for k in keys if single[k] == "none"]
+    none_to_edge = sum(1 for k in none_keys if batched[k] not in ("none", "error"))
+    flips: dict[str, int] = {}
+    for k in keys:
+        if single[k] != batched[k]:
+            flips[f"{single[k]}->{batched[k]}"] = flips.get(f"{single[k]}->{batched[k]}", 0) + 1
+    agree_rate = agree / n if n else 0.0
+    none_to_edge_rate = none_to_edge / len(none_keys) if none_keys else 0.0
+    return {
+        "n": n, "agree_rate": round(agree_rate, 3),
+        "none_to_edge_rate": round(none_to_edge_rate, 3), "flips": flips,
+        "gate_pass": agree_rate >= GATE_MIN_AGREEMENT
+                     and none_to_edge_rate <= GATE_MAX_NONE_TO_EDGE,
+    }

--- a/eval/maintenance/runner.py
+++ b/eval/maintenance/runner.py
@@ -1,0 +1,64 @@
+"""Single-vs-batched A/B runner for the maintenance auto-link eval (#87).
+
+Runs the SAME mined pairs through the single-pair path and the batched path and
+records each pair's relationship verdict, so report.agreement can compare them.
+Uses a bare Settings() so the run picks up the machine's real LLM provider.
+"""
+from __future__ import annotations
+
+import json
+
+from ormah.background import auto_linker
+from ormah.background.llm import normalize_link_type, pair_batch
+from ormah.config import Settings
+
+
+def _load_pairs(pairs_path: str) -> list[dict]:
+    pairs = []
+    with open(pairs_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                pairs.append(json.loads(line))
+    return pairs
+
+
+def _to_link_pair(raw: dict) -> dict:
+    """Adapt a mined pair to the {node, other, match_id} shape the linker uses."""
+    a, b = raw["node_a"], raw["node_b"]
+    return {"node": a, "other": b, "match_id": b["id"],
+            "similarity": raw.get("similarity", 0.0)}
+
+
+def _relationship(verdict: dict | None) -> str:
+    """Normalize a link verdict to a relationship label, 'error' when unusable."""
+    if verdict is None:
+        return "error"
+    raw_rel = verdict.get("relationship", "error")
+    return "error" if raw_rel == "error" else normalize_link_type(raw_rel)
+
+
+def run(pairs_path: str, mode: str, k: int, out_path: str) -> None:
+    settings = Settings()
+    raw_pairs = _load_pairs(pairs_path)
+    pairs = [_to_link_pair(r) for r in raw_pairs]
+    verdicts: dict[str, str] = {}
+
+    if mode == "single":
+        for raw, pair in zip(raw_pairs, pairs):
+            result = auto_linker._llm_classify_link(settings, pair["node"], pair["other"])
+            verdicts[raw["pair_id"]] = _relationship(result)
+    else:
+        settings.maintenance_pairs_per_call = k
+        results = pair_batch.judge_pairs(
+            settings, auto_linker._LLM_LINK_INSTRUCTIONS, pairs,
+            auto_linker._render_link_pair,
+            judge_single=lambda p: auto_linker._llm_classify_link(
+                settings, p["node"], p["other"]),
+            k=k,
+        )
+        for raw, result in zip(raw_pairs, results):
+            verdicts[raw["pair_id"]] = _relationship(result)
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(verdicts, f, indent=2)

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -434,13 +434,20 @@ def run_auto_linker(engine) -> dict | None:
             text = f"{node['title'] or ''} {node['content']}".strip()
             node_vec = vec_store.get(node["id"]) if text else None
             if text and node_vec is None:
-                # Node has no vector yet (e.g. node_vectors wiped mid full_rebuild). search()
-                # would find nothing and the watermark would pass a node never checked — so
-                # leave it unresolved and let a later run reprocess it (fail-closed, same as
-                # the LLM-unavailable path). ponytail: a node that never embeds blocks the
-                # watermark forever; acceptable today, revisit if one ever stalls the cursor.
-                stopped = True
-                break
+                # Vectorless node (store mid-backfill). Don't abort the whole run —
+                # that froze the cursor for the entire store. Park the watermark here
+                # (resolved=False → never advance past it, fail-closed) but keep
+                # processing later nodes so they still get edges. A later run advances
+                # once this node's vector lands. A PERMANENTLY vectorless node parks
+                # the cursor for good — hence the WARNING (deferred: retry set
+                # decoupled from the cursor).
+                logger.warning(
+                    "auto_linker: node %s (seq %s) has no vector; watermark parked, "
+                    "continuing with later nodes",
+                    node["id"][:8], node["seq"],
+                )
+                active.append({"node": node, "resolved": False, "pending": 0, "collected": True})
+                continue
             state = {"node": node, "resolved": True, "pending": 0, "collected": False}
             active.append(state)
             if text:

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -417,6 +417,9 @@ def run_auto_linker(engine) -> dict | None:
         if last_complete is not None:
             _set_watermark(engine, last_complete)
 
+        # `seq` is 1-based (meta.node_seq_next starts at 1 — see index/builder.py and
+        # the legacy backfill in index/db.py), so a real node's seq is never 0 and
+        # `last_complete or watermark` cannot silently fall back on a completed run.
         backlog = conn.execute(
             "SELECT COUNT(*) FROM nodes WHERE seq > ?", (last_complete or watermark,)
         ).fetchone()[0]
@@ -426,7 +429,7 @@ def run_auto_linker(engine) -> dict | None:
             "pairs_evaluated": pairs_evaluated,
             "edges_created": created,
             "backlog_nodes": backlog,
-            "duration_s": round(duration, 1),
+            "duration_s": round(duration, 3),
             "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
         }
         logger.info("auto_linker run: %s", stats)
@@ -434,4 +437,4 @@ def run_auto_linker(engine) -> dict | None:
 
     except Exception as e:
         logger.warning("Auto-linker failed: %s", e)
-        return None
+        return {"error": str(e)}

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -171,99 +171,94 @@ def _find_link_candidates(engine, limit: int = 8) -> list[dict]:
     ``run_auto_linker`` (similarity threshold, cross-space penalty,
     not in auto_link_checked, no existing edge).
     """
-    try:
-        from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
+    from ormah.embeddings.encoder import get_encoder
+    from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
-        settings = engine.settings
-        encoder = get_encoder(settings)
-        vec_store = VectorStore(engine.db)
+    settings = engine.settings
+    encoder = get_encoder(settings)
+    vec_store = VectorStore(engine.db)
 
-        conn = engine.db.conn
-        watermark = _get_watermark(conn)
-        nodes = _select_nodes_after(conn, watermark, settings.auto_link_max_nodes_per_run)
-        threshold = settings.auto_link_similarity_threshold
-        cross_space_penalty = settings.auto_link_cross_space_penalty
+    conn = engine.db.conn
+    watermark = _get_watermark(conn)
+    nodes = _select_nodes_after(conn, watermark, settings.auto_link_max_nodes_per_run)
+    threshold = settings.auto_link_similarity_threshold
+    cross_space_penalty = settings.auto_link_cross_space_penalty
 
-        candidates: list[dict] = []
-        seen_pairs: set[tuple[str, str]] = set()
+    candidates: list[dict] = []
+    seen_pairs: set[tuple[str, str]] = set()
 
-        for node in nodes:
+    for node in nodes:
+        if len(candidates) >= limit:
+            break
+
+        text = f"{node['title'] or ''} {node['content']}".strip()
+        if not text:
+            continue
+
+        query_vec = stored_or_encoded(
+            vec_store,
+            encoder,
+            node["id"],
+            node["title"],
+            node["content"],
+            settings.embedding_max_content_chars,
+        )
+        similar = vec_store.search(query_vec, limit=6)
+
+        for match in similar:
             if len(candidates) >= limit:
                 break
-
-            text = f"{node['title'] or ''} {node['content']}".strip()
-            if not text:
+            if match["id"] == node["id"]:
                 continue
 
-            query_vec = stored_or_encoded(
-                vec_store,
-                encoder,
-                node["id"],
-                node["title"],
-                node["content"],
-                settings.embedding_max_content_chars,
-            )
-            similar = vec_store.search(query_vec, limit=6)
+            similarity = match["similarity"]
 
-            for match in similar:
-                if len(candidates) >= limit:
-                    break
-                if match["id"] == node["id"]:
-                    continue
+            other_space = conn.execute(
+                "SELECT space FROM nodes WHERE id = ?", (match["id"],)
+            ).fetchone()
+            if other_space is not None:
+                src_space = node["space"] or ""
+                tgt_space = other_space["space"] or ""
+                if src_space != tgt_space:
+                    similarity -= cross_space_penalty
 
-                similarity = match["similarity"]
+            if similarity < threshold:
+                continue
 
-                other_space = conn.execute(
-                    "SELECT space FROM nodes WHERE id = ?", (match["id"],)
-                ).fetchone()
-                if other_space is not None:
-                    src_space = node["space"] or ""
-                    tgt_space = other_space["space"] or ""
-                    if src_space != tgt_space:
-                        similarity -= cross_space_penalty
+            pair = tuple(sorted([node["id"], match["id"]]))
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
 
-                if similarity < threshold:
-                    continue
+            already_checked = conn.execute(
+                "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?",
+                pair,
+            ).fetchone()
+            if already_checked:
+                continue
 
-                pair = tuple(sorted([node["id"], match["id"]]))
-                if pair in seen_pairs:
-                    continue
-                seen_pairs.add(pair)
+            existing = conn.execute(
+                "SELECT 1 FROM edges WHERE "
+                "(source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?)",
+                (node["id"], match["id"], match["id"], node["id"]),
+            ).fetchone()
+            if existing:
+                continue
 
-                already_checked = conn.execute(
-                    "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?",
-                    pair,
-                ).fetchone()
-                if already_checked:
-                    continue
+            other = conn.execute(
+                "SELECT id, title, content, type, space FROM nodes WHERE id = ?",
+                (match["id"],),
+            ).fetchone()
+            if other is None:
+                continue
 
-                existing = conn.execute(
-                    "SELECT 1 FROM edges WHERE "
-                    "(source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?)",
-                    (node["id"], match["id"], match["id"], node["id"]),
-                ).fetchone()
-                if existing:
-                    continue
+            candidates.append({
+                "node_a": _node_dict(node),
+                "node_b": _node_dict(other),
+                "similarity": round(similarity, 3),
+            })
 
-                other = conn.execute(
-                    "SELECT id, title, content, type, space FROM nodes WHERE id = ?",
-                    (match["id"],),
-                ).fetchone()
-                if other is None:
-                    continue
-
-                candidates.append({
-                    "node_a": _node_dict(node),
-                    "node_b": _node_dict(other),
-                    "similarity": round(similarity, 3),
-                })
-
-        return candidates
-
-    except Exception as e:
-        logger.warning("_find_link_candidates failed: %s", e)
-        return []
+    return candidates
 
 
 def _apply_edge(
@@ -401,8 +396,9 @@ def run_auto_linker(engine) -> dict | None:
                         # is unresolved, so the whole run waits — no single node blocks others.
                         node_resolved = False
                         continue
-                    pairs_evaluated += 1
                     relationship = llm_result["relationship"]  # may be 'error' (invalid output)
+                    if relationship != "error":
+                        pairs_evaluated += 1
                     _apply_edge(
                         engine, node["id"], match["id"], relationship,
                         llm_result.get("reason", ""), similarity,

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -41,9 +41,10 @@ def _select_nodes_after(conn, watermark: int, limit: int) -> list:
         (watermark, limit),
     ).fetchall()
 
-_LLM_LINK_PROMPT = """\
-You are classifying the relationship between two memories in a knowledge graph. These edges power spreading activation during search — when a user finds Memory A, the system traverses edges to surface related context. Bad edges inject noise; good edges dilute the signal from good ones.
+_LLM_LINK_INTRO = """\
+You are classifying the relationship between two memories in a knowledge graph. These edges power spreading activation during search — when a user finds Memory A, the system traverses edges to surface related context. Bad edges inject noise; good edges dilute the signal from good ones."""
 
+_LLM_LINK_PAIR = """\
 Memory A:
 - Title: {title_a}
 - Type: {type_a}
@@ -54,8 +55,9 @@ Memory B:
 - Title: {title_b}
 - Type: {type_b}
 - Space: {space_b}
-- Content: {content_b}
+- Content: {content_b}"""
 
+_LLM_LINK_RULES = """\
 ## Decision process
 
 **Step 1: Would surfacing B actually help someone reading A?**
@@ -106,6 +108,27 @@ Return JSON:
   "relationship": "supports|contradicts|part_of|depends_on|related_to|none",
   "reason": "one concrete sentence: what specific insight does finding A give you about B?"
 }}"""
+
+_LLM_LINK_PROMPT = _LLM_LINK_INTRO + "\n\n" + _LLM_LINK_PAIR + "\n\n" + _LLM_LINK_RULES
+_LLM_LINK_INSTRUCTIONS = _LLM_LINK_INTRO + "\n\n" + _LLM_LINK_RULES  # fixed block, sent once per batch
+
+
+def _render_link_pair(pair: dict) -> str:
+    """Render one candidate pair for a batched link prompt (#87)."""
+    node, other = pair["node"], pair["other"]
+
+    def _get(row, key, default="unknown"):
+        try:
+            return row[key]
+        except (KeyError, IndexError):
+            return default
+
+    return _LLM_LINK_PAIR.format(
+        title_a=node["title"] or "(untitled)", type_a=_get(node, "type"),
+        space_a=_get(node, "space", "global"), content_a=node["content"][:2000],
+        title_b=other["title"] or "(untitled)", type_b=_get(other, "type"),
+        space_b=_get(other, "space", "global"), content_b=other["content"][:2000],
+    )
 
 
 def _llm_classify_link(settings, node_row, other_row) -> dict | None:
@@ -308,10 +331,21 @@ def _apply_edge(
 
 
 def run_auto_linker(engine) -> dict | None:
-    """Incrementally link nodes with seq above the watermark; advance only past
-    fully-resolved nodes."""
+    """Incrementally link nodes with seq above the watermark, judging candidate
+    pairs in K-sized LLM calls (#87) and advancing only past fully-resolved nodes.
+
+    One streaming loop for every K: pairs are collected across nodes into a window
+    of size K; when it fills it is judged (via pair_batch) and applied. At K=1 the
+    window is a single pair, so the flow is exactly the interleaved single-pair
+    loop — one judgment applied before the next pair is collected — which the
+    existing suite pins as the K=1 regression net. `active` holds the node states
+    whose pairs are still in flight, in seq order; a node advances the watermark
+    only once it is fully collected, drained, and resolved, with every earlier
+    node already advanced.
+    """
     t0 = time.monotonic()
     try:
+        from ormah.background.llm.pair_batch import judge_pairs
         from ormah.embeddings.vector_store import VectorStore
 
         settings = engine.settings
@@ -324,100 +358,148 @@ def run_auto_linker(engine) -> dict | None:
         threshold = settings.auto_link_similarity_threshold
         cross_space_penalty = settings.auto_link_cross_space_penalty
         max_edges = settings.auto_link_max_edges_per_run
+        max_pairs = settings.auto_link_max_pairs_per_run      # 0 = unbounded (default)
+        k = max(settings.auto_link_pairs_per_call or settings.maintenance_pairs_per_call, 1)
 
         watermark = _get_watermark(conn)
         nodes = _select_nodes_after(conn, watermark, settings.auto_link_max_nodes_per_run)
 
+        seen_pairs: set[tuple[str, str]] = set()
+        window: list[dict] = []          # pending {state, pair}, at most K, across nodes
+        active: list[dict] = []          # node states with pairs in flight, seq order
         created = 0
         pairs_attempted = 0
         pairs_evaluated = 0
         last_complete: int | None = None
+        cap_hit = False
+        stopped = False
+
+        def _advance_watermark() -> None:
+            """Pop fully-collected, drained, resolved nodes off the front of `active`;
+            each sets the watermark. Stop at the first node not yet done — it and
+            everything after it must be reprocessed next run."""
+            nonlocal last_complete
+            while active:
+                head = active[0]
+                if not head["collected"] or head["pending"] > 0 or not head["resolved"]:
+                    break
+                last_complete = head["node"]["seq"]
+                active.pop(0)
+
+        def _flush() -> bool:
+            """Judge + apply the pairs in `window` (one K-chunk). Returns False when
+            the run must stop (LLM outage or edge budget spent)."""
+            nonlocal created, pairs_attempted, pairs_evaluated
+            verdicts = judge_pairs(
+                settings, _LLM_LINK_INSTRUCTIONS, [slot["pair"] for slot in window],
+                _render_link_pair,
+                judge_single=lambda p: _llm_classify_link(settings, p["node"], p["other"]),
+                k=k,
+            )
+            ok = True
+            for slot, v in zip(window, verdicts):
+                state = slot["state"]
+                state["pending"] -= 1
+                if not ok:
+                    continue          # already stopping — just drain pending counts
+                if created >= max_edges:
+                    state["resolved"] = False   # budget spent -> don't advance past this node
+                    ok = False
+                    continue
+                pairs_attempted += 1
+                if v is None:                   # unavailable/unjudged -> fail closed
+                    state["resolved"] = False
+                    ok = False
+                    continue
+                # The "error" sentinel (unparseable/missing output) must never be
+                # normalized — normalize_link_type maps unknowns to related_to, which
+                # would forge an edge from poison content. Real values are normalized
+                # (matches _llm_classify_link's single-pair path and #90).
+                raw_rel = v.get("relationship", "error")
+                relationship = "error" if raw_rel == "error" else normalize_link_type(raw_rel)
+                if relationship != "error":
+                    pairs_evaluated += 1
+                _apply_edge(engine, state["node"]["id"], slot["pair"]["match_id"],
+                            relationship, v.get("reason", ""), slot["pair"]["similarity"])
+                # 'error' (poison content) is recorded in auto_link_checked by _apply_edge
+                # and the node still counts as resolved → watermark advances (council v2 crit#2).
+                if relationship not in ("none", "error"):
+                    created += 1
+            window.clear()
+            return ok
 
         for node in nodes:
-            if created >= max_edges:
-                break  # batch budget spent; do not advance past this node
-
-            node_resolved = True
+            if stopped or cap_hit:
+                break
             text = f"{node['title'] or ''} {node['content']}".strip()
             node_vec = vec_store.get(node["id"]) if text else None
             if text and node_vec is None:
-                # Node has no vector yet (e.g. node_vectors wiped mid full_rebuild,
-                # before _reindex_all_embeddings restores them). search() would return no
-                # candidates and the watermark would advance past a node never actually
-                # checked — so leave it unresolved and let a later run reprocess it.
-                # Same fail-closed contract as the LLM-unavailable path below.
-                # ponytail: a node that never embeds blocks the watermark forever;
-                # acceptable today (embedding failures are already logged), revisit if a
-                # permanently-unembeddable node ever stalls the cursor in practice.
-                node_resolved = False
-            elif text:
-                query_vec = node_vec
-                similar = vec_store.search(query_vec, limit=6)
-
-                for match in similar:
+                # Node has no vector yet (e.g. node_vectors wiped mid full_rebuild). search()
+                # would find nothing and the watermark would pass a node never checked — so
+                # leave it unresolved and let a later run reprocess it (fail-closed, same as
+                # the LLM-unavailable path). ponytail: a node that never embeds blocks the
+                # watermark forever; acceptable today, revisit if one ever stalls the cursor.
+                stopped = True
+                break
+            state = {"node": node, "resolved": True, "pending": 0, "collected": False}
+            active.append(state)
+            if text:
+                for match in vec_store.search(node_vec, limit=6):
                     if created >= max_edges:
-                        node_resolved = False  # interrupted mid-node
+                        state["resolved"] = False   # budget spent mid-node -> interrupted
+                        stopped = True
                         break
                     if match["id"] == node["id"]:
                         continue
-
                     similarity = match["similarity"]
                     other_space = conn.execute(
-                        "SELECT space FROM nodes WHERE id = ?", (match["id"],)
-                    ).fetchone()
+                        "SELECT space FROM nodes WHERE id = ?", (match["id"],)).fetchone()
                     if other_space is not None and (node["space"] or "") != (other_space["space"] or ""):
                         similarity -= cross_space_penalty
                     if similarity < threshold:
                         continue
-
-                    pair = tuple(sorted([node["id"], match["id"]]))
-                    if conn.execute(
-                        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
-                    ).fetchone():
+                    pair_key = tuple(sorted([node["id"], match["id"]]))
+                    if pair_key in seen_pairs:
+                        continue
+                    if conn.execute("SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?",
+                                    pair_key).fetchone():
                         continue
                     if conn.execute(
-                        "SELECT 1 FROM edges WHERE (source_id = ? AND target_id = ?) "
-                        "OR (source_id = ? AND target_id = ?)",
-                        (node["id"], match["id"], match["id"], node["id"]),
-                    ).fetchone():
+                            "SELECT 1 FROM edges WHERE (source_id = ? AND target_id = ?) "
+                            "OR (source_id = ? AND target_id = ?)",
+                            (node["id"], match["id"], match["id"], node["id"])).fetchone():
                         continue
                     other = conn.execute(
                         "SELECT title, content, type, space FROM nodes WHERE id = ?",
-                        (match["id"],),
-                    ).fetchone()
+                        (match["id"],)).fetchone()
                     if other is None:
                         continue
+                    if max_pairs and (pairs_attempted + len(window)) >= max_pairs:
+                        cap_hit = True
+                        state["resolved"] = False   # partially collected -> never advance past
+                        break
+                    seen_pairs.add(pair_key)
+                    state["pending"] += 1
+                    window.append({"state": state, "pair": {
+                        "node": node, "other": other,
+                        "match_id": match["id"], "similarity": similarity}})
+                    if len(window) >= k:
+                        if not _flush():
+                            stopped = True
+                            break
+            state["collected"] = True
+            if not stopped and not cap_hit:
+                _advance_watermark()
 
-                    pairs_attempted += 1
-                    llm_result = _llm_classify_link(settings, node, other)
-                    if llm_result is None:
-                        # LLM UNAVAILABLE (raw None) — transient. Leave node unresolved so the
-                        # watermark does not pass it. Not a poison: if the LLM is down, EVERY node
-                        # is unresolved, so the whole run waits — no single node blocks others.
-                        node_resolved = False
-                        continue
-                    relationship = llm_result["relationship"]  # may be 'error' (invalid output)
-                    if relationship != "error":
-                        pairs_evaluated += 1
-                    _apply_edge(
-                        engine, node["id"], match["id"], relationship,
-                        llm_result.get("reason", ""), similarity,
-                    )
-                    # 'error' (poison content) is recorded in auto_link_checked by _apply_edge
-                    # and the node still counts as resolved → watermark advances (council v2 crit#2).
-                    if relationship not in ("none", "error"):
-                        created += 1
-
-            if not node_resolved:
-                break  # crit#1/imp#4: stop; watermark stays at the last fully-resolved node
-            last_complete = node["seq"]
+        if window and not stopped and not cap_hit:
+            _flush()
+        _advance_watermark()
 
         if last_complete is not None:
             _set_watermark(engine, last_complete)
 
-        # `seq` is 1-based (meta.node_seq_next starts at 1 — see index/builder.py and
-        # the legacy backfill in index/db.py), so a real node's seq is never 0 and
-        # `last_complete or watermark` cannot silently fall back on a completed run.
+        # `seq` is 1-based (meta.node_seq_next starts at 1), so a real node's seq is
+        # never 0 and `last_complete or watermark` cannot silently fall back.
         backlog = conn.execute(
             "SELECT COUNT(*) FROM nodes WHERE seq > ?", (last_complete or watermark,)
         ).fetchone()[0]
@@ -427,6 +509,7 @@ def run_auto_linker(engine) -> dict | None:
             "pairs_attempted": pairs_attempted,
             "pairs_evaluated": pairs_evaluated,
             "edges_created": created,
+            "cap_hit": cap_hit,
             "backlog_nodes": backlog,
             "duration_s": round(duration, 3),
             "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -334,6 +334,7 @@ def run_auto_linker(engine) -> dict | None:
         nodes = _select_nodes_after(conn, watermark, settings.auto_link_max_nodes_per_run)
 
         created = 0
+        pairs_attempted = 0
         pairs_evaluated = 0
         last_complete: int | None = None
 
@@ -392,7 +393,7 @@ def run_auto_linker(engine) -> dict | None:
                     if other is None:
                         continue
 
-                    pairs_evaluated += 1
+                    pairs_attempted += 1
                     llm_result = _llm_classify_link(settings, node, other)
                     if llm_result is None:
                         # LLM UNAVAILABLE (raw None) — transient. Leave node unresolved so the
@@ -400,6 +401,7 @@ def run_auto_linker(engine) -> dict | None:
                         # is unresolved, so the whole run waits — no single node blocks others.
                         node_resolved = False
                         continue
+                    pairs_evaluated += 1
                     relationship = llm_result["relationship"]  # may be 'error' (invalid output)
                     _apply_edge(
                         engine, node["id"], match["id"], relationship,
@@ -426,6 +428,7 @@ def run_auto_linker(engine) -> dict | None:
         duration = time.monotonic() - t0
         stats = {
             "nodes_scanned": len(nodes),
+            "pairs_attempted": pairs_attempted,
             "pairs_evaluated": pairs_evaluated,
             "edges_created": created,
             "backlog_nodes": backlog,

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from datetime import datetime, timezone
 
 from ormah.background.llm import normalize_link_type
@@ -311,16 +312,17 @@ def _apply_edge(
             logger.debug("Failed to persist connection to markdown for %s: %s", node_a_id[:8], e)
 
 
-def run_auto_linker(engine) -> None:
+def run_auto_linker(engine) -> dict | None:
     """Incrementally link nodes with seq above the watermark; advance only past
     fully-resolved nodes."""
+    t0 = time.monotonic()
     try:
         from ormah.embeddings.vector_store import VectorStore
 
         settings = engine.settings
         if not settings.llm_enabled:
             logger.debug("Auto-linker skipped: LLM not enabled")
-            return
+            return {"skipped": "llm_disabled"}
 
         vec_store = VectorStore(engine.db)
         conn = engine.db.conn
@@ -332,6 +334,7 @@ def run_auto_linker(engine) -> None:
         nodes = _select_nodes_after(conn, watermark, settings.auto_link_max_nodes_per_run)
 
         created = 0
+        pairs_evaluated = 0
         last_complete: int | None = None
 
         for node in nodes:
@@ -389,6 +392,7 @@ def run_auto_linker(engine) -> None:
                     if other is None:
                         continue
 
+                    pairs_evaluated += 1
                     llm_result = _llm_classify_link(settings, node, other)
                     if llm_result is None:
                         # LLM UNAVAILABLE (raw None) — transient. Leave node unresolved so the
@@ -412,8 +416,22 @@ def run_auto_linker(engine) -> None:
 
         if last_complete is not None:
             _set_watermark(engine, last_complete)
-        if created:
-            logger.info("Auto-linker created %d edges", created)
+
+        backlog = conn.execute(
+            "SELECT COUNT(*) FROM nodes WHERE seq > ?", (last_complete or watermark,)
+        ).fetchone()[0]
+        duration = time.monotonic() - t0
+        stats = {
+            "nodes_scanned": len(nodes),
+            "pairs_evaluated": pairs_evaluated,
+            "edges_created": created,
+            "backlog_nodes": backlog,
+            "duration_s": round(duration, 1),
+            "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
+        }
+        logger.info("auto_linker run: %s", stats)
+        return stats
 
     except Exception as e:
         logger.warning("Auto-linker failed: %s", e)
+        return None

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -12,15 +12,17 @@ from ormah.models.node import Connection, EdgeType
 
 logger = logging.getLogger(__name__)
 
-_LLM_CONFLICT_PROMPT = """\
-You are checking whether two memories genuinely contradict each other. False positives create noise in the graph and waste the user's time resolving non-conflicts. Be very conservative — only flag true contradictions.
+_LLM_CONFLICT_INTRO = """\
+You are checking whether two memories genuinely contradict each other. False positives create noise in the graph and waste the user's time resolving non-conflicts. Be very conservative — only flag true contradictions."""
 
+_LLM_CONFLICT_PAIR = """\
 Memory A (created: {created_a}, space: {space_a}): "{title_a}"
 {content_a}
 
 Memory B (created: {created_b}, space: {space_b}): "{title_b}"
-{content_b}
+{content_b}"""
 
+_LLM_CONFLICT_RULES = """\
 ## Decision process (stop at first "no")
 
 **1. Same space AND same specific subject?**
@@ -56,6 +58,20 @@ Return JSON only:
   "evolved_node": "a" or "b" (the NEWER view per creation dates — only if type=evolution),
   "explanation": "one sentence using actual memory titles"
 }}"""
+
+_LLM_CONFLICT_PROMPT = _LLM_CONFLICT_INTRO + "\n\n" + _LLM_CONFLICT_PAIR + "\n\n" + _LLM_CONFLICT_RULES
+_LLM_CONFLICT_INSTRUCTIONS = _LLM_CONFLICT_INTRO + "\n\n" + _LLM_CONFLICT_RULES  # sent once per batch
+
+
+def _render_conflict_pair(pair: dict) -> str:
+    """Render one candidate pair for a batched conflict prompt (#87)."""
+    a, b = pair["node_a"], pair["node_b"]
+    return _LLM_CONFLICT_PAIR.format(
+        title_a=a["title"] or "(untitled)", content_a=a["content"][:500],
+        created_a=a.get("created", "unknown"), space_a=a.get("space") or "global",
+        title_b=b["title"] or "(untitled)", content_b=b["content"][:500],
+        created_b=b.get("created", "unknown"), space_b=b.get("space") or "global",
+    )
 
 
 def _llm_check_conflict(settings, node_row, other_row) -> dict | None:
@@ -209,27 +225,47 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
 
 
 def run_conflict_detection(engine) -> dict | None:
-    """Find potentially contradicting nodes and create edges."""
+    """Find potentially contradicting nodes and create edges.
+
+    Candidate pairs from _find_conflict_candidates are judged in K-sized LLM
+    calls (#87). At K=1 the judge is a pure map — one _llm_check_conflict per
+    candidate, exactly as before — so the existing suite is the K=1 regression
+    net. The finder already collects the full candidate list, so no streaming
+    window is needed here: judge the list, then apply verdicts by index.
+    """
     t0 = time.monotonic()
     try:
+        from ormah.background.llm.pair_batch import judge_pairs
+
         settings = engine.settings
 
         if not settings.llm_enabled:
             logger.debug("Conflict detection skipped: LLM not enabled")
             return {"skipped": "llm_disabled"}
 
-        candidates = _find_conflict_candidates(engine, limit=10000)
+        # Pair-denominated cap (#87): default 10000 == the previous hardcoded limit,
+        # so out-of-the-box behavior is unchanged; now operator-configurable. The
+        # finder scans ORDER BY RANDOM(), so a lowered cap stays fair across runs.
+        max_pairs = settings.conflict_check_max_pairs_per_run
+        candidates = _find_conflict_candidates(engine, limit=max_pairs)
+        k = max(settings.conflict_check_pairs_per_call or settings.maintenance_pairs_per_call, 1)
+
+        verdicts = judge_pairs(
+            settings, _LLM_CONFLICT_INSTRUCTIONS, candidates, _render_conflict_pair,
+            judge_single=lambda c: _llm_check_conflict(settings, c["node_a"], c["node_b"]),
+            k=k,
+        )
+
         edges_created = 0
         pairs_attempted = 0
         pairs_evaluated = 0
         dirty_nodes: dict[str, list[Connection]] = {}
 
-        for candidate in candidates:
+        for candidate, llm_result in zip(candidates, verdicts):
             node_a = candidate["node_a"]
             node_b = candidate["node_b"]
 
             pairs_attempted += 1
-            llm_result = _llm_check_conflict(settings, node_a, node_b)
             if llm_result is None:
                 continue
             pairs_evaluated += 1
@@ -237,6 +273,10 @@ def run_conflict_detection(engine) -> dict | None:
                 continue
             if not llm_result.get("same_subject", True):
                 continue
+            # Batch verdicts arrive un-normalized; the single path already
+            # normalized inside _llm_check_conflict (double-normalize is idempotent).
+            if "type" in llm_result:
+                llm_result["type"] = normalize_conflict_type(llm_result["type"])
 
             explanation = llm_result.get("explanation", "")
             now = datetime.now(timezone.utc).isoformat()
@@ -291,6 +331,7 @@ def run_conflict_detection(engine) -> dict | None:
             "pairs_attempted": pairs_attempted,
             "pairs_evaluated": pairs_evaluated,
             "edges_created": edges_created,
+            "cap_hit": len(candidates) >= max_pairs,
             "duration_s": round(duration, 3),
             "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
         }

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -225,6 +225,7 @@ def run_conflict_detection(engine) -> dict | None:
 
         candidates = _find_conflict_candidates(engine, limit=10000)
         edges_created = 0
+        pairs_attempted = 0
         pairs_evaluated = 0
         dirty_nodes: dict[str, list[Connection]] = {}
 
@@ -232,10 +233,11 @@ def run_conflict_detection(engine) -> dict | None:
             node_a = candidate["node_a"]
             node_b = candidate["node_b"]
 
-            pairs_evaluated += 1
+            pairs_attempted += 1
             llm_result = _llm_check_conflict(settings, node_a, node_b)
             if llm_result is None:
                 continue
+            pairs_evaluated += 1
             if not llm_result.get("conflict"):
                 continue
             if not llm_result.get("same_subject", True):
@@ -291,6 +293,7 @@ def run_conflict_detection(engine) -> dict | None:
         duration = time.monotonic() - t0
         stats = {
             "candidates_found": len(candidates),
+            "pairs_attempted": pairs_attempted,
             "pairs_evaluated": pairs_evaluated,
             "edges_created": edges_created,
             "duration_s": round(duration, 3),

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from datetime import datetime, timezone
 
 from ormah.background.llm import normalize_conflict_type
@@ -212,23 +213,26 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
         return []
 
 
-def run_conflict_detection(engine) -> None:
+def run_conflict_detection(engine) -> dict | None:
     """Find potentially contradicting nodes and create edges."""
+    t0 = time.monotonic()
     try:
         settings = engine.settings
 
         if not settings.llm_enabled:
             logger.debug("Conflict detection skipped: LLM not enabled")
-            return
+            return {"skipped": "llm_disabled"}
 
         candidates = _find_conflict_candidates(engine, limit=10000)
         edges_created = 0
+        pairs_evaluated = 0
         dirty_nodes: dict[str, list[Connection]] = {}
 
         for candidate in candidates:
             node_a = candidate["node_a"]
             node_b = candidate["node_b"]
 
+            pairs_evaluated += 1
             llm_result = _llm_check_conflict(settings, node_a, node_b)
             if llm_result is None:
                 continue
@@ -284,8 +288,17 @@ def run_conflict_detection(engine) -> None:
             except Exception as e:
                 logger.debug("Failed to persist conflict edge to markdown for %s: %s", nid[:8], e)
 
-        if edges_created:
-            logger.info("Conflict detector created %d edges", edges_created)
+        duration = time.monotonic() - t0
+        stats = {
+            "candidates_found": len(candidates),
+            "pairs_evaluated": pairs_evaluated,
+            "edges_created": edges_created,
+            "duration_s": round(duration, 1),
+            "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
+        }
+        logger.info("conflict_detector run: %s", stats)
+        return stats
 
     except Exception as e:
         logger.warning("Conflict detection failed: %s", e)
+        return None

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -293,7 +293,7 @@ def run_conflict_detection(engine) -> dict | None:
             "candidates_found": len(candidates),
             "pairs_evaluated": pairs_evaluated,
             "edges_created": edges_created,
-            "duration_s": round(duration, 1),
+            "duration_s": round(duration, 3),
             "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
         }
         logger.info("conflict_detector run: %s", stats)
@@ -301,4 +301,4 @@ def run_conflict_detection(engine) -> dict | None:
 
     except Exception as e:
         logger.warning("Conflict detection failed: %s", e)
-        return None
+        return {"error": str(e)}

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -110,107 +110,102 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
     Node dicts include ``created`` so they can be passed directly to the
     LLM conflict-check prompt.  Does NOT call the LLM.
     """
-    try:
-        from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
+    from ormah.embeddings.encoder import get_encoder
+    from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
-        settings = engine.settings
-        encoder = get_encoder(settings)
-        vec_store = VectorStore(engine.db)
+    settings = engine.settings
+    encoder = get_encoder(settings)
+    vec_store = VectorStore(engine.db)
 
-        if settings.conflict_check_all_spaces:
-            nodes = engine.db.conn.execute(
-                "SELECT id, content, title, type, created, space FROM nodes "
-                "WHERE type IN (?, ?, ?, ?) ORDER BY RANDOM()",
-                _BELIEF_TYPES,
-            ).fetchall()
-        else:
-            nodes = engine.db.conn.execute(
-                "SELECT id, content, title, type, created, space FROM nodes "
-                "WHERE type IN (?, ?, ?, ?) AND (space IS NULL OR space = 'null') ORDER BY RANDOM()",
-                _BELIEF_TYPES,
-            ).fetchall()
+    if settings.conflict_check_all_spaces:
+        nodes = engine.db.conn.execute(
+            "SELECT id, content, title, type, created, space FROM nodes "
+            "WHERE type IN (?, ?, ?, ?) ORDER BY RANDOM()",
+            _BELIEF_TYPES,
+        ).fetchall()
+    else:
+        nodes = engine.db.conn.execute(
+            "SELECT id, content, title, type, created, space FROM nodes "
+            "WHERE type IN (?, ?, ?, ?) AND (space IS NULL OR space = 'null') ORDER BY RANDOM()",
+            _BELIEF_TYPES,
+        ).fetchall()
 
-        checked: set[tuple[str, str]] = set()
-        candidates: list[dict] = []
+    checked: set[tuple[str, str]] = set()
+    candidates: list[dict] = []
 
-        for node in nodes:
+    for node in nodes:
+        if len(candidates) >= limit:
+            break
+
+        text = f"{node['title'] or ''} {node['content']}".strip()
+        if not text:
+            continue
+
+        query_vec = stored_or_encoded(
+            vec_store,
+            encoder,
+            node["id"],
+            node["title"],
+            node["content"],
+            settings.embedding_max_content_chars,
+        )
+        similar = vec_store.search(query_vec, limit=15)
+
+        for match in similar:
             if len(candidates) >= limit:
                 break
-
-            text = f"{node['title'] or ''} {node['content']}".strip()
-            if not text:
+            if match["id"] == node["id"]:
                 continue
 
-            query_vec = stored_or_encoded(
-                vec_store,
-                encoder,
-                node["id"],
-                node["title"],
-                node["content"],
-                settings.embedding_max_content_chars,
-            )
-            similar = vec_store.search(query_vec, limit=15)
+            pair = tuple(sorted([node["id"], match["id"]]))
+            if pair in checked:
+                continue
+            checked.add(pair)
 
-            for match in similar:
-                if len(candidates) >= limit:
-                    break
-                if match["id"] == node["id"]:
-                    continue
+            already_checked = engine.db.conn.execute(
+                "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+            ).fetchone()
+            if already_checked:
+                continue
 
-                pair = tuple(sorted([node["id"], match["id"]]))
-                if pair in checked:
-                    continue
-                checked.add(pair)
+            similarity = match["similarity"]
+            if similarity < 0.4:
+                continue
 
-                already_checked = engine.db.conn.execute(
-                    "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
-                ).fetchone()
-                if already_checked:
-                    continue
+            other = engine.db.conn.execute(
+                "SELECT id, title, content, type, created, space FROM nodes WHERE id = ?",
+                (match["id"],),
+            ).fetchone()
+            if other is None:
+                continue
+            if other["type"] not in _BELIEF_TYPES:
+                continue
 
-                similarity = match["similarity"]
-                if similarity < 0.4:
-                    continue
+            has_edge = engine.db.conn.execute(
+                "SELECT 1 FROM edges WHERE edge_type IN ('contradicts', 'evolved_from') AND "
+                "((source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?))",
+                (node["id"], match["id"], match["id"], node["id"]),
+            ).fetchone()
+            if has_edge:
+                continue
 
-                other = engine.db.conn.execute(
-                    "SELECT id, title, content, type, created, space FROM nodes WHERE id = ?",
-                    (match["id"],),
-                ).fetchone()
-                if other is None:
-                    continue
-                if other["type"] not in _BELIEF_TYPES:
-                    continue
+            def _nd(row) -> dict:
+                return {
+                    "id": row["id"],
+                    "title": row["title"] or "",
+                    "type": row["type"] or "",
+                    "space": row["space"] or "",
+                    "content": (row["content"] or "")[:400],
+                    "created": row["created"] or "",
+                }
 
-                has_edge = engine.db.conn.execute(
-                    "SELECT 1 FROM edges WHERE edge_type IN ('contradicts', 'evolved_from') AND "
-                    "((source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?))",
-                    (node["id"], match["id"], match["id"], node["id"]),
-                ).fetchone()
-                if has_edge:
-                    continue
+            candidates.append({
+                "node_a": _nd(node),
+                "node_b": _nd(other),
+                "similarity": round(similarity, 3),
+            })
 
-                def _nd(row) -> dict:
-                    return {
-                        "id": row["id"],
-                        "title": row["title"] or "",
-                        "type": row["type"] or "",
-                        "space": row["space"] or "",
-                        "content": (row["content"] or "")[:400],
-                        "created": row["created"] or "",
-                    }
-
-                candidates.append({
-                    "node_a": _nd(node),
-                    "node_b": _nd(other),
-                    "similarity": round(similarity, 3),
-                })
-
-        return candidates
-
-    except Exception as e:
-        logger.warning("_find_conflict_candidates failed: %s", e)
-        return []
+    return candidates
 
 
 def run_conflict_detection(engine) -> dict | None:

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -41,10 +41,7 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
     if len(rows) < min_size:
         return []
 
-    try:
-        vec_store = VectorStore(engine.db)
-    except Exception:
-        return []
+    vec_store = VectorStore(engine.db)
 
     clustered_ids: set[str] = set()
     clusters: list[list[dict]] = []

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -176,17 +177,22 @@ def _apply_consolidation(
     return new_id
 
 
-def run_consolidation(engine) -> None:
+def run_consolidation(engine) -> dict | None:
     """Find clusters of similar working memories and consolidate via LLM."""
+    t0 = time.monotonic()
     settings = engine.settings
     if not settings.llm_enabled:
-        return
+        return {"skipped": "llm_disabled"}
 
     clusters = _find_consolidation_clusters(
         engine, limit=settings.consolidation_max_clusters_per_run
     )
     if not clusters:
-        return
+        return {
+            "clusters_found": 0,
+            "clusters_consolidated": 0,
+            "duration_s": round(time.monotonic() - t0, 1),
+        }
 
     consolidated_count = 0
     for cluster in clusters:
@@ -196,8 +202,13 @@ def run_consolidation(engine) -> None:
         except Exception as e:
             logger.warning("Failed to consolidate cluster: %s", e)
 
-    if consolidated_count:
-        logger.info("Consolidated %d cluster(s)", consolidated_count)
+    stats = {
+        "clusters_found": len(clusters),
+        "clusters_consolidated": consolidated_count,
+        "duration_s": round(time.monotonic() - t0, 1),
+    }
+    logger.info("consolidator run: %s", stats)
+    return stats
 
 
 def _consolidate_cluster(engine, cluster: list[dict]) -> None:

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -205,7 +205,7 @@ def run_consolidation(engine) -> dict | None:
     stats = {
         "clusters_found": len(clusters),
         "clusters_consolidated": consolidated_count,
-        "duration_s": round(time.monotonic() - t0, 1),
+        "duration_s": round(time.monotonic() - t0, 3),
     }
     logger.info("consolidator run: %s", stats)
     return stats

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -191,7 +191,7 @@ def run_consolidation(engine) -> dict | None:
         return {
             "clusters_found": 0,
             "clusters_consolidated": 0,
-            "duration_s": round(time.monotonic() - t0, 1),
+            "duration_s": round(time.monotonic() - t0, 3),
         }
 
     consolidated_count = 0

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -16,9 +16,10 @@ _W_TITLE = 0.2
 _W_TOKEN = 0.2
 _COMPOSITE_THRESHOLD = 0.60
 
-_LLM_DUPLICATE_PROMPT = """\
-You are deciding whether two memories in a knowledge graph are duplicates that should be merged into one. If merged, the resulting memory replaces both originals — one is kept (updated), one is deleted. All edges from the deleted node are remapped to the kept node. This is irreversible (though undoable), so be conservative.
+_LLM_DUP_INTRO = """\
+You are deciding whether two memories in a knowledge graph are duplicates that should be merged into one. If merged, the resulting memory replaces both originals — one is kept (updated), one is deleted. All edges from the deleted node are remapped to the kept node. This is irreversible (though undoable), so be conservative."""
 
+_LLM_DUP_PAIR = """\
 Memory A:
 - Title: {title_a}
 - Type: {type_a}
@@ -27,8 +28,9 @@ Memory A:
 Memory B:
 - Title: {title_b}
 - Type: {type_b}
-- Content: {content_b}
+- Content: {content_b}"""
 
+_LLM_DUP_RULES = """\
 ## Are they duplicates?
 
 **YES — merge** if they describe the same core fact, decision, or preference and keeping both would create redundancy. One might be more detailed than the other, or they might phrase the same information differently. The test: if an AI assistant retrieved both while helping the user, would it think "these are saying the same thing"?
@@ -61,6 +63,20 @@ Return JSON:
   "merged_content": "merged content preserving ALL unique details from both (only if is_duplicate=true)",
   "reason": "one sentence referencing the actual memory titles"
 }}"""
+
+_LLM_DUPLICATE_PROMPT = _LLM_DUP_INTRO + "\n\n" + _LLM_DUP_PAIR + "\n\n" + _LLM_DUP_RULES
+_LLM_DUP_INSTRUCTIONS = _LLM_DUP_INTRO + "\n\n" + _LLM_DUP_RULES  # fixed block, sent once per batch
+
+
+def _render_dup_pair(pair: dict) -> str:
+    """Render one candidate pair for a batched duplicate prompt (#87)."""
+    node, other = pair["node"], pair["other"]
+    return _LLM_DUP_PAIR.format(
+        title_a=node["title"] or "(untitled)", type_a=node["type"],
+        content_a=node["content"][:2000],
+        title_b=other["title"] or "(untitled)", type_b=other["type"],
+        content_b=other["content"][:2000],
+    )
 
 
 def _title_similarity(title_a: str | None, title_b: str | None) -> float:
@@ -243,6 +259,7 @@ def run_duplicate_detection(engine) -> dict | None:
     """
     t0 = time.monotonic()
     try:
+        from ormah.background.llm.pair_batch import judge_pairs
         from ormah.embeddings.encoder import get_encoder
         from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
@@ -254,132 +271,126 @@ def run_duplicate_detection(engine) -> dict | None:
             logger.debug("Duplicate detection skipped: LLM not enabled")
             return {"skipped": "llm_disabled"}
 
+        conn = engine.db.conn
         user_node_id = getattr(engine, "user_node_id", None)
+        max_pairs = settings.duplicate_check_max_pairs_per_run   # 0 = unbounded (default)
+        k = max(settings.duplicate_check_pairs_per_call or settings.maintenance_pairs_per_call, 1)
 
-        nodes = engine.db.conn.execute("SELECT id, content, title, type FROM nodes").fetchall()
-        checked = set()
+        # #87: candidate pairs are collected across nodes into a window of size K,
+        # judged in one pair_batch call, then applied. At K=1 the window is one
+        # pair, so each is confirmed and applied before the next is collected —
+        # the existing suite is the K=1 regression net. Council C2: randomize the
+        # scan only when capped, so a capped run doesn't re-judge the same
+        # deterministic front every time (negative verdicts aren't persisted
+        # until #81).
+        nodes = conn.execute(
+            "SELECT id, content, title, type FROM nodes" + _scan_order(max_pairs)).fetchall()
+
+        checked: set[tuple[str, str]] = set()
+        window: list[dict] = []          # pending candidate pairs, at most K, across nodes
         proposals_created = 0
         pairs_attempted = 0
         pairs_evaluated = 0
+        cap_hit = False
 
-        for node in nodes:
-            if node["id"] == user_node_id:
-                continue
-            text = f"{node['title'] or ''} {node['content']}".strip()
-            if not text:
-                continue
-
-            query_vec = stored_or_encoded(
-                vec_store,
-                encoder,
-                node["id"],
-                node["title"],
-                node["content"],
-                settings.embedding_max_content_chars,
+        def _flush() -> None:
+            """Judge the windowed pairs (one K-chunk) and apply merges/proposals."""
+            nonlocal proposals_created, pairs_attempted, pairs_evaluated
+            verdicts = judge_pairs(
+                settings, _LLM_DUP_INSTRUCTIONS, window, _render_dup_pair,
+                judge_single=lambda p: _llm_check_duplicate(settings, p["node"], p["other"]),
+                k=k,
             )
-            # Fetch more candidates since we use a lower embedding pre-filter
-            similar = vec_store.search(query_vec, limit=6)
-
-            for match in similar:
-                if match["id"] == node["id"]:
-                    continue
-                if match["id"] == user_node_id:
-                    continue
-
-                pair = tuple(sorted([node["id"], match["id"]]))
-                if pair in checked:
-                    continue
-                checked.add(pair)
-
-                embedding_sim = match["similarity"]
-                # Pre-filter: skip very dissimilar pairs to avoid wasted work
-                if embedding_sim < 0.25:
-                    continue
-
-                # Same type only
-                other = engine.db.conn.execute(
-                    "SELECT type, title, content FROM nodes WHERE id = ?", (match["id"],)
-                ).fetchone()
-                if other is None or other["type"] != node["type"]:
-                    continue
-
-                # Compute multi-signal score
-                title_sim = _title_similarity(node["title"], other["title"])
-                other_text = f"{other['title'] or ''} {other['content']}".strip()
-                token_sim = _token_overlap(text, other_text)
-                score = _composite_score(embedding_sim, title_sim, token_sim)
-
-                if score < _COMPOSITE_THRESHOLD:
-                    continue
-
-                # --- LLM confirmation (mandatory) ---
+            for pair, llm_result in zip(window, verdicts):
                 pairs_attempted += 1
-                llm_result = _llm_check_duplicate(settings, node, other)
-                if llm_result is None:
-                    # LLM unavailable for this pair — skip
+                if llm_result is None:          # LLM unavailable for this pair — skip
                     continue
                 pairs_evaluated += 1
                 if not llm_result.get("is_duplicate"):
-                    logger.debug(
-                        "LLM rejected duplicate for %s / %s: %s",
-                        node["id"][:8], match["id"][:8],
-                        llm_result.get("reason", ""),
-                    )
+                    logger.debug("LLM rejected duplicate for %s / %s: %s",
+                                 pair["node"]["id"][:8], pair["other"]["id"][:8],
+                                 llm_result.get("reason", ""))
                     continue
-
-                # Extract LLM-generated merge content
                 merged_content = llm_result.get("merged_content")
                 merged_title = llm_result.get("merged_title")
                 reason = llm_result.get("reason", "LLM confirmed duplicate")
-                reason += f" (score={score:.3f}, embed={embedding_sim:.2f}, title={title_sim:.2f}, token={token_sim:.2f})"
-
+                reason += (f" (score={pair['score']:.3f}, embed={pair['embedding_sim']:.2f}, "
+                           f"title={pair['title_sim']:.2f}, token={pair['token_sim']:.2f})")
                 # Auto-merge for high-confidence duplicates
-                if score >= engine.settings.auto_merge_threshold:
+                if pair["score"] >= settings.auto_merge_threshold:
                     try:
                         result = engine.execute_merge(
-                            node["id"], match["id"],
-                            merged_content=merged_content,
-                            merged_title=merged_title,
-                        )
+                            pair["node"]["id"], pair["other"]["id"],
+                            merged_content=merged_content, merged_title=merged_title)
                         logger.info("Auto-merged: %s", result)
                         proposals_created += 1
                         continue
                     except Exception as e:
                         logger.warning("Auto-merge failed for %s / %s: %s",
-                                       node["id"][:8], match["id"][:8], e)
-
-                # Check no existing merge proposal
-                existing = engine.db.conn.execute(
+                                       pair["node"]["id"][:8], pair["other"]["id"][:8], e)
+                existing = conn.execute(
                     "SELECT 1 FROM proposals WHERE type = 'merge' AND status = 'pending' "
                     "AND (source_nodes LIKE ? OR source_nodes LIKE ?)",
-                    (f"%{node['id']}%", f"%{match['id']}%"),
-                ).fetchone()
-
+                    (f"%{pair['node']['id']}%", f"%{pair['other']['id']}%")).fetchone()
                 if existing:
                     continue
-
-                # Build proposed_action — include merged content preview when available
-                proposed_action = f"Merge two {node['type']} memories into one"
+                proposed_action = f"Merge two {pair['node']['type']} memories into one"
                 if merged_content is not None:
-                    proposed_action += (
-                        f"\n\nMerged content preview:\n---\n"
-                        f"{merged_title or ''}\n{merged_content}\n---"
-                    )
-
-                proposal_id = str(uuid.uuid4())
-                with engine.db.transaction() as conn:
-                    conn.execute(
-                        "INSERT INTO proposals (id, type, status, source_nodes, proposed_action, reason, created) "
-                        "VALUES (?, 'merge', 'pending', ?, ?, ?, ?)",
-                        (
-                            proposal_id,
-                            json.dumps([node["id"], match["id"]]),
-                            proposed_action,
-                            reason,
-                            datetime.now(timezone.utc).isoformat(),
-                        ),
-                    )
+                    proposed_action += (f"\n\nMerged content preview:\n---\n"
+                                        f"{merged_title or ''}\n{merged_content}\n---")
+                with engine.db.transaction() as conn_tx:
+                    conn_tx.execute(
+                        "INSERT INTO proposals (id, type, status, source_nodes, proposed_action, "
+                        "reason, created) VALUES (?, 'merge', 'pending', ?, ?, ?, ?)",
+                        (str(uuid.uuid4()), json.dumps([pair["node"]["id"], pair["other"]["id"]]),
+                         proposed_action, reason, datetime.now(timezone.utc).isoformat()))
                 proposals_created += 1
+            window.clear()
+
+        for node in nodes:
+            if cap_hit:
+                break
+            if node["id"] == user_node_id:
+                continue
+            text = f"{node['title'] or ''} {node['content']}".strip()
+            if not text:
+                continue
+            node_vec = stored_or_encoded(
+                vec_store, encoder, node["id"], node["title"], node["content"],
+                settings.embedding_max_content_chars,
+            )
+            for match in vec_store.search(node_vec, limit=6):
+                if match["id"] in (node["id"], user_node_id):
+                    continue
+                pair_key = tuple(sorted([node["id"], match["id"]]))
+                if pair_key in checked:
+                    continue
+                checked.add(pair_key)
+                embedding_sim = match["similarity"]
+                if embedding_sim < 0.25:          # pre-filter: skip very dissimilar pairs
+                    continue
+                other = conn.execute(
+                    "SELECT id, type, title, content FROM nodes WHERE id = ?",
+                    (match["id"],)).fetchone()
+                if other is None or other["type"] != node["type"]:   # same type only
+                    continue
+                title_sim = _title_similarity(node["title"], other["title"])
+                other_text = f"{other['title'] or ''} {other['content']}".strip()
+                token_sim = _token_overlap(text, other_text)
+                score = _composite_score(embedding_sim, title_sim, token_sim)
+                if score < _COMPOSITE_THRESHOLD:
+                    continue
+                if max_pairs and (pairs_attempted + len(window)) >= max_pairs:
+                    cap_hit = True
+                    break
+                window.append({"node": node, "other": other, "score": score,
+                               "embedding_sim": embedding_sim, "title_sim": title_sim,
+                               "token_sim": token_sim})
+                if len(window) >= k:
+                    _flush()
+
+        if window:
+            _flush()
 
         duration = time.monotonic() - t0
         stats = {
@@ -387,6 +398,7 @@ def run_duplicate_detection(engine) -> dict | None:
             "pairs_attempted": pairs_attempted,
             "pairs_evaluated": pairs_evaluated,
             "proposals_created": proposals_created,
+            "cap_hit": cap_hit,
             "duration_s": round(duration, 3),
             "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
         }
@@ -396,3 +408,10 @@ def run_duplicate_detection(engine) -> dict | None:
     except Exception as e:
         logger.warning("Duplicate detection failed: %s", e)
         return {"error": str(e)}
+
+
+def _scan_order(max_pairs: int) -> str:
+    """Council C2 (#87): randomize the node scan only when a per-run cap is set,
+    so a capped run doesn't re-judge the same deterministic front every time
+    (negative verdicts aren't persisted until #81). Uncapped == today's order."""
+    return " ORDER BY RANDOM()" if max_pairs else ""

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -142,100 +142,95 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
     Does NOT call the LLM — just applies the same pre-filters as
     ``run_duplicate_detection`` (same type, composite score threshold).
     """
-    try:
-        from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
+    from ormah.embeddings.encoder import get_encoder
+    from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
 
-        settings = engine.settings
-        encoder = get_encoder(settings)
-        vec_store = VectorStore(engine.db)
+    settings = engine.settings
+    encoder = get_encoder(settings)
+    vec_store = VectorStore(engine.db)
 
-        user_node_id = getattr(engine, "user_node_id", None)
-        nodes = engine.db.conn.execute("SELECT id, content, title, type FROM nodes ORDER BY RANDOM()").fetchall()
-        checked: set[tuple[str, str]] = set()
-        candidates: list[dict] = []
+    user_node_id = getattr(engine, "user_node_id", None)
+    nodes = engine.db.conn.execute("SELECT id, content, title, type FROM nodes ORDER BY RANDOM()").fetchall()
+    checked: set[tuple[str, str]] = set()
+    candidates: list[dict] = []
 
-        for node in nodes:
+    for node in nodes:
+        if len(candidates) >= limit:
+            break
+        if node["id"] == user_node_id:
+            continue
+
+        text = f"{node['title'] or ''} {node['content']}".strip()
+        if not text:
+            continue
+
+        query_vec = stored_or_encoded(
+            vec_store,
+            encoder,
+            node["id"],
+            node["title"],
+            node["content"],
+            settings.embedding_max_content_chars,
+        )
+        similar = vec_store.search(query_vec, limit=6)
+
+        for match in similar:
             if len(candidates) >= limit:
                 break
-            if node["id"] == user_node_id:
+            if match["id"] == node["id"]:
+                continue
+            if match["id"] == user_node_id:
                 continue
 
-            text = f"{node['title'] or ''} {node['content']}".strip()
-            if not text:
+            pair = tuple(sorted([node["id"], match["id"]]))
+            if pair in checked:
+                continue
+            checked.add(pair)
+
+            already_checked = engine.db.conn.execute(
+                "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+            ).fetchone()
+            if already_checked:
                 continue
 
-            query_vec = stored_or_encoded(
-                vec_store,
-                encoder,
-                node["id"],
-                node["title"],
-                node["content"],
-                settings.embedding_max_content_chars,
-            )
-            similar = vec_store.search(query_vec, limit=6)
+            embedding_sim = match["similarity"]
+            if embedding_sim < 0.25:
+                continue
 
-            for match in similar:
-                if len(candidates) >= limit:
-                    break
-                if match["id"] == node["id"]:
-                    continue
-                if match["id"] == user_node_id:
-                    continue
+            other = engine.db.conn.execute(
+                "SELECT id, type, title, content FROM nodes WHERE id = ?", (match["id"],)
+            ).fetchone()
+            if other is None or other["type"] != node["type"]:
+                continue
 
-                pair = tuple(sorted([node["id"], match["id"]]))
-                if pair in checked:
-                    continue
-                checked.add(pair)
+            title_sim = _title_similarity(node["title"], other["title"])
+            other_text = f"{other['title'] or ''} {other['content']}".strip()
+            token_sim = _token_overlap(text, other_text)
+            score = _composite_score(embedding_sim, title_sim, token_sim)
 
-                already_checked = engine.db.conn.execute(
-                    "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
-                ).fetchone()
-                if already_checked:
-                    continue
+            if score < _COMPOSITE_THRESHOLD:
+                continue
 
-                embedding_sim = match["similarity"]
-                if embedding_sim < 0.25:
-                    continue
+            def _nd(row) -> dict:
+                return {
+                    "id": row["id"],
+                    "title": row["title"] or "",
+                    "type": row["type"] or "",
+                    "space": "",
+                    "content": (row["content"] or "")[:400],
+                }
 
-                other = engine.db.conn.execute(
-                    "SELECT id, type, title, content FROM nodes WHERE id = ?", (match["id"],)
-                ).fetchone()
-                if other is None or other["type"] != node["type"]:
-                    continue
+            candidates.append({
+                "node_a": _nd(node),
+                "node_b": _nd(other),
+                "similarity": round(embedding_sim, 3),
+                "score": round(score, 3),
+                "embedding_sim": round(embedding_sim, 3),
+                "title_sim": round(title_sim, 3),
+                "token_sim": round(token_sim, 3),
+            })
 
-                title_sim = _title_similarity(node["title"], other["title"])
-                other_text = f"{other['title'] or ''} {other['content']}".strip()
-                token_sim = _token_overlap(text, other_text)
-                score = _composite_score(embedding_sim, title_sim, token_sim)
-
-                if score < _COMPOSITE_THRESHOLD:
-                    continue
-
-                def _nd(row) -> dict:
-                    return {
-                        "id": row["id"],
-                        "title": row["title"] or "",
-                        "type": row["type"] or "",
-                        "space": "",
-                        "content": (row["content"] or "")[:400],
-                    }
-
-                candidates.append({
-                    "node_a": _nd(node),
-                    "node_b": _nd(other),
-                    "similarity": round(embedding_sim, 3),
-                    "score": round(score, 3),
-                    "embedding_sim": round(embedding_sim, 3),
-                    "title_sim": round(title_sim, 3),
-                    "token_sim": round(token_sim, 3),
-                })
-
-        return candidates
-
-    except Exception as e:
-        logger.warning("_find_merge_candidates failed: %s", e)
-        return []
+    return candidates
 
 
 def run_duplicate_detection(engine) -> dict | None:

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -389,7 +389,7 @@ def run_duplicate_detection(engine) -> dict | None:
             "nodes_scanned": len(nodes),
             "pairs_evaluated": pairs_evaluated,
             "proposals_created": proposals_created,
-            "duration_s": round(duration, 1),
+            "duration_s": round(duration, 3),
             "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
         }
         logger.info("duplicate_merger run: %s", stats)
@@ -397,4 +397,4 @@ def run_duplicate_detection(engine) -> dict | None:
 
     except Exception as e:
         logger.warning("Duplicate detection failed: %s", e)
-        return None
+        return {"error": str(e)}

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -264,6 +264,7 @@ def run_duplicate_detection(engine) -> dict | None:
         nodes = engine.db.conn.execute("SELECT id, content, title, type FROM nodes").fetchall()
         checked = set()
         proposals_created = 0
+        pairs_attempted = 0
         pairs_evaluated = 0
 
         for node in nodes:
@@ -317,11 +318,12 @@ def run_duplicate_detection(engine) -> dict | None:
                     continue
 
                 # --- LLM confirmation (mandatory) ---
-                pairs_evaluated += 1
+                pairs_attempted += 1
                 llm_result = _llm_check_duplicate(settings, node, other)
                 if llm_result is None:
                     # LLM unavailable for this pair — skip
                     continue
+                pairs_evaluated += 1
                 if not llm_result.get("is_duplicate"):
                     logger.debug(
                         "LLM rejected duplicate for %s / %s: %s",
@@ -387,6 +389,7 @@ def run_duplicate_detection(engine) -> dict | None:
         duration = time.monotonic() - t0
         stats = {
             "nodes_scanned": len(nodes),
+            "pairs_attempted": pairs_attempted,
             "pairs_evaluated": pairs_evaluated,
             "proposals_created": proposals_created,
             "duration_s": round(duration, 3),

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -311,6 +311,16 @@ def run_duplicate_detection(engine) -> dict | None:
                                  pair["node"]["id"][:8], pair["other"]["id"][:8],
                                  llm_result.get("reason", ""))
                     continue
+                # An earlier auto-merge in this window may have deleted one of these
+                # nodes (execute_merge picks the keeper by quality, not arg order, and
+                # silently no-ops on a missing node — which would miscount it as a
+                # merge). Skip stale pairs; they are re-collected next run against
+                # fresh state. (#87 council: overlapping in-flight pairs.)
+                if (conn.execute("SELECT 1 FROM nodes WHERE id = ?",
+                                 (pair["node"]["id"],)).fetchone() is None
+                        or conn.execute("SELECT 1 FROM nodes WHERE id = ?",
+                                        (pair["other"]["id"],)).fetchone() is None):
+                    continue
                 merged_content = llm_result.get("merged_content")
                 merged_title = llm_result.get("merged_title")
                 reason = llm_result.get("reason", "LLM confirmed duplicate")

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import uuid
 from datetime import datetime, timezone
 
@@ -237,7 +238,7 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
         return []
 
 
-def run_duplicate_detection(engine) -> None:
+def run_duplicate_detection(engine) -> dict | None:
     """Find near-duplicate nodes and create merge proposals.
 
     Uses a multi-signal approach: embedding similarity (primary),
@@ -245,6 +246,7 @@ def run_duplicate_detection(engine) -> None:
     LLM confirmation is mandatory — no merges happen without LLM
     saying ``is_duplicate: true``.
     """
+    t0 = time.monotonic()
     try:
         from ormah.embeddings.encoder import get_encoder
         from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
@@ -255,13 +257,14 @@ def run_duplicate_detection(engine) -> None:
 
         if not settings.llm_enabled:
             logger.debug("Duplicate detection skipped: LLM not enabled")
-            return
+            return {"skipped": "llm_disabled"}
 
         user_node_id = getattr(engine, "user_node_id", None)
 
         nodes = engine.db.conn.execute("SELECT id, content, title, type FROM nodes").fetchall()
         checked = set()
         proposals_created = 0
+        pairs_evaluated = 0
 
         for node in nodes:
             if node["id"] == user_node_id:
@@ -314,6 +317,7 @@ def run_duplicate_detection(engine) -> None:
                     continue
 
                 # --- LLM confirmation (mandatory) ---
+                pairs_evaluated += 1
                 llm_result = _llm_check_duplicate(settings, node, other)
                 if llm_result is None:
                     # LLM unavailable for this pair — skip
@@ -379,8 +383,18 @@ def run_duplicate_detection(engine) -> None:
                         ),
                     )
                 proposals_created += 1
-        if proposals_created:
-            logger.info("Duplicate merger created %d proposals/auto-merges", proposals_created)
+
+        duration = time.monotonic() - t0
+        stats = {
+            "nodes_scanned": len(nodes),
+            "pairs_evaluated": pairs_evaluated,
+            "proposals_created": proposals_created,
+            "duration_s": round(duration, 1),
+            "pairs_per_s": round(pairs_evaluated / duration, 2) if duration > 0 else 0.0,
+        }
+        logger.info("duplicate_merger run: %s", stats)
+        return stats
 
     except Exception as e:
         logger.warning("Duplicate detection failed: %s", e)
+        return None

--- a/src/ormah/background/job_tracker.py
+++ b/src/ormah/background/job_tracker.py
@@ -23,6 +23,7 @@ class JobStatus:
     run_count: int = 0
     error_count: int = 0
     last_duration_ms: float = 0.0
+    last_stats: dict[str, Any] | None = None
 
 
 class JobTracker:
@@ -32,7 +33,9 @@ class JobTracker:
         self._jobs: dict[str, JobStatus] = {}
         self._lock = threading.Lock()
 
-    def record_success(self, job_id: str, duration_ms: float) -> None:
+    def record_success(
+        self, job_id: str, duration_ms: float, stats: dict[str, Any] | None = None
+    ) -> None:
         now = datetime.now(timezone.utc)
         with self._lock:
             status = self._jobs.setdefault(job_id, JobStatus())
@@ -40,6 +43,7 @@ class JobTracker:
             status.last_success = now
             status.run_count += 1
             status.last_duration_ms = duration_ms
+            status.last_stats = stats
 
     def record_failure(self, job_id: str, error: str, duration_ms: float) -> None:
         now = datetime.now(timezone.utc)
@@ -65,6 +69,7 @@ class JobTracker:
                     "run_count": s.run_count,
                     "error_count": s.error_count,
                     "last_duration_ms": round(s.last_duration_ms, 1),
+                    "last_stats": s.last_stats,
                 }
             return result
 
@@ -75,9 +80,10 @@ def tracked(tracker: JobTracker, job_id: str, fn: Callable, *args: Any) -> Calla
     def _wrapper():
         t0 = time.monotonic()
         try:
-            fn(*args)
+            result = fn(*args)
             duration_ms = (time.monotonic() - t0) * 1000
-            tracker.record_success(job_id, duration_ms)
+            stats = result if isinstance(result, dict) else None
+            tracker.record_success(job_id, duration_ms, stats=stats)
         except Exception as e:
             duration_ms = (time.monotonic() - t0) * 1000
             tracker.record_failure(job_id, str(e), duration_ms)

--- a/src/ormah/background/job_tracker.py
+++ b/src/ormah/background/job_tracker.py
@@ -45,7 +45,13 @@ class JobTracker:
             status.last_duration_ms = duration_ms
             status.last_stats = stats
 
-    def record_failure(self, job_id: str, error: str, duration_ms: float) -> None:
+    def record_failure(
+        self,
+        job_id: str,
+        error: str,
+        duration_ms: float,
+        stats: dict[str, Any] | None = None,
+    ) -> None:
         now = datetime.now(timezone.utc)
         with self._lock:
             status = self._jobs.setdefault(job_id, JobStatus())
@@ -55,6 +61,7 @@ class JobTracker:
             status.run_count += 1
             status.error_count += 1
             status.last_duration_ms = duration_ms
+            status.last_stats = stats
 
     def snapshot(self) -> dict[str, dict[str, Any]]:
         """Return a JSON-serialisable snapshot of all job statuses."""
@@ -83,7 +90,13 @@ def tracked(tracker: JobTracker, job_id: str, fn: Callable, *args: Any) -> Calla
             result = fn(*args)
             duration_ms = (time.monotonic() - t0) * 1000
             stats = result if isinstance(result, dict) else None
-            tracker.record_success(job_id, duration_ms, stats=stats)
+            if stats is not None and "error" in stats:
+                tracker.record_failure(job_id, str(stats["error"]), duration_ms, stats=stats)
+                logger.warning(
+                    "Job %s reported an error after %.0fms: %s", job_id, duration_ms, stats["error"]
+                )
+            else:
+                tracker.record_success(job_id, duration_ms, stats=stats)
         except Exception as e:
             duration_ms = (time.monotonic() - t0) * 1000
             tracker.record_failure(job_id, str(e), duration_ms)

--- a/src/ormah/background/llm/base.py
+++ b/src/ormah/background/llm/base.py
@@ -17,6 +17,7 @@ class LLMAdapter(abc.ABC):
         response_format: dict | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
+        timeout_hint_seconds: float | None = None,
     ) -> str | None:
         """Send *prompt* to the LLM and return the raw response text.
 
@@ -24,4 +25,6 @@ class LLMAdapter(abc.ABC):
         When *json_mode* is True the adapter should request structured JSON
         output from the backend (if supported). *response_format* lets callers
         provide a provider-specific structured-output schema.
+        *timeout_hint_seconds* is the caller's estimate for long batched calls;
+        adapters may ignore it.
         """

--- a/src/ormah/background/llm/litellm_adapter.py
+++ b/src/ormah/background/llm/litellm_adapter.py
@@ -22,6 +22,7 @@ class LiteLLMAdapter(LLMAdapter):
         response_format: dict | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
+        timeout_hint_seconds: float | None = None,
     ) -> str | None:
         try:
             import litellm  # lazy import
@@ -35,7 +36,7 @@ class LiteLLMAdapter(LLMAdapter):
         kwargs: dict = {
             "model": self.model,
             "messages": messages,
-            "timeout": self.timeout,
+            "timeout": timeout_hint_seconds or self.timeout,
         }
         if response_format is not None:
             kwargs["response_format"] = response_format

--- a/src/ormah/background/llm/ollama_adapter.py
+++ b/src/ormah/background/llm/ollama_adapter.py
@@ -30,6 +30,7 @@ class OllamaAdapter(LLMAdapter):
         response_format: dict | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
+        timeout_hint_seconds: float | None = None,
     ) -> str | None:
         import httpx
 
@@ -56,7 +57,7 @@ class OllamaAdapter(LLMAdapter):
             resp = httpx.post(
                 f"{self.base_url}/api/generate",
                 json=payload,
-                timeout=self.timeout,
+                timeout=timeout_hint_seconds or self.timeout,
             )
             resp.raise_for_status()
             return resp.json().get("response")

--- a/src/ormah/background/llm/pair_batch.py
+++ b/src/ormah/background/llm/pair_batch.py
@@ -1,0 +1,100 @@
+"""Batch judgment of candidate pairs — shared by the pairwise maintenance jobs (#87).
+
+K=1 (the default) never builds a batch prompt: callers' existing single-pair
+functions run unchanged, so upstream behavior is byte-identical out of the box.
+At K>1, an LLM-unavailable chunk aborts the remaining chunks (outage guard).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable
+
+from ormah.background.llm_client import extract_json, llm_generate
+
+logger = logging.getLogger(__name__)
+
+_BATCH_PREAMBLE = """\
+You will judge {n} independent pairs below. Judge each pair strictly on its own; \
+do not let any other pair influence a verdict.
+
+Return ONE JSON object: {{"verdicts": [<one verdict object per pair, with the fields \
+specified above PLUS a "pair_id" integer matching the pair's number>]}}. \
+Include every pair_id exactly once."""
+
+
+def build_batch_prompt(instruction_block: str, rendered_pairs: list[str]) -> str:
+    parts = [instruction_block, _BATCH_PREAMBLE.format(n=len(rendered_pairs))]
+    parts += [f"### Pair {i}\n{rp}" for i, rp in enumerate(rendered_pairs)]
+    return "\n\n".join(parts)
+
+
+def parse_batch_verdicts(raw: str, valid_ids: set[int]) -> dict[int, dict] | None:
+    """Verdicts keyed by pair_id, or None when the payload is unusable."""
+    try:
+        data = json.loads(extract_json(raw))
+    except (json.JSONDecodeError, TypeError):
+        return None
+    verdicts = data.get("verdicts") if isinstance(data, dict) else None
+    if not isinstance(verdicts, list):
+        return None
+    out: dict[int, dict] = {}
+    for item in verdicts:
+        if isinstance(item, dict) and item.get("pair_id") in valid_ids:
+            out.setdefault(item["pair_id"], item)
+    return out
+
+
+def judge_pairs(
+    settings,
+    instruction_block: str,
+    pairs: list[Any],
+    render_pair: Callable[[Any], str],
+    judge_single: Callable[[Any], dict | None],
+    k: int | None = None,
+) -> list[dict | None]:
+    """Judge every pair; result aligned by index. None = no verdict this run.
+
+    *k* overrides settings.maintenance_pairs_per_call (jobs pass their per-job
+    K resolved as `job_pairs_per_call or maintenance_pairs_per_call`).
+    """
+    k = settings.maintenance_pairs_per_call if k is None else k
+    if k <= 1:
+        return [judge_single(p) for p in pairs]   # legacy flow, unchanged
+    results: list[dict | None] = [None] * len(pairs)
+    for start in range(0, len(pairs), k):
+        idx = list(range(start, min(start + k, len(pairs))))
+        if not _judge_chunk(settings, instruction_block, pairs, render_pair,
+                            judge_single, idx, results):
+            logger.warning("LLM unavailable; leaving %d of %d pairs unjudged this run",
+                           len(pairs) - start, len(pairs))
+            break
+    return results
+
+
+def _judge_chunk(settings, instruction_block, pairs, render_pair, judge_single,
+                 idx, results) -> bool:
+    """Judge one chunk. Returns False when the LLM looks unavailable (abort signal)."""
+    if len(idx) == 1:
+        verdict = judge_single(pairs[idx[0]])
+        results[idx[0]] = verdict
+        return verdict is not None   # single-path None = unavailable/unusable -> abort
+    rendered = [render_pair(pairs[i]) for i in idx]
+    prompt = build_batch_prompt(instruction_block, rendered)
+    hint = settings.llm_timeout_seconds + settings.maintenance_timeout_per_pair_seconds * len(idx)
+    raw = llm_generate(settings, prompt, json_mode=True, timeout_hint_seconds=hint)
+    if raw is None:
+        return False   # transient outage — no bisect, abort remaining work
+    verdicts = parse_batch_verdicts(raw, set(range(len(idx))))
+    if verdicts is None:
+        logger.warning("batch of %d pairs returned unparseable output; bisecting", len(idx))
+        mid = len(idx) // 2
+        if not _judge_chunk(settings, instruction_block, pairs, render_pair,
+                            judge_single, idx[:mid], results):
+            return False
+        return _judge_chunk(settings, instruction_block, pairs, render_pair,
+                            judge_single, idx[mid:], results)
+    for local_id, item in verdicts.items():
+        results[idx[local_id]] = item
+    return True

--- a/src/ormah/background/llm_client.py
+++ b/src/ormah/background/llm_client.py
@@ -81,6 +81,7 @@ def llm_generate(
     response_format: dict | None = None,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    timeout_hint_seconds: float | None = None,
 ) -> str | None:
     """Call configured LLM. Returns raw response text, or None on failure."""
     adapter = _get_or_create_adapter(settings)
@@ -92,4 +93,5 @@ def llm_generate(
         response_format=response_format,
         temperature=temperature,
         max_tokens=max_tokens,
+        timeout_hint_seconds=timeout_hint_seconds,
     )

--- a/src/ormah/background/maintenance_manager.py
+++ b/src/ormah/background/maintenance_manager.py
@@ -107,6 +107,11 @@ class MaintenanceManager:
         try:
             batches = self._engine.get_maintenance_batches()
             duration_ms = (time.monotonic() - t0) * 1000
+            # batch_errors is additive: healthy batches still flow to phase 2
+            # (status stays "awaiting_results", job.batches keeps all four
+            # keys), but a finder failure must not look like a clean tracker
+            # success — /admin is the #90 observability surface.
+            errors = batches.get("batch_errors") or {}
             with self._lock:
                 if self._job is None or self._job.job_id != job_id:
                     return
@@ -115,13 +120,29 @@ class MaintenanceManager:
                 self._job.batches = batches
                 self._job.phase1_finished_at = datetime.now(timezone.utc)
             if self._tracker is not None:
-                self._tracker.record_success("maintenance_phase1", duration_ms)
-            logger.info(
-                "Maintenance phase 1 ready: %s in %.0fms (%s)",
-                job_id[:8],
-                duration_ms,
-                batches.get("summary", "no summary"),
-            )
+                if errors:
+                    self._tracker.record_failure(
+                        "maintenance_phase1",
+                        f"finder failures: {', '.join(sorted(errors))}",
+                        duration_ms,
+                        stats={"batch_errors": errors},
+                    )
+                else:
+                    self._tracker.record_success("maintenance_phase1", duration_ms)
+            if errors:
+                logger.warning(
+                    "Maintenance phase 1 ready with failed batches: %s in %.0fms (%s)",
+                    job_id[:8],
+                    duration_ms,
+                    ", ".join(sorted(errors)),
+                )
+            else:
+                logger.info(
+                    "Maintenance phase 1 ready: %s in %.0fms (%s)",
+                    job_id[:8],
+                    duration_ms,
+                    batches.get("summary", "no summary"),
+                )
         except Exception as exc:
             self._record_failure(job_id, "phase1", exc, time.monotonic() - t0)
 

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -20,8 +20,9 @@ _MISFIRE_GRACE = 120
 # Spread the four LLM jobs so they don't burst together 24h after boot (#90).
 # Offset is relative to process start, not wall-clock — a restart loop shorter than
 # the offset (e.g. crash-looping every 2 min against a 5+ min offset) defers the first run indefinitely.
-def _staggered(minutes: int) -> datetime:
-    return datetime.now(timezone.utc) + timedelta(minutes=minutes)
+def _staggered(minutes: int, interval_minutes: int) -> datetime:
+    """First run is offset to spread the LLM jobs, but never past one interval."""
+    return datetime.now(timezone.utc) + timedelta(minutes=min(minutes, interval_minutes))
 
 
 def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTracker]:
@@ -42,7 +43,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.auto_link_interval_minutes,
         id="auto_linker",
         name="Auto-linker",
-        next_run_time=_staggered(5),
+        next_run_time=_staggered(5, s.auto_link_interval_minutes),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -65,7 +66,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.conflict_check_interval_minutes,
         id="conflict_detector",
         name="Conflict detector",
-        next_run_time=_staggered(15),
+        next_run_time=_staggered(15, s.conflict_check_interval_minutes),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -77,7 +78,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.duplicate_check_interval_minutes,
         id="duplicate_merger",
         name="Duplicate merger",
-        next_run_time=_staggered(30),
+        next_run_time=_staggered(30, s.duplicate_check_interval_minutes),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -100,7 +101,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.consolidation_interval_minutes,
         id="consolidator",
         name="Consolidator",
-        next_run_time=_staggered(45),
+        next_run_time=_staggered(45, s.consolidation_interval_minutes),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -18,6 +18,8 @@ _MISFIRE_GRACE = 120
 
 
 # Spread the four LLM jobs so they don't burst together 24h after boot (#90).
+# Offset is relative to process start, not wall-clock — a restart loop shorter than
+# the offset (e.g. crash-looping every 2 min against a 5+ min offset) defers the first run indefinitely.
 def _staggered(minutes: int) -> datetime:
     return datetime.now(timezone.utc) + timedelta(minutes=minutes)
 

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import logging
 
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 # How long (seconds) a misfired job is still allowed to run.
 # If the scheduler was blocked longer than this, the run is skipped.
 _MISFIRE_GRACE = 120
+
+
+# Spread the four LLM jobs so they don't burst together 24h after boot (#90).
+def _staggered(minutes: int) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(minutes=minutes)
 
 
 def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTracker]:
@@ -35,6 +40,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.auto_link_interval_minutes,
         id="auto_linker",
         name="Auto-linker",
+        next_run_time=_staggered(5),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -57,6 +63,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.conflict_check_interval_minutes,
         id="conflict_detector",
         name="Conflict detector",
+        next_run_time=_staggered(15),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -68,6 +75,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.duplicate_check_interval_minutes,
         id="duplicate_merger",
         name="Duplicate merger",
+        next_run_time=_staggered(30),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -90,6 +98,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.consolidation_interval_minutes,
         id="consolidator",
         name="Consolidator",
+        next_run_time=_staggered(45),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -21,8 +21,13 @@ _MISFIRE_GRACE = 120
 # Offset is relative to process start, not wall-clock — a restart loop shorter than
 # the offset (e.g. crash-looping every 2 min against a 5+ min offset) defers the first run indefinitely.
 def _staggered(minutes: int, interval_minutes: int) -> datetime:
-    """First run is offset to spread the LLM jobs, but never past one interval."""
-    return datetime.now(timezone.utc) + timedelta(minutes=min(minutes, interval_minutes))
+    """First run is offset to spread the LLM jobs, always inside one interval.
+
+    Scales (not clamps) the nominal offset so short intervals keep distinct
+    offsets instead of collapsing onto the same boundary (council R2 finding 3).
+    """
+    factor = min(1.0, interval_minutes / 60)
+    return datetime.now(timezone.utc) + timedelta(minutes=minutes * factor)
 
 
 def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTracker]:

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -20,13 +20,25 @@ _MISFIRE_GRACE = 120
 # Spread the four LLM jobs so they don't burst together 24h after boot (#90).
 # Offset is relative to process start, not wall-clock — a restart loop shorter than
 # the offset (e.g. crash-looping every 2 min against a 5+ min offset) defers the first run indefinitely.
-def _staggered(minutes: int, interval_minutes: int) -> datetime:
-    """First run is offset to spread the LLM jobs, always inside one interval.
+_STAGGER_REFERENCE_MINUTES = 60
 
-    Scales (not clamps) the nominal offset so short intervals keep distinct
-    offsets instead of collapsing onto the same boundary (council R2 finding 3).
-    """
-    factor = min(1.0, interval_minutes / 60)
+
+def _stagger_factor(s) -> float:
+    """One shared factor for all four jobs, so distinct nominal offsets stay
+    distinct regardless of which job has the shortest configured interval
+    (council R3 finding 2 — per-job scaling let jobs with different intervals
+    collide at the same offset)."""
+    shortest = min(
+        s.auto_link_interval_minutes,
+        s.conflict_check_interval_minutes,
+        s.duplicate_check_interval_minutes,
+        s.consolidation_interval_minutes,
+    )
+    return min(1.0, shortest / _STAGGER_REFERENCE_MINUTES)
+
+
+def _staggered(minutes: int, factor: float) -> datetime:
+    """First run is offset to spread the LLM jobs, always inside one interval."""
     return datetime.now(timezone.utc) + timedelta(minutes=minutes * factor)
 
 
@@ -39,6 +51,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
     scheduler = BackgroundScheduler()
     tracker = JobTracker()
     s = engine.settings
+    stagger_factor = _stagger_factor(s)
 
     from ormah.background.auto_linker import run_auto_linker
 
@@ -48,7 +61,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.auto_link_interval_minutes,
         id="auto_linker",
         name="Auto-linker",
-        next_run_time=_staggered(5, s.auto_link_interval_minutes),
+        next_run_time=_staggered(5, stagger_factor),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -71,7 +84,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.conflict_check_interval_minutes,
         id="conflict_detector",
         name="Conflict detector",
-        next_run_time=_staggered(15, s.conflict_check_interval_minutes),
+        next_run_time=_staggered(15, stagger_factor),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -83,7 +96,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.duplicate_check_interval_minutes,
         id="duplicate_merger",
         name="Duplicate merger",
-        next_run_time=_staggered(30, s.duplicate_check_interval_minutes),
+        next_run_time=_staggered(30, stagger_factor),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
@@ -106,7 +119,7 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         minutes=s.consolidation_interval_minutes,
         id="consolidator",
         name="Consolidator",
-        next_run_time=_staggered(45, s.consolidation_interval_minutes),
+        next_run_time=_staggered(45, stagger_factor),
         misfire_grace_time=_MISFIRE_GRACE,
     )
 

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -124,6 +124,24 @@ class Settings(BaseSettings):
     auto_link_max_edges_per_run: int = 500
     auto_link_max_nodes_per_run: int = 500  # cursor batch: nodes scanned per run
 
+    # Pairwise-maintenance batching (#87). K=1 keeps today's single-pair flow;
+    # operators on per-call-expensive providers raise K (10-16). Per-job
+    # overrides (0 = use the global K) let one job batch while others stay
+    # single — the A/B eval gate is per job (council C3).
+    maintenance_pairs_per_call: int = 1
+    auto_link_pairs_per_call: int = 0
+    duplicate_check_pairs_per_call: int = 0
+    conflict_check_pairs_per_call: int = 0
+    maintenance_timeout_per_pair_seconds: int = 10
+    # Per-run caps, denominated in PAIRS EVALUATED (not LLM calls). Defaults
+    # preserve CURRENT behavior exactly (council I1): 0 = no extra bound
+    # (auto_link/dedup today), conflict keeps its existing 10000 candidate
+    # bound. Raising these is an explicit operator/config decision, not part
+    # of this PR.
+    auto_link_max_pairs_per_run: int = 0
+    duplicate_check_max_pairs_per_run: int = 0
+    conflict_check_max_pairs_per_run: int = 10000
+
     # Auto-merge
     auto_merge_threshold: float = 0.85
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1544,10 +1544,32 @@ class MemoryEngine:
         if limit_per_batch is None:
             limit_per_batch = getattr(self.settings, "claude_maintenance_batch_size", 25)
 
-        link_candidates = _find_link_candidates(self, limit_per_batch)
-        conflict_candidates = _find_conflict_candidates(self, limit_per_batch)
-        merge_candidates = _find_merge_candidates(self, limit_per_batch)
-        consolidation_clusters = _find_consolidation_clusters(self, limit=4)
+        # Each finder can now raise on internal failure (issue #90 council R2
+        # finding 1 — a finder no longer swallows its own exceptions so a
+        # broken detector isn't invisible on /admin). This is the only caller
+        # outside the finders' own tracked() run_* jobs, so it must keep its
+        # pre-existing contract: one broken finder yields an empty batch for
+        # that key, not an uncaught exception for the whole batches response.
+        try:
+            link_candidates = _find_link_candidates(self, limit_per_batch)
+        except Exception as e:
+            logger.warning("_find_link_candidates failed: %s", e)
+            link_candidates = []
+        try:
+            conflict_candidates = _find_conflict_candidates(self, limit_per_batch)
+        except Exception as e:
+            logger.warning("_find_conflict_candidates failed: %s", e)
+            conflict_candidates = []
+        try:
+            merge_candidates = _find_merge_candidates(self, limit_per_batch)
+        except Exception as e:
+            logger.warning("_find_merge_candidates failed: %s", e)
+            merge_candidates = []
+        try:
+            consolidation_clusters = _find_consolidation_clusters(self, limit=4)
+        except Exception as e:
+            logger.warning("_find_consolidation_clusters failed: %s", e)
+            consolidation_clusters = []
 
         def _norm(node: dict) -> dict:
             return {

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1544,32 +1544,15 @@ class MemoryEngine:
         if limit_per_batch is None:
             limit_per_batch = getattr(self.settings, "claude_maintenance_batch_size", 25)
 
-        # Each finder can now raise on internal failure (issue #90 council R2
-        # finding 1 — a finder no longer swallows its own exceptions so a
-        # broken detector isn't invisible on /admin). This is the only caller
-        # outside the finders' own tracked() run_* jobs, so it must keep its
-        # pre-existing contract: one broken finder yields an empty batch for
-        # that key, not an uncaught exception for the whole batches response.
-        try:
-            link_candidates = _find_link_candidates(self, limit_per_batch)
-        except Exception as e:
-            logger.warning("_find_link_candidates failed: %s", e)
-            link_candidates = []
-        try:
-            conflict_candidates = _find_conflict_candidates(self, limit_per_batch)
-        except Exception as e:
-            logger.warning("_find_conflict_candidates failed: %s", e)
-            conflict_candidates = []
-        try:
-            merge_candidates = _find_merge_candidates(self, limit_per_batch)
-        except Exception as e:
-            logger.warning("_find_merge_candidates failed: %s", e)
-            merge_candidates = []
-        try:
-            consolidation_clusters = _find_consolidation_clusters(self, limit=4)
-        except Exception as e:
-            logger.warning("_find_consolidation_clusters failed: %s", e)
-            consolidation_clusters = []
+        # Finder failures propagate on purpose (issue #90 council R3 finding 1).
+        # A finder raising means a shared dependency (encoder/vector-store/DB)
+        # is down, so all four batches are suspect — swallowing it here would
+        # let Phase 2 stamp last_maintenance_run and silence the maintenance
+        # signal for a whole interval while the detector stays broken.
+        link_candidates = _find_link_candidates(self, limit_per_batch)
+        conflict_candidates = _find_conflict_candidates(self, limit_per_batch)
+        merge_candidates = _find_merge_candidates(self, limit_per_batch)
+        consolidation_clusters = _find_consolidation_clusters(self, limit=4)
 
         def _norm(node: dict) -> dict:
             return {

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1544,15 +1544,49 @@ class MemoryEngine:
         if limit_per_batch is None:
             limit_per_batch = getattr(self.settings, "claude_maintenance_batch_size", 25)
 
-        # Finder failures propagate on purpose (issue #90 council R3 finding 1).
-        # A finder raising means a shared dependency (encoder/vector-store/DB)
-        # is down, so all four batches are suspect — swallowing it here would
-        # let Phase 2 stamp last_maintenance_run and silence the maintenance
-        # signal for a whole interval while the detector stays broken.
-        link_candidates = _find_link_candidates(self, limit_per_batch)
-        conflict_candidates = _find_conflict_candidates(self, limit_per_batch)
-        merge_candidates = _find_merge_candidates(self, limit_per_batch)
-        consolidation_clusters = _find_consolidation_clusters(self, limit=4)
+        # Finders fail INDEPENDENTLY (issue #90 council R4) — each has its own
+        # query and data-dependent path, not a shared crash point, so a
+        # persistent defect in one must not block the other three. A healthy
+        # batch must still reach Phase 2; a failed batch must be explicit
+        # (batch_errors) rather than indistinguishable from "nothing found".
+        batch_errors: dict[str, str] = {}
+
+        try:
+            link_candidates = _find_link_candidates(self, limit_per_batch)
+        except Exception as e:
+            logger.warning("_find_link_candidates failed: %s", e)
+            link_candidates = []
+            batch_errors["link_candidates"] = f"{type(e).__name__}: {e}"
+        try:
+            conflict_candidates = _find_conflict_candidates(self, limit_per_batch)
+        except Exception as e:
+            logger.warning("_find_conflict_candidates failed: %s", e)
+            conflict_candidates = []
+            batch_errors["conflict_candidates"] = f"{type(e).__name__}: {e}"
+        try:
+            merge_candidates = _find_merge_candidates(self, limit_per_batch)
+        except Exception as e:
+            logger.warning("_find_merge_candidates failed: %s", e)
+            merge_candidates = []
+            batch_errors["merge_candidates"] = f"{type(e).__name__}: {e}"
+        try:
+            consolidation_clusters = _find_consolidation_clusters(self, limit=4)
+        except Exception as e:
+            logger.warning("_find_consolidation_clusters failed: %s", e)
+            consolidation_clusters = []
+            batch_errors["consolidation_clusters"] = f"{type(e).__name__}: {e}"
+
+        # Phase 2 (apply_maintenance_results) is a separate MCP call that never
+        # sees this return value — it learns about a failed batch only through
+        # this meta marker, so it can skip stamping last_maintenance_run.
+        with self.db.transaction() as conn:
+            if batch_errors:
+                conn.execute(
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES ('maintenance_phase1_errors', ?)",
+                    (json.dumps(batch_errors),),
+                )
+            else:
+                conn.execute("DELETE FROM meta WHERE key = 'maintenance_phase1_errors'")
 
         def _norm(node: dict) -> dict:
             return {
@@ -1580,8 +1614,11 @@ class MemoryEngine:
         if consolidation_clusters:
             parts.append(f"{len(consolidation_clusters)} cluster(s)")
         summary = ", ".join(parts) if parts else "nothing to process"
+        if batch_errors:
+            summary += "; FAILED: " + ", ".join(sorted(batch_errors))
 
         return {
+            "batch_errors": batch_errors,
             "link_candidates": [_norm_pair(c) for c in link_candidates],
             "conflict_candidates": [_norm_pair(c) for c in conflict_candidates],
             "merge_candidates": [_norm_pair(c) for c in merge_candidates],
@@ -1646,16 +1683,30 @@ class MemoryEngine:
             except Exception as exc:
                 logger.warning("apply_maintenance_results: consolidation failed: %s", exc)
 
-        # Record completion timestamp — silences maintenance_due signal for interval_hours.
-        try:
-            now = datetime.now(timezone.utc).isoformat()
-            with self.db.transaction() as conn:
-                conn.execute(
-                    "INSERT OR REPLACE INTO meta (key, value) VALUES ('last_maintenance_run', ?)",
-                    (now,),
-                )
-        except Exception as exc:
-            logger.warning("apply_maintenance_results: failed to record timestamp: %s", exc)
+        # Skip the stamp if the Phase 1 that produced these results had a
+        # failed batch — apply_maintenance_results is a separate MCP call
+        # and only learns this via the meta marker get_maintenance_batches
+        # left behind (issue #90 council R4).
+        phase1_errors_row = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'maintenance_phase1_errors'"
+        ).fetchone()
+        if phase1_errors_row is not None:
+            logger.warning(
+                "apply_maintenance_results: skipping last_maintenance_run stamp — "
+                "Phase 1 had failed batches: %s",
+                phase1_errors_row["value"],
+            )
+        else:
+            # Record completion timestamp — silences maintenance_due signal for interval_hours.
+            try:
+                now = datetime.now(timezone.utc).isoformat()
+                with self.db.transaction() as conn:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO meta (key, value) VALUES ('last_maintenance_run', ?)",
+                        (now,),
+                    )
+            except Exception as exc:
+                logger.warning("apply_maintenance_results: failed to record timestamp: %s", exc)
 
         return counts
 

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -296,3 +296,75 @@ def test_maintenance_phase2_apply_completes_via_routes(client):
     finally:
         app.state.engine.get_maintenance_batches = original_batches
         app.state.engine.apply_maintenance_results = original_apply
+
+
+def _wait_for_status(manager, job_id, not_status="running_phase1", timeout=2):
+    deadline = time.time() + timeout
+    status = manager.get_status(job_id=job_id)
+    while status["status"] == not_status and time.time() < deadline:
+        time.sleep(0.01)
+        status = manager.get_status(job_id=job_id)
+    return status
+
+
+def test_phase1_finder_failure_is_recorded_as_tracker_failure(engine):
+    """Issue #90 (dev council follow-up): a Phase 1 with a broken finder must
+    still deliver the healthy batches to Phase 2 (status stays
+    "awaiting_results", job.batches is kept) but must NOT look like a clean
+    success in JobTracker — /admin is the #90 observability surface and must
+    not lie about a maintenance cycle whose link candidates never computed."""
+    from ormah.background.job_tracker import JobTracker
+
+    def batches_with_error():
+        return {
+            "batch_errors": {"link_candidates": "RuntimeError: boom"},
+            "link_candidates": [],
+            "conflict_candidates": [{"fake": "candidate"}],
+            "merge_candidates": [],
+            "consolidation_clusters": [],
+            "summary": "1 conflict candidates; FAILED: link_candidates",
+        }
+
+    engine.get_maintenance_batches = batches_with_error
+    tracker = JobTracker()
+    manager = MaintenanceManager(engine, tracker=tracker)
+
+    payload = manager.start_phase1()
+    status = _wait_for_status(manager, payload["job_id"])
+
+    # Healthy batches must still flow to phase 2.
+    assert status["status"] == "awaiting_results"
+    assert status["batches"]["conflict_candidates"] == [{"fake": "candidate"}]
+
+    # But the tracker must show this as a failure, not a clean run.
+    snap = tracker.snapshot()["maintenance_phase1"]
+    assert snap["error_count"] == 1
+    assert snap["last_success"] is None
+    assert "link_candidates" in snap["last_error"]
+    assert snap["last_stats"]["batch_errors"] == {"link_candidates": "RuntimeError: boom"}
+
+
+def test_phase1_clean_run_still_records_tracker_success(engine):
+    from ormah.background.job_tracker import JobTracker
+
+    def clean_batches():
+        return {
+            "batch_errors": {},
+            "link_candidates": [],
+            "conflict_candidates": [],
+            "merge_candidates": [],
+            "consolidation_clusters": [],
+            "summary": "nothing to process",
+        }
+
+    engine.get_maintenance_batches = clean_batches
+    tracker = JobTracker()
+    manager = MaintenanceManager(engine, tracker=tracker)
+
+    payload = manager.start_phase1()
+    status = _wait_for_status(manager, payload["job_id"])
+
+    assert status["status"] == "awaiting_results"
+    snap = tracker.snapshot()["maintenance_phase1"]
+    assert snap["error_count"] == 0
+    assert snap["last_success"] is not None

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -562,3 +562,47 @@ def test_k1_stops_llm_calls_at_max_edges(engine):
     with patch(_LLM_PATCH, single):
         al.run_auto_linker(engine)
     assert calls["n"] <= 2   # budget 1 -> at most the winning call + the boundary check
+
+
+def test_vectorless_node_skipped_then_heals(engine):
+    """A vectorless node must not kill the run: later nodes still get edges,
+    the watermark parks BEFORE the orphan, and once the orphan's vector lands
+    a later run advances past it (skip-then-heal)."""
+    import numpy as np
+
+    from ormah.background.auto_linker import _get_watermark, run_auto_linker
+    from ormah.embeddings.vector_store import VectorStore
+    from ormah.models.node import CreateNodeRequest
+
+    # Orphan: lowest seq above the watermark, vector deleted.
+    a_id, _ = engine.remember(
+        CreateNodeRequest(title="orphan", content="a node whose vector was lost", tags=["test"])
+    )
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (a_id,))
+
+    id_b, id_c = _create_pair(engine)  # both embedded, similar
+
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    _reset_adapter()
+
+    orphan_seq = engine.db.conn.execute(
+        "SELECT seq FROM nodes WHERE id = ?", (a_id,)
+    ).fetchone()["seq"]
+    verdict = json.dumps({"relationship": "supports", "reason": "same topic"})
+
+    with patch(_LLM_PATCH, return_value=verdict):
+        stats = run_auto_linker(engine)
+
+    assert len(_edges_between(engine, id_b, id_c)) >= 1  # pair linked despite orphan
+    assert stats["pairs_attempted"] >= 1
+    assert _get_watermark(engine.db.conn) < orphan_seq  # parked before the orphan
+
+    # Heal: the orphan's vector lands (backfill), next run advances past it.
+    dim = engine.settings.embedding_dim
+    VectorStore(engine.db).upsert(a_id, np.ones(dim, dtype=np.float32))
+    with patch(_LLM_PATCH, return_value=verdict):
+        run_auto_linker(engine)
+
+    assert _get_watermark(engine.db.conn) >= orphan_seq

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -454,3 +454,26 @@ def test_pairs_attempted_counts_llm_unavailable_pair_but_not_evaluated(engine):
 
     assert stats["pairs_attempted"] == 1
     assert stats["pairs_evaluated"] == 0
+
+
+def test_pairs_attempted_counts_invalid_llm_output_but_not_evaluated(engine):
+    """Issue #90 council R2 finding 2: the 'error' sentinel (invalid/malformed
+    LLM output) must count as attempted but NOT as a valid evaluation — a
+    degraded provider must not report healthy pairs_per_s with zero real
+    decisions. duplicate_merger/conflict_detector already exclude their
+    equivalent None-decision case; auto_linker's sentinel is a dict, not
+    None, so it needs its own check."""
+    id_a, id_b = _create_pair(engine)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    with patch(
+        "ormah.background.auto_linker._llm_classify_link",
+        return_value={"relationship": "error", "reason": "invalid LLM output"},
+    ):
+        from ormah.background.auto_linker import run_auto_linker
+        stats = run_auto_linker(engine)
+
+    assert stats["pairs_attempted"] == 1
+    assert stats["pairs_evaluated"] == 0

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -411,3 +411,25 @@ def test_checked_pairs_invalidated_on_update(engine):
         run_auto_linker(engine)
 
     assert mock_llm.call_count >= 1  # LLM was called again for this pair
+
+
+def test_pairs_evaluated_counts_one_candidate_pair(engine):
+    """Issue #90: pairs_evaluated must reflect exactly one LLM decision call.
+
+    Uses the default similarity threshold (not 0.0): the auto-created "Self"
+    node is far enough below threshold that it does not count as a second
+    candidate, leaving exactly the id_a/id_b pair.
+    """
+    id_a, id_b = _create_pair(engine)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    with patch(
+        "ormah.background.auto_linker._llm_classify_link",
+        return_value={"relationship": "none", "reason": "not related"},
+    ):
+        from ormah.background.auto_linker import run_auto_linker
+        stats = run_auto_linker(engine)
+
+    assert stats["pairs_evaluated"] == 1

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -477,3 +477,88 @@ def test_pairs_attempted_counts_invalid_llm_output_but_not_evaluated(engine):
 
     assert stats["pairs_attempted"] == 1
     assert stats["pairs_evaluated"] == 0
+
+
+# --- #87 pair batching ---
+
+def test_link_prompt_is_composed_from_parts():
+    from ormah.background import auto_linker as al
+    assert al._LLM_LINK_PROMPT == (
+        al._LLM_LINK_INTRO + "\n\n" + al._LLM_LINK_PAIR + "\n\n" + al._LLM_LINK_RULES
+    )
+    assert al._LLM_LINK_INSTRUCTIONS == al._LLM_LINK_INTRO + "\n\n" + al._LLM_LINK_RULES
+
+
+def _seed_similar_nodes(engine, n=3):
+    ids = []
+    for _ in range(n):
+        nid, _created = engine.remember(CreateNodeRequest(
+            content="ormah uses sqlite-vec for vector search in the memory index",
+            title="ormah vector search"))
+        ids.append(nid)
+    return ids
+
+
+def test_batched_run_creates_edges_and_advances_watermark(engine):
+    from ormah.background import auto_linker as al
+    _seed_similar_nodes(engine)
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    engine.settings.maintenance_pairs_per_call = 2
+    _reset_adapter()
+
+    def fake_batch(settings, prompt, json_mode=True, **kw):
+        n = prompt.count("### Pair ")
+        return json.dumps({"verdicts": [
+            {"pair_id": i, "relationship": "related_to", "reason": "same subsystem"}
+            for i in range(n)]})
+
+    single = MagicMock(return_value=json.dumps({"relationship": "related_to", "reason": "x"}))
+    with patch("ormah.background.llm.pair_batch.llm_generate", fake_batch), \
+            patch(_LLM_PATCH, single):
+        stats = al.run_auto_linker(engine)
+
+    edges = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM edges WHERE edge_type = 'related_to'").fetchone()[0]
+    assert edges >= 1
+    assert stats["pairs_evaluated"] >= 1
+    assert al._get_watermark(engine.db.conn) > 0
+
+
+def test_outage_stops_after_first_window_and_blocks_watermark(engine):
+    """Council C1 regression: LLM down -> exactly one batch attempt, watermark held."""
+    from ormah.background import auto_linker as al
+    _seed_similar_nodes(engine)
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    engine.settings.maintenance_pairs_per_call = 2
+    _reset_adapter()
+    calls = {"n": 0}
+
+    def down(*a, **k):
+        calls["n"] += 1
+        return None
+
+    with patch("ormah.background.llm.pair_batch.llm_generate", down):
+        al.run_auto_linker(engine)
+    assert calls["n"] == 1
+    assert al._get_watermark(engine.db.conn) == 0
+
+
+def test_k1_stops_llm_calls_at_max_edges(engine):
+    """Cursor regression: no pair is judged once the edge budget is spent (K=1 path)."""
+    from ormah.background import auto_linker as al
+    _seed_similar_nodes(engine, n=4)
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    engine.settings.auto_link_max_edges_per_run = 1
+    _reset_adapter()
+    calls = {"n": 0}
+
+    def single(settings, prompt, json_mode=True, **kw):
+        calls["n"] += 1
+        return json.dumps({"relationship": "related_to", "reason": "r"})
+
+    with patch(_LLM_PATCH, single):
+        al.run_auto_linker(engine)
+    assert calls["n"] <= 2   # budget 1 -> at most the winning call + the boundary check

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -432,4 +432,25 @@ def test_pairs_evaluated_counts_one_candidate_pair(engine):
         from ormah.background.auto_linker import run_auto_linker
         stats = run_auto_linker(engine)
 
+    assert stats["pairs_attempted"] == 1
     assert stats["pairs_evaluated"] == 1
+
+
+def test_pairs_attempted_counts_llm_unavailable_pair_but_not_evaluated(engine):
+    """Issue #90 (council finding 2): an LLM-unavailable pair (None decision)
+    must count as attempted but NOT as evaluated — otherwise pairs_per_s is
+    inflated by calls that never produced a decision."""
+    id_a, id_b = _create_pair(engine)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    with patch(
+        "ormah.background.auto_linker._llm_classify_link",
+        return_value=None,
+    ):
+        from ormah.background.auto_linker import run_auto_linker
+        stats = run_auto_linker(engine)
+
+    assert stats["pairs_attempted"] == 1
+    assert stats["pairs_evaluated"] == 0

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -199,6 +199,24 @@ def test_llm_disabled_skips_detection(engine):
     assert len(proposals) == 0
 
 
+def test_pairs_evaluated_counts_one_candidate_pair(engine):
+    """Issue #90: pairs_evaluated must reflect exactly one LLM decision call."""
+    id_a, id_b = _create_pair(engine, node_type=NodeType.fact)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    with patch(
+        "ormah.background.conflict_detector._llm_check_conflict",
+        return_value={"same_subject": True, "conflict": False, "type": "none",
+                      "explanation": "no conflict"},
+    ):
+        from ormah.background.conflict_detector import run_conflict_detection
+        stats = run_conflict_detection(engine)
+
+    assert stats["pairs_evaluated"] == 1
+
+
 def test_project_scoped_nodes_checked_when_flag_enabled(engine):
     """With conflict_check_all_spaces=True, project-scoped nodes are checked."""
     original_threshold = engine.settings.auto_link_similarity_threshold

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -214,7 +214,27 @@ def test_pairs_evaluated_counts_one_candidate_pair(engine):
         from ormah.background.conflict_detector import run_conflict_detection
         stats = run_conflict_detection(engine)
 
+    assert stats["pairs_attempted"] == 1
     assert stats["pairs_evaluated"] == 1
+
+
+def test_pairs_attempted_counts_llm_unavailable_pair_but_not_evaluated(engine):
+    """Issue #90 (council finding 2): an LLM-unavailable pair (None decision)
+    must count as attempted but NOT as evaluated."""
+    id_a, id_b = _create_pair(engine, node_type=NodeType.fact)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    with patch(
+        "ormah.background.conflict_detector._llm_check_conflict",
+        return_value=None,
+    ):
+        from ormah.background.conflict_detector import run_conflict_detection
+        stats = run_conflict_detection(engine)
+
+    assert stats["pairs_attempted"] == 1
+    assert stats["pairs_evaluated"] == 0
 
 
 def test_project_scoped_nodes_checked_when_flag_enabled(engine):

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -321,3 +321,47 @@ def test_project_scoped_nodes_skipped_by_default(engine):
 
     # LLM should never be called since project-scoped nodes are skipped
     mock_llm.assert_not_called()
+
+
+# --- #87 pair batching ---
+
+def test_conflict_prompt_is_composed_from_parts():
+    from ormah.background import conflict_detector as cd
+    assert cd._LLM_CONFLICT_PROMPT == (
+        cd._LLM_CONFLICT_INTRO + "\n\n" + cd._LLM_CONFLICT_PAIR + "\n\n" + cd._LLM_CONFLICT_RULES
+    )
+    assert cd._LLM_CONFLICT_INSTRUCTIONS == (
+        cd._LLM_CONFLICT_INTRO + "\n\n" + cd._LLM_CONFLICT_RULES
+    )
+
+
+def test_batched_conflict_creates_evolution_edge(engine):
+    from ormah.background import conflict_detector as cd
+    for content, title in [
+        ("the main editor is vim", "editor choice"),
+        ("the main editor changed to vscode", "editor choice update"),
+        ("the main editor is now vscode for everyone", "editor standard"),
+    ]:
+        engine.remember(CreateNodeRequest(content=content, title=title,
+                                          type=NodeType.preference))
+    engine.settings.llm_provider = "ollama"
+    engine.settings.maintenance_pairs_per_call = 2
+    _reset_adapter()
+
+    def fake_batch(settings, prompt, json_mode=True, **kw):
+        n = prompt.count("### Pair ")
+        return json.dumps({"verdicts": [
+            {"pair_id": i, "same_subject": True, "conflict": True,
+             "type": "evolution", "evolved_node": "b", "explanation": "editor changed"}
+            for i in range(n)]})
+
+    single = {"same_subject": True, "conflict": True, "type": "evolution",
+              "evolved_node": "b", "explanation": "editor changed"}
+    with patch("ormah.background.llm.pair_batch.llm_generate", fake_batch), \
+            patch("ormah.background.conflict_detector._llm_check_conflict", return_value=single):
+        stats = cd.run_conflict_detection(engine)
+
+    edges = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM edges WHERE edge_type = 'evolved_from'").fetchone()[0]
+    assert edges >= 1
+    assert stats["pairs_evaluated"] >= 1

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -156,3 +156,23 @@ def test_merged_content_stored_in_proposal(engine):
     assert "Python Programming Language" in proposal["proposed_action"]
     assert "Python is a popular programming language used widely." in proposal["proposed_action"]
     assert "Both describe Python" in proposal["reason"]
+
+
+def test_pairs_evaluated_counts_one_candidate_pair(engine):
+    """Issue #90: pairs_evaluated must reflect exactly one LLM decision call."""
+    id_a, id_b = _create_pair(engine)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    with patch(
+        "ormah.background.duplicate_merger._llm_check_duplicate",
+        return_value={"is_duplicate": False, "reason": "not a duplicate"},
+    ):
+        from ormah.background.duplicate_merger import run_duplicate_detection
+        stats = run_duplicate_detection(engine)
+
+    assert stats["pairs_evaluated"] == 1
+    # duration_s must have millisecond resolution — a fast mocked-LLM run
+    # must not silently round down to 0.0 (issue #90 finding 2).
+    assert stats["duration_s"] > 0

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -196,3 +196,48 @@ def test_pairs_attempted_counts_llm_unavailable_pair_but_not_evaluated(engine):
 
     assert stats["pairs_attempted"] == 1
     assert stats["pairs_evaluated"] == 0
+
+
+# --- #87 pair batching ---
+
+def test_duplicate_prompt_is_composed_from_parts():
+    from ormah.background import duplicate_merger as dm
+    assert dm._LLM_DUPLICATE_PROMPT == (
+        dm._LLM_DUP_INTRO + "\n\n" + dm._LLM_DUP_PAIR + "\n\n" + dm._LLM_DUP_RULES
+    )
+    assert dm._LLM_DUP_INSTRUCTIONS == dm._LLM_DUP_INTRO + "\n\n" + dm._LLM_DUP_RULES
+
+
+def test_scan_order_randomizes_only_when_capped():
+    """Council C2: capped runs randomize scan order for fair coverage across runs."""
+    from ormah.background import duplicate_merger as dm
+    assert dm._scan_order(0) == ""
+    assert dm._scan_order(5) == " ORDER BY RANDOM()"
+
+
+def test_batched_dedup_creates_proposals(engine):
+    from ormah.background import duplicate_merger as dm
+    for _ in range(3):
+        engine.remember(CreateNodeRequest(
+            content="ormah stores memories in sqlite with fts5", title="ormah storage"))
+    engine.settings.llm_provider = "ollama"
+    engine.settings.maintenance_pairs_per_call = 2
+    engine.settings.auto_merge_threshold = 2.0     # force proposal path, not auto-merge
+    _reset_adapter()
+
+    def fake_batch(settings, prompt, json_mode=True, **kw):
+        n = prompt.count("### Pair ")
+        return json.dumps({"verdicts": [
+            {"pair_id": i, "is_duplicate": True, "merged_title": "t",
+             "merged_content": "c", "reason": "same fact"} for i in range(n)]})
+
+    single = {"is_duplicate": True, "merged_title": "t", "merged_content": "c",
+              "reason": "same fact"}
+    with patch("ormah.background.llm.pair_batch.llm_generate", fake_batch), \
+            patch("ormah.background.duplicate_merger._llm_check_duplicate", return_value=single):
+        stats = dm.run_duplicate_detection(engine)
+
+    n_props = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM proposals WHERE type = 'merge'").fetchone()[0]
+    assert n_props >= 1
+    assert stats["pairs_evaluated"] >= 1

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -241,3 +241,42 @@ def test_batched_dedup_creates_proposals(engine):
         "SELECT COUNT(*) FROM proposals WHERE type = 'merge'").fetchone()[0]
     assert n_props >= 1
     assert stats["pairs_evaluated"] >= 1
+
+
+def test_batched_dedup_skips_pairs_whose_node_was_merged_away(engine):
+    """Codex council finding (#87): overlapping pairs in one window (e.g. (A,B)
+    and (B,C)) — once an auto-merge deletes a shared node, a later pair must be
+    skipped, not re-merged on the stale (now-missing) node. execute_merge silently
+    no-ops on a missing node ('Node X not found.'), which would otherwise miscount
+    it as a successful merge."""
+    from ormah.background import duplicate_merger as dm
+    for _ in range(3):
+        engine.remember(CreateNodeRequest(
+            content="ormah stores memories in sqlite with fts5", title="ormah storage"))
+    engine.settings.llm_provider = "ollama"
+    engine.settings.maintenance_pairs_per_call = 3      # all candidate pairs in one window
+    engine.settings.auto_merge_threshold = 0.0          # force the auto-merge path for every pair
+    _reset_adapter()
+
+    real_merge = engine.execute_merge
+    bad_calls = []
+
+    def spy_merge(node_id_a, node_id_b, **kw):
+        for nid in (node_id_a, node_id_b):
+            if engine.db.conn.execute("SELECT 1 FROM nodes WHERE id = ?", (nid,)).fetchone() is None:
+                bad_calls.append(nid)
+        return real_merge(node_id_a, node_id_b, **kw)
+
+    def fake_batch(settings, prompt, json_mode=True, **kw):
+        n = prompt.count("### Pair ")
+        return json.dumps({"verdicts": [
+            {"pair_id": i, "is_duplicate": True, "merged_title": "t",
+             "merged_content": "c", "reason": "same"} for i in range(n)]})
+
+    single = {"is_duplicate": True, "merged_title": "t", "merged_content": "c", "reason": "same"}
+    with patch("ormah.background.llm.pair_batch.llm_generate", fake_batch), \
+            patch("ormah.background.duplicate_merger._llm_check_duplicate", return_value=single), \
+            patch.object(engine, "execute_merge", spy_merge):
+        dm.run_duplicate_detection(engine)
+
+    assert bad_calls == [], f"execute_merge called on already-deleted node(s): {bad_calls}"

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -172,7 +172,27 @@ def test_pairs_evaluated_counts_one_candidate_pair(engine):
         from ormah.background.duplicate_merger import run_duplicate_detection
         stats = run_duplicate_detection(engine)
 
+    assert stats["pairs_attempted"] == 1
     assert stats["pairs_evaluated"] == 1
     # duration_s must have millisecond resolution — a fast mocked-LLM run
     # must not silently round down to 0.0 (issue #90 finding 2).
     assert stats["duration_s"] > 0
+
+
+def test_pairs_attempted_counts_llm_unavailable_pair_but_not_evaluated(engine):
+    """Issue #90 (council finding 2): an LLM-unavailable pair (None decision)
+    must count as attempted but NOT as evaluated."""
+    id_a, id_b = _create_pair(engine)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    with patch(
+        "ormah.background.duplicate_merger._llm_check_duplicate",
+        return_value=None,
+    ):
+        from ormah.background.duplicate_merger import run_duplicate_detection
+        stats = run_duplicate_detection(engine)
+
+    assert stats["pairs_attempted"] == 1
+    assert stats["pairs_evaluated"] == 0

--- a/tests/test_background/test_job_tracker.py
+++ b/tests/test_background/test_job_tracker.py
@@ -87,3 +87,24 @@ def test_multiple_jobs_independent():
     snap = tracker.snapshot()
     assert snap["job_a"]["error_count"] == 0
     assert snap["job_b"]["error_count"] == 1
+
+
+def test_record_success_stores_stats():
+    tracker = JobTracker()
+    tracker.record_success("auto_linker", 12.0, stats={"pairs_evaluated": 7})
+    snap = tracker.snapshot()
+    assert snap["auto_linker"]["last_stats"] == {"pairs_evaluated": 7}
+
+
+def test_tracked_captures_dict_return():
+    tracker = JobTracker()
+    job = tracked(tracker, "j", lambda: {"pairs_evaluated": 3})
+    job()
+    assert tracker.snapshot()["j"]["last_stats"] == {"pairs_evaluated": 3}
+
+
+def test_tracked_non_dict_return_keeps_stats_none():
+    tracker = JobTracker()
+    job = tracked(tracker, "j", lambda: None)
+    job()
+    assert tracker.snapshot()["j"]["last_stats"] is None

--- a/tests/test_background/test_job_tracker.py
+++ b/tests/test_background/test_job_tracker.py
@@ -108,3 +108,26 @@ def test_tracked_non_dict_return_keeps_stats_none():
     job = tracked(tracker, "j", lambda: None)
     job()
     assert tracker.snapshot()["j"]["last_stats"] is None
+
+
+def test_tracked_error_dict_return_records_failure():
+    """A run_* that returns {"error": ...} must be recorded as a FAILURE, not
+    a healthy success with a suspicious-looking last_stats (#90 council finding 1)."""
+    tracker = JobTracker()
+    job = tracked(tracker, "j", lambda: {"error": "boom"})
+    job()
+    snap = tracker.snapshot()["j"]
+    assert snap["error_count"] == 1
+    assert snap["last_error"] == "boom"
+    assert snap["last_success"] is None
+    assert snap["last_stats"] == {"error": "boom"}
+
+
+def test_tracked_normal_stats_dict_still_records_success():
+    tracker = JobTracker()
+    job = tracked(tracker, "j", lambda: {"pairs_evaluated": 2})
+    job()
+    snap = tracker.snapshot()["j"]
+    assert snap["error_count"] == 0
+    assert snap["last_success"] is not None
+    assert snap["last_stats"] == {"pairs_evaluated": 2}

--- a/tests/test_background/test_llm_adapters.py
+++ b/tests/test_background/test_llm_adapters.py
@@ -128,6 +128,39 @@ def test_litellm_adapter_failure():
     assert result is None
 
 
+# --- timeout hint (#87) ---
+
+def test_ollama_generate_uses_timeout_hint():
+    adapter = OllamaAdapter(model="llama3.2", timeout=60)
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"response": "{}"}
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("httpx.post", return_value=mock_resp) as mock_post:
+        adapter.generate("p", timeout_hint_seconds=130)
+    assert mock_post.call_args[1]["timeout"] == 130
+
+    with patch("httpx.post", return_value=mock_resp) as mock_post:
+        adapter.generate("p")  # no hint -> constructor timeout
+    assert mock_post.call_args[1]["timeout"] == 60
+
+
+def test_litellm_generate_uses_timeout_hint():
+    adapter = LiteLLMAdapter(model="claude-sonnet-4-20250514", timeout=60)
+    mock_choice = MagicMock()
+    mock_choice.message.content = "{}"
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+
+    mock_litellm = MagicMock()
+    mock_litellm.completion.return_value = mock_response
+    with patch.dict(sys.modules, {"litellm": mock_litellm}):
+        adapter.generate("p", timeout_hint_seconds=130)
+        assert mock_litellm.completion.call_args[1]["timeout"] == 130
+        adapter.generate("p")  # no hint -> constructor timeout
+        assert mock_litellm.completion.call_args[1]["timeout"] == 60
+
+
 # --- get_adapter factory ---
 
 def test_get_adapter_ollama():

--- a/tests/test_background/test_pair_batch.py
+++ b/tests/test_background/test_pair_batch.py
@@ -1,0 +1,16 @@
+"""Issue #87: pair batching — settings, timeout hint, batch module."""
+from ormah.config import Settings
+
+
+def test_batching_settings_defaults(tmp_path):
+    s = Settings(memory_dir=tmp_path)
+    assert s.maintenance_pairs_per_call == 1          # K=1 -> legacy flow untouched
+    assert s.maintenance_timeout_per_pair_seconds == 10
+    # per-job K overrides (council C3): 0 = fall back to the global K
+    assert s.auto_link_pairs_per_call == 0
+    assert s.duplicate_check_pairs_per_call == 0
+    assert s.conflict_check_pairs_per_call == 0
+    # caps default to CURRENT-equivalent bounds (council I1): 0 = unbounded
+    assert s.auto_link_max_pairs_per_run == 0
+    assert s.duplicate_check_max_pairs_per_run == 0
+    assert s.conflict_check_max_pairs_per_run == 10000   # today's exact bound

--- a/tests/test_background/test_pair_batch.py
+++ b/tests/test_background/test_pair_batch.py
@@ -1,4 +1,7 @@
 """Issue #87: pair batching — settings, timeout hint, batch module."""
+import json
+
+from ormah.background.llm import pair_batch
 from ormah.config import Settings
 
 
@@ -14,3 +17,89 @@ def test_batching_settings_defaults(tmp_path):
     assert s.auto_link_max_pairs_per_run == 0
     assert s.duplicate_check_max_pairs_per_run == 0
     assert s.conflict_check_max_pairs_per_run == 10000   # today's exact bound
+
+
+# --- pair_batch.judge_pairs (Task 05) ---
+
+def _settings(tmp_path, k):
+    return Settings(memory_dir=tmp_path, maintenance_pairs_per_call=k,
+                    llm_timeout_seconds=60, maintenance_timeout_per_pair_seconds=10)
+
+
+PAIRS = [{"id": i} for i in range(4)]
+RENDER = lambda p: f"pair-{p['id']}"       # noqa: E731
+INSTR = "JUDGE THE PAIR"
+
+
+def test_k1_is_a_pure_map_over_judge_single(tmp_path, monkeypatch):
+    monkeypatch.setattr(pair_batch, "llm_generate",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("no batch call at K=1")))
+    out = pair_batch.judge_pairs(_settings(tmp_path, 1), INSTR, PAIRS, RENDER,
+                                 judge_single=lambda p: {"ok": p["id"]})
+    assert out == [{"ok": 0}, {"ok": 1}, {"ok": 2}, {"ok": 3}]
+
+
+def test_explicit_k_overrides_settings(tmp_path, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_generate(settings, prompt, json_mode=True, **kw):
+        calls["n"] += 1
+        n = prompt.count("### Pair ")
+        return json.dumps({"verdicts": [{"pair_id": i, "v": i} for i in range(n)]})
+
+    monkeypatch.setattr(pair_batch, "llm_generate", fake_generate)
+    out = pair_batch.judge_pairs(_settings(tmp_path, 1), INSTR, PAIRS, RENDER,
+                                 judge_single=lambda p: {"single": True}, k=4)
+    assert calls["n"] == 1 and [v["v"] for v in out] == [0, 1, 2, 3]
+
+
+def test_valid_batch_applies_all_verdicts(tmp_path, monkeypatch):
+    prompts = []
+
+    def fake_generate(settings, prompt, json_mode=True, **kw):
+        prompts.append((prompt, kw.get("timeout_hint_seconds")))
+        return json.dumps({"verdicts": [{"pair_id": i, "v": i} for i in range(4)]})
+
+    monkeypatch.setattr(pair_batch, "llm_generate", fake_generate)
+    out = pair_batch.judge_pairs(_settings(tmp_path, 4), INSTR, PAIRS, RENDER,
+                                 judge_single=lambda p: {"single": True})
+    assert [v["v"] for v in out] == [0, 1, 2, 3]
+    assert prompts[0][1] == 60 + 10 * 4          # base + per_pair * K
+    assert INSTR in prompts[0][0] and "pair-3" in prompts[0][0]
+
+
+def test_partial_verdicts_leave_missing_as_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(pair_batch, "llm_generate",
+                        lambda *a, **k: json.dumps({"verdicts": [{"pair_id": 1, "v": 1}]}))
+    out = pair_batch.judge_pairs(_settings(tmp_path, 4), INSTR, PAIRS, RENDER,
+                                 judge_single=lambda p: {"single": True})
+    assert out[1] == {"pair_id": 1, "v": 1}
+    assert out[0] is None and out[2] is None and out[3] is None
+
+
+def test_parse_failure_bisects_to_single(tmp_path, monkeypatch):
+    monkeypatch.setattr(pair_batch, "llm_generate", lambda *a, **k: "NOT JSON {{{")
+    singles = []
+
+    def judge_single(p):
+        singles.append(p["id"])
+        return {"single": p["id"]}
+
+    out = pair_batch.judge_pairs(_settings(tmp_path, 4), INSTR, PAIRS, RENDER, judge_single)
+    assert singles == [0, 1, 2, 3]               # ladder bottomed out per pair
+    assert [v["single"] for v in out] == [0, 1, 2, 3]
+
+
+def test_llm_unavailable_aborts_remaining_chunks(tmp_path, monkeypatch):
+    """Council C1: an outage must not iterate the whole collected list."""
+    calls = {"n": 0}
+
+    def fake_generate(*a, **k):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(pair_batch, "llm_generate", fake_generate)
+    out = pair_batch.judge_pairs(_settings(tmp_path, 2), INSTR, PAIRS, RENDER,
+                                 judge_single=lambda p: {"single": True})
+    assert out == [None, None, None, None]
+    assert calls["n"] == 1                        # chunk 1 fails -> chunk 2 never attempted

--- a/tests/test_background/test_run_maintenance.py
+++ b/tests/test_background/test_run_maintenance.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
 from ormah.models.node import CreateNodeRequest, NodeType
 
@@ -234,26 +232,45 @@ class TestGetMaintenanceBatches:
             for node in (c["node_a"], c["node_b"]):
                 assert len(node["content"]) <= 400
 
-    def test_finder_failure_raises(self, engine, monkeypatch):
-        """Issue #90 council R3 finding 1: a broken finder must make Phase 1
-        fail loudly, not substitute an empty batch. A finder failure means a
-        shared dependency (encoder/vector-store/DB) is down, so all four
-        batches are suspect anyway — silently reporting "nothing to process"
-        would let Phase 2 stamp last_maintenance_run and silence the
-        maintenance signal for a whole interval while the detector stays
-        broken (context_builder.py's "self-limiting" signal check)."""
+    def _read_stamp(self, engine):
+        row = engine.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'last_maintenance_run'"
+        ).fetchone()
+        return row["value"] if row else None
+
+    def _read_phase1_errors_marker(self, engine):
+        return engine.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'maintenance_phase1_errors'"
+        ).fetchone()
+
+    def test_finder_failure_does_not_raise_and_is_named_in_batch_errors(self, engine, monkeypatch):
+        """Issue #90 council R4: the finders fail INDEPENDENTLY (distinct
+        queries, no shared crash point) — one broken finder must not block the
+        three healthy batches. get_maintenance_batches must swallow the
+        failure, report it explicitly via batch_errors, and still return the
+        healthy batches."""
         from ormah.background import auto_linker
 
         def boom(*a, **kw):
             raise RuntimeError("boom")
 
         monkeypatch.setattr(auto_linker, "_find_link_candidates", boom)
-        with pytest.raises(RuntimeError, match="boom"):
-            engine.get_maintenance_batches()
 
-    def test_finder_failure_does_not_stamp_last_maintenance_run(self, engine, monkeypatch):
-        """Phase 2's last_maintenance_run stamp must never happen off the back
-        of a Phase 1 that raised."""
+        batches = engine.get_maintenance_batches()
+
+        assert isinstance(batches["conflict_candidates"], list)
+        assert isinstance(batches["merge_candidates"], list)
+        assert isinstance(batches["consolidation_clusters"], list)
+        assert batches["link_candidates"] == []
+        assert set(batches["batch_errors"].keys()) == {"link_candidates"}
+        assert "boom" in batches["batch_errors"]["link_candidates"]
+        assert "FAILED: link_candidates" in batches["summary"]
+
+    def test_finder_failure_leaves_last_maintenance_run_unchanged(self, engine, monkeypatch):
+        """A failing batch must block Phase 2's stamp, even though Phase 1
+        itself no longer raises. apply_maintenance_results is a SEPARATE MCP
+        call that never sees phase-1 metadata directly — the meta marker is
+        how it learns a batch failed."""
         from ormah.background import auto_linker
 
         def boom(*a, **kw):
@@ -261,17 +278,42 @@ class TestGetMaintenanceBatches:
 
         monkeypatch.setattr(auto_linker, "_find_link_candidates", boom)
 
-        def _read_stamp():
-            row = engine.db.conn.execute(
-                "SELECT value FROM meta WHERE key = 'last_maintenance_run'"
-            ).fetchone()
-            return row["value"] if row else None
+        before = self._read_stamp(engine)
+        engine.get_maintenance_batches()
+        assert self._read_phase1_errors_marker(engine) is not None
 
-        before = _read_stamp()
-        with pytest.raises(RuntimeError):
-            engine.get_maintenance_batches()
-        after = _read_stamp()
+        engine.apply_maintenance_results({})
+        after = self._read_stamp(engine)
         assert after == before
+
+    def test_clean_phase1_has_no_batch_errors_and_stamp_proceeds(self, engine):
+        """No failures -> batch_errors == {}, no meta marker, and Phase 2
+        stamps last_maintenance_run normally."""
+        batches = engine.get_maintenance_batches()
+        assert batches["batch_errors"] == {}
+        assert self._read_phase1_errors_marker(engine) is None
+
+        before = self._read_stamp(engine)
+        engine.apply_maintenance_results({})
+        after = self._read_stamp(engine)
+        assert after is not None
+        assert after != before
+
+    def test_clean_phase1_after_failure_clears_the_marker(self, engine, monkeypatch):
+        """A recovered system (finder works again) must stop being blocked —
+        the next clean Phase 1 clears the stale marker."""
+        from ormah.background import auto_linker
+
+        def boom(*a, **kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(auto_linker, "_find_link_candidates", boom)
+        engine.get_maintenance_batches()
+        assert self._read_phase1_errors_marker(engine) is not None
+
+        monkeypatch.undo()  # restore the real _find_link_candidates
+        engine.get_maintenance_batches()
+        assert self._read_phase1_errors_marker(engine) is None
 
 
 class TestWhisperSignal:

--- a/tests/test_background/test_run_maintenance.py
+++ b/tests/test_background/test_run_maintenance.py
@@ -232,6 +232,25 @@ class TestGetMaintenanceBatches:
             for node in (c["node_a"], c["node_b"]):
                 assert len(node["content"]) <= 400
 
+    def test_survives_finder_failure(self, engine, monkeypatch):
+        """Issue #90 council R2 finding 1: get_maintenance_batches is the only
+        caller of the four finders outside their own run_* jobs and must keep
+        today's behavior — a blown-up finder yields an empty batch for that
+        key, not an uncaught exception, even though the finders themselves no
+        longer swallow exceptions internally."""
+        from ormah.background import auto_linker
+
+        def boom(*a, **kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(auto_linker, "_find_link_candidates", boom)
+        batches = engine.get_maintenance_batches()
+        assert batches["link_candidates"] == []
+        # The other three batches must be unaffected.
+        assert "conflict_candidates" in batches
+        assert "merge_candidates" in batches
+        assert "consolidation_clusters" in batches
+
 
 class TestWhisperSignal:
 

--- a/tests/test_background/test_run_maintenance.py
+++ b/tests/test_background/test_run_maintenance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
 from ormah.models.node import CreateNodeRequest, NodeType
 
@@ -232,24 +234,44 @@ class TestGetMaintenanceBatches:
             for node in (c["node_a"], c["node_b"]):
                 assert len(node["content"]) <= 400
 
-    def test_survives_finder_failure(self, engine, monkeypatch):
-        """Issue #90 council R2 finding 1: get_maintenance_batches is the only
-        caller of the four finders outside their own run_* jobs and must keep
-        today's behavior — a blown-up finder yields an empty batch for that
-        key, not an uncaught exception, even though the finders themselves no
-        longer swallow exceptions internally."""
+    def test_finder_failure_raises(self, engine, monkeypatch):
+        """Issue #90 council R3 finding 1: a broken finder must make Phase 1
+        fail loudly, not substitute an empty batch. A finder failure means a
+        shared dependency (encoder/vector-store/DB) is down, so all four
+        batches are suspect anyway — silently reporting "nothing to process"
+        would let Phase 2 stamp last_maintenance_run and silence the
+        maintenance signal for a whole interval while the detector stays
+        broken (context_builder.py's "self-limiting" signal check)."""
         from ormah.background import auto_linker
 
         def boom(*a, **kw):
             raise RuntimeError("boom")
 
         monkeypatch.setattr(auto_linker, "_find_link_candidates", boom)
-        batches = engine.get_maintenance_batches()
-        assert batches["link_candidates"] == []
-        # The other three batches must be unaffected.
-        assert "conflict_candidates" in batches
-        assert "merge_candidates" in batches
-        assert "consolidation_clusters" in batches
+        with pytest.raises(RuntimeError, match="boom"):
+            engine.get_maintenance_batches()
+
+    def test_finder_failure_does_not_stamp_last_maintenance_run(self, engine, monkeypatch):
+        """Phase 2's last_maintenance_run stamp must never happen off the back
+        of a Phase 1 that raised."""
+        from ormah.background import auto_linker
+
+        def boom(*a, **kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(auto_linker, "_find_link_candidates", boom)
+
+        def _read_stamp():
+            row = engine.db.conn.execute(
+                "SELECT value FROM meta WHERE key = 'last_maintenance_run'"
+            ).fetchone()
+            return row["value"] if row else None
+
+        before = _read_stamp()
+        with pytest.raises(RuntimeError):
+            engine.get_maintenance_batches()
+        after = _read_stamp()
+        assert after == before
 
 
 class TestWhisperSignal:

--- a/tests/test_background/test_run_stats.py
+++ b/tests/test_background/test_run_stats.py
@@ -1,0 +1,45 @@
+"""Issue #90: maintenance runs return a stats dict."""
+from ormah.background.auto_linker import run_auto_linker
+from ormah.background.conflict_detector import run_conflict_detection
+from ormah.background.duplicate_merger import run_duplicate_detection
+
+
+def test_auto_linker_returns_stats(engine):
+    engine.settings.llm_provider = "none"  # llm disabled -> early return, still a dict
+    stats = run_auto_linker(engine)
+    assert stats == {"skipped": "llm_disabled"}
+
+
+def test_conflict_detector_stats_shape(engine):
+    # enable llm; no candidates exist, so no LLM call happens
+    engine.settings.llm_provider = "ollama"
+    stats = run_conflict_detection(engine)
+    for key in ("candidates_found", "pairs_evaluated", "edges_created", "duration_s"):
+        assert key in stats
+
+
+def test_duplicate_merger_stats_shape(engine):
+    engine.settings.llm_provider = "ollama"
+    stats = run_duplicate_detection(engine)
+    for key in ("nodes_scanned", "pairs_evaluated", "proposals_created", "duration_s"):
+        assert key in stats
+
+
+def test_llm_jobs_are_staggered(engine, monkeypatch):
+    from apscheduler.schedulers.background import BackgroundScheduler
+    from ormah.background import scheduler as sched_mod
+
+    recorded = {}
+    orig_add = BackgroundScheduler.add_job
+
+    def spy(self, func, *a, **kw):
+        recorded[kw.get("id")] = kw.get("next_run_time")
+        return orig_add(self, func, *a, **kw)
+
+    monkeypatch.setattr(BackgroundScheduler, "add_job", spy)
+    monkeypatch.setattr(BackgroundScheduler, "start", lambda self: None)
+    sched_mod.start_scheduler(engine)
+    llm_jobs = ["auto_linker", "conflict_detector", "duplicate_merger", "consolidator"]
+    times = [recorded[j] for j in llm_jobs]
+    assert all(t is not None for t in times)
+    assert len({t.replace(microsecond=0) for t in times}) == len(times)

--- a/tests/test_background/test_run_stats.py
+++ b/tests/test_background/test_run_stats.py
@@ -1,5 +1,8 @@
 """Issue #90: maintenance runs return a stats dict."""
+import pytest
+
 from ormah.background import auto_linker
+from ormah.background import duplicate_merger
 from ormah.background.auto_linker import run_auto_linker
 from ormah.background.conflict_detector import run_conflict_detection
 from ormah.background.duplicate_merger import run_duplicate_detection
@@ -40,19 +43,109 @@ def test_run_failure_is_visible_as_error_stats(engine, monkeypatch):
     assert stats is not None
     assert stats["error"] == "watermark read failed"
 
-    # tracked() must store the error dict as last_stats, not None.
+    # tracked() must route the error dict to record_failure, not record_success
+    # (council R2 finding 4: last_stats alone doesn't prove the routing).
     tracker = JobTracker()
     job = tracked(tracker, "auto_linker", run_auto_linker, engine)
     job()
-    last_stats = tracker.snapshot()["auto_linker"]["last_stats"]
-    assert last_stats is not None
-    assert "error" in last_stats
+    snap = tracker.snapshot()["auto_linker"]
+    assert snap["error_count"] == 1
+    assert snap["last_error"] == "watermark read failed"
+    assert snap["last_success"] is None
+    assert snap["last_stats"] is not None
+    assert "error" in snap["last_stats"]
+
+
+def test_find_link_candidates_propagates_finder_failure(engine, monkeypatch):
+    """Issue #90 council R2 finding 1: a DB/encoder failure inside the finder
+    must not be swallowed as "no candidates". _find_link_candidates is only
+    called by get_maintenance_batches (run_auto_linker has its own inline
+    candidate loop and never calls this finder), so there is no run_*/tracked()
+    path to exercise here — the finder itself must raise."""
+
+    def boom(*a, **kw):
+        raise RuntimeError("encoder boom")
+
+    # get_encoder is imported locally inside the function; patch the source module.
+    import ormah.embeddings.encoder as encoder_mod
+    monkeypatch.setattr(encoder_mod, "get_encoder", boom)
+
+    with pytest.raises(RuntimeError, match="encoder boom"):
+        auto_linker._find_link_candidates(engine)
+
+
+def test_find_merge_candidates_propagates_finder_failure(engine, monkeypatch):
+    """Same as above for duplicate_merger's finder (also only reachable via
+    get_maintenance_batches, never via the scheduled run_duplicate_detection)."""
+
+    def boom(*a, **kw):
+        raise RuntimeError("encoder boom")
+
+    import ormah.embeddings.encoder as encoder_mod
+    monkeypatch.setattr(encoder_mod, "get_encoder", boom)
+
+    with pytest.raises(RuntimeError, match="encoder boom"):
+        duplicate_merger._find_merge_candidates(engine)
+
+
+def test_conflict_detector_finder_failure_is_visible_via_tracked(engine, monkeypatch):
+    """Issue #90 council R2 finding 1: unlike auto_linker/duplicate_merger,
+    run_conflict_detection DOES call _find_conflict_candidates directly, so an
+    internal finder failure (not the finder-doesn't-exist case) must surface
+    through tracked() as a recorded failure, not a green run. Patches the
+    encoder (called unconditionally near the top of the finder) rather than
+    the finder function itself, so this actually exercises the finder's own
+    (now-removed) blanket except."""
+    import ormah.embeddings.encoder as encoder_mod
+
+    def boom(*a, **kw):
+        raise RuntimeError("encoder boom")
+
+    monkeypatch.setattr(encoder_mod, "get_encoder", boom)
+    engine.settings.llm_provider = "ollama"
+
+    tracker = JobTracker()
+    job = tracked(tracker, "conflict_detector", run_conflict_detection, engine)
+    job()
+    snap = tracker.snapshot()["conflict_detector"]
+    assert snap["error_count"] == 1
+    assert snap["last_success"] is None
+    assert snap["last_error"] is not None
+
+
+def test_consolidator_finder_failure_is_visible_via_tracked(engine, monkeypatch):
+    """run_consolidation calls _find_consolidation_clusters directly and has no
+    catch-all of its own — an internal VectorStore-construction failure must
+    reach tracked()'s own except, not the finder's (now-removed) blanket except."""
+    from ormah.background.consolidator import run_consolidation
+    from ormah.models.node import CreateNodeRequest, NodeType
+
+    # Need >= 2 working-tier nodes to get past the "nothing to cluster" early
+    # return and actually reach the VectorStore(...) construction.
+    for i in range(2):
+        engine.remember(CreateNodeRequest(content=f"note number {i}", type=NodeType.fact, title=f"n{i}"))
+
+    import ormah.embeddings.vector_store as vs_mod
+
+    class _BoomVectorStore:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("vector store boom")
+
+    monkeypatch.setattr(vs_mod, "VectorStore", _BoomVectorStore)
+    engine.settings.llm_provider = "ollama"
+
+    tracker = JobTracker()
+    job = tracked(tracker, "consolidator", run_consolidation, engine)
+    job()
+    snap = tracker.snapshot()["consolidator"]
+    assert snap["error_count"] == 1
+    assert snap["last_success"] is None
+    assert snap["last_error"] is not None
 
 
 def test_llm_jobs_are_staggered(engine, monkeypatch):
     """At default (1440-minute) intervals, all four offsets fit under the
-    interval and stay distinct. See test_staggered_offset_bounded_by_configured_interval
-    for the short-interval case where the offsets collapse (issue #90 finding 3)."""
+    interval and stay distinct."""
     from apscheduler.schedulers.background import BackgroundScheduler
     from ormah.background import scheduler as sched_mod
 
@@ -72,36 +165,47 @@ def test_llm_jobs_are_staggered(engine, monkeypatch):
     assert len({t.replace(microsecond=0) for t in times}) == len(times)
 
 
-def test_staggered_offset_bounded_by_configured_interval(engine, monkeypatch):
-    """Issue #90 (council finding 3): a fixed stagger offset must never exceed
-    a job's own configured interval — otherwise a supported short interval
-    (e.g. consolidation_interval_minutes=1) waits up to 45 minutes for its
-    first run after every restart, instead of the ~1 minute the base gave it."""
+def test_staggered_offsets_scale_and_stay_distinct(engine, monkeypatch):
+    """Issue #90 council R2 finding 3: clamping offsets with min() collapses
+    distinct offsets onto the same boundary at short intervals (e.g. interval=30
+    -> [5,15,30,30], interval=1 -> [1,1,1,1]), recreating the concurrent-LLM-load
+    burst the stagger exists to prevent. Offsets must instead scale
+    proportionally so they stay distinct and always land inside one interval."""
     from datetime import timedelta, timezone
     from apscheduler.schedulers.background import BackgroundScheduler
     from ormah.background import scheduler as sched_mod
 
-    engine.settings.auto_link_interval_minutes = 1
-    engine.settings.conflict_check_interval_minutes = 1
-    engine.settings.duplicate_check_interval_minutes = 1
-    engine.settings.consolidation_interval_minutes = 1
-
-    recorded = {}
-    orig_add = BackgroundScheduler.add_job
-
-    def spy(self, func, *a, **kw):
-        recorded[kw.get("id")] = kw.get("next_run_time")
-        return orig_add(self, func, *a, **kw)
-
-    monkeypatch.setattr(BackgroundScheduler, "add_job", spy)
-    monkeypatch.setattr(BackgroundScheduler, "start", lambda self: None)
-
-    from datetime import datetime
-    before = datetime.now(timezone.utc)
-    sched_mod.start_scheduler(engine)
-
     llm_jobs = ["auto_linker", "conflict_detector", "duplicate_merger", "consolidator"]
-    for job_id in llm_jobs:
-        t = recorded[job_id]
-        assert t is not None
-        assert t <= before + timedelta(minutes=1, seconds=5)
+
+    def run_with_interval(interval_minutes: int) -> dict:
+        engine.settings.auto_link_interval_minutes = interval_minutes
+        engine.settings.conflict_check_interval_minutes = interval_minutes
+        engine.settings.duplicate_check_interval_minutes = interval_minutes
+        engine.settings.consolidation_interval_minutes = interval_minutes
+
+        recorded = {}
+        orig_add = BackgroundScheduler.add_job
+
+        def spy(self, func, *a, **kw):
+            recorded[kw.get("id")] = kw.get("next_run_time")
+            return orig_add(self, func, *a, **kw)
+
+        monkeypatch.setattr(BackgroundScheduler, "add_job", spy)
+        monkeypatch.setattr(BackgroundScheduler, "start", lambda self: None)
+
+        from datetime import datetime
+        before = datetime.now(timezone.utc)
+        sched_mod.start_scheduler(engine)
+
+        for job_id in llm_jobs:
+            t = recorded[job_id]
+            assert t is not None
+            assert t < before + timedelta(minutes=interval_minutes)
+        return recorded
+
+    for interval_minutes in (1, 30):
+        recorded = run_with_interval(interval_minutes)
+        times = [recorded[j] for j in llm_jobs]
+        assert len({t.replace(microsecond=0) for t in times}) == len(times), (
+            f"offsets collapsed at interval_minutes={interval_minutes}: {times}"
+        )

--- a/tests/test_background/test_run_stats.py
+++ b/tests/test_background/test_run_stats.py
@@ -1,7 +1,9 @@
 """Issue #90: maintenance runs return a stats dict."""
+from ormah.background import auto_linker
 from ormah.background.auto_linker import run_auto_linker
 from ormah.background.conflict_detector import run_conflict_detection
 from ormah.background.duplicate_merger import run_duplicate_detection
+from ormah.background.job_tracker import JobTracker, tracked
 
 
 def test_auto_linker_returns_stats(engine):
@@ -23,6 +25,28 @@ def test_duplicate_merger_stats_shape(engine):
     stats = run_duplicate_detection(engine)
     for key in ("nodes_scanned", "pairs_evaluated", "proposals_created", "duration_s"):
         assert key in stats
+
+
+def test_run_failure_is_visible_as_error_stats(engine, monkeypatch):
+    """A run whose internals raise must NOT look like a clean, empty success."""
+    engine.settings.llm_provider = "ollama"
+
+    def boom(conn):
+        raise RuntimeError("watermark read failed")
+
+    monkeypatch.setattr(auto_linker, "_get_watermark", boom)
+
+    stats = run_auto_linker(engine)
+    assert stats is not None
+    assert stats["error"] == "watermark read failed"
+
+    # tracked() must store the error dict as last_stats, not None.
+    tracker = JobTracker()
+    job = tracked(tracker, "auto_linker", run_auto_linker, engine)
+    job()
+    last_stats = tracker.snapshot()["auto_linker"]["last_stats"]
+    assert last_stats is not None
+    assert "error" in last_stats
 
 
 def test_llm_jobs_are_staggered(engine, monkeypatch):

--- a/tests/test_background/test_run_stats.py
+++ b/tests/test_background/test_run_stats.py
@@ -143,11 +143,8 @@ def test_consolidator_finder_failure_is_visible_via_tracked(engine, monkeypatch)
     assert snap["last_error"] is not None
 
 
-def test_llm_jobs_are_staggered(engine, monkeypatch):
-    """At default (1440-minute) intervals, all four offsets fit under the
-    interval and stay distinct."""
+def _spy_add_job(monkeypatch):
     from apscheduler.schedulers.background import BackgroundScheduler
-    from ormah.background import scheduler as sched_mod
 
     recorded = {}
     orig_add = BackgroundScheduler.add_job
@@ -158,54 +155,60 @@ def test_llm_jobs_are_staggered(engine, monkeypatch):
 
     monkeypatch.setattr(BackgroundScheduler, "add_job", spy)
     monkeypatch.setattr(BackgroundScheduler, "start", lambda self: None)
-    sched_mod.start_scheduler(engine)
-    llm_jobs = ["auto_linker", "conflict_detector", "duplicate_merger", "consolidator"]
-    times = [recorded[j] for j in llm_jobs]
-    assert all(t is not None for t in times)
-    assert len({t.replace(microsecond=0) for t in times}) == len(times)
+    return recorded
 
 
-def test_staggered_offsets_scale_and_stay_distinct(engine, monkeypatch):
-    """Issue #90 council R2 finding 3: clamping offsets with min() collapses
-    distinct offsets onto the same boundary at short intervals (e.g. interval=30
-    -> [5,15,30,30], interval=1 -> [1,1,1,1]), recreating the concurrent-LLM-load
-    burst the stagger exists to prevent. Offsets must instead scale
-    proportionally so they stay distinct and always land inside one interval."""
-    from datetime import timedelta, timezone
-    from apscheduler.schedulers.background import BackgroundScheduler
+def test_staggered_offsets_exact_at_default_intervals(engine, monkeypatch):
+    """At the 1440-minute defaults the nominal offsets (5/15/30/45) are
+    unscaled — shortest configured interval (1440) >> reference (60)."""
+    from datetime import datetime, timedelta, timezone
     from ormah.background import scheduler as sched_mod
 
-    llm_jobs = ["auto_linker", "conflict_detector", "duplicate_merger", "consolidator"]
+    recorded = _spy_add_job(monkeypatch)
+    before = datetime.now(timezone.utc)
+    sched_mod.start_scheduler(engine)
+    after = datetime.now(timezone.utc)
 
-    def run_with_interval(interval_minutes: int) -> dict:
-        engine.settings.auto_link_interval_minutes = interval_minutes
-        engine.settings.conflict_check_interval_minutes = interval_minutes
-        engine.settings.duplicate_check_interval_minutes = interval_minutes
-        engine.settings.consolidation_interval_minutes = interval_minutes
+    expected_offsets = {"auto_linker": 5, "conflict_detector": 15,
+                         "duplicate_merger": 30, "consolidator": 45}
+    for job_id, nominal in expected_offsets.items():
+        t = recorded[job_id]
+        assert before + timedelta(minutes=nominal) <= t <= after + timedelta(minutes=nominal)
 
-        recorded = {}
-        orig_add = BackgroundScheduler.add_job
 
-        def spy(self, func, *a, **kw):
-            recorded[kw.get("id")] = kw.get("next_run_time")
-            return orig_add(self, func, *a, **kw)
+def test_staggered_offsets_share_one_factor_across_mixed_intervals(engine, monkeypatch):
+    """Issue #90 council R3 finding 2: scaling each job by ITS OWN interval
+    let jobs with different intervals collide (e.g. auto_link=3min nominal-5
+    -> 0.25min, conflict_check=1min nominal-15 -> 0.25min: both fire at 15s
+    and re-collide every 3 minutes). All four jobs must share ONE factor
+    derived from the shortest configured interval, so distinct nominal
+    offsets (5/15/30/45) stay distinct regardless of which job has the
+    shortest interval."""
+    from datetime import datetime, timedelta, timezone
+    from ormah.background import scheduler as sched_mod
 
-        monkeypatch.setattr(BackgroundScheduler, "add_job", spy)
-        monkeypatch.setattr(BackgroundScheduler, "start", lambda self: None)
+    engine.settings.auto_link_interval_minutes = 3
+    engine.settings.conflict_check_interval_minutes = 1
+    # duplicate_check / consolidation stay at their 1440-minute default.
 
-        from datetime import datetime
-        before = datetime.now(timezone.utc)
-        sched_mod.start_scheduler(engine)
+    recorded = _spy_add_job(monkeypatch)
 
-        for job_id in llm_jobs:
-            t = recorded[job_id]
-            assert t is not None
-            assert t < before + timedelta(minutes=interval_minutes)
-        return recorded
+    before = datetime.now(timezone.utc)
+    sched_mod.start_scheduler(engine)
 
-    for interval_minutes in (1, 30):
-        recorded = run_with_interval(interval_minutes)
-        times = [recorded[j] for j in llm_jobs]
-        assert len({t.replace(microsecond=0) for t in times}) == len(times), (
-            f"offsets collapsed at interval_minutes={interval_minutes}: {times}"
-        )
+    llm_jobs_intervals = {
+        "auto_linker": engine.settings.auto_link_interval_minutes,
+        "conflict_detector": engine.settings.conflict_check_interval_minutes,
+        "duplicate_merger": engine.settings.duplicate_check_interval_minutes,
+        "consolidator": engine.settings.consolidation_interval_minutes,
+    }
+    times = []
+    for job_id, interval_minutes in llm_jobs_intervals.items():
+        t = recorded[job_id]
+        assert t is not None
+        assert t < before + timedelta(minutes=interval_minutes)
+        times.append(t)
+
+    assert len({t.replace(microsecond=0) for t in times}) == len(times), (
+        f"offsets collapsed across mixed intervals: {times}"
+    )

--- a/tests/test_background/test_run_stats.py
+++ b/tests/test_background/test_run_stats.py
@@ -50,6 +50,9 @@ def test_run_failure_is_visible_as_error_stats(engine, monkeypatch):
 
 
 def test_llm_jobs_are_staggered(engine, monkeypatch):
+    """At default (1440-minute) intervals, all four offsets fit under the
+    interval and stay distinct. See test_staggered_offset_bounded_by_configured_interval
+    for the short-interval case where the offsets collapse (issue #90 finding 3)."""
     from apscheduler.schedulers.background import BackgroundScheduler
     from ormah.background import scheduler as sched_mod
 
@@ -67,3 +70,38 @@ def test_llm_jobs_are_staggered(engine, monkeypatch):
     times = [recorded[j] for j in llm_jobs]
     assert all(t is not None for t in times)
     assert len({t.replace(microsecond=0) for t in times}) == len(times)
+
+
+def test_staggered_offset_bounded_by_configured_interval(engine, monkeypatch):
+    """Issue #90 (council finding 3): a fixed stagger offset must never exceed
+    a job's own configured interval — otherwise a supported short interval
+    (e.g. consolidation_interval_minutes=1) waits up to 45 minutes for its
+    first run after every restart, instead of the ~1 minute the base gave it."""
+    from datetime import timedelta, timezone
+    from apscheduler.schedulers.background import BackgroundScheduler
+    from ormah.background import scheduler as sched_mod
+
+    engine.settings.auto_link_interval_minutes = 1
+    engine.settings.conflict_check_interval_minutes = 1
+    engine.settings.duplicate_check_interval_minutes = 1
+    engine.settings.consolidation_interval_minutes = 1
+
+    recorded = {}
+    orig_add = BackgroundScheduler.add_job
+
+    def spy(self, func, *a, **kw):
+        recorded[kw.get("id")] = kw.get("next_run_time")
+        return orig_add(self, func, *a, **kw)
+
+    monkeypatch.setattr(BackgroundScheduler, "add_job", spy)
+    monkeypatch.setattr(BackgroundScheduler, "start", lambda self: None)
+
+    from datetime import datetime
+    before = datetime.now(timezone.utc)
+    sched_mod.start_scheduler(engine)
+
+    llm_jobs = ["auto_linker", "conflict_detector", "duplicate_merger", "consolidator"]
+    for job_id in llm_jobs:
+        t = recorded[job_id]
+        assert t is not None
+        assert t <= before + timedelta(minutes=1, seconds=5)

--- a/tests/test_eval_maintenance/test_report.py
+++ b/tests/test_eval_maintenance/test_report.py
@@ -1,0 +1,19 @@
+from eval.maintenance.report import agreement
+
+
+def test_agreement_and_gate():
+    single = {"p1": "none", "p2": "supports", "p3": "none", "p4": "related_to"}
+    batched = {"p1": "none", "p2": "supports", "p3": "related_to", "p4": "related_to"}
+    r = agreement(single, batched)
+    assert r["n"] == 4
+    assert r["agree_rate"] == 0.75
+    assert r["none_to_edge_rate"] == 0.5      # 1 of the 2 'none' singles flipped
+    assert r["gate_pass"] is False
+
+
+def test_gate_passes_at_thresholds():
+    single = {f"p{i}": "none" for i in range(10)}
+    batched = dict(single, p0="related_to")   # 0.9 agreement, 0.1 none->edge
+    r = agreement(single, batched)
+    assert r["agree_rate"] == 0.9 and r["none_to_edge_rate"] == 0.1
+    assert r["gate_pass"] is True


### PR DESCRIPTION
Closes #87. Sibling of #92 (both from the sleep-cycle performance work).

## Problem
The three pairwise LLM jobs (auto_linker, duplicate_merger, conflict_detector) send **one pair per LLM call**, re-sending the fixed instruction block (~50–70% of the prompt) every time, through a **new `claude -p` process per call, serialized** (`claude_cli_max_concurrency=1`). Observed: ~6–23 s/pair, 10–38 min per 100-call job, ~1h–1h15 per full cycle. Every production run hits `cap=100 cap_hit=True` while the backlog is ~9.4k of ~10.3k nodes never checked — at this throughput the cycle **never converges**.

## Change
**Batch K pairs per LLM call** — the consolidator already proves the multi-item prompt + JSON-array pattern internally. One code path with a **per-provider batch-size knob** (not two implementations). Same wall-clock, ~3–5× throughput; fixed-prompt tokens drop ~90%.

Estimated (claude_cli, batch=10): 100 pairs go from ~22 min to ~4–7 min; inverted, the same 22 min buys ~300–500 pairs instead of 100.

## Notes
- Rebased onto main @ 2e76b5b; local suite green (same 11 environmental failures as clean main; 0 new).
- Conflict-resolution notes vs #88 vec-reuse / #90 exceptions are in the #92 discussion.
- Follow-up (tracked): redefine the cap in **pairs** rather than calls and raise it, so throughput ≥ arrival and the backlog drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)