### PR TITLE
fix(index): normalize and bound whisper diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,14 @@ ORMAH_LLM_BASE_URL=http://localhost:11434
 # ORMAH_FEEDBACK_LLM_JUDGE_ENABLED=false
 # ORMAH_FEEDBACK_LLM_JUDGE_MIN_CONFIDENCE=0.75
 
+# ── Whisper diagnostic retention ─────────────────────────────────────────────
+# Prompt embeddings are stored once per retrieval event rather than once per
+# candidate. A background job removes only old rejected candidates that have
+# no affinity/signal references; injected feedback history is retained.
+# ORMAH_WHISPER_LOG_REJECTED_RETENTION_DAYS=30
+# ORMAH_WHISPER_LOG_CLEANUP_INTERVAL_HOURS=24
+# ORMAH_WHISPER_LOG_CLEANUP_BATCH_SIZE=1000
+
 # ── API Keys (only when ORMAH_LLM_PROVIDER=litellm) ──────────────────────────
 #
 # API keys are inherited from your shell environment at daemon startup.

--- a/docs/03 - Search and Ranking.md
+++ b/docs/03 - Search and Ranking.md
@@ -159,6 +159,10 @@ This does not infer a preference mode from prompt keywords and does not alter or
 
 For session-scoped whispers, `whisper_log` retains every non-temporal retrieved candidate, including candidates removed before reranking. Rows include retrieval rank and score, raw cosine, cross-encoder signals when available, the absolute gate score, final rank, and the stage that injected or rejected the candidate. This makes floor, topical-filter, gate, and candidate-cap failures distinguishable in live replays.
 
+Prompt-level payloads live in `retrieval_events`: one text/vector record is shared by every candidate from the same whisper or deliberate-recall call. `whisper_log.id` remains the stable candidate-event key used by exact feedback, while legacy rows are migrated without changing those IDs.
+
+Rejected diagnostic rows are retained for 30 days by default and cleaned in bounded background batches. Cleanup never deletes injected rows or rejected rows referenced by `affinity` or `signals`; this preserves all-time whisper-health denominators and feedback provenance. The policy is configurable with `whisper_log_rejected_retention_days`, `whisper_log_cleanup_interval_hours`, and `whisper_log_cleanup_batch_size`. SQLite reuses released pages automatically, but Ormah does not run `VACUUM` during startup or cleanup.
+
 ## Spreading Activation
 
 **Code**: `src/ormah/engine/memory_engine.py:_spread_activation()`

--- a/eval/whisper/miner.py
+++ b/eval/whisper/miner.py
@@ -76,8 +76,28 @@ def _load_prompt_groups(conn: sqlite3.Connection) -> list[dict]:
         ).fetchall()
     }
 
-    rows = conn.execute(
+    has_events = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name='retrieval_events'"
+    ).fetchone() is not None
+    if has_events:
+        rows_sql = """
+        SELECT
+               wl.session_id, wl.prompt_hash,
+               COALESCE(re.prompt_text, wl.prompt_text) AS prompt_text,
+               COALESCE(re.space, wl.space) AS space,
+               wl.node_id,
+               MAX(wl.score) AS score, MAX(wl.was_injected) AS was_injected,
+               MAX(wl.logged_at) AS logged_at
+        FROM whisper_log wl
+        LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id
+        WHERE COALESCE(re.prompt_text, wl.prompt_text) IS NOT NULL
+          AND TRIM(COALESCE(re.prompt_text, wl.prompt_text)) != ''
+        GROUP BY wl.session_id, wl.prompt_hash, wl.node_id
         """
+    else:
+        # Read-only mining can target a DB that has not yet been opened by the
+        # upgraded server, so retain the legacy query until migration runs.
+        rows_sql = """
         SELECT session_id, prompt_hash, prompt_text, space, node_id,
                MAX(score) AS score, MAX(was_injected) AS was_injected,
                MAX(logged_at) AS logged_at
@@ -85,7 +105,7 @@ def _load_prompt_groups(conn: sqlite3.Connection) -> list[dict]:
         WHERE prompt_text IS NOT NULL AND TRIM(prompt_text) != ''
         GROUP BY session_id, prompt_hash, node_id
         """
