### PR TITLE
feat(whisper): improve candidate diagnostics and preference applicability

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Ormah supports both deliberate recall and involuntary recall.
 
 When an agent knows it needs something, it can explicitly search memory. But memory should not always wait to be asked. Ormah is built to whisper the right memory at the right time, before the next prompt, so the agent starts with context instead of having to go looking for it.
 
+Whisper evaluates standing preferences through a separate applicability path. This lets a rule govern a task even when it does not read like a passage that directly answers the prompt, without allowing preference guesses to suppress ordinary factual retrieval.
+
 Whisper feedback can learn from transcript files after they stop changing: a local heuristic records clear usage for free, and an optional LLM judge can classify ambiguous turns into positive, negative, or uncertain retrieval signals.
 
 Read more: [Whisper - Involuntary Recall](https://www.ormah.me/docs/how-ormah-works/whisper), [Search and Ranking](https://www.ormah.me/docs/how-ormah-works/search-and-ranking), [Affinity and Feedback](https://www.ormah.me/docs/operations/affinity-and-feedback)

--- a/docs/03 - Search and Ranking.md
+++ b/docs/03 - Search and Ranking.md
@@ -1,6 +1,6 @@
 # Search and Ranking
 
-Verified against the current repository state on 2026-04-07.
+Verified against the current repository state on 2026-07-11.
 
 Ormah search is a hybrid pipeline that combines:
 
@@ -140,6 +140,24 @@ Recall fetches a `3 x limit` pool from hybrid search **before** applying space s
 ## Recall relevance floor
 
 Deliberate recall drops results below `recall_min_relevance_score` (default `0.35`) instead of padding to `limit` with cross-space noise — recall may legitimately return fewer results than requested. Recency-vouched temporal supplements (`source="temporal"`) are exempt. Whisper's internal candidate fetch bypasses this floor (`min_relevance=0.0`): it applies its own floors and an absolute-signal gate downstream.
+
+## Standing preference applicability
+
+Whisper has a second, typed retrieval path for standing preferences. The main path still asks whether a memory answers or directly relates to the prompt. The preference path instead asks whether a stored rule applies to the action the user is taking.
+
+The preference path:
+
+- searches only `type="preference"` nodes
+- does not apply date filters from temporal wording, because standing rules are timeless
+- disables graph spreading so related non-preference nodes cannot enter the channel
+- cross-encodes candidates against an applicability-framed query
+- applies an absolute applicability gate and merges at most two results
+
+This does not infer a preference mode from prompt keywords and does not alter or suppress the main factual ranking. Those constraints avoid the failure mode of the removed prompt-shape heuristic, which treated broad words such as `build`, `design`, and `style` as permission to boost all preferences and discard factual results.
+
+## Whisper candidate diagnostics
+
+For session-scoped whispers, `whisper_log` retains every non-temporal retrieved candidate, including candidates removed before reranking. Rows include retrieval rank and score, raw cosine, cross-encoder signals when available, the absolute gate score, final rank, and the stage that injected or rejected the candidate. This makes floor, topical-filter, gate, and candidate-cap failures distinguishable in live replays.
 
 ## Spreading Activation
 

--- a/eval/whisper/cli.py
+++ b/eval/whisper/cli.py
@@ -32,6 +32,9 @@ _EVAL_SETTINGS_OVERRIDES = {
     "whisper_injection_gate": 0.45,
     "whisper_no_overlap_ce_floor": 0.45,
     "whisper_no_overlap_cosine_floor": 0.70,
+    "whisper_preference_applicability_enabled": True,
+    "whisper_preference_applicability_gate": 0.40,
+    "whisper_preference_max_nodes": 2,
     "whisper_exploration_enabled": True,
     # Ranking adjustments used by whisper post-processing
     "affinity_similarity_threshold": 0.70,

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -214,6 +214,13 @@ class Settings(BaseSettings):
     whisper_no_overlap_ce_floor: float = 0.45
     whisper_no_overlap_cosine_floor: float = 0.70
 
+    # Standing preferences are applicability rules, not passages that answer
+    # the prompt. A separate typed retrieval channel asks the reranker whether
+    # each preference applies to the current action, then merges at most two.
+    whisper_preference_applicability_enabled: bool = True
+    whisper_preference_applicability_gate: float = 0.40
+    whisper_preference_max_nodes: int = 2
+
     # Injection gate when the reranker did not run (unavailable, still
     # downloading, or disabled): the gate then cuts raw_cosine, a weaker
     # absolute signal, so demand a higher bar — degraded mode is more
@@ -419,6 +426,7 @@ class Settings(BaseSettings):
         "auto_merge_threshold",
         "feedback_llm_judge_min_confidence",
         "consolidation_cluster_threshold",
+        "whisper_preference_applicability_gate",
     )
     @classmethod
     def _threshold_range(cls, v: float) -> float:

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -34,6 +34,8 @@ _REVIEW_FRAMING = (
     "this won't be surfaced again for 14 days."
 )
 
+_PREFERENCE_APPLICABILITY_PREFIX = "Relevant user preference for this action: "
+
 def _truncate_at_word_boundary(text: str, max_len: int = 300) -> str:
     """Return *text* truncated to *max_len* characters at a word boundary."""
     if len(text) <= max_len:
@@ -336,6 +338,9 @@ class ContextBuilder:
         injection_gate: float = 0.55,
         no_overlap_ce_floor: float = 0.45,
         no_overlap_cosine_floor: float = 0.70,
+        preference_applicability_enabled: bool = False,
+        preference_applicability_gate: float = 0.40,
+        preference_max_nodes: int = 2,
         session_id: str | None = None,
         _return_debug: bool = False,
     ) -> str | tuple[str, list[str]]:
