### PR TITLE
perf(whisper): avoid redundant preference query work

### DIFF
--- a/docs/03 - Search and Ranking.md
+++ b/docs/03 - Search and Ranking.md
@@ -152,6 +152,8 @@ The preference path:
 - disables graph spreading so related non-preference nodes cannot enter the channel
 - cross-encodes candidates against an applicability-framed query
 - applies an absolute applicability gate and merges at most two results
+- skips the channel when no active core/working preference exists
+- reuses the main search's `encode_query()` vector when both channels use the exact same query
 
 This does not infer a preference mode from prompt keywords and does not alter or suppress the main factual ranking. Those constraints avoid the failure mode of the removed prompt-shape heuristic, which treated broad words such as `build`, `design`, and `style` as permission to boost all preferences and discard factual results.
 

--- a/src/ormah/embeddings/hybrid_search.py
+++ b/src/ormah/embeddings/hybrid_search.py
@@ -92,8 +92,15 @@ class HybridSearch:
         tags: list[str] | None = None,
         created_after: str | None = None,
         created_before: str | None = None,
+        query_vec: Any | None = None,
     ) -> list[dict[str, Any]]:
-        """Hybrid search with Reciprocal Rank Fusion."""
+        """Hybrid search with Reciprocal Rank Fusion.
+
+        ``query_vec`` may be supplied by a caller that performs multiple
+        searches for the identical query. It must come from ``encode_query``;
+        document-style ``encode`` vectors are not interchangeable for models
+        with query-specific prefixes.
+        """
         sim_threshold = self.settings.similarity_threshold
 
         # Widen candidate pool when temporal filters are active so the
@@ -108,7 +115,8 @@ class HybridSearch:
         # Vector results — use cosine similarity, drop below threshold
         vec_scores: dict[str, float] = {}
         try:
-            query_vec = self.encoder.encode_query(query)
+            if query_vec is None:
+                query_vec = self.encoder.encode_query(query)
             vec_results = self.vec_store.search(query_vec, limit=limit * candidate_multiplier)
             vec_scores = {
                 r["id"]: r["similarity"]

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -542,6 +542,30 @@ class ContextBuilder:
         # sense with the session context ("and the second one?").
         effective_query = search_kwargs["query"]
 
+        # Search uses encode_query(), which may apply model-specific query
+        # prefixes and is therefore not interchangeable with the classifier's
+        # document-style prompt_vec. Cache by exact query text so the factual
+        # and preference channels share work only when their queries match.
+        query_vectors: dict[str, np.ndarray] = {}
+
+        def _query_vector(query: str) -> np.ndarray | None:
+            if query in query_vectors:
+                return query_vectors[query]
+            try:
+                hybrid_search = self.engine._get_hybrid_search()
+                if hybrid_search is None:
+                    return None
+                vector = hybrid_search.encoder.encode_query(query)
+                query_vectors[query] = vector
+                return vector
+            except Exception as e:
+                logger.warning("Failed to compute search query vector: %s", e)
+                return None
+
+        effective_query_vec = _query_vector(effective_query)
+        if effective_query_vec is not None:
+            search_kwargs["query_vec"] = effective_query_vec
+
         # Always run search — even for identity-only queries, search finds
         # location/work/study nodes that graph neighbors alone miss.
         try:
@@ -857,6 +881,7 @@ class ContextBuilder:
             preference_applicability_enabled
             and reranker_enabled
             and preference_max_nodes > 0
+            and self.engine.has_searchable_preferences()
         ):
             try:
                 from ormah.embeddings.reranker import rerank
@@ -872,6 +897,7 @@ class ContextBuilder:
                     min_relevance=0.0,
                     auto_temporal=False,
                     spread_activation=False,