-    ).fetchall()
+    rows = conn.execute(rows_sql).fetchall()
     groups: dict[tuple[str, str], dict] = {}
     for r in rows:
         key = (r["session_id"], r["prompt_hash"])

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -113,6 +113,17 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
+    from ormah.background.whisper_log_cleanup import run_whisper_log_cleanup
+
+    scheduler.add_job(
+        tracked(tracker, "whisper_log_cleanup", run_whisper_log_cleanup, engine),
+        "interval",
+        hours=s.whisper_log_cleanup_interval_hours,
+        id="whisper_log_cleanup",
+        name="Whisper log cleanup",
+        misfire_grace_time=_MISFIRE_GRACE,
+    )
+
     from ormah.backup import run_auto_backup
 
     scheduler.add_job(

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -405,8 +405,13 @@ def _record_whisper_usage_signals(
     rows = engine.db.conn.execute(
         """
         SELECT
-            wl.id, wl.node_id, wl.prompt_text, wl.prompt_hash, wl.prompt_vec,
-            wl.session_id, wl.space, n.title, n.content,
+            wl.id, wl.node_id,
+            COALESCE(re.prompt_text, wl.prompt_text) AS prompt_text,
+            COALESCE(re.prompt_hash, wl.prompt_hash) AS prompt_hash,
+            COALESCE(re.prompt_vec, wl.prompt_vec) AS prompt_vec,
+            COALESCE(re.session_id, wl.session_id) AS session_id,
+            COALESCE(re.space, wl.space) AS space,
+            n.title, n.content,
             (
                 SELECT s.polarity FROM signals s
                 WHERE s.whisper_log_id = wl.id
@@ -420,6 +425,7 @@ def _record_whisper_usage_signals(
                   AND s.source = ?
             ) AS has_llm_judge
         FROM whisper_log wl
+        LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id
         JOIN nodes n ON n.id = wl.node_id
         WHERE wl.session_id = ?
           AND wl.was_injected = 1

--- a/src/ormah/background/whisper_log_cleanup.py
+++ b/src/ormah/background/whisper_log_cleanup.py
@@ -1,0 +1,89 @@
+"""Bounded retention for high-volume whisper candidate diagnostics."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import logging
+
+from ormah.engine.memory_engine import MemoryEngine
+
+logger = logging.getLogger(__name__)
+
+
+def run_whisper_log_cleanup(
+    engine: MemoryEngine,
+    *,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Delete one bounded batch of stale, unreferenced rejected candidates.
+
+    Injected rows remain the durable denominator for whisper health. Rejected
+    rows that received affinity or signal feedback also remain because their
+    exact whisper_log IDs are part of the learning audit trail.
+    """
+    settings = engine.settings
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(
+        days=settings.whisper_log_rejected_retention_days
+    )
+    cutoff_iso = cutoff.isoformat()
+    batch_size = settings.whisper_log_cleanup_batch_size
+
+    with engine.db.transaction() as conn:
+        rows = conn.execute(
+            """
+            SELECT wl.id, wl.retrieval_event_id
+            FROM whisper_log wl
+            WHERE wl.was_injected = 0
+              AND wl.logged_at < ?
+              AND NOT EXISTS (
+                  SELECT 1 FROM affinity a WHERE a.whisper_log_id = wl.id
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM signals s WHERE s.whisper_log_id = wl.id
+              )
+            ORDER BY wl.logged_at ASC, wl.id ASC
+            LIMIT ?
+            """,
+            (cutoff_iso, batch_size),
+        ).fetchall()
+        if not rows:
+            return {"candidate_rows_deleted": 0, "events_deleted": 0}
+
+        candidate_ids = [int(row["id"]) for row in rows]
+        event_ids = {
+            int(row["retrieval_event_id"])
+            for row in rows
+            if row["retrieval_event_id"] is not None
+        }
+        marks = ",".join("?" for _ in candidate_ids)
+        conn.execute(
+            f"DELETE FROM whisper_log WHERE id IN ({marks})",
+            candidate_ids,
+        )
+
+        events_deleted = 0
+        if event_ids:
+            event_marks = ",".join("?" for _ in event_ids)
+            cursor = conn.execute(
+                f"""
+                DELETE FROM retrieval_events
+                WHERE id IN ({event_marks})
+                  AND NOT EXISTS (
+                      SELECT 1 FROM whisper_log wl
+                      WHERE wl.retrieval_event_id = retrieval_events.id
+                  )
+                """,
+                tuple(event_ids),
+            )
+            events_deleted = cursor.rowcount
+
+    result = {
+        "candidate_rows_deleted": len(candidate_ids),
+        "events_deleted": events_deleted,
+    }
+    logger.info(
+        "Whisper log cleanup deleted %d rejected candidates and %d orphan events",
+        result["candidate_rows_deleted"],
+        result["events_deleted"],
+    )
+    return result

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -243,6 +243,14 @@ class Settings(BaseSettings):
     feedback_llm_judge_enabled: bool = False
     feedback_llm_judge_min_confidence: float = 0.75
 
+    # Candidate diagnostics are high-volume. Prompt payloads are normalized
+    # separately, while stale rejected rows with no feedback references are
+    # pruned in bounded background batches. Injected rows are retained for
+    # all-time whisper health and exact feedback history.
+    whisper_log_rejected_retention_days: int = 30
+    whisper_log_cleanup_interval_hours: int = 24
+    whisper_log_cleanup_batch_size: int = 1000
+
     # Space prioritization
     space_boost_global: float = 1.0
     space_boost_other: float = 0.6
@@ -390,6 +398,17 @@ class Settings(BaseSettings):
     def _backup_retention_count_positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError(f"backup_retention_count must be >= 1, got {v}")
+        return v
+
+    @field_validator(
+        "whisper_log_rejected_retention_days",
+        "whisper_log_cleanup_interval_hours",
+        "whisper_log_cleanup_batch_size",
+    )
+    @classmethod
+    def _whisper_log_cleanup_positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(f"whisper log cleanup settings must be >= 1, got {v}")
         return v
 
     @field_validator("core_memory_cap")

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -81,12 +81,15 @@ def _find_review_candidate(conn, threshold: float) -> dict | None:
             """
             WITH ranked AS (
               SELECT
-                wl.node_id, wl.score, wl.session_id, wl.space, wl.prompt_text,
+                wl.node_id, wl.score, wl.session_id,
+                COALESCE(re.space, wl.space) AS space,
+                COALESCE(re.prompt_text, wl.prompt_text) AS prompt_text,
                 wl.id AS whisper_log_id,
-                wl.prompt_vec,
+                COALESCE(re.prompt_vec, wl.prompt_vec) AS prompt_vec,
                 n.title, n.content,
                 ROW_NUMBER() OVER (PARTITION BY wl.node_id ORDER BY wl.score DESC) AS rn
               FROM whisper_log wl
+              LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id
               JOIN nodes n ON n.id = wl.node_id
               WHERE wl.was_injected = 0
                 AND wl.decision_stage IN ('injection_gate', 'candidate_cap', 'legacy')
@@ -265,8 +268,10 @@ class ContextBuilder:
             return True
         try:
             rows = self.graph.conn.execute(
-                "SELECT DISTINCT prompt_vec FROM whisper_log "
-                "WHERE session_id = ? AND was_injected = 1",
+                "SELECT DISTINCT COALESCE(re.prompt_vec, wl.prompt_vec) AS prompt_vec "
+                "FROM whisper_log wl "
+                "LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id "
+                "WHERE wl.session_id = ? AND wl.was_injected = 1",
                 (session_id,),
             ).fetchall()
             norm_current = float(np.linalg.norm(prompt_vec))
@@ -963,6 +968,16 @@ class ContextBuilder:
                 vec_blob = prompt_vec.astype(np.float32).tobytes()
                 injected_ids = {r["node"]["id"] for r in search_results}
                 with self.engine.db.transaction() as conn:
+                    retrieval_event_id = self.engine.db.insert_retrieval_event(
+                        conn,
+                        surface="whisper",
+                        session_id=session_id,
+                        space=space,
+                        prompt_hash=prompt_hash,
+                        prompt_text=prompt,
+                        prompt_vec=vec_blob,
+                        logged_at=now_iso,
+                    )
                     for node_id, trace in candidate_trace.items():
                         r = trace["latest"]
                         score = r.get("_pre_boost_score", r.get("score", 0.0))
@@ -972,14 +987,16 @@ class ContextBuilder:
                             "(session_id, space, prompt_hash, prompt_text, prompt_vec, "
                             "node_id, score, retrieval_score, raw_cosine, "
                             "cross_encoder_score, ce_absolute, gate_score, source, "
-                            "retrieval_rank, final_rank, decision_stage, was_injected, logged_at) "
-                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                            (session_id, space, prompt_hash, prompt, vec_blob,
+                            "retrieval_rank, final_rank, decision_stage, was_injected, logged_at, "
+                            "retrieval_event_id) "
+                            "VALUES (?, ?, ?, NULL, X'', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            (session_id, space, prompt_hash,
                              node_id, score, trace["retrieval_score"],
                              r.get("raw_cosine"), r.get("cross_encoder_score"),
                              r.get("ce_absolute"), _gate_score(r), r.get("source"),
                              trace["retrieval_rank"], trace.get("final_rank"),
-                             trace["decision_stage"], was_injected, now_iso),
+                             trace["decision_stage"], was_injected, now_iso,
+                             retrieval_event_id),
                         )
                         if was_injected:
                             whisper_log_ids[node_id] = int(cursor.lastrowid)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -514,6 +514,7 @@ class MemoryEngine:
         *,
         session_id: str | None = None,
         space: str | None = None,
+        surface: str,
     ) -> dict[str, int]:
         """Log surfaced memories so submit_feedback can learn from them later."""
         if not node_scores:
@@ -532,26 +533,35 @@ class MemoryEngine:
         inserted: dict[str, int] = {}
         try:
             with self.db.transaction() as conn:
+                retrieval_event_id = self.db.insert_retrieval_event(
+                    conn,
+                    surface=surface,
+                    session_id=session_id or "",
+                    space=space,
+                    prompt_hash=prompt_hash,
+                    prompt_text=prompt_text,
+                    prompt_vec=prompt_vec_blob,
+                    logged_at=now_iso,
+                )
                 for candidate_node_id, score in unique_scores.items():
                     cursor = conn.execute(
                         """
                         INSERT INTO whisper_log
                             (
                                 session_id, space, prompt_hash, prompt_text, prompt_vec,
-                                node_id, score, was_injected, logged_at
+                                node_id, score, was_injected, logged_at, retrieval_event_id
                             )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        VALUES (?, ?, ?, NULL, X'', ?, ?, ?, ?, ?)
                         """,
                         (
                             session_id or "",
                             space,
                             prompt_hash,
-                            prompt_text,
-                            prompt_vec_blob,
                             candidate_node_id,
                             score,
                             1,
                             now_iso,
+                            retrieval_event_id,
                         ),
                     )
                     inserted[candidate_node_id] = int(cursor.lastrowid)
@@ -593,6 +603,7 @@ class MemoryEngine:
             ],
             session_id=session_id,
             space=node.get("space"),
+            surface="recall_node",
         )
         node_for_format = dict(node)
         if resolved_node_id in whisper_log_ids:
@@ -808,6 +819,7 @@ class MemoryEngine:
                 ],
                 session_id=session_id,
                 space=default_space,
+                surface="recall_search",
             )
             results = self._attach_feedback_log_ids(results, whisper_log_ids)
             return format_search_results(results)
@@ -853,6 +865,7 @@ class MemoryEngine:
             ],
             session_id=session_id,
             space=default_space,
+            surface="recall_search",
         )
 
         enriched = self._attach_feedback_log_ids(enriched, whisper_log_ids)
@@ -2308,9 +2321,16 @@ class MemoryEngine:
         if whisper_log_id is not None:
             row = self.db.conn.execute(
                 """
-                SELECT id, node_id, prompt_vec, prompt_text, prompt_hash, session_id, space
-                FROM whisper_log
-                WHERE id = ?
+                SELECT
+                    wl.id, wl.node_id,
+                    COALESCE(re.prompt_vec, wl.prompt_vec) AS prompt_vec,
+                    COALESCE(re.prompt_text, wl.prompt_text) AS prompt_text,
+                    COALESCE(re.prompt_hash, wl.prompt_hash) AS prompt_hash,
+                    COALESCE(re.session_id, wl.session_id) AS session_id,
+                    COALESCE(re.space, wl.space) AS space
+                FROM whisper_log wl
+                LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id
+                WHERE wl.id = ?
                 """,
                 (whisper_log_id,),
             ).fetchone()