@@ -495,6 +500,7 @@ class ContextBuilder:
             # improve ambiguous prompts without polluting explicit ones.
             context_parts = recent_prompts[-2:] + [prompt]
             search_query = " ".join(context_parts)
+        preference_query = search_query
 
         # Build search kwargs, merging any intent-derived params
         # Fetch a deep candidate pool so the reranker/gate can rescue memories
@@ -830,6 +836,82 @@ class ContextBuilder:
             search_results.sort(
                 key=lambda r: (r.get("_space_factor", 1.0), r["node"].get("created") or ""),
                 reverse=True,
+            )
+
+        # Standing preferences need a different relevance relation from the
+        # topical channel: they govern an action rather than answer its prompt.
+        # This is intentionally a parallel typed search, not the removed April
+        # heuristic: no prompt regex changes the core path, facts are never
+        # suppressed, and every added preference must pass an applicability CE.
+        applicable_preferences: list[dict] = []
+        if (
+            preference_applicability_enabled
+            and reranker_enabled
+            and preference_max_nodes > 0
+        ):
+            try:
+                from ormah.embeddings.reranker import rerank
+
+                existing_ids = {r["node"]["id"] for r in search_results}
+                preference_candidates = self.engine.recall_search_structured(
+                    query=preference_query,
+                    limit=max_nodes * max(candidate_pool_multiplier, 1),
+                    default_space=space,
+                    types=["preference"],
+                    tiers=["core", "working"],
+                    touch_access=False,
+                    min_relevance=0.0,
+                    auto_temporal=False,
+                    spread_activation=False,
+                )
+                preference_candidates = [
+                    r for r in preference_candidates if r["node"]["id"] not in existing_ids
+                ]
+                _record_candidate_versions(preference_candidates)
+                applicability_results = rerank(
+                    query=_PREFERENCE_APPLICABILITY_PREFIX + preference_query,
+                    candidates=preference_candidates,
+                    model_name=reranker_model,
+                    min_score=0.0,
+                    blend_alpha=reranker_blend_alpha,
+                    max_doc_chars=reranker_max_doc_chars,
+                )
+                applicability_results = [
+                    {**r, "source": "preference_applicability"}
+                    for r in applicability_results
+                ]
+                _record_candidate_versions(applicability_results)
+                for result in applicability_results:
+                    trace = candidate_trace[result["node"]["id"]]
+                    trace["decision_stage"] = "candidate"
+                passed_applicability = [
+                    r
+                    for r in applicability_results
+                    if _gate_score(r) >= preference_applicability_gate
+                ]
+                _mark_removed(
+                    applicability_results,
+                    passed_applicability,
+                    "preference_applicability_gate",
+                )
+                applicable_preferences = passed_applicability[:preference_max_nodes]
+                _mark_removed(
+                    passed_applicability,
+                    applicable_preferences,
+                    "preference_candidate_cap",
+                )
+            except Exception as e:
+                logger.warning("Preference applicability search failed: %s", e)
+
+        if applicable_preferences:
+            # Reserve room without discarding the topical ranking wholesale.
+            # The strongest applicable rule is first so its content, not just
+            # its title, reaches the agent; remaining topical results keep order.
+            room_for_main = max(max_nodes - len(applicable_preferences), 0)
+            search_results = (
+                applicable_preferences[:1]
+                + search_results[:room_for_main]
+                + applicable_preferences[1:]
             )
 
         # Cap to max_nodes (already ordered by relevance score, or by recency for temporal queries)

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -85,6 +85,7 @@ def _find_review_candidate(conn, threshold: float) -> dict | None:
               FROM whisper_log wl
               JOIN nodes n ON n.id = wl.node_id
               WHERE wl.was_injected = 0
