### PR TITLE
feat(sync): mutation stamping and deleted_at tombstones (Sync v1 Step 0)

### DIFF
--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -46,6 +46,7 @@ def run_auto_cluster(engine) -> None:
             node = engine.file_store.load(node_id)
             if node:
                 node.space = most_common
+                node.touch_updated()
                 engine.file_store.save(node)
 
             assigned += 1

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -306,6 +306,7 @@ def _apply_edge(
                     weight=round(similarity, 2),
                 )
                 mem_node.connections.append(md_conn)
+                mem_node.touch_updated()
                 engine.file_store.save(mem_node)
         except Exception as e:
             logger.debug("Failed to persist connection to markdown for %s: %s", node_a_id[:8], e)

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -280,6 +280,7 @@ def run_conflict_detection(engine) -> None:
                 if mem_node is None:
                     continue
                 mem_node.connections.extend(new_connections)
+                mem_node.touch_updated()
                 engine.file_store.save(mem_node)
             except Exception as e:
                 logger.debug("Failed to persist conflict edge to markdown for %s: %s", nid[:8], e)

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -153,6 +153,7 @@ def _apply_consolidation(
             new_node = engine.file_store.load(new_id)
             if new_node and "about_self" not in new_node.tags:
                 new_node.tags.append("about_self")
+                new_node.touch_updated()
                 engine.file_store.save(new_node)
                 with engine.db.transaction() as tx_conn:
                     tx_conn.execute(

--- a/src/ormah/background/importance_scorer.py
+++ b/src/ormah/background/importance_scorer.py
@@ -106,6 +106,7 @@ def run_importance_scoring(engine) -> None:
         node = engine.file_store.load(nid)
         if node is not None:
             node.importance = round(importance, 4)
+            node.touch_updated()
             engine.file_store.save(node)
 
         updated += 1

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -276,6 +276,11 @@ class MemoryEngine:
                             node = self.file_store.load(nid)
                             if node and node.tier == Tier.core and node.type != NodeType.person:
                                 node.tier = Tier.working
+                                # Tier change is a content mutation; the one-time
+                                # completion flag means it never reruns, so an
+                                # unstamped save could lose permanently to a stale
+                                # remote copy under LWW sync.
+                                node.touch_updated()
                                 self.file_store.save(node)
                         logger.info("Migrated %d identity nodes from core to working tier", demoted)
 
@@ -313,6 +318,28 @@ class MemoryEngine:
                     )
                     linked += 1
 
+                # Persist repaired edges to the self node's markdown too — the
+                # edges table is derived and wiped on full_rebuild, and the
+                # completion flag means this repair never reruns.
+                if linked:
+                    self_node = self.file_store.load(self.user_node_id)
+                    if self_node:
+                        existing_targets = {c.target for c in self_node.connections}
+                        added_md = 0
+                        for row in orphaned:
+                            if row["id"] not in existing_targets:
+                                self_node.connections.append(
+                                    Connection(
+                                        target=row["id"],
+                                        edge=EdgeType.defines,
+                                        weight=1.0,
+                                    )
+                                )
+                                added_md += 1
+                        if added_md:
+                            self_node.touch_updated()
+                            self.file_store.save(self_node)
+
                 # Also demote any remaining core preferences (missed by phase 1
                 # because they had no defines edge at that time)
                 demoted = conn.execute(
@@ -341,6 +368,7 @@ class MemoryEngine:
                         node = self.file_store.load(row["id"])
                         if node and node.tier == Tier.core:
                             node.tier = Tier.working
+                            node.touch_updated()
                             self.file_store.save(node)
 
                 if linked:
@@ -849,6 +877,11 @@ class MemoryEngine:
         if req.add_connections:
             node.connections.extend(req.add_connections)
             changed_fields.append("connections")
+
+        # No-op guard: a request that changed nothing must not advance
+        # `updated`, or it could beat a real remote edit under LWW sync.
+        if node.model_dump(mode="json") == old_snapshot:
+            return f"Updated [{node.type.value}]: {node.title or node.content[:80]}\nID: {node.id}"
 
         node.touch_updated()
         path = self.file_store.save(node)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -850,7 +850,7 @@ class MemoryEngine:
             node.connections.extend(req.add_connections)
             changed_fields.append("connections")
 
-        node.updated = datetime.now(timezone.utc)
+        node.touch_updated()
         path = self.file_store.save(node)
         self.builder.index_single(path)
         self._index_embedding(node)
@@ -944,6 +944,7 @@ class MemoryEngine:
             source_node.connections.append(
                 Connection(target=req.target_id, edge=req.edge, weight=req.weight)
             )
+            source_node.touch_updated()
             self.file_store.save(source_node)
 
         return f"Connected {req.source_id[:8]}... →[{req.edge.value}]→ {req.target_id[:8]}..."
@@ -1056,7 +1057,7 @@ class MemoryEngine:
         node.valid_until = datetime.now(timezone.utc)
         if reason:
             node.content = node.content.rstrip() + f"\n\n[Outdated: {reason}]"
-        node.updated = datetime.now(timezone.utc)
+        node.touch_updated()
 
         path = self.file_store.save(node)
         self.builder.index_single(path)
@@ -1300,7 +1301,7 @@ class MemoryEngine:
         # Save kept node, re-index, re-embed
         # NOTE: index_single calls _remove_node internally which wipes edges,
         # so we must remap edges and restore incoming edges AFTER this step.
-        kept.updated = datetime.now(timezone.utc)
+        kept.touch_updated()
         path = self.file_store.save(kept)
         self.builder.index_single(path)
         self._index_embedding(kept)
@@ -1397,15 +1398,17 @@ class MemoryEngine:
                     c.target = kept.id
                     updated = True
             if updated:
+                neighbor.touch_updated()
                 self.file_store.save(neighbor)
 
         # Also fix the kept node's own connections that pointed to removed
         reload_kept = self.file_store.load(kept.id)
         if reload_kept:
-            reload_kept.connections = [
-                c for c in reload_kept.connections if c.target != removed.id
-            ]
-            self.file_store.save(reload_kept)
+            pruned = [c for c in reload_kept.connections if c.target != removed.id]
+            if len(pruned) != len(reload_kept.connections):
+                reload_kept.connections = pruned
+                reload_kept.touch_updated()
+                self.file_store.save(reload_kept)
 
         kept_title = kept.title or kept.content[:60]
         removed_title = removed.title or removed.content[:60]
@@ -1433,6 +1436,10 @@ class MemoryEngine:
         # Reconstruct removed node from snapshot
         snapshot = json.loads(row["removed_node_snapshot"])
         node = MemoryNode.model_validate(snapshot)
+        # Restoration is a new mutation event: stamping `updated` lets the live
+        # node outrank the tombstone left in deleted/ during sync merges.
+        node.deleted_at = None
+        node.touch_updated()
         path = self.file_store.save(node)
         self.builder.index_single(path)
         self._index_embedding(node)
@@ -1751,6 +1758,7 @@ class MemoryEngine:
             self_node.connections.append(
                 Connection(target=node.id, edge=EdgeType.defines, weight=1.0)
             )
+            self_node.touch_updated()
             self.file_store.save(self_node)
 
     def _touch_access(self, node_id: str) -> None:
@@ -2060,6 +2068,7 @@ class MemoryEngine:
                             Connection(target=match_id, edge=EdgeType.related_to,
                                        weight=round(similarity, 2))
                         )
+                node.touch_updated()
                 self.file_store.save(node)  # persist auto-linked connections
 
             return links

--- a/src/ormah/engine/tier_manager.py
+++ b/src/ormah/engine/tier_manager.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 
 from ormah.models.node import MemoryNode, Tier
 
@@ -26,7 +25,7 @@ class TierManager:
             return False
 
         node.tier = target_tier
-        node.updated = datetime.now(timezone.utc)
+        node.touch_updated()
         return True
 
     def demote(self, node: MemoryNode, target_tier: Tier) -> bool:
@@ -39,7 +38,7 @@ class TierManager:
             return False
 
         node.tier = target_tier
-        node.updated = datetime.now(timezone.utc)
+        node.touch_updated()
         return True
 
     def enforce_core_cap(

--- a/src/ormah/models/node.py
+++ b/src/ormah/models/node.py
@@ -59,6 +59,7 @@ class MemoryNode(BaseModel):
     stability: float = Field(default=1.0, ge=0.0)  # FSRS: days until ~37% retrievability
     last_review: datetime | None = None  # last stability update (distinct from last_accessed)
     valid_until: datetime | None = None
+    deleted_at: datetime | None = None  # tombstone stamp; ordering for sync merges uses this, never `updated`
     space: str | None = None
     tags: list[str] = Field(default_factory=list)
     connections: list[Connection] = Field(default_factory=list)
@@ -68,6 +69,11 @@ class MemoryNode(BaseModel):
     @property
     def short_id(self) -> str:
         return self.id.split("-")[0]
+
+    def touch_updated(self) -> None:
+        """Advance `updated`. Call before saving any content mutation; never for
+        read-side access metadata (last_accessed, access_count, FSRS review state)."""
+        self.updated = datetime.now(timezone.utc)
 
 
 class CreateNodeRequest(BaseModel):

--- a/src/ormah/store/file_store.py
+++ b/src/ormah/store/file_store.py
@@ -80,10 +80,21 @@ class FileStore:
         return True
 
     def soft_delete(self, node_id: str) -> bool:
-        """Move a node file to the deleted/ directory. Returns True if moved."""
+        """Move a node file to the deleted/ directory, stamping `deleted_at`
+        into its frontmatter first so tombstones carry their deletion time
+        (sync merge ordering depends on it). Returns True if moved.
+        """
         path = self._find_file(node_id)
         if path is None:
             return False
+        try:
+            node = self._load_path(path)
+            node.deleted_at = datetime.now(timezone.utc)
+            path.write_text(serialize_node(node), encoding="utf-8")
+        except Exception:
+            logger.warning(
+                "soft_delete: could not stamp deleted_at on %s; moving as-is", path
+            )
         deleted_dir = self.nodes_dir.parent / "deleted"
         deleted_dir.mkdir(parents=True, exist_ok=True)
         dest = deleted_dir / path.name

--- a/src/ormah/store/file_store.py
+++ b/src/ormah/store/file_store.py
@@ -90,7 +90,9 @@ class FileStore:
         try:
             node = self._load_path(path)
             node.deleted_at = datetime.now(timezone.utc)
-            path.write_text(serialize_node(node), encoding="utf-8")
+            # save() writes atomically (tmp + os.replace) onto the existing
+            # path, so an interruption can never truncate the live node file.
+            self.save(node)
         except Exception:
             logger.warning(
                 "soft_delete: could not stamp deleted_at on %s; moving as-is", path

--- a/src/ormah/store/markdown.py
+++ b/src/ormah/store/markdown.py
@@ -27,6 +27,9 @@ def parse_node(text: str) -> MemoryNode:
     valid_until_raw = meta.get("valid_until")
     valid_until = _parse_dt(valid_until_raw) if valid_until_raw else None
 
+    deleted_at_raw = meta.get("deleted_at")
+    deleted_at = _parse_dt(deleted_at_raw) if deleted_at_raw else None
+
     return MemoryNode(
         id=meta["id"],
         type=NodeType(meta["type"]),
@@ -41,6 +44,7 @@ def parse_node(text: str) -> MemoryNode:
         stability=meta.get("stability", 1.0),
         last_review=_parse_dt(meta["last_review"]) if meta.get("last_review") else None,
         valid_until=valid_until,
+        deleted_at=deleted_at,
         space=meta.get("space"),
         tags=meta.get("tags", []),
         connections=connections,
@@ -69,6 +73,8 @@ def serialize_node(node: MemoryNode) -> str:
         meta["last_review"] = _format_dt(node.last_review)
     if node.valid_until is not None:
         meta["valid_until"] = _format_dt(node.valid_until)
+    if node.deleted_at is not None:
+        meta["deleted_at"] = _format_dt(node.deleted_at)
     if node.title:
         meta["title"] = node.title
     if node.space:

--- a/tests/test_engine/test_mutation_stamping.py
+++ b/tests/test_engine/test_mutation_stamping.py
@@ -309,3 +309,86 @@ def test_auto_cluster_advances_updated(engine):
     node = engine.file_store.load(id_floating)
     assert node.space == "projx"
     assert node.updated > PAST
+
+# ---------------------------------------------------------------------------
+# Review fixes (Codex review of PR #105)
+# ---------------------------------------------------------------------------
+
+
+def test_update_node_noop_does_not_advance_updated(engine):
+    from ormah.models.node import UpdateNodeRequest
+
+    node_id = _create(engine, "Stable", "Unchanging content.")
+    _backdate(engine.file_store, node_id)
+
+    # Empty request
+    engine.update_node(node_id, UpdateNodeRequest())
+    assert _updated(engine.file_store, node_id) == PAST
+
+    # Request assigning identical values
+    node = engine.file_store.load(node_id)
+    engine.update_node(
+        node_id, UpdateNodeRequest(content=node.content, title=node.title)
+    )
+    assert _updated(engine.file_store, node_id) == PAST
+
+    # A real change still stamps
+    engine.update_node(node_id, UpdateNodeRequest(content="Actually new content."))
+    assert _updated(engine.file_store, node_id) > PAST
+
+
+def test_identity_tier_migration_stamps_updated(engine):
+    from ormah.models.node import Tier
+
+    node_id = _create(engine, "About me", "I prefer tea.", about_self=True)
+
+    # Force the pre-migration state: core tier on disk and in the index
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.core
+    node.updated = PAST
+    engine.file_store.save(node)
+    engine.db.conn.execute("UPDATE nodes SET tier = 'core' WHERE id = ?", (node_id,))
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'identity_tier_migrated'")
+    engine.db.conn.commit()
+
+    engine._migrate_identity_tiers()
+
+    migrated = engine.file_store.load(node_id)
+    assert migrated.tier == Tier.working
+    assert migrated.updated > PAST
+
+
+def test_identity_edge_repair_persists_to_markdown(engine):
+    """Phase-2 repaired defines edges must live in the self node's markdown so
+    they survive a full index rebuild (edges table is derived)."""
+    node_id = _create(engine, "Orphaned identity fact", "I am left-handed.")
+
+    # Tag as about_self without a defines edge (the orphan scenario)
+    node = engine.file_store.load(node_id)
+    node.tags.append("about_self")
+    engine.file_store.save(node)
+    engine.db.conn.execute(
+        "INSERT OR IGNORE INTO node_tags (node_id, tag) VALUES (?, 'about_self')",
+        (node_id,),
+    )
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'identity_edges_repaired'")
+    engine.db.conn.commit()
+    _backdate(engine.file_store, engine.user_node_id)
+
+    engine._migrate_identity_tiers()
+
+    # Markdown source of truth carries the edge and the stamp
+    self_node = engine.file_store.load(engine.user_node_id)
+    assert any(
+        c.target == node_id and c.edge == EdgeType.defines
+        for c in self_node.connections
+    )
+    assert self_node.updated > PAST
+
+    # And the edge survives a full rebuild
+    engine.builder.full_rebuild()
+    row = engine.db.conn.execute(
+        "SELECT 1 FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = 'defines'",
+        (engine.user_node_id, node_id),
+    ).fetchone()
+    assert row is not None

--- a/tests/test_engine/test_mutation_stamping.py
+++ b/tests/test_engine/test_mutation_stamping.py
@@ -1,0 +1,311 @@
+"""Mutation-stamping guarantees (Sync v1 Step 0).
+
+Every content mutation must advance `updated` before save; soft-deletes must
+stamp `deleted_at`; read-side access metadata must never advance `updated`.
+Sync's last-write-wins merge depends on these invariants.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType
+from ormah.store.markdown import parse_node
+
+PAST = datetime(2020, 1, 1, tzinfo=timezone.utc)
+
+_LLM_PATCH = "ormah.background.llm_client.llm_generate"
+
+
+def _create(engine, title, content, **kwargs):
+    """Create a node with auto-linking suppressed, return its id."""
+    original = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        node_id, _ = engine.remember(
+            CreateNodeRequest(content=content, type=NodeType.fact, title=title, **kwargs),
+            agent_id="test",
+        )
+    finally:
+        engine.settings.auto_link_similarity_threshold = original
+    return node_id
+
+
+def _backdate(file_store, node_id):
+    node = file_store.load(node_id)
+    node.updated = PAST
+    file_store.save(node)
+
+
+def _updated(file_store, node_id):
+    return file_store.load(node_id).updated
+
+
+def _tombstone(file_store, node_id):
+    """Parse the tombstone file for a node from deleted/."""
+    deleted_dir = file_store.nodes_dir.parent / "deleted"
+    short_id = node_id.split("-")[0]
+    matches = list(deleted_dir.glob(f"*_{short_id}.md"))
+    assert matches, f"no tombstone found for {node_id}"
+    return parse_node(matches[0].read_text(encoding="utf-8"))
+
+
+def _reset_adapter():
+    from ormah.background.llm_client import reset_adapter
+
+    reset_adapter()
+
+
+# ---------------------------------------------------------------------------
+# Store level
+# ---------------------------------------------------------------------------
+
+
+def test_soft_delete_stamps_deleted_at(file_store):
+    from ormah.models.node import MemoryNode
+
+    node = MemoryNode(type=NodeType.fact, content="delete me", title="Doomed")
+    node.updated = PAST
+    file_store.save(node)
+
+    assert file_store.soft_delete(node.id) is True
+
+    tombstone = _tombstone(file_store, node.id)
+    assert tombstone.deleted_at is not None
+    assert tombstone.deleted_at.tzinfo is not None
+    assert tombstone.deleted_at > PAST
+    # Deletion ordering uses deleted_at, never updated
+    assert tombstone.updated == PAST
+
+
+def test_soft_delete_unparseable_file_still_moves(file_store):
+    from ormah.models.node import MemoryNode
+
+    node = MemoryNode(type=NodeType.fact, content="will be corrupted", title="Corrupt")
+    path = file_store.save(node)
+    path.write_text("::: not valid frontmatter :::", encoding="utf-8")
+
+    assert file_store.soft_delete(node.id) is True
+    deleted_dir = file_store.nodes_dir.parent / "deleted"
+    assert (deleted_dir / path.name).exists()
+
+
+def test_touch_access_does_not_advance_updated(file_store):
+    from ormah.models.node import MemoryNode
+
+    node = MemoryNode(type=NodeType.fact, content="access me", title="Accessed")
+    node.updated = PAST
+    file_store.save(node)
+
+    result = file_store.touch_access(node.id)
+    assert result.access_count == 1
+    assert _updated(file_store, node.id) == PAST
+
+
+# ---------------------------------------------------------------------------
+# Engine mutations
+# ---------------------------------------------------------------------------
+
+
+def test_connect_advances_source_updated(engine):
+    id_a = _create(engine, "Source", "Source node content.")
+    id_b = _create(engine, "Target", "Target node content.")
+    _backdate(engine.file_store, id_a)
+
+    engine.connect(ConnectRequest(source_id=id_a, target_id=id_b, edge=EdgeType.related_to))
+
+    assert _updated(engine.file_store, id_a) > PAST
+
+
+def test_update_node_advances_updated(engine):
+    from ormah.models.node import UpdateNodeRequest
+
+    node_id = _create(engine, "Editable", "Original content.")
+    _backdate(engine.file_store, node_id)
+
+    engine.update_node(node_id, UpdateNodeRequest(content="New content."))
+
+    assert _updated(engine.file_store, node_id) > PAST
+
+
+def test_mark_outdated_advances_updated(engine):
+    node_id = _create(engine, "Stale", "Old truth.")
+    _backdate(engine.file_store, node_id)
+
+    engine.mark_outdated(node_id, reason="superseded")
+
+    assert _updated(engine.file_store, node_id) > PAST
+
+
+def test_engine_access_tracking_does_not_advance_updated(engine):
+    node_id = _create(engine, "Read often", "Frequently accessed fact.")
+    _backdate(engine.file_store, node_id)
+
+    engine._touch_access(node_id)
+
+    node = engine.file_store.load(node_id)
+    assert node.updated == PAST
+    assert node.access_count == 1
+    assert node.last_review is not None
+
+
+def test_merge_stamps_kept_node_and_tombstone(engine):
+    id_short = _create(engine, "Short", "Brief.")
+    id_long = _create(engine, "Long", "Much longer content that wins the keep decision.")
+    _backdate(engine.file_store, id_short)
+    _backdate(engine.file_store, id_long)
+
+    engine.execute_merge(id_short, id_long)
+
+    # Kept node stamped
+    assert _updated(engine.file_store, id_long) > PAST
+    # Removed node's tombstone carries deleted_at
+    tombstone = _tombstone(engine.file_store, id_short)
+    assert tombstone.deleted_at is not None
+    assert tombstone.deleted_at > PAST
+
+
+def test_merge_neighbor_remap_advances_updated(engine):
+    id_removed = _create(engine, "Removed", "Brief.")
+    id_kept = _create(engine, "Kept", "Much longer content that wins the keep decision.")
+    id_neighbor = _create(engine, "Neighbor", "Points at the removed node.")
+    engine.connect(
+        ConnectRequest(source_id=id_neighbor, target_id=id_removed, edge=EdgeType.supports)
+    )
+    _backdate(engine.file_store, id_neighbor)
+
+    engine.execute_merge(id_removed, id_kept)
+
+    neighbor = engine.file_store.load(id_neighbor)
+    assert neighbor.updated > PAST
+    assert any(c.target == id_kept for c in neighbor.connections)
+
+
+def test_undo_merge_restored_node_outranks_tombstone(engine):
+    id_removed = _create(engine, "Removed", "Brief.")
+    id_kept = _create(engine, "Kept", "Much longer content that wins the keep decision.")
+    engine.execute_merge(id_removed, id_kept)
+    tombstone = _tombstone(engine.file_store, id_removed)
+
+    merge = engine.list_merges(limit=1)[0]
+    engine.undo_merge(merge["id"])
+
+    restored = engine.file_store.load(id_removed)
+    assert restored is not None
+    assert restored.deleted_at is None
+    # The live node must win the node-vs-tombstone rule (deleted_at >= updated)
+    assert restored.updated > tombstone.deleted_at
+
+
+def test_link_to_self_advances_self_node_updated(engine):
+    _backdate(engine.file_store, engine.user_node_id)
+
+    _create(engine, "About me", "I prefer dark roast coffee.", about_self=True)
+
+    assert _updated(engine.file_store, engine.user_node_id) > PAST
+
+
+def test_tier_change_advances_updated(engine):
+    from ormah.models.node import Tier
+
+    node_id = _create(engine, "Promotable", "Should move tiers.")
+    node = engine.file_store.load(node_id)
+    node.updated = PAST
+
+    assert engine.tier_manager.promote(node, Tier.core) is True
+    assert node.updated > PAST
+
+
+# ---------------------------------------------------------------------------
+# Background jobs
+# ---------------------------------------------------------------------------
+
+
+def test_importance_scorer_advances_updated(engine):
+    node_id = _create(engine, "Scored", "A node whose importance will change.")
+    _backdate(engine.file_store, node_id)
+    # Force a meaningful importance delta so the scorer rewrites the file
+    engine.db.conn.execute("UPDATE nodes SET importance = 0.0 WHERE id = ?", (node_id,))
+    engine.db.conn.commit()
+
+    from ormah.background.importance_scorer import run_importance_scoring
+
+    run_importance_scoring(engine)
+
+    node = engine.file_store.load(node_id)
+    assert node.importance > 0.0
+    assert node.updated > PAST
+
+
+def test_auto_linker_advances_updated(engine):
+    id_a = _create(engine, "Python language", "Python is a programming language.")
+    id_b = _create(engine, "Python lang", "Python is a popular programming language.")
+    _backdate(engine.file_store, id_a)
+    _backdate(engine.file_store, id_b)
+
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    _reset_adapter()
+    llm_response = json.dumps({"relationship": "supports", "reason": "Same topic."})
+
+    with patch(_LLM_PATCH, return_value=llm_response):
+        from ormah.background.auto_linker import run_auto_linker
+
+        run_auto_linker(engine)
+
+    stamped = [
+        nid
+        for nid in (id_a, id_b)
+        if engine.file_store.load(nid).connections and _updated(engine.file_store, nid) > PAST
+    ]
+    assert stamped, "the node that received the markdown connection must be stamped"
+
+
+def test_conflict_detector_advances_updated(engine):
+    id_a = _create(engine, "Use PostgreSQL", "We decided to use PostgreSQL for the database.")
+    id_b = _create(engine, "Use MySQL", "We decided to use MySQL for the database.")
+    _backdate(engine.file_store, id_a)
+    _backdate(engine.file_store, id_b)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    llm_response = json.dumps(
+        {"conflict": True, "same_subject": True, "type": "tension", "explanation": "Conflicting choices."}
+    )
+
+    with patch(_LLM_PATCH, return_value=llm_response):
+        from ormah.background.conflict_detector import run_conflict_detection
+
+        run_conflict_detection(engine)
+
+    stamped = [
+        nid
+        for nid in (id_a, id_b)
+        if engine.file_store.load(nid).connections and _updated(engine.file_store, nid) > PAST
+    ]
+    assert stamped, "the node that received the conflict edge must be stamped"
+
+
+def test_auto_cluster_advances_updated(engine):
+    id_anchor = _create(engine, "Anchor", "Node with a space.", space="projx")
+    id_floating = _create(engine, "Floating", "Node without a space.")
+    engine.connect(
+        ConnectRequest(source_id=id_anchor, target_id=id_floating, edge=EdgeType.related_to)
+    )
+    # Clear any space the engine assigned at creation, then backdate
+    engine.db.conn.execute("UPDATE nodes SET space = NULL WHERE id = ?", (id_floating,))
+    engine.db.conn.commit()
+    node = engine.file_store.load(id_floating)
+    node.space = None
+    node.updated = PAST
+    engine.file_store.save(node)
+
+    from ormah.background.auto_cluster import run_auto_cluster
+
+    run_auto_cluster(engine)
+
+    node = engine.file_store.load(id_floating)
+    assert node.space == "projx"
+    assert node.updated > PAST

--- a/tests/test_store/test_markdown.py
+++ b/tests/test_store/test_markdown.py
@@ -50,3 +50,27 @@ This is a simple fact."""
     assert node.content == "This is a simple fact."
     assert node.tier == Tier.working  # default
     assert node.connections == []
+    assert node.deleted_at is None  # legacy files without deleted_at parse fine
+
+
+def test_deleted_at_roundtrip():
+    from datetime import datetime, timezone
+
+    stamp = datetime(2026, 7, 12, 10, 30, 0, tzinfo=timezone.utc)
+    node = MemoryNode(
+        type=NodeType.fact,
+        source="agent:test",
+        content="Tombstoned fact.",
+        deleted_at=stamp,
+    )
+
+    text = serialize_node(node)
+    assert "deleted_at" in text
+    parsed = parse_node(text)
+    assert parsed.deleted_at == stamp
+
+
+def test_deleted_at_omitted_when_none():
+    node = MemoryNode(type=NodeType.fact, source="agent:test", content="Live fact.")
+    text = serialize_node(node)
+    assert "deleted_at" not in text


### PR DESCRIPTION
## What

**Sync v1 Step 0** — the merge-blocking prerequisite defined in E06/E08 §4.1 of the paid-tier plans. Sync's last-write-wins merge needs three invariants this PR establishes:

1. Every content mutation advances `updated` to `now(UTC)` before `file_store.save()` — via a new `MemoryNode.touch_updated()` helper (replaces the 5 hand-rolled datetime assignments too).
2. `soft_delete` stamps `deleted_at` into frontmatter **before** moving the file to `deleted/`, so tombstones carry their deletion time (node-vs-tombstone ordering uses `deleted_at`, never `updated`). Unparseable files fall back to the bare rename with a warning — deletion never crashes.
3. Read-side access metadata (`last_accessed`, `access_count`, FSRS `stability`/`last_review`) explicitly does **not** advance `updated` — reads must not cause sync conflicts.

## Save-site classification (all 22 `file_store.save()` call sites audited)

### Now stamped (was missing)
| Site | Mutation |
|---|---|
| `memory_engine.py` `connect()` | edge append (named explicitly in E08 §4.1) |
| `memory_engine.py` merge neighbor remap | connection retarget removed→kept |
| `memory_engine.py` merge kept-node cleanup | connection prune (only when it actually changes) |
| `memory_engine.py` `undo_merge()` | restore = new mutation event; also clears `deleted_at` so the live node outranks the stale tombstone left in `deleted/` |
| `memory_engine.py` `_link_to_self()` | defines-edge append on self node |
| `memory_engine.py` `_auto_link_node()` | auto-link connection appends on remember |
| `background/importance_scorer.py` | importance change (named in E08 §4.1) |
| `background/auto_linker.py` | edge append |
| `background/auto_cluster.py` | space reassignment |
| `background/consolidator.py` | about_self tag append |
| `background/conflict_detector.py` | contradicts/evolved_from edge append |

### Already stamped (now via `touch_updated()`)
`update_node`, `mark_outdated`, `execute_merge` kept node, `TierManager.promote/demote` (covers decay demotions, core-cap enforcement, consolidator demotions), and — per review — both `_migrate_identity_tiers` phases (the one-time completion flag means they never rerun, so an unstamped tier change could lose permanently to a stale remote under LWW).

### Deliberately NOT stamped
| Site | Why |
|---|---|
| `FileStore.touch_access`, `MemoryEngine._touch_access` | read-side metadata + FSRS review state — must not cause sync conflicts (guarded by tests) |
| `_migrate_fsrs` (one-time FSRS migration) | sets stability/last_review only — FSRS review-state metadata, same class as access tracking |
| new-node creation (`remember`, `_ensure_self_node`) | `updated` set by construction default |
| `undo_merge` snapshot restore | stamped (see above) — listed here for completeness since the snapshot's own timestamps are otherwise preserved |

Legacy files without `deleted_at`/`updated` need no backfill: the E06 merge treats missing stamps as epoch (always lose) and warns.

## Tests

- New `tests/test_engine/test_mutation_stamping.py` — 16 tests, one per stamped path plus negatives (access tracking never advances `updated`; tombstone keeps its old `updated`).
- `test_markdown.py`: `deleted_at` round-trip, omitted-when-None, legacy parse.
- Full suite: **1201 passed** (whisper pipeline suite untouched: 99 passed). `ruff` clean.
- Live smoke on a scratch store: `connect()` advanced `updated` on disk; deleted node's tombstone carries `deleted_at`. 

Known pre-existing failure (unrelated, also fails on clean main): `test_config.py::test_llm_provider_defaults_to_none` reads the developer's real `~/.config/ormah/.env` — test-isolation bug, filed separately.

Part of the Sync v1 effort (E06); ships alone before any merge/sync code per the plan.