@@ -2334,10 +2354,17 @@ class MemoryEngine:
 
         row = self.db.conn.execute(
             """
-            SELECT id, node_id, prompt_vec, prompt_text, prompt_hash, session_id, space
-            FROM whisper_log
-            WHERE node_id = ?
-            ORDER BY logged_at DESC, id DESC
+            SELECT
+                wl.id, wl.node_id,
+                COALESCE(re.prompt_vec, wl.prompt_vec) AS prompt_vec,
+                COALESCE(re.prompt_text, wl.prompt_text) AS prompt_text,
+                COALESCE(re.prompt_hash, wl.prompt_hash) AS prompt_hash,
+                COALESCE(re.session_id, wl.session_id) AS session_id,
+                COALESCE(re.space, wl.space) AS space
+            FROM whisper_log wl
+            LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id
+            WHERE wl.node_id = ?
+            ORDER BY wl.logged_at DESC, wl.id DESC
             LIMIT 1
             """,
             (resolved_node_id,),
@@ -2348,6 +2375,22 @@ class MemoryEngine:
         return resolved_node_id, row, None
 
     def submit_feedback(
+        self,
+        node_id: str,
+        signal: int,
+        source: str = "explicit",
+        whisper_log_id: int | None = None,
+    ) -> str:
+        """Record feedback while preventing retention from deleting its event."""
+        with self.db.transaction():
+            return self._submit_feedback_locked(
+                node_id=node_id,
+                signal=signal,
+                source=source,
+                whisper_log_id=whisper_log_id,
+            )
+
+    def _submit_feedback_locked(
         self,
         node_id: str,
         signal: int,

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -88,6 +88,37 @@ class Database:
         self.conn.executescript(schema)
         self._migrate()
 
+    @staticmethod
+    def insert_retrieval_event(
+        conn: sqlite3.Connection,
+        *,
+        surface: str,
+        session_id: str,
+        space: str | None,
+        prompt_hash: str,
+        prompt_text: str,
+        prompt_vec: bytes,
+        logged_at: str,
+    ) -> int:
+        """Insert one prompt payload shared by its candidate log rows."""
+        cursor = conn.execute(
+            """
+            INSERT INTO retrieval_events
+                (surface, session_id, space, prompt_hash, prompt_text, prompt_vec, logged_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                surface,
+                session_id,
+                space,
+                prompt_hash,
+                prompt_text,
+                prompt_vec,
+                logged_at,
+            ),
+        )
+        return int(cursor.lastrowid)
+
     def _migrate(self) -> None:
         """Run migrations for existing databases."""
         with self.transaction() as conn:
@@ -166,7 +197,9 @@ class Database:
                         final_rank          INTEGER,
                         decision_stage      TEXT NOT NULL DEFAULT 'legacy',
                         was_injected        INTEGER NOT NULL,
-                        logged_at           TEXT NOT NULL
+                        logged_at           TEXT NOT NULL,
+                        retrieval_event_id  INTEGER REFERENCES retrieval_events(id)
+                            ON DELETE RESTRICT
                     )
                     """
                 )
@@ -181,6 +214,7 @@ class Database:
                 )
 
             self._migrate_whisper_log_schema(conn)
+            self._migrate_retrieval_event_schema(conn)
 
             self._migrate_affinity_schema(conn, existing_tables)
             self._ensure_signals_schema(conn)
@@ -221,6 +255,110 @@ class Database:
         for name, column_type in additions.items():
             if name not in cols:
                 conn.execute(f"ALTER TABLE whisper_log ADD COLUMN {name} {column_type}")
+
+    def _migrate_retrieval_event_schema(self, conn: sqlite3.Connection) -> None:
+        """Normalize prompt payloads without rebuilding exact feedback rows."""
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS retrieval_events (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                surface     TEXT NOT NULL,
+                session_id  TEXT NOT NULL,
+                space       TEXT,
+                prompt_hash TEXT NOT NULL,
+                prompt_text TEXT,
+                prompt_vec  BLOB NOT NULL,
+                logged_at   TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_retrieval_events_session "
+            "ON retrieval_events(session_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_retrieval_events_logged "
+            "ON retrieval_events(logged_at)"
+        )
+
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(whisper_log)").fetchall()}
+        if "retrieval_event_id" not in cols:
+            conn.execute(
+                "ALTER TABLE whisper_log ADD COLUMN retrieval_event_id INTEGER "
+                "REFERENCES retrieval_events(id) ON DELETE RESTRICT"
+            )
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_whisper_log_event "
+            "ON whisper_log(retrieval_event_id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_whisper_log_retention "
+            "ON whisper_log(was_injected, logged_at)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_whisper_log_session_injected "
+            "ON whisper_log(session_id, was_injected)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_whisper_log_node_injected_logged "
+            "ON whisper_log(node_id, was_injected, logged_at)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_whisper_log_event_key "
+            "ON whisper_log(session_id, prompt_hash, logged_at)"
+        )
+
+        # Older schemas duplicated the same prompt payload on every candidate.
+        # Backfill one parent per writer event, preserve candidate IDs, then
+        # release the duplicate blobs for SQLite to reuse. No VACUUM runs on
+        # startup: compacting the file is an explicit operator choice.
+        groups = conn.execute(
+            """
+            SELECT
+                session_id, prompt_hash, logged_at,
+                MAX(space) AS space,
+                MAX(prompt_text) AS prompt_text,
+                MIN(id) AS sample_id
+            FROM whisper_log
+            WHERE retrieval_event_id IS NULL
+            GROUP BY session_id, prompt_hash, logged_at
+            """
+        ).fetchall()
+        for group in groups:
+            sample = conn.execute(
+                "SELECT prompt_vec FROM whisper_log WHERE id = ?",
+                (group["sample_id"],),
+            ).fetchone()
+            cursor = conn.execute(
+                """
+                INSERT INTO retrieval_events
+                    (surface, session_id, space, prompt_hash, prompt_text, prompt_vec, logged_at)
+                VALUES ('legacy', ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    group["session_id"],
+                    group["space"],
+                    group["prompt_hash"],
+                    group["prompt_text"],
+                    sample["prompt_vec"] if sample is not None else b"",
+                    group["logged_at"],
+                ),
+            )
+            conn.execute(
+                """
+                UPDATE whisper_log
+                SET retrieval_event_id = ?, prompt_text = NULL, prompt_vec = X''
+                WHERE retrieval_event_id IS NULL
+                  AND session_id = ? AND prompt_hash = ? AND logged_at = ?
+                """,
+                (
+                    int(cursor.lastrowid),
+                    group["session_id"],
+                    group["prompt_hash"],
+                    group["logged_at"],
+                ),
+            )
 
     def _create_affinity_table(self, conn: sqlite3.Connection, table: str = "affinity") -> None:
         conn.execute(

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -97,6 +97,22 @@ CREATE TABLE IF NOT EXISTS audit_log (
     performed_at TEXT NOT NULL
 );
 
+-- Prompt-level payload shared by every candidate produced by one retrieval.
+-- Candidate rows keep their own stable whisper_log.id because feedback and
+-- signals refer to that exact surfaced/rejected event.
+CREATE TABLE IF NOT EXISTS retrieval_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    surface       TEXT NOT NULL,
+    session_id    TEXT NOT NULL,
+    space         TEXT,
+    prompt_hash   TEXT NOT NULL,
+    prompt_text   TEXT,
+    prompt_vec    BLOB NOT NULL,
+    logged_at     TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_retrieval_events_session ON retrieval_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_retrieval_events_logged  ON retrieval_events(logged_at);
+
 CREATE TABLE IF NOT EXISTS whisper_log (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     session_id          TEXT NOT NULL,
@@ -116,11 +132,18 @@ CREATE TABLE IF NOT EXISTS whisper_log (
     final_rank          INTEGER,
     decision_stage      TEXT NOT NULL DEFAULT 'legacy',
     was_injected        INTEGER NOT NULL,
-    logged_at           TEXT NOT NULL
+    logged_at           TEXT NOT NULL,
+    retrieval_event_id  INTEGER REFERENCES retrieval_events(id) ON DELETE RESTRICT
 );
 CREATE INDEX IF NOT EXISTS idx_whisper_log_session ON whisper_log(session_id);
 CREATE INDEX IF NOT EXISTS idx_whisper_log_node    ON whisper_log(node_id);
 CREATE INDEX IF NOT EXISTS idx_whisper_log_logged  ON whisper_log(logged_at);
+CREATE INDEX IF NOT EXISTS idx_whisper_log_retention
+    ON whisper_log(was_injected, logged_at);
+CREATE INDEX IF NOT EXISTS idx_whisper_log_session_injected
+    ON whisper_log(session_id, was_injected);
+CREATE INDEX IF NOT EXISTS idx_whisper_log_node_injected_logged
+    ON whisper_log(node_id, was_injected, logged_at);
 
 CREATE TABLE IF NOT EXISTS affinity (
     id           INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/test_background/test_whisper_log_cleanup.py
+++ b/tests/test_background/test_whisper_log_cleanup.py
@@ -1,0 +1,195 @@
+"""Tests for normalized whisper payload retention."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from ormah.background.whisper_log_cleanup import run_whisper_log_cleanup
+from ormah.config import Settings
+
+
+NOW = datetime(2026, 7, 12, tzinfo=timezone.utc)
+
+
+def _event(engine, suffix: str, *, age_days: int, injected: int) -> tuple[int, int]:
+    logged_at = (NOW - timedelta(days=age_days)).isoformat()
+    with engine.db.transaction() as conn:
+        event_id = engine.db.insert_retrieval_event(
+            conn,
+            surface="whisper",
+            session_id=f"session-{suffix}",
+            space="ormah",
+            prompt_hash=f"hash-{suffix}",
+            prompt_text=f"prompt {suffix}",
+            prompt_vec=b"v" * 3072,
+            logged_at=logged_at,
+        )
+        cursor = conn.execute(
+            """
+            INSERT INTO whisper_log
+                (session_id, space, prompt_hash, prompt_text, prompt_vec,
+                 node_id, score, was_injected, logged_at, retrieval_event_id)
+            VALUES (?, 'ormah', ?, NULL, X'', ?, 0.5, ?, ?, ?)
+            """,
+            (
+                f"session-{suffix}",
+                f"hash-{suffix}",
+                f"node-{suffix}",
+                injected,
+                logged_at,
+                event_id,
+            ),
+        )
+    return int(cursor.lastrowid), event_id
+
+
+def test_cleanup_deletes_only_stale_unreferenced_rejections(engine):
+    engine.settings.whisper_log_rejected_retention_days = 30
+    engine.settings.whisper_log_cleanup_batch_size = 100
+    stale_id, stale_event = _event(engine, "stale", age_days=31, injected=0)
+    recent_id, _ = _event(engine, "recent", age_days=29, injected=0)
+    injected_id, _ = _event(engine, "injected", age_days=90, injected=1)
+    referenced_id, _ = _event(engine, "referenced", age_days=90, injected=0)
+    signaled_id, _ = _event(engine, "signaled", age_days=90, injected=0)
+    with engine.db.transaction() as conn:
+        conn.execute(
+            """
+            INSERT INTO affinity
+                (prompt_vec, prompt_text, node_id, signal, source,
+                 confirmed_at, session_id, whisper_log_id)
+            VALUES (X'', 'prompt', 'node-referenced', 1, 'explicit', ?,
+                    'session-referenced', ?)
+            """,
+            (NOW.isoformat(), referenced_id),
+        )
+        conn.execute(
+            """
+            INSERT INTO signals
+                (whisper_log_id, node_id, signal_type, polarity, strength,
+                 source, session_id, created)
+            VALUES (?, 'node-signaled', 'feedback_submitted', -1, 1.0,
+                    'implicit', 'session-signaled', ?)
+            """,
+            (signaled_id, NOW.isoformat()),
+        )
+
+    result = run_whisper_log_cleanup(engine, now=NOW)
+
+    assert result == {"candidate_rows_deleted": 1, "events_deleted": 1}
+    remaining = {
+        row["id"] for row in engine.db.conn.execute("SELECT id FROM whisper_log").fetchall()
+    }
+    assert stale_id not in remaining
+    assert recent_id in remaining
+    assert injected_id in remaining
+    assert referenced_id in remaining
+    assert signaled_id in remaining
+    assert engine.db.conn.execute(
+        "SELECT 1 FROM retrieval_events WHERE id = ?", (stale_event,)
+    ).fetchone() is None
+
+
+def test_cleanup_is_bounded_and_idempotent(engine):
+    engine.settings.whisper_log_rejected_retention_days = 30
+    engine.settings.whisper_log_cleanup_batch_size = 2
+    for i in range(3):
+        _event(engine, f"old-{i}", age_days=60, injected=0)
+
+    first = run_whisper_log_cleanup(engine, now=NOW)
+    second = run_whisper_log_cleanup(engine, now=NOW)
+    third = run_whisper_log_cleanup(engine, now=NOW)
+
+    assert first["candidate_rows_deleted"] == 2
+    assert second["candidate_rows_deleted"] == 1
+    assert third == {"candidate_rows_deleted": 0, "events_deleted": 0}
+
+
+def test_normalized_event_stores_one_vector_for_many_candidates(engine):
+    payload = b"v" * 3072
+    with engine.db.transaction() as conn:
+        event_id = engine.db.insert_retrieval_event(
+            conn,
+            surface="whisper",
+            session_id="storage-session",
+            space="ormah",
+            prompt_hash="storage-hash",
+            prompt_text="storage prompt",
+            prompt_vec=payload,
+            logged_at=NOW.isoformat(),
+        )
+        for i in range(40):
+            conn.execute(
+                """
+                INSERT INTO whisper_log
+                    (session_id, prompt_hash, prompt_vec, node_id, score,
+                     was_injected, logged_at, retrieval_event_id)
+                VALUES ('storage-session', 'storage-hash', X'', ?, 0.5, 0, ?, ?)
+                """,
+                (f"node-{i}", NOW.isoformat(), event_id),
+            )
+
+    candidate_bytes = engine.db.conn.execute(
+        "SELECT SUM(length(prompt_vec)) FROM whisper_log WHERE retrieval_event_id = ?",
+        (event_id,),
+    ).fetchone()[0]
+    event_bytes = engine.db.conn.execute(
+        "SELECT length(prompt_vec) FROM retrieval_events WHERE id = ?",
+        (event_id,),
+    ).fetchone()[0]
+    assert candidate_bytes == 0
+    assert event_bytes == 3072
+
+    plan = engine.db.conn.execute(
+        "EXPLAIN QUERY PLAN SELECT id FROM whisper_log "
+        "WHERE was_injected = 0 AND logged_at < ? ORDER BY logged_at LIMIT 1000",
+        ((NOW - timedelta(days=30)).isoformat(),),
+    ).fetchall()
+    assert any("idx_whisper_log_retention" in row["detail"] for row in plan)
+
+    session_plan = engine.db.conn.execute(
+        "EXPLAIN QUERY PLAN SELECT id FROM whisper_log "
+        "WHERE session_id = ? AND was_injected = 1",
+        ("storage-session",),
+    ).fetchall()
+    assert any("idx_whisper_log_session_injected" in row["detail"] for row in session_plan)
+
+    node_plan = engine.db.conn.execute(
+        "EXPLAIN QUERY PLAN SELECT 1 FROM whisper_log "
+        "WHERE node_id = ? AND was_injected = 1 AND logged_at > ?",
+        ("node-1", (NOW - timedelta(days=7)).isoformat()),
+    ).fetchall()
+    assert any("idx_whisper_log_node_injected_logged" in row["detail"] for row in node_plan)
+
+
+def test_scheduler_registers_whisper_log_cleanup(tmp_path, monkeypatch):
+    from ormah.background import scheduler as scheduler_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.jobs = []
+
+        def add_job(self, func, trigger, **kwargs):
+            self.jobs.append({"func": func, "trigger": trigger, **kwargs})
+
+        def start(self):
+            pass
+
+        def get_jobs(self):
+            return self.jobs
+
+    monkeypatch.setattr(scheduler_module, "BackgroundScheduler", FakeScheduler)
+    settings = Settings(
+        memory_dir=tmp_path / "memory",
+        whisper_log_cleanup_interval_hours=12,
+    )
+    engine = SimpleNamespace(
+        settings=settings,
+        builder=SimpleNamespace(incremental_update=lambda: (0, 0)),
+    )
+
+    scheduler, _tracker = scheduler_module.start_scheduler(engine)
+
+    job = next(job for job in scheduler.jobs if job["id"] == "whisper_log_cleanup")
+    assert job["trigger"] == "interval"
+    assert job["hours"] == 12

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,6 +119,26 @@ def test_backup_retention_zero():
         _settings(backup_retention_count=0)
 
 
+def test_whisper_log_cleanup_defaults():
+    s = _settings()
+    assert s.whisper_log_rejected_retention_days == 30
+    assert s.whisper_log_cleanup_interval_hours == 24
+    assert s.whisper_log_cleanup_batch_size == 1000
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "whisper_log_rejected_retention_days",
+        "whisper_log_cleanup_interval_hours",
+        "whisper_log_cleanup_batch_size",
+    ],
+)
+def test_whisper_log_cleanup_settings_must_be_positive(field):
+    with pytest.raises(ValidationError, match="whisper log cleanup settings must be >= 1"):
+        _settings(**{field: 0})
+
+
 # --- Core cap ---
 
 def test_core_cap_zero():