+                AND wl.decision_stage IN ('injection_gate', 'candidate_cap', 'legacy')
                 AND wl.logged_at > datetime('now', '-7 days')
                 AND NOT EXISTS (
                   SELECT 1 FROM whisper_log wl2
@@ -540,6 +541,38 @@ class ContextBuilder:
                 return "", _injected_ids
             return ""
 
+        candidate_trace: dict[str, dict] = {}
+
+        def _record_candidate_versions(results: list[dict]) -> None:
+            for rank, result in enumerate(results, start=1):
+                if result.get("source") == "temporal":
+                    continue
+                node_id = result.get("node", {}).get("id")
+                if not node_id:
+                    continue
+                trace = candidate_trace.setdefault(
+                    node_id,
+                    {
+                        "retrieval_score": result.get("score", 0.0),
+                        "retrieval_rank": rank,
+                        "decision_stage": "candidate",
+                    },
+                )
+                trace["latest"] = result
+
+        def _mark_removed(before: list[dict], after: list[dict], stage: str) -> None:
+            after_ids = {r.get("node", {}).get("id") for r in after}
+            for result in before:
+                node_id = result.get("node", {}).get("id")
+                trace = candidate_trace.get(node_id)
+                if (
+                    trace is not None
+                    and node_id not in after_ids
+                    and trace["decision_stage"] == "candidate"
+                ):
+                    trace["decision_stage"] = stage
+
+        _record_candidate_versions(search_results)
         initial_candidate_count = len(search_results)
         reranker_applied = False
         reranker_before_count = 0
@@ -566,12 +599,14 @@ class ContextBuilder:
         # strongest match can otherwise be the lowest-blended candidate).
         # The cross-encoder + absolute gate downstream handle any noise this
         # lets through.
+        before_min_score = search_results
         search_results = [
             r for r in search_results
             if r.get("score", 0) >= effective_min_score
             or r.get("raw_cosine", 0.0) >= effective_min_score
             or r.get("source") == "temporal"
         ]
+        _mark_removed(before_min_score, search_results, "pre_rerank_floor")
         post_min_score_count = len(search_results)
         # Cross-encoder reranking — always pass min_score=0.0 so affinity boost
         # can rescue candidates before any floor is applied (spec: reranker_min_score
@@ -582,6 +617,7 @@ class ContextBuilder:
 
                 reranker_applied = True
                 reranker_before_count = len(search_results)
+                before_rerank = search_results
                 search_results = rerank(
                     query=effective_query,
                     candidates=search_results,
@@ -590,6 +626,8 @@ class ContextBuilder:
                     blend_alpha=reranker_blend_alpha,
                     max_doc_chars=reranker_max_doc_chars,
                 )
+                _record_candidate_versions(search_results)
+                _mark_removed(before_rerank, search_results, "reranker_floor")
                 reranker_after_count = len(search_results)
 
             except Exception as e:
@@ -623,13 +661,16 @@ class ContextBuilder:
                 # Apply 0.40 floor AFTER boost (spec: reranker_min_score is now a post-boost floor).
                 # Use the reranker_min_score parameter (passed from engine.settings); fall back to 0.40.
                 effective_floor = reranker_min_score if reranker_min_score > 0.0 else 0.40
+                _record_candidate_versions(boosted)
                 pre_gate_candidates = [r for r in boosted if r["score"] >= effective_floor]
+                _mark_removed(boosted, pre_gate_candidates, "post_rerank_floor")
                 search_results = pre_gate_candidates
             except Exception as e:
                 logger.warning("Affinity boost failed, using unmodified scores: %s", e)
 
         if search_results:
             if identity_only:
+                before_identity_filter = search_results
                 global_results = [
                     r for r in search_results
                     if r["node"].get("space") in (None, "null")
@@ -640,6 +681,11 @@ class ContextBuilder:
                         r for r in pre_gate_candidates
                         if r["node"].get("space") in (None, "null")
                     ] or pre_gate_candidates
+                    _mark_removed(
+                        before_identity_filter,
+                        search_results,
+                        "identity_space_filter",
+                    )
 
             prompt_tokens = _topic_tokens(prompt)
             if space:
@@ -687,7 +733,9 @@ class ContextBuilder:
                 # overlapped.
                 return not overlapping_ids
 
+            before_topical_filter = search_results
             search_results = [r for r in search_results if _keep(r)]
+            _mark_removed(before_topical_filter, search_results, "topical_filter")
             if pre_gate_candidates:
                 pre_gate_candidates = [r for r in pre_gate_candidates if _keep(r)]
 
@@ -700,6 +748,7 @@ class ContextBuilder:
         if search_results:
             max_gate_score = max(_gate_score(r) for r in search_results)
         if not has_temporal and search_results:
+            before_injection_gate = search_results
             if max_gate_score < injection_gate:
                 logger.info(
                     "Whisper diagnostics: prompt=%r gate_reject max_gate_score=%.3f gate=%.3f",
@@ -713,6 +762,7 @@ class ContextBuilder:
                 # injection gate.  Weak queries naturally get fewer results
                 # instead of padding to max_nodes with marginal matches.
                 search_results = [r for r in search_results if _gate_score(r) >= injection_gate]
+            _mark_removed(before_injection_gate, search_results, "injection_gate")
 
         # Exploration slot: inject one unconfirmed gated-out candidate to
         # surface false negatives and collect affinity signal for them.
@@ -764,6 +814,7 @@ class ContextBuilder:
                             # long-shot differently from a confident whisper,
                             # and feedback on it stays honest.
                             search_results.append({**candidate, "_exploration": True})
+                            candidate_trace[nid]["decision_stage"] = "candidate"
                             break  # one exploration slot only
             except Exception as e:
                 logger.warning("Exploration slot failed: %s", e)
@@ -782,9 +833,21 @@ class ContextBuilder:
             )
 
         # Cap to max_nodes (already ordered by relevance score, or by recency for temporal queries)
+        before_candidate_cap = search_results
         search_results = search_results[:max_nodes]
+        _mark_removed(before_candidate_cap, search_results, "candidate_cap")
         final_candidate_count = len(search_results)
         _injected_ids = [r["node"]["id"] for r in search_results]
+        for final_rank, result in enumerate(search_results, start=1):
+            node_id = result["node"]["id"]
+            trace = candidate_trace.get(node_id)
+            if trace is None:
+                continue
+            trace["latest"] = result
+            trace["final_rank"] = final_rank
+            trace["decision_stage"] = (
+                "exploration_injected" if result.get("_exploration") else "injected"
+            )
 
         # Per-prompt outcome row (silence instrumentation): exactly one row
         # per whisper call so silence rate has a denominator.
@@ -829,34 +892,34 @@ class ContextBuilder:
 
         body = "\n".join(lines).rstrip()
 
-        # Write whisper_log: one row per non-temporal candidate with boosted_score >= 0.40.
-        # Uses pre_gate_candidates (all above the 0.40 floor) so gated-out candidates
-        # are also logged. was_injected reflects the final post-gate, post-exploration decision.
+        # Write one diagnostic row for every non-temporal retrieved candidate.
+        # Absolute signals and the first destructive stage are retained so live
+        # replays can distinguish retrieval misses from floor, topical, and gate
+        # rejections. Existing feedback consumers still key off was_injected.
         if session_id and prompt_vec is not None and self.engine is not None:
             try:
                 prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()
                 now_iso = datetime.now(timezone.utc).isoformat()
                 vec_blob = prompt_vec.astype(np.float32).tobytes()
-                # Use pre_gate_candidates when available (after affinity boost),
-                # otherwise fall back to the current search_results
-                candidates_to_log = pre_gate_candidates if pre_gate_candidates else search_results
                 injected_ids = {r["node"]["id"] for r in search_results}
                 with self.engine.db.transaction() as conn:
-                    for r in candidates_to_log:
-                        if r.get("source") == "temporal":
-                            continue
-                        boosted_score = r["score"]
-                        if boosted_score < 0.40:
-                            continue  # below noise floor, skip
-                        pre_boost_score = r.get("_pre_boost_score", r["score"])
-                        was_injected = 1 if r["node"]["id"] in injected_ids else 0
+                    for node_id, trace in candidate_trace.items():
+                        r = trace["latest"]
+                        score = r.get("_pre_boost_score", r.get("score", 0.0))
+                        was_injected = 1 if node_id in injected_ids else 0
                         conn.execute(
                             "INSERT INTO whisper_log "
                             "(session_id, space, prompt_hash, prompt_text, prompt_vec, "
-                            "node_id, score, was_injected, logged_at) "
-                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            "node_id, score, retrieval_score, raw_cosine, "
+                            "cross_encoder_score, ce_absolute, gate_score, source, "
+                            "retrieval_rank, final_rank, decision_stage, was_injected, logged_at) "
+                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                             (session_id, space, prompt_hash, prompt, vec_blob,
-                             r["node"]["id"], pre_boost_score, was_injected, now_iso),
+                             node_id, score, trace["retrieval_score"],
+                             r.get("raw_cosine"), r.get("cross_encoder_score"),
+                             r.get("ce_absolute"), _gate_score(r), r.get("source"),
+                             trace["retrieval_rank"], trace.get("final_rank"),
+                             trace["decision_stage"], was_injected, now_iso),
                         )
             except Exception as e:
                 logger.warning("whisper_log write failed: %s", e)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -586,7 +586,8 @@ class MemoryEngine:
 
     def recall_search_structured(
         self, query: str, limit: int = 10, default_space: str | None = None,
-        touch_access: bool = True, min_relevance: float | None = None, **filters,
+        touch_access: bool = True, min_relevance: float | None = None,
+        auto_temporal: bool = True, spread_activation: bool = True, **filters,
     ) -> list[dict]:
         """Search memories and return structured results (list of dicts).
 
@@ -601,8 +602,14 @@ class MemoryEngine:
         the raw candidate pool because it applies its own floors and an
         absolute-signal gate downstream.
         """