+                    query_vec=_query_vector(preference_query),
                 )
                 preference_candidates = [
                     r for r in preference_candidates if r["node"]["id"] not in existing_ids

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -628,7 +628,8 @@ class MemoryEngine:
     def recall_search_structured(
         self, query: str, limit: int = 10, default_space: str | None = None,
         touch_access: bool = True, min_relevance: float | None = None,
-        auto_temporal: bool = True, spread_activation: bool = True, **filters,
+        auto_temporal: bool = True, spread_activation: bool = True,
+        query_vec: Any | None = None, **filters,
     ) -> list[dict]:
         """Search memories and return structured results (list of dicts).
 
@@ -657,7 +658,13 @@ class MemoryEngine:
             if has_temporal_phrases(query):
                 time_params = extract_time_params(query)
                 filters.update(time_params)
-                query = strip_temporal_phrases(query)
+                stripped_query = strip_temporal_phrases(query)
+                if stripped_query != query:
+                    # A supplied vector belongs to the caller's original
+                    # query. Once temporal preprocessing changes that query,
+                    # HybridSearch must encode the effective text itself.
+                    query_vec = None
+                query = stripped_query
 
         explicit_spaces = filters.get("spaces")
 
@@ -666,7 +673,12 @@ class MemoryEngine:
             # Fetch a wider pool so the space penalty decides what SURVIVES,
             # not just the order of whatever fit in `limit` — a current-space
             # match at raw rank 11 can now outlive a penalized cross-space hit.
-            results = search.search(query, limit=limit * 3, **filters)
+            results = search.search(
+                query,
+                limit=limit * 3,
+                query_vec=query_vec,
+                **filters,
+            )
             if default_space and not explicit_spaces:
                 results = self._apply_space_scores(results, default_space)
 
@@ -748,6 +760,23 @@ class MemoryEngine:
                     self._touch_access(r["node"]["id"])
 
         return enriched
+
+    def has_searchable_preferences(self) -> bool:
+        """Return whether the applicability channel has any eligible nodes."""
+        row = self.db.conn.execute(
+            """
+            SELECT 1
+            FROM nodes
+            WHERE type = 'preference'
+              AND tier IN ('core', 'working')
+              AND (
+                  valid_until IS NULL
+                  OR valid_until > strftime('%Y-%m-%dT%H:%M:%f+00:00', 'now')
+              )
+            LIMIT 1
+            """
+        ).fetchone()
+        return row is not None
 
     def recall_search(
         self,

--- a/tests/test_engine/test_hybrid_search.py
+++ b/tests/test_engine/test_hybrid_search.py
@@ -61,6 +61,17 @@ def test_rrf_weights_scale_contribution():
     assert scores["b"] > scores["a"]
 
 
+def test_provided_query_vector_skips_duplicate_encoding(mock_hybrid):
+    query_vec = [0.1, 0.2, 0.3]
+    mock_hybrid.graph.fts_search.return_value = []
+    mock_hybrid.vec_store.search.return_value = []
+
+    mock_hybrid.search("same query", query_vec=query_vec)
+
+    mock_hybrid.encoder.encode_query.assert_not_called()
+    mock_hybrid.vec_store.search.assert_called_once_with(query_vec, limit=30)
+
+
 # ---------------------------------------------------------------------------
 # Fusion: score combination and ranking
 # ---------------------------------------------------------------------------

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -304,6 +304,48 @@ def test_get_whisper_context_threads_preference_applicability_settings(engine):
     assert build.call_args.kwargs["preference_max_nodes"] == 1
 
 
+def test_has_searchable_preferences_ignores_expired_and_archival(engine):
+    now = "2026-07-12T00:00:00+00:00"
+    with engine.db.transaction() as conn:
+        conn.execute(
+            """
+            INSERT INTO nodes
+                (id, type, tier, source, title, content, created, updated,
+                 last_accessed, file_path, file_hash, valid_until)
+            VALUES ('expired-pref', 'preference', 'working', 'test', 'Expired',
+                    'Expired', ?, ?, ?, '/tmp/expired', 'expired',
+                    '2020-01-01T00:00:00+00:00')
+            """,
+            (now, now, now),
+        )
+        conn.execute(
+            """
+            INSERT INTO nodes
+                (id, type, tier, source, title, content, created, updated,
+                 last_accessed, file_path, file_hash)
+            VALUES ('archival-pref', 'preference', 'archival', 'test', 'Archival',
+                    'Archival', ?, ?, ?, '/tmp/archival', 'archival')
+            """,
+            (now, now, now),
+        )
+
+    assert engine.has_searchable_preferences() is False
+
+    with engine.db.transaction() as conn:
+        conn.execute(
+            """
+            INSERT INTO nodes
+                (id, type, tier, source, title, content, created, updated,
+                 last_accessed, file_path, file_hash)
+            VALUES ('active-pref', 'preference', 'working', 'test', 'Active',
+                    'Active', ?, ?, ?, '/tmp/active', 'active')
+            """,
+            (now, now, now),
+        )
+
+    assert engine.has_searchable_preferences() is True
+
+
 def test_startup_seeds_maintenance_grace_period(settings):
     settings.claude_maintenance_enabled = True
     engine = MemoryEngine(settings)
@@ -471,6 +513,7 @@ class TestRecallFloorAndSpaceOrdering:
 
     def test_pool_widened_and_floor_drops_cross_space_noise(self, engine):
         """Cross-space noise penalized below the floor is dropped, not padded."""
+        query_vec = [0.1, 0.2, 0.3]
         results = [
             {"node": self._node("good-1", space="proj"), "score": 0.80, "source": "hybrid"},
             {"node": self._node("good-2", space="proj"), "score": 0.62, "source": "hybrid"},
@@ -481,10 +524,12 @@ class TestRecallFloorAndSpaceOrdering:
         with ctx:
             out = engine.recall_search_structured(
                 "project question", limit=4, default_space="proj", touch_access=False,
+                query_vec=query_vec,
             )
 
         # Pool widened to limit*3
         assert mock_search.search.call_args.kwargs.get("limit") == 12
+        assert mock_search.search.call_args.kwargs["query_vec"] is query_vec
         ids = [r["node"]["id"] for r in out if r.get("source") == "hybrid"]
         # other-space results: 0.50*0.6=0.30 and 0.48*0.6=0.288 < 0.35 floor
         assert ids == ["good-1", "good-2"]
@@ -520,6 +565,21 @@ class TestRecallFloorAndSpaceOrdering:
             )
 
         assert any(r["node"]["id"] == "recent-1" for r in out)
+
+    def test_temporal_preprocessing_invalidates_original_query_vector(self, engine):
+        query_vec = [0.1, 0.2, 0.3]
+        ctx, mock_search = self._search_mock(engine, [])
+
+        with ctx:
+            engine.recall_search_structured(
+                "auth changes yesterday",
+                limit=4,
+                touch_access=False,
+                query_vec=query_vec,
+            )
+
+        assert mock_search.search.call_args.args[0] == "auth changes"
+        assert mock_search.search.call_args.kwargs["query_vec"] is None
 
     def test_temporal_supplements_respect_space_priority(self, engine):
         """A newer other-space node must NOT outrank an older current-space node."""

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -1170,6 +1170,7 @@ class TestPreferenceApplicability:
     def _builder(self, mock_graph, main_results, preference_results):
         mock_engine = _make_engine_with_encoder(mock_graph)
         mock_engine.settings.whisper_exploration_enabled = False
+        mock_engine.has_searchable_preferences.return_value = True
         mock_engine.recall_search_structured.side_effect = [
             main_results,
             preference_results,
@@ -1212,6 +1213,11 @@ class TestPreferenceApplicability:
         assert preference_call.kwargs["types"] == ["preference"]
         assert preference_call.kwargs["auto_temporal"] is False
         assert preference_call.kwargs["spread_activation"] is False
+        main_query_vec = engine.recall_search_structured.call_args_list[0].kwargs["query_vec"]
+        assert preference_call.kwargs["query_vec"] is main_query_vec
+        engine._get_hybrid_search.return_value.encoder.encode_query.assert_called_once_with(
+            "build the graph component"
+        )
         assert mock_ce.rerank.call_args_list[1].args[0].startswith(
             "Relevant user preference for this action:"
         )
@@ -1248,6 +1254,85 @@ class TestPreferenceApplicability:
 
         assert "Graph component implementation" in result
         assert "Prefer dark themes" not in result
+
+    def test_empty_preference_store_skips_search_and_rerank(self, mock_graph):
+        factual = _make_node_dict("fact-1", "Graph component implementation")
+        builder, engine = self._builder(
+            mock_graph,
+            [{"node": factual, "score": 0.80, "source": "hybrid"}],
+            [],
+        )
+        engine.has_searchable_preferences.return_value = False
+        mock_ce = MagicMock()
+        mock_ce.rerank.return_value = [3.0]
+
+        with patch("ormah.embeddings.reranker._get_model", return_value=mock_ce), patch(
+            "ormah.engine.context_builder.ContextBuilder._get_classifier",
+            return_value=None,
+        ), patch(
+            "ormah.engine.affinity.batch_fetch_affinity", return_value={}
+        ), patch(
+            "ormah.engine.affinity.compute_affinity_boost", return_value=0.0
+        ):
+            result = builder.build_whisper_context(
+                prompt="build the graph component",
+                min_score=0.1,
+                reranker_enabled=True,
+                reranker_min_score=0.0,
+                injection_gate=0.45,
+                preference_applicability_enabled=True,
+                preference_applicability_gate=0.40,
+            )
+
+        assert "Graph component implementation" in result
+        assert engine.recall_search_structured.call_count == 1
+        assert mock_ce.rerank.call_count == 1
+        engine._get_hybrid_search.return_value.encoder.encode_query.assert_called_once()
+
+    def test_different_effective_and_preference_queries_use_distinct_vectors(
+        self, mock_graph
+    ):
+        from ormah.engine.prompt_classifier import PromptIntent
+
+        factual = _make_node_dict("fact-1", "Graph component implementation")
+        preference = _make_node_dict(
+            "pref-1", "Prefer simple designs", node_type="preference"
+        )
+        builder, engine = self._builder(
+            mock_graph,
+            [{"node": factual, "score": 0.80, "source": "hybrid"}],
+            [{"node": preference, "score": 0.65, "source": "hybrid"}],
+        )
+        mock_classifier = MagicMock()
+        mock_classifier.classify.return_value = PromptIntent(
+            categories=["temporal"],
+            search_params={"search_query": "build the graph component"},
+            prompt_vec=np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        )
+        builder._classifier = mock_classifier
+        main_vec = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        preference_vec = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+        encoder = engine._get_hybrid_search.return_value.encoder
+        encoder.encode_query.side_effect = [main_vec, preference_vec]
+        mock_ce = MagicMock()
+        mock_ce.rerank.side_effect = [[3.0], [0.0]]
+
+        with patch("ormah.embeddings.reranker._get_model", return_value=mock_ce):
+            builder.build_whisper_context(
+                prompt="build the graph component yesterday",
+                min_score=0.1,
+                reranker_enabled=True,
+                injection_gate=0.45,
+                preference_applicability_enabled=True,
+                preference_applicability_gate=0.40,
+            )
+
+        main_call, preference_call = engine.recall_search_structured.call_args_list
+        assert main_call.kwargs["query"] == "build the graph component"
+        assert main_call.kwargs["query_vec"] is main_vec
+        assert preference_call.kwargs["query"] == "build the graph component yesterday"
+        assert preference_call.kwargs["query_vec"] is preference_vec
+        assert encoder.encode_query.call_count == 2
 
     def test_topical_overlap_guard_drops_unrelated_extra_result(self, mock_graph):
         mock_engine = MagicMock()
@@ -1718,6 +1803,7 @@ def _make_engine_with_encoder(mock_graph, prompt_vec=None):
 
     mock_encoder = MagicMock()
     mock_encoder.encode.return_value = prompt_vec
+    mock_encoder.encode_query.return_value = prompt_vec
     mock_hybrid = MagicMock()
     mock_hybrid.encoder = mock_encoder
     mock_engine._get_hybrid_search.return_value = mock_hybrid


### PR DESCRIPTION
## Problem

The preference-applicability channel introduced by PR #98 repeated search-query encoding and ran a full typed retrieval even when no eligible preference existed.

Closes #100.

## Mechanism

- Thread an optional vector produced by `encode_query()` through `ContextBuilder -> recall_search_structured -> HybridSearch`.
- Cache vectors by exact effective query within one whisper call.
- Reuse only when factual and preference query strings match.
- Keep classifier `encode()` vectors separate because query/document encodings are not interchangeable.
- Invalidate supplied vectors if recall temporal preprocessing changes the query.
- Skip the preference channel when no unexpired core/working preference exists.
- Do not cap CE candidates: retrieval rank is not applicability rank, so a cap could recreate the preference misses this channel fixed.

## Benchmark

Same CPU, 1,644-node scratch backup of the live read-only DB, 12 active preferences, five prompts repeated three times after warmup:

| Metric | Before | After |
|---|---:|---:|
| Preference-on mean whisper latency | 617 ms | 531 ms |
| Preference-on median whisper latency | 583 ms | 494 ms |
| Incremental preference overhead vs off | 113 ms | 65 ms |
| `encode_query` calls / 15 whispers | 30 | 15 |
| Preference search time / call | 50.1 ms | 14.9 ms |

On a scratch copy with zero eligible preferences, the previous channel still added roughly 38-48 ms. After this change it performs zero second searches/reranks and measured 464 ms mean versus 466 ms with the feature disabled.

The live database was opened read-only and copied with SQLite backup; all mutation and measurement used scratch copies.

## Verification

- 1,215 tests passed, 1 deselected
- Ruff clean
- Whisper preference F1: 0.56 (unchanged)
- Overall whisper F1 / suppression: 0.73 / 0.95 (unchanged)
- Recall R@8 / P@8 / F1: 0.99 / 0.46 / 0.57 (unchanged)
- No eval corpus labels changed