--- a/tests/test_engine/test_submit_feedback.py
+++ b/tests/test_engine/test_submit_feedback.py
@@ -311,12 +311,20 @@ class TestSubmitFeedbackBasic:
 
         assert "FastAPI" in text
         row = engine.db.conn.execute(
-            "SELECT id, session_id, prompt_text, was_injected FROM whisper_log WHERE node_id = ?",
+            """
+            SELECT wl.id, wl.session_id, wl.prompt_text, wl.prompt_vec,
+                   wl.was_injected, re.prompt_text AS event_prompt_text
+            FROM whisper_log wl
+            JOIN retrieval_events re ON re.id = wl.retrieval_event_id
+            WHERE wl.node_id = ?
+            """,
             (node_id,),
         ).fetchone()
         assert row is not None
         assert row["session_id"] == "recall-search-session"
-        assert row["prompt_text"] == "FastAPI"
+        assert row["prompt_text"] is None
+        assert row["prompt_vec"] == b""
+        assert row["event_prompt_text"] == "FastAPI"
         assert row["was_injected"] == 1
         assert f"whisper_log_id: {row['id']}" in text
 
@@ -337,12 +345,20 @@ class TestSubmitFeedbackBasic:
 
         assert "SQLite choice" in text
         row = engine.db.conn.execute(
-            "SELECT id, session_id, prompt_text, was_injected FROM whisper_log WHERE node_id = ?",
+            """
+            SELECT wl.id, wl.session_id, wl.prompt_text, wl.prompt_vec,
+                   wl.was_injected, re.prompt_text AS event_prompt_text
+            FROM whisper_log wl
+            JOIN retrieval_events re ON re.id = wl.retrieval_event_id
+            WHERE wl.node_id = ?
+            """,
             (node_id,),
         ).fetchone()
         assert row is not None
         assert row["session_id"] == "recall-node-session"