-        # Auto-extract temporal filters from query when none provided
-        if not filters.get("created_after") and not filters.get("created_before"):
+        # Auto-extract temporal filters from query when none provided. Typed
+        # applicability searches disable this: a standing rule remains relevant
+        # even when the action mentions yesterday or last week.
+        if (
+            auto_temporal
+            and not filters.get("created_after")
+            and not filters.get("created_before")
+        ):
             from ormah.engine.prompt_classifier import (
                 extract_time_params, has_temporal_phrases, strip_temporal_phrases,
             )
@@ -656,7 +663,8 @@ class MemoryEngine:
                         default_space=default_space,
                     )
 
-            results = self._spread_activation(results, limit)
+            if spread_activation:
+                results = self._spread_activation(results, limit)
             if touch_access:
                 for r in results:
                     if r.get("source") not in ("activated", "conflict"):
@@ -691,7 +699,8 @@ class MemoryEngine:
                 default_space=default_space,
             )
 
-        enriched = self._spread_activation(enriched, limit)
+        if spread_activation:
+            enriched = self._spread_activation(enriched, limit)
         if touch_access:
             for r in enriched:
                 if r.get("source") not in ("activated", "conflict"):
@@ -999,6 +1008,13 @@ class MemoryEngine:
             ),
             no_overlap_ce_floor=self.settings.whisper_no_overlap_ce_floor,
             no_overlap_cosine_floor=self.settings.whisper_no_overlap_cosine_floor,
+            preference_applicability_enabled=(
+                self.settings.whisper_preference_applicability_enabled
+            ),
+            preference_applicability_gate=(
+                self.settings.whisper_preference_applicability_gate
+            ),
+            preference_max_nodes=self.settings.whisper_preference_max_nodes,
             topic_shift_enabled=self.settings.whisper_topic_shift_enabled,
             topic_shift_threshold=self.settings.whisper_topic_shift_threshold,
             session_id=session_id,

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -148,16 +148,25 @@ class Database:
                 conn.execute(
                     """
                     CREATE TABLE IF NOT EXISTS whisper_log (
-                        id           INTEGER PRIMARY KEY AUTOINCREMENT,
-                        session_id   TEXT NOT NULL,
-                        space        TEXT,
-                        prompt_hash  TEXT NOT NULL,
-                        prompt_text  TEXT,
-                        prompt_vec   BLOB NOT NULL,
-                        node_id      TEXT NOT NULL,
-                        score        REAL NOT NULL,
-                        was_injected INTEGER NOT NULL,
-                        logged_at    TEXT NOT NULL
+                        id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                        session_id          TEXT NOT NULL,
+                        space               TEXT,
+                        prompt_hash         TEXT NOT NULL,
+                        prompt_text         TEXT,
+                        prompt_vec          BLOB NOT NULL,
+                        node_id             TEXT NOT NULL,
+                        score               REAL NOT NULL,
+                        retrieval_score     REAL,
+                        raw_cosine          REAL,
+                        cross_encoder_score REAL,
+                        ce_absolute         REAL,
+                        gate_score          REAL,
+                        source              TEXT,
+                        retrieval_rank      INTEGER,
+                        final_rank          INTEGER,
+                        decision_stage      TEXT NOT NULL DEFAULT 'legacy',
+                        was_injected        INTEGER NOT NULL,
+                        logged_at           TEXT NOT NULL
                     )
                     """
                 )
@@ -170,6 +179,8 @@ class Database:
                 conn.execute(
                     "CREATE INDEX IF NOT EXISTS idx_whisper_log_logged ON whisper_log(logged_at)"
                 )
+
+            self._migrate_whisper_log_schema(conn)
 
             self._migrate_affinity_schema(conn, existing_tables)
             self._ensure_signals_schema(conn)
@@ -192,6 +203,24 @@ class Database:
 
         # Migrate FTS table to porter stemmer if needed
         self._migrate_fts_tokenizer()