-        assert row["prompt_text"] == f"recall_node:{node_id}"
+        assert row["prompt_text"] is None
+        assert row["prompt_vec"] == b""
+        assert row["event_prompt_text"] == f"recall_node:{node_id}"
         assert row["was_injected"] == 1
         assert f"whisper_log_id: {row['id']}" in text
 

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -2210,7 +2210,15 @@ class TestWhisperLog:
         assert row["session_id"] == "test-session-abc"
         assert row["node_id"] == "node-log-1"
         assert row["was_injected"] == 1
-        assert row["prompt_text"] == "how does search work"
+        assert row["prompt_text"] is None
+        assert row["prompt_vec"] == b""
+        event = db.conn.execute(
+            "SELECT * FROM retrieval_events WHERE id = ?",
+            (row["retrieval_event_id"],),
+        ).fetchone()
+        assert event["surface"] == "whisper"
+        assert event["prompt_text"] == "how does search work"
+        assert len(event["prompt_vec"]) == 12
         assert row["decision_stage"] == "injected"
         assert row["retrieval_rank"] == 1
         assert row["final_rank"] == 1

--- a/tests/test_eval_whisper/test_miner.py
+++ b/tests/test_eval_whisper/test_miner.py
@@ -115,6 +115,56 @@ def test_recall_contamination_excluded(tmp_path):
     assert prompts == {"a whisper prompt"}
 
 