+
+    def _migrate_whisper_log_schema(self, conn: sqlite3.Connection) -> None:
+        """Add candidate-stage diagnostics without rebuilding feedback history."""
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(whisper_log)").fetchall()}
+        additions = {
+            "retrieval_score": "REAL",
+            "raw_cosine": "REAL",
+            "cross_encoder_score": "REAL",
+            "ce_absolute": "REAL",
+            "gate_score": "REAL",
+            "source": "TEXT",
+            "retrieval_rank": "INTEGER",
+            "final_rank": "INTEGER",
+            "decision_stage": "TEXT NOT NULL DEFAULT 'legacy'",
+        }
+        for name, column_type in additions.items():
+            if name not in cols:
+                conn.execute(f"ALTER TABLE whisper_log ADD COLUMN {name} {column_type}")
 
     def _create_affinity_table(self, conn: sqlite3.Connection, table: str = "affinity") -> None:
         conn.execute(

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -98,16 +98,25 @@ CREATE TABLE IF NOT EXISTS audit_log (
 );
 
 CREATE TABLE IF NOT EXISTS whisper_log (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_id   TEXT NOT NULL,
-    space        TEXT,
-    prompt_hash  TEXT NOT NULL,
-    prompt_text  TEXT,
-    prompt_vec   BLOB NOT NULL,
-    node_id      TEXT NOT NULL,
-    score        REAL NOT NULL,
-    was_injected INTEGER NOT NULL,
-    logged_at    TEXT NOT NULL
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id          TEXT NOT NULL,
+    space               TEXT,
+    prompt_hash         TEXT NOT NULL,
+    prompt_text         TEXT,
+    prompt_vec          BLOB NOT NULL,
+    node_id             TEXT NOT NULL,
+    score               REAL NOT NULL,
+    retrieval_score     REAL,
+    raw_cosine          REAL,
+    cross_encoder_score REAL,
+    ce_absolute         REAL,
+    gate_score          REAL,
+    source              TEXT,
+    retrieval_rank      INTEGER,
+    final_rank          INTEGER,
+    decision_stage      TEXT NOT NULL DEFAULT 'legacy',
+    was_injected        INTEGER NOT NULL,
+    logged_at           TEXT NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_whisper_log_session ON whisper_log(session_id);
 CREATE INDEX IF NOT EXISTS idx_whisper_log_node    ON whisper_log(node_id);

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -290,6 +290,20 @@ def test_get_whisper_context_threads_pool_and_content_cap_settings(engine):
     assert build.call_args.kwargs["injected_content_max_chars"] == 450
 
 
+def test_get_whisper_context_threads_preference_applicability_settings(engine):
+    engine._whisper_reranker_available = True
+    engine.settings.whisper_preference_applicability_enabled = True
+    engine.settings.whisper_preference_applicability_gate = 0.42
+    engine.settings.whisper_preference_max_nodes = 1
+
+    with patch.object(engine.context_builder, "build_whisper_context", return_value="") as build:
+        engine.get_whisper_context("auth prompt")
+
+    assert build.call_args.kwargs["preference_applicability_enabled"] is True
+    assert build.call_args.kwargs["preference_applicability_gate"] == 0.42
+    assert build.call_args.kwargs["preference_max_nodes"] == 1
+
+
 def test_startup_seeds_maintenance_grace_period(settings):
     settings.claude_maintenance_enabled = True
     engine = MemoryEngine(settings)

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -1163,6 +1163,92 @@ class TestWhisperPrecisionGuards:
 
         assert "Theme system implementation" in result
 
+
+class TestPreferenceApplicability:
+    """Standing rules use a typed applicability channel without biasing facts."""
+
+    def _builder(self, mock_graph, main_results, preference_results):
+        mock_engine = _make_engine_with_encoder(mock_graph)
+        mock_engine.settings.whisper_exploration_enabled = False
+        mock_engine.recall_search_structured.side_effect = [
+            main_results,
+            preference_results,
+        ]
+        return ContextBuilder(mock_graph, engine=mock_engine), mock_engine
+
+    def test_applicable_preference_is_merged_without_suppressing_fact(self, mock_graph):
+        factual = _make_node_dict("fact-1", "Graph component implementation")
+        preference = _make_node_dict(
+            "pref-1", "Prefer simple designs", node_type="preference"
+        )
+        builder, engine = self._builder(
+            mock_graph,
+            [{"node": factual, "score": 0.80, "source": "hybrid"}],
+            [{"node": preference, "score": 0.65, "source": "hybrid"}],
+        )
+        mock_ce = MagicMock()
+        mock_ce.rerank.side_effect = [[3.0], [0.0]]
+
+        with patch("ormah.embeddings.reranker._get_model", return_value=mock_ce), \
+             patch(
+                 "ormah.engine.context_builder.ContextBuilder._get_classifier",
+                 return_value=None,
+             ), \
+             patch("ormah.engine.affinity.batch_fetch_affinity", return_value={}), \
+             patch("ormah.engine.affinity.compute_affinity_boost", return_value=0.0):
+            result = builder.build_whisper_context(
+                prompt="build the graph component",
+                min_score=0.1,
+                reranker_enabled=True,
+                reranker_min_score=0.0,
+                injection_gate=0.45,
+                preference_applicability_enabled=True,
+                preference_applicability_gate=0.40,
+            )
+
+        assert "Prefer simple designs" in result
+        assert "Graph component implementation" in result
+        preference_call = engine.recall_search_structured.call_args_list[1]
+        assert preference_call.kwargs["types"] == ["preference"]
+        assert preference_call.kwargs["auto_temporal"] is False
+        assert preference_call.kwargs["spread_activation"] is False
+        assert mock_ce.rerank.call_args_list[1].args[0].startswith(
+            "Relevant user preference for this action:"
+        )
+
+    def test_inapplicable_preference_cannot_suppress_factual_result(self, mock_graph):
+        factual = _make_node_dict("fact-1", "Graph component implementation")
+        preference = _make_node_dict(
+            "pref-1", "Prefer dark themes", node_type="preference"
+        )
+        builder, _ = self._builder(
+            mock_graph,
+            [{"node": factual, "score": 0.80, "source": "hybrid"}],
+            [{"node": preference, "score": 0.65, "source": "hybrid"}],
+        )
+        mock_ce = MagicMock()
+        mock_ce.rerank.side_effect = [[3.0], [-12.0]]
+
+        with patch("ormah.embeddings.reranker._get_model", return_value=mock_ce), \
+             patch(
+                 "ormah.engine.context_builder.ContextBuilder._get_classifier",
+                 return_value=None,
+             ), \
+             patch("ormah.engine.affinity.batch_fetch_affinity", return_value={}), \
+             patch("ormah.engine.affinity.compute_affinity_boost", return_value=0.0):
+            result = builder.build_whisper_context(
+                prompt="build the graph component",
+                min_score=0.1,
+                reranker_enabled=True,
+                reranker_min_score=0.0,
+                injection_gate=0.45,
+                preference_applicability_enabled=True,
+                preference_applicability_gate=0.40,
+            )
+
+        assert "Graph component implementation" in result
+        assert "Prefer dark themes" not in result
+
     def test_topical_overlap_guard_drops_unrelated_extra_result(self, mock_graph):
         mock_engine = MagicMock()
         builder = ContextBuilder(mock_graph, engine=mock_engine)

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -2125,6 +2125,10 @@ class TestWhisperLog:
         assert row["node_id"] == "node-log-1"
         assert row["was_injected"] == 1
         assert row["prompt_text"] == "how does search work"
+        assert row["decision_stage"] == "injected"
+        assert row["retrieval_rank"] == 1
+        assert row["final_rank"] == 1
+        assert row["ce_absolute"] is not None
 
     def test_whisper_log_not_written_without_session_id(self, db_graph):
         """When session_id is None, no whisper_log rows should be written."""
@@ -2255,6 +2259,90 @@ class TestWhisperLog:
         # The logged score is the pre-boost (CE blended), not boosted
         # We just verify a row was written — exact value depends on reranker mock
         assert logged_score >= 0.0
+
+    def test_whisper_log_records_candidates_rejected_before_reranking(self, db_graph):
+        db, graph = db_graph
+        prompt_vec = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        mock_engine = MagicMock()
+        mock_engine.settings = _make_settings_mock()
+        mock_encoder = MagicMock()
+        mock_encoder.encode.return_value = prompt_vec
+        mock_hybrid = MagicMock()
+        mock_hybrid.encoder = mock_encoder
+        mock_engine._get_hybrid_search.return_value = mock_hybrid
+        mock_engine.db = db
+
+        builder = ContextBuilder(graph, engine=mock_engine)
+        node = _make_node_dict("trimmed-node", "Unrelated candidate")
+        mock_engine.recall_search_structured.return_value = [
+            {
+                "node": node,
+                "score": 0.20,
+                "source": "hybrid",
+                "raw_cosine": 0.25,
+            }
+        ]
+
+        builder.build_whisper_context(
+            prompt="deployment pipeline",
+            min_score=0.45,
+            session_id="session-pretrim",
+        )
+
+        row = db.conn.execute(
+            "SELECT * FROM whisper_log WHERE node_id = 'trimmed-node'"
+        ).fetchone()
+        assert row is not None
+        assert row["decision_stage"] == "pre_rerank_floor"
+        assert row["retrieval_score"] == pytest.approx(0.20)
+        assert row["raw_cosine"] == pytest.approx(0.25)
+        assert row["ce_absolute"] is None
+        assert row["was_injected"] == 0
+
+    def test_whisper_log_records_topical_rejection_with_absolute_scores(self, db_graph):
+        db, graph = db_graph
+        prompt_vec = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        mock_engine = MagicMock()
+        mock_engine.settings = _make_settings_mock()
+        mock_encoder = MagicMock()
+        mock_encoder.encode.return_value = prompt_vec
+        mock_hybrid = MagicMock()
+        mock_hybrid.encoder = mock_encoder
+        mock_engine._get_hybrid_search.return_value = mock_hybrid
+        mock_engine.db = db
+
+        builder = ContextBuilder(graph, engine=mock_engine)
+        relevant = _make_node_dict("overlap-node", "Deployment pipeline details")
+        rejected = _make_node_dict("rejected-node", "Unrelated embedding neighbor")
+        mock_engine.recall_search_structured.return_value = [
+            {"node": relevant, "score": 0.80, "source": "hybrid"},
+            {"node": rejected, "score": 0.75, "source": "hybrid"},
+        ]
+        mock_ce = MagicMock()
+        mock_ce.rerank.return_value = [3.0, -5.0]
+
+        with patch("ormah.embeddings.reranker._get_model", return_value=mock_ce), \
+             patch("ormah.engine.affinity.batch_fetch_affinity", return_value={}), \
+             patch("ormah.engine.affinity.compute_affinity_boost", return_value=0.0):
+            builder.build_whisper_context(
+                prompt="deployment pipeline problems",
+                min_score=0.1,
+                reranker_enabled=True,
+                reranker_min_score=0.0,
+                injection_gate=0.45,
+                no_overlap_ce_floor=0.45,
+                session_id="session-topical",
+            )
+
+        row = db.conn.execute(
+            "SELECT * FROM whisper_log WHERE node_id = 'rejected-node'"
+        ).fetchone()
+        assert row is not None
+        assert row["decision_stage"] == "topical_filter"
+        assert row["cross_encoder_score"] == pytest.approx(-5.0)
+        assert row["ce_absolute"] == pytest.approx(7 / 18)
+        assert row["gate_score"] == pytest.approx(7 / 18)
+        assert row["was_injected"] == 0
 
 
 class TestWhisperFlatRankedDisplay:

--- a/tests/test_index/test_feedback_schema.py
+++ b/tests/test_index/test_feedback_schema.py
@@ -49,6 +49,15 @@ def test_whisper_log_columns(db):
         "prompt_vec",
         "node_id",
         "score",
+        "retrieval_score",
+        "raw_cosine",
+        "cross_encoder_score",
+        "ce_absolute",
+        "gate_score",
+        "source",
+        "retrieval_rank",
+        "final_rank",
+        "decision_stage",
         "was_injected",
         "logged_at",
     ]:
@@ -204,6 +213,46 @@ def test_migrate_creates_whisper_log(tmp_path):
     assert not _table_exists(db, "whisper_log")
     db._migrate()
     assert _table_exists(db, "whisper_log")
+    db.close()
+
+
+def test_migrate_adds_whisper_candidate_diagnostics(tmp_path):
+    path = tmp_path / "index.db"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE whisper_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            space TEXT,
+            prompt_hash TEXT NOT NULL,
+            prompt_text TEXT,
+            prompt_vec BLOB NOT NULL,
+            node_id TEXT NOT NULL,
+            score REAL NOT NULL,
+            was_injected INTEGER NOT NULL,
+            logged_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO whisper_log "
+        "(session_id, prompt_hash, prompt_vec, node_id, score, was_injected, logged_at) "
+        "VALUES ('s1', 'h1', X'00', 'n1', 0.5, 0, '2026-01-01T00:00:00Z')"
+    )
+    conn.commit()
+    conn.close()
+
+    db = Database(path)
+    db.init_schema()
+
+    cols = _table_columns(db, "whisper_log")
+    assert "decision_stage" in cols
+    assert "ce_absolute" in cols
+    row = db.conn.execute(
+        "SELECT node_id, decision_stage FROM whisper_log WHERE node_id = 'n1'"
+    ).fetchone()
+    assert tuple(row) == ("n1", "legacy")
     db.close()
 
 


### PR DESCRIPTION
## Summary

- log every whisper candidate with absolute scoring and first rejection-stage provenance
- retrieve standing preferences through an independent applicability relation instead of answer relevance
- preserve factual retrieval and active-learning behavior while adding migration coverage and diagnostics

## Evidence

- whisper F1: 0.69 -> 0.73
- preference F1: 0.42 -> 0.56
- whisper suppression: 0.95 (unchanged)
- recall: R@8 0.99, P@8 0.46, F1 0.57 (unchanged)
- scratch silence replay: 30/30 retrieved candidates logged versus no candidate rows before

Two structural prototypes were measured and reverted rather than shipped:

- candidate-specific temporal exemption reduced FP 0.13 -> 0.10 but regressed whisper F1 0.73 -> 0.64
- recall evidence admission raised P@8 0.46 -> 0.61 but regressed R@8 0.99 -> 0.973

## Verification

- `make test`: 1190 passed, 1 deselected with `ORMAH_LLM_PROVIDER=none`
- `make lint`: passed
- `make eval`: passed all regression bars
- `uv tool install . --reinstall`; installed CLI reports `ormah 0.13.6`

Golden corpus labels were not changed. Local corpus and live database contents are not included.

## Fast follows

- #96
- #97