+def test_normalized_retrieval_event_supplies_prompt_payload(tmp_path):
+    db = tmp_path / "live.db"
+    _make_db(db)
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE retrieval_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            surface TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            space TEXT,
+            prompt_hash TEXT NOT NULL,
+            prompt_text TEXT,
+            prompt_vec BLOB NOT NULL,
+            logged_at TEXT NOT NULL
+        );
+        ALTER TABLE whisper_log ADD COLUMN retrieval_event_id INTEGER;
+        """
+    )
+    for node in ("n1", "n2"):
+        _node(conn, node, node)
+    cursor = conn.execute(
+        """
+        INSERT INTO retrieval_events
+            (surface, session_id, space, prompt_hash, prompt_text, prompt_vec, logged_at)
+        VALUES ('whisper', 'sess', 'ormah', 'hash', 'normalized prompt', X'01', ?)
+        """,
+        ("2026-07-01T10:00:00Z",),
+    )
+    event_id = cursor.lastrowid
+    for node_id, score, injected in (("n1", 0.7, 1), ("n2", 0.2, 0)):
+        conn.execute(
+            """
+            INSERT INTO whisper_log
+                (session_id, space, prompt_hash, prompt_text, prompt_vec,
+                 node_id, score, was_injected, logged_at, retrieval_event_id)
+            VALUES ('sess', 'ormah', 'hash', NULL, X'', ?, ?, ?, ?, ?)
+            """,
+            (node_id, score, injected, "2026-07-01T10:00:00Z", event_id),
+        )
+    _decision(conn, "sess", "hash", "2026-07-01T10:00:00Z")
+    conn.commit()
+    conn.close()
+
+    cases = _run_mine(tmp_path, db)
+
+    assert len(cases) == 1
+    assert cases[0]["prompts"][0]["text"] == "normalized prompt"
+
+
 def test_deterministic_truncation_keeps_injected_node(tmp_path):
     db = tmp_path / "live.db"
     _make_db(db)

--- a/tests/test_index/test_feedback_schema.py
+++ b/tests/test_index/test_feedback_schema.py
@@ -60,6 +60,7 @@ def test_whisper_log_columns(db):
         "decision_stage",
         "was_injected",
         "logged_at",
+        "retrieval_event_id",
     ]:
         assert expected in cols, f"Missing column '{expected}' in whisper_log"
 
@@ -68,6 +69,26 @@ def test_whisper_log_indexes(db):
     assert _index_exists(db, "idx_whisper_log_session")
     assert _index_exists(db, "idx_whisper_log_node")
     assert _index_exists(db, "idx_whisper_log_logged")
+    assert _index_exists(db, "idx_whisper_log_event")
+    assert _index_exists(db, "idx_whisper_log_retention")
+    assert _index_exists(db, "idx_whisper_log_session_injected")
+    assert _index_exists(db, "idx_whisper_log_node_injected_logged")
+
+
+def test_retrieval_events_schema(db):
+    assert _table_exists(db, "retrieval_events")
+    assert _table_columns(db, "retrieval_events") == [
+        "id",
+        "surface",
+        "session_id",
+        "space",
+        "prompt_hash",
+        "prompt_text",
+        "prompt_vec",
+        "logged_at",
+    ]
+    assert _index_exists(db, "idx_retrieval_events_session")
+    assert _index_exists(db, "idx_retrieval_events_logged")
 
 
 def test_affinity_table_exists(db):
@@ -250,9 +271,70 @@ def test_migrate_adds_whisper_candidate_diagnostics(tmp_path):
     assert "decision_stage" in cols
     assert "ce_absolute" in cols
     row = db.conn.execute(
-        "SELECT node_id, decision_stage FROM whisper_log WHERE node_id = 'n1'"
+        """
+        SELECT wl.id, wl.node_id, wl.decision_stage, wl.retrieval_event_id,
+               length(wl.prompt_vec), re.prompt_vec
+        FROM whisper_log wl
+        JOIN retrieval_events re ON re.id = wl.retrieval_event_id
+        WHERE wl.node_id = 'n1'
+        """
     ).fetchone()
-    assert tuple(row) == ("n1", "legacy")
+    assert tuple(row[:5]) == (1, "n1", "legacy", 1, 0)
+    assert row["prompt_vec"] == b"\x00"
+    db.close()
+
+
+def test_migrate_normalizes_duplicate_payloads_and_preserves_candidate_ids(tmp_path):
+    path = tmp_path / "index.db"
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """
+        CREATE TABLE whisper_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            space TEXT,
+            prompt_hash TEXT NOT NULL,
+            prompt_text TEXT,
+            prompt_vec BLOB NOT NULL,
+            node_id TEXT NOT NULL,
+            score REAL NOT NULL,
+            was_injected INTEGER NOT NULL,
+            logged_at TEXT NOT NULL
+        )
+        """
+    )
+    payload = b"x" * 3072
+    for node_id in ("node-a", "node-b"):
+        conn.execute(
+            """
+            INSERT INTO whisper_log
+                (session_id, space, prompt_hash, prompt_text, prompt_vec,
+                 node_id, score, was_injected, logged_at)
+            VALUES ('sess', 'ormah', 'hash', 'shared prompt', ?, ?, 0.5, 0, ?)
+            """,
+            (payload, node_id, "2026-01-01T00:00:00+00:00"),
+        )
+    conn.commit()
+    conn.close()
+
+    db = Database(path)
+    db.init_schema()
+
+    rows = db.conn.execute(
+        "SELECT id, retrieval_event_id, length(prompt_vec) AS prompt_vec_bytes, prompt_text "
+        "FROM whisper_log ORDER BY id"
+    ).fetchall()
+    assert [row["id"] for row in rows] == [1, 2]
+    assert len({row["retrieval_event_id"] for row in rows}) == 1
+    assert [row["prompt_vec_bytes"] for row in rows] == [0, 0]
+    assert [row["prompt_text"] for row in rows] == [None, None]
+
+    event = db.conn.execute("SELECT * FROM retrieval_events").fetchone()
+    assert event["prompt_text"] == "shared prompt"
+    assert event["prompt_vec"] == payload
+
+    db.init_schema()
+    assert db.conn.execute("SELECT COUNT(*) FROM retrieval_events").fetchone()[0] == 1
     db.close()
 
 


### PR DESCRIPTION
## Problem\n\nFull candidate instrumentation duplicates each prompt embedding across roughly 30-45 whisper_log rows and leaves rejected diagnostics unbounded.\n\nCloses #97.\n\n## Solution\n\n- Store prompt text and embedding once in a retrieval_events parent row.\n- Preserve whisper_log.id as the exact candidate feedback key.\n- Migrate legacy rows without changing candidate IDs or feedback references.\n- Clean stale unreferenced rejected candidates in bounded background batches.\n- Retain injected rows and any rejected row referenced by affinity or signals.\n- Add composite indexes for retention, active review, and session feedback reads.\n- Keep old read-only eval databases compatible through a legacy miner fallback.\n\nDefaults:\n- rejected retention: 30 days\n- cleanup interval: 24 hours\n- cleanup batch: 1000 rows\n\n## Evidence\n\nScratch replay of the live DB, using SQLite backup and never writing to the live database:\n\n- 4,331 candidate IDs preserved\n- 113 affinity and 113 signal references preserved\n- zero foreign-key errors\n- prompt-vector bytes: 13.30 MB to 3.94 MB\n- active-review query: about 30 ms to 0.8 ms\n- session feedback query: about 6.3 ms to 0.3 ms\n- cleanup removed 260 eligible rejected rows and 45 orphan events\n\n## Verification\n\n- 1,210 tests passed, 1 deselected\n- Ruff clean\n- Whisper F1 0.73, suppression 0.95\n- Recall R@8 / P@8 / F1: 0.99 / 0.46 / 0.57\n\nNo corpus labels were changed.