### PR TITLE
feat(cloud): encrypted snapshot engine (E02)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ ORMAH_PORT=8787
 # ORMAH_BACKUP_INTERVAL_HOURS=24
 # ORMAH_BACKUP_RETENTION_COUNT=10
 
+# Encrypted cloud backups (paid tier). Bundles are encrypted on your machine
+# with keys only you hold (see `ormah cloud init`); the service never sees
+# plaintext. Disabled until an account is configured.
+# ORMAH_CLOUD_BACKUP_ENABLED=false
+# ORMAH_CLOUD_API_URL=https://api.ormah.dev
+
 # Embeddings model
 ORMAH_EMBEDDING_MODEL=all-MiniLM-L6-v2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "websockets>=14.0",
     "python-slugify>=8.0.0",
     "pyyaml>=6.0.0",
+    "pyrage>=1.3.0",
 ]
 
 [project.optional-dependencies]
@@ -48,6 +49,7 @@ litellm = ["litellm>=1.0.0"]
 
 [dependency-groups]
 dev = [
+    "boto3>=1.43.46",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-httpx>=0.35.0",

--- a/scripts/cloud_spike.py
+++ b/scripts/cloud_spike.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""E02 round-trip spike: snapshot → encrypt → R2 → decrypt → verify → restore.
+
+Dev-only script (boto3 lives in the dev dependency group; it never enters the
+shipped package). Requires a dev R2 bucket:
+
+    export ORMAH_DEV_R2_ENDPOINT="https://<account-id>.r2.cloudflarestorage.com"
+    export ORMAH_DEV_R2_ACCESS_KEY_ID="..."
+    export ORMAH_DEV_R2_SECRET="..."
+    export ORMAH_DEV_R2_BUCKET="ormah-dev"
+
+    uv run python scripts/cloud_spike.py
+
+The transcript this prints is the founding-member demo: the object in the
+bucket is ciphertext, and the restored graph is byte-identical to the source.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+import boto3
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from ormah.backup import BackupService  # noqa: E402
+from ormah.cloud.bundle import open_bundle, build_bundle  # noqa: E402
+from ormah.cloud.crypto import AGE_HEADER, generate_identity, recipient_for  # noqa: E402
+from ormah.index.builder import IndexBuilder  # noqa: E402
+from ormah.index.db import Database  # noqa: E402
+from ormah.store.file_store import FileStore  # noqa: E402
+from ormah.models.node import MemoryNode, NodeType  # noqa: E402
+
+STEP = 0
+
+
+def step(msg: str) -> None:
+    global STEP
+    STEP += 1
+    print(f"\n[{STEP}] {msg}")
+
+
+def sha_map(root: Path) -> dict[str, str]:
+    return {
+        p.relative_to(root).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(root.rglob("*.md"))
+        if p.is_file()
+    }
+
+
+def main() -> int:
+    endpoint = os.environ.get("ORMAH_DEV_R2_ENDPOINT")
+    key_id = os.environ.get("ORMAH_DEV_R2_ACCESS_KEY_ID")
+    secret = os.environ.get("ORMAH_DEV_R2_SECRET")
+    bucket = os.environ.get("ORMAH_DEV_R2_BUCKET")
+    if not all([endpoint, key_id, secret, bucket]):
+        print("Missing ORMAH_DEV_R2_* env (ENDPOINT, ACCESS_KEY_ID, SECRET, BUCKET).")
+        return 1
+
+    work = Path(tempfile.mkdtemp(prefix="ormah-spike-"))
+    print(f"Ormah E02 encrypted round-trip spike — working dir {work}")
+
+    step("Create a scratch memory store with real nodes")
+    memory_dir = work / "memory"
+    store = FileStore(memory_dir / "nodes")
+    for i in range(5):
+        store.save(MemoryNode(
+            type=NodeType.fact,
+            title=f"Spike fact {i}",
+            content=f"Memory number {i} for the encrypted round-trip demo.",
+        ))
+    source_hashes = sha_map(memory_dir / "nodes")
+    print(f"    {len(source_hashes)} nodes written")
+
+    step("Local backup (BackupService.create)")
+    service = BackupService(memory_dir=memory_dir, backup_dir=work / "backups")
+    backup = service.create(reason="spike")
+    print(f"    backup: {backup.name} ({backup.node_count} nodes)")
+
+    step("Generate age identity and build encrypted bundle")
+    identity = generate_identity()
+    store_id = str(uuid.uuid4())
+    bundle_path = build_bundle(
+        backup.path, work / "spike.age", [recipient_for(identity)],
+        store_id=store_id, reason="spike",
+    )
+    print(f"    bundle: {bundle_path} ({bundle_path.stat().st_size} bytes, store {store_id[:8]}…)")
+
+    step("Presign PUT and upload with httpx (no boto3 in the client path)")
+    s3 = boto3.client(
+        "s3", endpoint_url=endpoint,
+        aws_access_key_id=key_id, aws_secret_access_key=secret,
+        region_name="auto",
+    )
+    object_key = f"spike/{store_id}/{bundle_path.name}"
+    put_url = s3.generate_presigned_url(
+        "put_object", Params={"Bucket": bucket, "Key": object_key}, ExpiresIn=900
+    )
+    response = httpx.put(put_url, content=bundle_path.read_bytes(), timeout=120)
+    response.raise_for_status()
+    print(f"    uploaded to r2://{bucket}/{object_key} (HTTP {response.status_code})")
+
+    step("Presign GET, download, and verify the bucket object is ciphertext")
+    get_url = s3.generate_presigned_url(
+        "get_object", Params={"Bucket": bucket, "Key": object_key}, ExpiresIn=900
+    )
+    downloaded = httpx.get(get_url, timeout=120).raise_for_status().content
+    assert downloaded == bundle_path.read_bytes(), "download differs from upload"
+    assert downloaded.startswith(AGE_HEADER), "object in bucket is not age ciphertext!"
+    assert b"Memory number" not in downloaded, "plaintext leaked into the bucket!"
+    print(f"    downloaded {len(downloaded)} bytes; starts with {AGE_HEADER!r}; no plaintext")
+
+    step("Decrypt + hash-verify + extract (open_bundle)")
+    bundle_copy = work / "downloaded.age"
+    bundle_copy.write_bytes(downloaded)
+    restored_snapshot = work / "restored-snapshot"
+    info = open_bundle(bundle_copy, restored_snapshot, [identity])
+    print(f"    manifest verified: {info.file_count} files, store {info.store_id[:8]}…, "
+          f"{info.node_count} nodes / {info.deleted_count} deleted")
+
+    step("Restore into a fresh memory dir and rebuild the index")
+    fresh_memory = work / "fresh-memory"
+    (fresh_memory / "nodes").mkdir(parents=True)
+    for sub in ("nodes", "deleted"):
+        src = restored_snapshot / sub
+        if src.is_dir():
+            dest = fresh_memory / sub
+            dest.mkdir(exist_ok=True)
+            for f in src.glob("*.md"):
+                (dest / f.name).write_bytes(f.read_bytes())
+    db = Database(fresh_memory / "index.db")
+    db.init_schema()
+    try:
+        rebuilt = IndexBuilder(db, FileStore(fresh_memory / "nodes")).full_rebuild()
+    finally:
+        db.close()
+    print(f"    index rebuilt: {rebuilt} nodes")
+
+    step("Assert counts and per-file hashes match the source exactly")
+    restored_hashes = sha_map(fresh_memory / "nodes")
+    assert rebuilt == len(source_hashes), f"node count mismatch: {rebuilt} != {len(source_hashes)}"
+    assert restored_hashes == source_hashes, "restored node hashes differ from source!"
+    print(f"    {len(restored_hashes)}/{len(source_hashes)} files byte-identical ✓")
+
+    step("Clean up the spike object from the bucket")
+    s3.delete_object(Bucket=bucket, Key=object_key)
+    print("    deleted")
+
+    print("\nSPIKE OK — snapshot → encrypt → R2 → download → decrypt → verify → restore ✓")
+    print("The bucket only ever held ciphertext; the keys never left this machine.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ormah/backup.py
+++ b/src/ormah/backup.py
@@ -177,6 +177,7 @@ class BackupService:
                     "index.db-shm",
                     "index.db-wal",
                     ".env",
+                    ".store_id",
                     "logs",
                     "model_cache",
                 ],

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -348,9 +348,11 @@ def _cmd_cloud_init(args):
     from ormah.cloud.keys import (
         KEY_PATH,
         CloudKeyError,
+        extract_store_id,
         get_or_create_store_id,
         import_key,
         init_key,
+        install_store_id,
         load_identity_strings,
         write_recovery_kit,
     )
@@ -359,6 +361,13 @@ def _cmd_cloud_init(args):
 
     try:
         if args.import_key:
+            # The kit's store id is the remote namespace — it must be
+            # installed too, or the restored machine would point at a brand
+            # new store and orphan every existing backup. Installed first so
+            # a store-id conflict aborts before any key material is written.
+            imported_store_id = extract_store_id(args.import_key)
+            if imported_store_id:
+                install_store_id(settings.memory_dir, imported_store_id)
             import_key(args.import_key)
         else:
             init_key()

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -362,11 +362,18 @@ def _cmd_cloud_init(args):
             import_key(args.import_key)
         else:
             init_key()
+    except (CloudKeyError, CloudCryptoError, OSError) as exc:
+        _print_backup_error(str(exc))
+
+    try:
         store_id = get_or_create_store_id(settings.memory_dir)
         kit_path = write_recovery_kit(store_id)
         identity_count = len(load_identity_strings())
     except (CloudKeyError, CloudCryptoError, OSError) as exc:
-        _print_backup_error(str(exc))
+        _print_backup_error(
+            f"Encryption key was written to {KEY_PATH}, but finishing setup failed: {exc}\n"
+            "Complete it with: ormah cloud kit"
+        )
 
     if args.json:
         print(json.dumps({
@@ -388,6 +395,37 @@ def _cmd_cloud_init(args):
         "Store the recovery kit somewhere safe and OFFLINE. Anyone with it can "
         "read your backups; without it, nobody can — including us."
     )
+
+
+def _cmd_cloud_kit(args):
+    """Regenerate the recovery kit from the existing key file (idempotent)."""
+    from ormah.cloud.crypto import CloudCryptoError
+    from ormah.cloud.keys import (
+        CloudKeyError,
+        get_or_create_store_id,
+        load_identity_strings,
+        write_recovery_kit,
+    )
+    from ormah.config import settings
+    from ormah.console import ok, warn
+
+    try:
+        store_id = get_or_create_store_id(settings.memory_dir)
+        kit_path = write_recovery_kit(store_id)
+        identity_count = len(load_identity_strings())
+    except (CloudKeyError, CloudCryptoError, OSError) as exc:
+        _print_backup_error(str(exc))
+
+    if args.json:
+        print(json.dumps({
+            "identity_count": identity_count,
+            "recovery_kit": str(kit_path),
+            "store_id": store_id,
+        }, indent=2, sort_keys=True))
+        return
+
+    ok(f"Recovery kit regenerated: {kit_path} ({identity_count} identities)")
+    warn("Replace any stored copies of the old kit with this one.")
 
 
 def _cmd_cloud_rotate_key(args):
@@ -413,11 +451,18 @@ def _cmd_cloud_rotate_key(args):
 
     try:
         rotate_key()
+    except (CloudKeyError, CloudCryptoError, OSError) as exc:
+        _print_backup_error(str(exc))
+
+    try:
         store_id = get_or_create_store_id(settings.memory_dir)
         kit_path = write_recovery_kit(store_id)
         identity_count = len(load_identity_strings())
     except (CloudKeyError, CloudCryptoError, OSError) as exc:
-        _print_backup_error(str(exc))
+        _print_backup_error(
+            f"Key was rotated, but recovery-kit regeneration failed: {exc}\n"
+            "Your stored kit is now MISSING the new key — run `ormah cloud kit` immediately."
+        )
 
     if args.json:
         print(json.dumps({
@@ -511,6 +556,10 @@ def main():
     cloud_rotate.add_argument("--yes", action="store_true", help="Skip interactive confirmation")
     cloud_rotate.add_argument("--json", action="store_true", help="Output result as JSON")
     cloud_rotate.set_defaults(func=_cmd_cloud_rotate_key)
+
+    cloud_kit = cloud_sub.add_parser("kit", help="Regenerate the recovery kit from the existing key")
+    cloud_kit.add_argument("--json", action="store_true", help="Output result as JSON")
+    cloud_kit.set_defaults(func=_cmd_cloud_kit)
 
     # --- setup ---
     setup_p = sub.add_parser("setup", help="One-shot setup (hooks, MCP, server)")

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -343,6 +343,96 @@ def _cmd_backup_restore(args):
         info(f"Rebuilt search index from {result.rebuilt_nodes} nodes")
 
 
+def _cmd_cloud_init(args):
+    from ormah.cloud.crypto import CloudCryptoError
+    from ormah.cloud.keys import (
+        KEY_PATH,
+        CloudKeyError,
+        get_or_create_store_id,
+        import_key,
+        init_key,
+        load_identity_strings,
+        write_recovery_kit,
+    )
+    from ormah.config import settings
+    from ormah.console import info, ok, warn
+
+    try:
+        if args.import_key:
+            import_key(args.import_key)
+        else:
+            init_key()
+        store_id = get_or_create_store_id(settings.memory_dir)
+        kit_path = write_recovery_kit(store_id)
+        identity_count = len(load_identity_strings())
+    except (CloudKeyError, CloudCryptoError, OSError) as exc:
+        _print_backup_error(str(exc))
+
+    if args.json:
+        print(json.dumps({
+            "key_path": str(KEY_PATH),
+            "identity_count": identity_count,
+            "imported": bool(args.import_key),
+            "store_id": store_id,
+            "recovery_kit": str(kit_path),
+        }, indent=2, sort_keys=True))
+        return
+
+    if args.import_key:
+        ok(f"Imported {identity_count} encryption identit{'y' if identity_count == 1 else 'ies'} to {KEY_PATH}")
+    else:
+        ok(f"Generated encryption key: {KEY_PATH}")
+    info(f"Store id: {store_id}")
+    ok(f"Recovery kit written: {kit_path}")
+    warn(
+        "Store the recovery kit somewhere safe and OFFLINE. Anyone with it can "
+        "read your backups; without it, nobody can — including us."
+    )
+
+
+def _cmd_cloud_rotate_key(args):
+    from ormah.cloud.crypto import CloudCryptoError
+    from ormah.cloud.keys import (
+        CloudKeyError,
+        get_or_create_store_id,
+        load_identity_strings,
+        rotate_key,
+        write_recovery_kit,
+    )
+    from ormah.config import settings
+    from ormah.console import info, ok, warn
+
+    if not args.yes:
+        if not sys.stdin.isatty():
+            _print_backup_error("Key rotation needs confirmation. Re-run with --yes in non-interactive shells.")
+        warn("Rotation generates a new encryption key. Old keys are retained so existing backups stay readable.")
+        answer = input("Rotate the cloud encryption key? (y/N) ").strip().lower()
+        if answer not in {"y", "yes"}:
+            info("Rotation cancelled")
+            return
+
+    try:
+        rotate_key()
+        store_id = get_or_create_store_id(settings.memory_dir)
+        kit_path = write_recovery_kit(store_id)
+        identity_count = len(load_identity_strings())
+    except (CloudKeyError, CloudCryptoError, OSError) as exc:
+        _print_backup_error(str(exc))
+
+    if args.json:
+        print(json.dumps({
+            "identity_count": identity_count,
+            "recovery_kit": str(kit_path),
+            "rotated": True,
+        }, indent=2, sort_keys=True))
+        return
+
+    ok("Rotated encryption key; new bundles use the new key.")
+    info(f"Identities on file: {identity_count} (all retained — older backups still decrypt)")
+    ok(f"Recovery kit regenerated: {kit_path}")
+    warn("Replace any stored copies of the old recovery kit with the new one.")
+
+
 def _cmd_mcp(args):
     from ormah.adapters.mcp_adapter import main as mcp_main
 
@@ -404,6 +494,23 @@ def main():
     backup_restore.add_argument("--yes", action="store_true", help="Skip interactive restore confirmation")
     backup_restore.add_argument("--no-rebuild", action="store_true", help="Skip search index rebuild")
     backup_restore.set_defaults(func=_cmd_backup_restore)
+
+    # --- cloud ---
+    cloud_p = sub.add_parser("cloud", help="Encrypted cloud backup keys and store identity")
+    cloud_sub = cloud_p.add_subparsers(dest="cloud_cmd", required=True)
+
+    cloud_init = cloud_sub.add_parser("init", help="Generate encryption key, store id, and recovery kit")
+    cloud_init.add_argument("--json", action="store_true", help="Output result as JSON")
+    cloud_init.add_argument(
+        "--import-key", metavar="PATH",
+        help="Install identities from a recovery kit or key file (fresh machine)",
+    )
+    cloud_init.set_defaults(func=_cmd_cloud_init)
+
+    cloud_rotate = cloud_sub.add_parser("rotate-key", help="Rotate the encryption key (old keys are retained)")
+    cloud_rotate.add_argument("--yes", action="store_true", help="Skip interactive confirmation")
+    cloud_rotate.add_argument("--json", action="store_true", help="Output result as JSON")
+    cloud_rotate.set_defaults(func=_cmd_cloud_rotate_key)
 
     # --- setup ---
     setup_p = sub.add_parser("setup", help="One-shot setup (hooks, MCP, server)")

--- a/src/ormah/cloud/__init__.py
+++ b/src/ormah/cloud/__init__.py
@@ -1,0 +1,6 @@
+"""Client-side cloud primitives: encryption, snapshot bundles, key lifecycle.
+
+Zero-knowledge by construction — keys are generated and kept on the user's
+machines only; everything uploaded is encrypted client-side. No service code
+lives here.
+"""

--- a/src/ormah/cloud/bundle.py
+++ b/src/ormah/cloud/bundle.py
@@ -14,8 +14,10 @@ import io
 import json
 import logging
 import os
+import shutil
 import tarfile
 import tempfile
+import unicodedata
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -150,40 +152,23 @@ def _add_member(tar: tarfile.TarFile, name: str, data: bytes) -> None:
     tar.addfile(info, io.BytesIO(data))
 
 
-def _member_allowed(name: str) -> bool:
-    """Strict allowlist: exactly nodes/*.md, deleted/*.md, and the two json files."""
-    if name in (BACKUP_MANIFEST_NAME, MANIFEST_NAME):
-        return True
-    for prefix in ("nodes/", "deleted/"):
-        if name.startswith(prefix):
-            rest = name[len(prefix):]
-            return bool(rest) and "/" not in rest and rest.endswith(".md")
-    return False
-
-
-def open_bundle(
-    bundle_path: Path,
-    dest_dir: Path,
-    identities: list,
+def _stream_members_to(
+    staging: Path,
+    plaintext: bytes,
     *,
-    max_members: int = MAX_MEMBERS,
-    max_expanded_bytes: int = MAX_EXPANDED_BYTES,
-) -> BundleInfo:
-    """Decrypt, safely extract, and hash-verify a bundle into dest_dir.
+    max_members: int,
+    max_expanded_bytes: int,
+) -> tuple[dict[str, str], dict[str, int]]:
+    """Validate and stream every tar member into the staging dir in chunks,
+    hashing while writing. Returns ({name: sha256}, {name: actual_size}).
 
-    Any manifest mismatch (hash, size, missing, or extra file) is a hard
-    failure. Members are validated against a strict allowlist and written
-    manually from ``extractfile`` bytes — tar metadata is never applied, which
-    is strictly stronger than ``filter="data"``.
+    The staging dir is freshly created by the caller, so there is nothing
+    pre-existing (symlinks included) for a write to follow. Limits are
+    enforced on actual streamed bytes, not tar-declared sizes.
     """
-    bundle_path = bundle_path.expanduser()
-    if not bundle_path.is_file():
-        raise BundleError(f"Bundle not found: {bundle_path}")
-
-    plaintext = decrypt_bytes(bundle_path.read_bytes(), identities)
-
-    extracted: dict[str, bytes] = {}
-    seen_casefold: set[str] = set()
+    hashes: dict[str, str] = {}
+    sizes: dict[str, int] = {}
+    seen_folded: set[str] = set()
     expanded = 0
     try:
         tar = tarfile.open(fileobj=io.BytesIO(plaintext), mode="r:gz")
@@ -202,57 +187,129 @@ def open_bundle(
                 raise BundleError(f"Bundle contains unsafe path: {name!r}")
             if not _member_allowed(name):
                 raise BundleError(f"Bundle contains disallowed member: {name!r}")
-            if name in extracted:
+            if name in hashes:
                 raise BundleError(f"Bundle contains duplicate member: {name!r}")
-            if name.casefold() in seen_casefold:
+            # Unicode-normalize before casefolding so canonically equivalent
+            # names (composed vs decomposed) also count as collisions.
+            folded = unicodedata.normalize("NFKC", name).casefold()
+            if folded in seen_folded:
                 raise BundleError(f"Bundle contains case-colliding member: {name!r}")
-            expanded += member.size
-            if expanded > max_expanded_bytes:
-                raise BundleError(
-                    f"Bundle exceeds expansion limit ({max_expanded_bytes} bytes)."
-                )
             fileobj = tar.extractfile(member)
             if fileobj is None:
                 raise BundleError(f"Bundle member unreadable: {name!r}")
-            extracted[name] = fileobj.read()
-            seen_casefold.add(name.casefold())
 
-    if MANIFEST_NAME not in extracted:
-        raise BundleError(f"Bundle is missing {MANIFEST_NAME}.")
-    try:
-        manifest = json.loads(extracted[MANIFEST_NAME].decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as e:
-        raise BundleError(f"Bundle manifest is not valid JSON: {e}") from e
-    if manifest.get("format_version") != BUNDLE_FORMAT_VERSION:
-        raise BundleError(
-            f"Unsupported bundle format_version: {manifest.get('format_version')!r}"
-        )
+            target = staging / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            digest = hashlib.sha256()
+            written = 0
+            with open(target, "wb") as out:
+                while chunk := fileobj.read(_STREAM_CHUNK):
+                    written += len(chunk)
+                    expanded += len(chunk)
+                    if expanded > max_expanded_bytes:
+                        raise BundleError(
+                            f"Bundle exceeds expansion limit ({max_expanded_bytes} bytes)."
+                        )
+                    digest.update(chunk)
+                    out.write(chunk)
+            hashes[name] = digest.hexdigest()
+            sizes[name] = written
+            seen_folded.add(folded)
+    return hashes, sizes
 
-    manifest_files = {entry["path"]: entry for entry in manifest.get("files", [])}
-    content_files = {n: d for n, d in extracted.items() if n != MANIFEST_NAME}
 
-    missing = sorted(set(manifest_files) - set(content_files))
-    extra = sorted(set(content_files) - set(manifest_files))
-    if missing:
-        raise BundleError(f"Bundle is missing manifest-listed files: {missing}")
-    if extra:
-        raise BundleError(f"Bundle contains files not in the manifest: {extra}")
+def _member_allowed(name: str) -> bool:
+    """Strict allowlist: exactly nodes/*.md, deleted/*.md, and the two json files."""
+    if name in (BACKUP_MANIFEST_NAME, MANIFEST_NAME):
+        return True
+    for prefix in ("nodes/", "deleted/"):
+        if name.startswith(prefix):
+            rest = name[len(prefix):]
+            return bool(rest) and "/" not in rest and rest.endswith(".md")
+    return False
 
-    for name, data in content_files.items():
-        entry = manifest_files[name]
-        if len(data) != entry["size"]:
-            raise BundleError(
-                f"Size mismatch for {name!r}: manifest {entry['size']}, got {len(data)}."
-            )
-        if _sha256(data) != entry["sha256"]:
-            raise BundleError(f"Hash mismatch for {name!r} — bundle is corrupt or tampered.")
+
+_STREAM_CHUNK = 1024 * 1024
+
+
+def open_bundle(
+    bundle_path: Path,
+    dest_dir: Path,
+    identities: list,
+    *,
+    max_members: int = MAX_MEMBERS,
+    max_expanded_bytes: int = MAX_EXPANDED_BYTES,
+) -> BundleInfo:
+    """Decrypt, safely extract, and hash-verify a bundle into dest_dir.
+
+    Any manifest mismatch (hash, size, missing, or extra file) is a hard
+    failure. Members are validated against a strict allowlist and streamed
+    into a fresh staging directory created by us — tar metadata is never
+    applied (strictly stronger than ``filter="data"``), nothing pre-existing
+    can be followed, and memory stays bounded regardless of expanded size.
+    dest_dir must not exist or must be empty; files land there only after
+    every hash has verified.
+    """
+    bundle_path = bundle_path.expanduser()
+    if not bundle_path.is_file():
+        raise BundleError(f"Bundle not found: {bundle_path}")
 
     dest_dir = dest_dir.expanduser()
-    for name, data in content_files.items():
-        target = dest_dir / name
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_bytes(data)
-    (dest_dir / MANIFEST_NAME).write_bytes(extracted[MANIFEST_NAME])
+    if dest_dir.exists():
+        if not dest_dir.is_dir() or any(dest_dir.iterdir()):
+            raise BundleError(
+                f"Destination {dest_dir} must be a new or empty directory."
+            )
+
+    plaintext = decrypt_bytes(bundle_path.read_bytes(), identities)
+
+    dest_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=".ormah_extract_", dir=str(dest_dir.parent)))
+    try:
+        hashes, sizes = _stream_members_to(
+            staging, plaintext, max_members=max_members,
+            max_expanded_bytes=max_expanded_bytes,
+        )
+
+        if MANIFEST_NAME not in hashes:
+            raise BundleError(f"Bundle is missing {MANIFEST_NAME}.")
+        try:
+            manifest = json.loads((staging / MANIFEST_NAME).read_text(encoding="utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            raise BundleError(f"Bundle manifest is not valid JSON: {e}") from e
+        if manifest.get("format_version") != BUNDLE_FORMAT_VERSION:
+            raise BundleError(
+                f"Unsupported bundle format_version: {manifest.get('format_version')!r}"
+            )
+
+        manifest_files = {entry["path"]: entry for entry in manifest.get("files", [])}
+        content_names = set(hashes) - {MANIFEST_NAME}
+
+        missing = sorted(set(manifest_files) - content_names)
+        extra = sorted(content_names - set(manifest_files))
+        if missing:
+            raise BundleError(f"Bundle is missing manifest-listed files: {missing}")
+        if extra:
+            raise BundleError(f"Bundle contains files not in the manifest: {extra}")
+
+        for name in content_names:
+            entry = manifest_files[name]
+            if sizes[name] != entry["size"]:
+                raise BundleError(
+                    f"Size mismatch for {name!r}: manifest {entry['size']}, got {sizes[name]}."
+                )
+            if hashes[name] != entry["sha256"]:
+                raise BundleError(
+                    f"Hash mismatch for {name!r} — bundle is corrupt or tampered."
+                )
+
+        # Everything verified — move staged files into the (empty) destination.
+        for name in sorted(hashes):
+            target = dest_dir / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(str(staging / name), str(target))
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
 
     sync = manifest.get("sync") or {}
     return BundleInfo(
@@ -262,7 +319,7 @@ def open_bundle(
         node_count=manifest.get("node_count", 0),
         deleted_count=manifest.get("deleted_count", 0),
         total_bytes=manifest.get("total_bytes", 0),
-        file_count=len(content_files),
+        file_count=len(content_names),
         sync_base_snapshot_id=sync.get("base_snapshot_id"),
         device_id=sync.get("device_id"),
     )

--- a/src/ormah/cloud/bundle.py
+++ b/src/ormah/cloud/bundle.py
@@ -1,0 +1,268 @@
+"""Encrypted snapshot bundles (E08 §2).
+
+A bundle is ``age-encrypt( gzip-tar( snapshot_dir ) )`` where the snapshot dir
+contains ``nodes/*.md``, ``deleted/*.md``, ``backup.json`` and a
+``bundle-manifest.json`` with per-file SHA-256 hashes. Opening a bundle always
+verifies every extracted file against the manifest — hash checking is not
+optional; restore and verification both consume it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import os
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ormah.cloud.crypto import decrypt_bytes, encrypt_bytes
+
+logger = logging.getLogger(__name__)
+
+BUNDLE_FORMAT_VERSION = 1
+MANIFEST_NAME = "bundle-manifest.json"
+BACKUP_MANIFEST_NAME = "backup.json"
+
+# Extraction hardening limits (E08 §2)
+MAX_MEMBERS = 100_000
+MAX_EXPANDED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB
+
+
+class BundleError(RuntimeError):
+    """Raised when building or opening a bundle fails."""
+
+
+@dataclass(frozen=True)
+class BundleInfo:
+    store_id: str
+    created_at: str
+    reason: str
+    node_count: int
+    deleted_count: int
+    total_bytes: int
+    file_count: int
+    sync_base_snapshot_id: str | None
+    device_id: str | None
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _iter_bundle_files(backup_dir: Path) -> list[Path]:
+    """Files that enter a bundle, as paths relative to backup_dir."""
+    files: list[Path] = []
+    for sub in ("nodes", "deleted"):
+        d = backup_dir / sub
+        if d.is_dir():
+            files.extend(sorted(p for p in d.glob("*.md") if p.is_file()))
+    backup_json = backup_dir / BACKUP_MANIFEST_NAME
+    if backup_json.is_file():
+        files.append(backup_json)
+    return files
+
+
+def build_bundle(
+    backup_dir: Path,
+    out_path: Path,
+    recipients: list,
+    *,
+    store_id: str,
+    reason: str = "manual",
+    sync_base_snapshot_id: str | None = None,
+    device_id: str | None = None,
+) -> Path:
+    """Build an encrypted bundle from a finished local backup directory.
+
+    Returns the written ``.age`` path. The write is atomic (tmp + rename).
+    """
+    backup_dir = backup_dir.expanduser()
+    if not backup_dir.is_dir():
+        raise BundleError(f"Backup directory not found: {backup_dir}")
+
+    files = _iter_bundle_files(backup_dir)
+    entries = []
+    node_count = deleted_count = total_bytes = 0
+    payloads: list[tuple[str, bytes]] = []
+    for path in files:
+        rel = path.relative_to(backup_dir).as_posix()
+        data = path.read_bytes()
+        entries.append({"path": rel, "size": len(data), "sha256": _sha256(data)})
+        payloads.append((rel, data))
+        total_bytes += len(data)
+        if rel.startswith("nodes/"):
+            node_count += 1
+        elif rel.startswith("deleted/"):
+            deleted_count += 1
+
+    manifest = {
+        "format_version": BUNDLE_FORMAT_VERSION,
+        "store_id": store_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "reason": reason,
+        "node_count": node_count,
+        "deleted_count": deleted_count,
+        "total_bytes": total_bytes,
+        "files": entries,
+        "sync": {"base_snapshot_id": sync_base_snapshot_id, "device_id": device_id},
+    }
+    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+    tar_buffer = io.BytesIO()
+    with tarfile.open(fileobj=tar_buffer, mode="w:gz") as tar:
+        for rel, data in payloads:
+            _add_member(tar, rel, data)
+        _add_member(tar, MANIFEST_NAME, manifest_bytes)
+
+    ciphertext = encrypt_bytes(tar_buffer.getvalue(), recipients)
+
+    out_path = out_path.expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(out_path.parent), suffix=".tmp", prefix=".ormah_bundle_")
+    try:
+        os.write(fd, ciphertext)
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp, str(out_path))
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return out_path
+
+
+def _add_member(tar: tarfile.TarFile, name: str, data: bytes) -> None:
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    info.mtime = 0  # deterministic archives; real times live in frontmatter
+    info.mode = 0o600
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _member_allowed(name: str) -> bool:
+    """Strict allowlist: exactly nodes/*.md, deleted/*.md, and the two json files."""
+    if name in (BACKUP_MANIFEST_NAME, MANIFEST_NAME):
+        return True
+    for prefix in ("nodes/", "deleted/"):
+        if name.startswith(prefix):
+            rest = name[len(prefix):]
+            return bool(rest) and "/" not in rest and rest.endswith(".md")
+    return False
+
+
+def open_bundle(
+    bundle_path: Path,
+    dest_dir: Path,
+    identities: list,
+    *,
+    max_members: int = MAX_MEMBERS,
+    max_expanded_bytes: int = MAX_EXPANDED_BYTES,
+) -> BundleInfo:
+    """Decrypt, safely extract, and hash-verify a bundle into dest_dir.
+
+    Any manifest mismatch (hash, size, missing, or extra file) is a hard
+    failure. Members are validated against a strict allowlist and written
+    manually from ``extractfile`` bytes — tar metadata is never applied, which
+    is strictly stronger than ``filter="data"``.
+    """
+    bundle_path = bundle_path.expanduser()
+    if not bundle_path.is_file():
+        raise BundleError(f"Bundle not found: {bundle_path}")
+
+    plaintext = decrypt_bytes(bundle_path.read_bytes(), identities)
+
+    extracted: dict[str, bytes] = {}
+    seen_casefold: set[str] = set()
+    expanded = 0
+    try:
+        tar = tarfile.open(fileobj=io.BytesIO(plaintext), mode="r:gz")
+    except tarfile.TarError as e:
+        raise BundleError(f"Bundle payload is not a valid tar.gz archive: {e}") from e
+    with tar:
+        members = 0
+        for member in tar:
+            members += 1
+            if members > max_members:
+                raise BundleError(f"Bundle exceeds member limit ({max_members}).")
+            name = member.name
+            if not member.isreg():
+                raise BundleError(f"Bundle contains non-regular member: {name!r}")
+            if name.startswith("/") or ".." in Path(name).parts or "\\" in name:
+                raise BundleError(f"Bundle contains unsafe path: {name!r}")
+            if not _member_allowed(name):
+                raise BundleError(f"Bundle contains disallowed member: {name!r}")
+            if name in extracted:
+                raise BundleError(f"Bundle contains duplicate member: {name!r}")
+            if name.casefold() in seen_casefold:
+                raise BundleError(f"Bundle contains case-colliding member: {name!r}")
+            expanded += member.size
+            if expanded > max_expanded_bytes:
+                raise BundleError(
+                    f"Bundle exceeds expansion limit ({max_expanded_bytes} bytes)."
+                )
+            fileobj = tar.extractfile(member)
+            if fileobj is None:
+                raise BundleError(f"Bundle member unreadable: {name!r}")
+            extracted[name] = fileobj.read()
+            seen_casefold.add(name.casefold())
+
+    if MANIFEST_NAME not in extracted:
+        raise BundleError(f"Bundle is missing {MANIFEST_NAME}.")
+    try:
+        manifest = json.loads(extracted[MANIFEST_NAME].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise BundleError(f"Bundle manifest is not valid JSON: {e}") from e
+    if manifest.get("format_version") != BUNDLE_FORMAT_VERSION:
+        raise BundleError(
+            f"Unsupported bundle format_version: {manifest.get('format_version')!r}"
+        )
+
+    manifest_files = {entry["path"]: entry for entry in manifest.get("files", [])}
+    content_files = {n: d for n, d in extracted.items() if n != MANIFEST_NAME}
+
+    missing = sorted(set(manifest_files) - set(content_files))
+    extra = sorted(set(content_files) - set(manifest_files))
+    if missing:
+        raise BundleError(f"Bundle is missing manifest-listed files: {missing}")
+    if extra:
+        raise BundleError(f"Bundle contains files not in the manifest: {extra}")
+
+    for name, data in content_files.items():
+        entry = manifest_files[name]
+        if len(data) != entry["size"]:
+            raise BundleError(
+                f"Size mismatch for {name!r}: manifest {entry['size']}, got {len(data)}."
+            )
+        if _sha256(data) != entry["sha256"]:
+            raise BundleError(f"Hash mismatch for {name!r} — bundle is corrupt or tampered.")
+
+    dest_dir = dest_dir.expanduser()
+    for name, data in content_files.items():
+        target = dest_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    (dest_dir / MANIFEST_NAME).write_bytes(extracted[MANIFEST_NAME])
+
+    sync = manifest.get("sync") or {}
+    return BundleInfo(
+        store_id=manifest.get("store_id", ""),
+        created_at=manifest.get("created_at", ""),
+        reason=manifest.get("reason", ""),
+        node_count=manifest.get("node_count", 0),
+        deleted_count=manifest.get("deleted_count", 0),
+        total_bytes=manifest.get("total_bytes", 0),
+        file_count=len(content_files),
+        sync_base_snapshot_id=sync.get("base_snapshot_id"),
+        device_id=sync.get("device_id"),
+    )

--- a/src/ormah/cloud/bundle.py
+++ b/src/ormah/cloud/bundle.py
@@ -33,6 +33,10 @@ BACKUP_MANIFEST_NAME = "backup.json"
 # Extraction hardening limits (E08 §2)
 MAX_MEMBERS = 100_000
 MAX_EXPANDED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GB
+# Accepted constraint: ciphertext + decrypted compressed tar are held in
+# memory (graphs are MBs; streaming decryption is not worth the complexity
+# yet), so the encrypted input itself is capped.
+MAX_BUNDLE_BYTES = 512 * 1024 * 1024  # 512 MB
 
 
 class BundleError(RuntimeError):
@@ -232,6 +236,19 @@ def _member_allowed(name: str) -> bool:
 _STREAM_CHUNK = 1024 * 1024
 
 
+def _check_dest(dest_dir: Path) -> None:
+    """The destination must be absent, or an empty real directory.
+
+    ``is_symlink`` uses lstat, so a symlink pointing at an (empty) directory
+    elsewhere is rejected rather than silently followed.
+    """
+    if dest_dir.is_symlink():
+        raise BundleError(f"Destination {dest_dir} is a symlink; refusing to follow it.")
+    if dest_dir.exists():
+        if not dest_dir.is_dir() or any(dest_dir.iterdir()):
+            raise BundleError(f"Destination {dest_dir} must be a new or empty directory.")
+
+
 def open_bundle(
     bundle_path: Path,
     dest_dir: Path,
@@ -239,6 +256,7 @@ def open_bundle(
     *,
     max_members: int = MAX_MEMBERS,
     max_expanded_bytes: int = MAX_EXPANDED_BYTES,
+    max_bundle_bytes: int = MAX_BUNDLE_BYTES,
 ) -> BundleInfo:
     """Decrypt, safely extract, and hash-verify a bundle into dest_dir.
 
@@ -253,13 +271,14 @@ def open_bundle(
     bundle_path = bundle_path.expanduser()
     if not bundle_path.is_file():
         raise BundleError(f"Bundle not found: {bundle_path}")
+    if bundle_path.stat().st_size > max_bundle_bytes:
+        raise BundleError(
+            f"Bundle exceeds size limit ({max_bundle_bytes} bytes); "
+            "refusing to load it into memory."
+        )
 
     dest_dir = dest_dir.expanduser()
-    if dest_dir.exists():
-        if not dest_dir.is_dir() or any(dest_dir.iterdir()):
-            raise BundleError(
-                f"Destination {dest_dir} must be a new or empty directory."
-            )
+    _check_dest(dest_dir)
 
     plaintext = decrypt_bytes(bundle_path.read_bytes(), identities)
 
@@ -304,6 +323,9 @@ def open_bundle(
                 )
 
         # Everything verified — move staged files into the (empty) destination.
+        # Re-check right before commit so a symlink swapped in after the
+        # initial validation cannot redirect the writes.
+        _check_dest(dest_dir)
         for name in sorted(hashes):
             target = dest_dir / name
             target.parent.mkdir(parents=True, exist_ok=True)

--- a/src/ormah/cloud/crypto.py
+++ b/src/ormah/cloud/crypto.py
@@ -1,0 +1,68 @@
+"""Thin wrappers around pyrage (age encryption) for snapshot bundles.
+
+All encryption happens in-process on bytes; never shell out to an `age`
+binary. Decryption always takes the full identity list (current + retained
+pre-rotation identities) so rotated stores stay decryptable.
+"""
+
+from __future__ import annotations
+
+import pyrage
+from pyrage import x25519
+
+
+class CloudCryptoError(RuntimeError):
+    """Raised when encryption or decryption fails."""
+
+
+# age binary-format header; used to verify uploaded objects are ciphertext.
+AGE_HEADER = b"age-encryption.org/v1"
+
+
+def generate_identity() -> x25519.Identity:
+    return x25519.Identity.generate()
+
+
+def identity_to_str(identity: x25519.Identity) -> str:
+    return str(identity)
+
+
+def identity_from_str(value: str) -> x25519.Identity:
+    try:
+        return x25519.Identity.from_str(value.strip())
+    except Exception as e:
+        raise CloudCryptoError(f"Invalid age identity: {e}") from e
+
+
+def recipient_from_str(value: str) -> x25519.Recipient:
+    try:
+        return x25519.Recipient.from_str(value.strip())
+    except Exception as e:
+        raise CloudCryptoError(f"Invalid age recipient: {e}") from e
+
+
+def recipient_for(identity: x25519.Identity) -> x25519.Recipient:
+    return identity.to_public()
+
+
+def encrypt_bytes(data: bytes, recipients: list[x25519.Recipient]) -> bytes:
+    if not recipients:
+        raise CloudCryptoError("No recipients to encrypt to.")
+    try:
+        return pyrage.encrypt(data, recipients)
+    except Exception as e:
+        raise CloudCryptoError(f"Encryption failed: {e}") from e
+
+
+def decrypt_bytes(data: bytes, identities: list[x25519.Identity]) -> bytes:
+    if not identities:
+        raise CloudCryptoError("No identities to decrypt with.")
+    try:
+        return pyrage.decrypt(data, identities)
+    except pyrage.DecryptError as e:
+        raise CloudCryptoError(
+            "Decryption failed: no matching key. If this bundle predates a key "
+            "rotation, make sure the full cloud.key (all identities) is present."
+        ) from e
+    except Exception as e:
+        raise CloudCryptoError(f"Decryption failed: {e}") from e

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -144,6 +144,19 @@ def rotate_key(key_path: Path | None = None) -> str:
 # --- store_id (E08 §1) ---
 
 
+def _validate_store_id(value: str) -> str:
+    """Strict store-id validator: RFC 4122 UUIDv4 only (E08 §1)."""
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError as e:
+        raise CloudKeyError(f"Invalid store id (not a UUID): {value!r}") from e
+    if parsed.version != 4 or parsed.variant != uuid.RFC_4122:
+        raise CloudKeyError(
+            f"Invalid store id (must be an RFC 4122 UUIDv4): {value!r}"
+        )
+    return str(parsed)
+
+
 def get_or_create_store_id(memory_dir: Path) -> str:
     """UUIDv4 per memory store, persisted at <memory_dir>/.store_id."""
     memory_dir = memory_dir.expanduser()
@@ -151,8 +164,8 @@ def get_or_create_store_id(memory_dir: Path) -> str:
     if store_path.is_file():
         value = store_path.read_text(encoding="utf-8").strip()
         try:
-            return str(uuid.UUID(value))
-        except ValueError as e:
+            return _validate_store_id(value)
+        except CloudKeyError as e:
             raise CloudKeyError(f"Corrupt store id at {store_path}: {value!r}") from e
     memory_dir.mkdir(parents=True, exist_ok=True)
     store_id = str(uuid.uuid4())
@@ -163,8 +176,10 @@ def get_or_create_store_id(memory_dir: Path) -> str:
 def extract_store_id(source: str) -> str | None:
     """Pull the store id out of recovery-kit material (path or raw text).
 
-    Looks for the ``store_id: <uuid>`` line the kit writes; returns None for
-    key material that carries no store id (e.g. a bare key file).
+    Fails closed: an explicit ``store_id:`` line that does not carry a valid
+    UUIDv4 raises — a damaged kit must abort the import, not silently mint a
+    new namespace. Returns None only when the material genuinely contains no
+    store identifier (e.g. a bare key file).
     """
     source_path = Path(source).expanduser()
     try:
@@ -176,17 +191,22 @@ def extract_store_id(source: str) -> str | None:
         if stripped.startswith("store_id:"):
             candidate = stripped.split(":", 1)[1].strip()
             try:
-                return str(uuid.UUID(candidate))
-            except ValueError:
-                continue
+                return _validate_store_id(candidate)
+            except CloudKeyError as e:
+                raise CloudKeyError(
+                    f"Recovery kit carries a malformed store id ({candidate!r}). "
+                    "Refusing to import — continuing would mint a new namespace "
+                    "and orphan the existing backups. Fix the kit's store_id line "
+                    "(or restore an undamaged copy of the kit) and retry."
+                ) from e
     # Older kits carried the store id as a bare UUID line.
     for line in text.splitlines():
         stripped = line.strip()
         if len(stripped) == 36:
             try:
-                return str(uuid.UUID(stripped))
-            except ValueError:
-                continue
+                return _validate_store_id(stripped)
+            except CloudKeyError:
+                continue  # arbitrary 36-char line, not a store id claim
     return None
 
 
@@ -197,7 +217,7 @@ def install_store_id(memory_dir: Path, store_id: str) -> str:
     a new one would orphan every existing backup. Fails if a *different* id
     is already installed; installing the same id is a no-op.
     """
-    store_id = str(uuid.UUID(store_id))  # validate
+    store_id = _validate_store_id(store_id)
     memory_dir = memory_dir.expanduser()
     store_path = memory_dir / STORE_ID_NAME
     if store_path.is_file():

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -1,0 +1,216 @@
+"""Key lifecycle, store identity, and the recovery kit (E08 §1, §5).
+
+The key file keeps every identity ever generated — the current one first,
+older ones retained below so pre-rotation bundles stay decryptable forever.
+Nothing here is ever destructive; there is no ``--force``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ormah.cloud.crypto import (
+    generate_identity,
+    identity_from_str,
+    identity_to_str,
+)
+
+logger = logging.getLogger(__name__)
+
+CONFIG_DIR = Path.home() / ".config" / "ormah"
+KEY_PATH = CONFIG_DIR / "cloud.key"
+RECOVERY_KIT_PATH = CONFIG_DIR / "ormah-recovery-kit.md"
+STORE_ID_NAME = ".store_id"
+
+
+class CloudKeyError(RuntimeError):
+    """Raised for key-file lifecycle failures."""
+
+
+def _atomic_write_0600(path: Path, text: str) -> None:
+    from ormah.setup import _atomic_write
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(str(path), text, mode=0o600)
+
+
+# --- Key file ---
+
+
+def key_file_exists(key_path: Path | None = None) -> bool:
+    key_path = KEY_PATH if key_path is None else key_path
+    return key_path.expanduser().is_file()
+
+
+def load_identity_strings(key_path: Path | None = None) -> list[str]:
+    """All identity strings in the key file, current first."""
+    key_path = (KEY_PATH if key_path is None else key_path).expanduser()
+    if not key_path.is_file():
+        raise CloudKeyError(
+            f"No cloud key found at {key_path}. Run `ormah cloud init` first."
+        )
+    strings = [
+        line.strip()
+        for line in key_path.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith("AGE-SECRET-KEY-")
+    ]
+    if not strings:
+        raise CloudKeyError(f"Cloud key file {key_path} contains no identities.")
+    return strings
+
+
+def load_identities(key_path: Path | None = None) -> list:
+    """All identities for decryption, current first."""
+    return [identity_from_str(s) for s in load_identity_strings(key_path)]
+
+
+def current_recipient(key_path: Path | None = None):
+    """The encryption recipient (public key of the current identity)."""
+    return load_identities(key_path)[0].to_public()
+
+
+def _serialize_key_file(identity_strings: list[str], rotated: bool) -> str:
+    """Current identity first; older identities retained below it."""
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        "# Ormah cloud encryption identities (age). KEEP THIS FILE SAFE.",
+        "# The first identity encrypts new bundles; all of them decrypt.",
+        "# Never delete old identities — older backups still need them.",
+        f"# current since {now}" + (" (rotation)" if rotated else ""),
+        identity_strings[0],
+    ]
+    for old in identity_strings[1:]:
+        lines.append("# retained pre-rotation identity")
+        lines.append(old)
+    return "\n".join(lines) + "\n"
+
+
+def init_key(key_path: Path | None = None) -> str:
+    """Generate the first identity. Refuses if a key file already exists."""
+    key_path = (KEY_PATH if key_path is None else key_path).expanduser()
+    if key_path.is_file():
+        raise CloudKeyError(
+            f"A cloud key already exists at {key_path}. "
+            "To get a new encryption key, run `ormah cloud rotate-key` — "
+            "it keeps old identities so existing backups stay readable."
+        )
+    identity_str = identity_to_str(generate_identity())
+    _atomic_write_0600(key_path, _serialize_key_file([identity_str], rotated=False))
+    return identity_str
+
+
+def import_key(source: str, key_path: Path | None = None) -> list[str]:
+    """Install identities from a recovery kit or key file (fresh machine).
+
+    Accepts a path or raw pasted text; extracts every AGE-SECRET-KEY line,
+    preserving order (current first). Refuses if a key file already exists.
+    """
+    key_path = (KEY_PATH if key_path is None else key_path).expanduser()
+    if key_path.is_file():
+        raise CloudKeyError(
+            f"A cloud key already exists at {key_path}; refusing to overwrite. "
+            "Move it aside first if you really mean to replace it."
+        )
+    source_path = Path(source).expanduser()
+    text = source_path.read_text(encoding="utf-8") if source_path.is_file() else source
+    strings = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip().startswith("AGE-SECRET-KEY-")
+    ]
+    if not strings:
+        raise CloudKeyError("No age identities found in the provided key material.")
+    for s in strings:  # validate before writing anything
+        identity_from_str(s)
+    _atomic_write_0600(key_path, _serialize_key_file(strings, rotated=False))
+    return strings
+
+
+def rotate_key(key_path: Path | None = None) -> str:
+    """Generate a new current identity, retaining all previous ones."""
+    key_path = KEY_PATH if key_path is None else key_path
+    existing = load_identity_strings(key_path)
+    new_identity = identity_to_str(generate_identity())
+    _atomic_write_0600(
+        key_path.expanduser(),
+        _serialize_key_file([new_identity, *existing], rotated=True),
+    )
+    return new_identity
+
+
+# --- store_id (E08 §1) ---
+
+
+def get_or_create_store_id(memory_dir: Path) -> str:
+    """UUIDv4 per memory store, persisted at <memory_dir>/.store_id."""
+    memory_dir = memory_dir.expanduser()
+    store_path = memory_dir / STORE_ID_NAME
+    if store_path.is_file():
+        value = store_path.read_text(encoding="utf-8").strip()
+        try:
+            return str(uuid.UUID(value))
+        except ValueError as e:
+            raise CloudKeyError(f"Corrupt store id at {store_path}: {value!r}") from e
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    store_id = str(uuid.uuid4())
+    store_path.write_text(store_id + "\n", encoding="utf-8")
+    return store_id
+
+
+# --- Recovery kit ---
+
+
+def write_recovery_kit(
+    store_id: str,
+    key_path: Path | None = None,
+    kit_path: Path | None = None,
+    account_email: str | None = None,
+) -> Path:
+    """(Re)generate the recovery kit with ALL identities.
+
+    The kit is the entire recovery story: anyone with this file can read the
+    backups; without it, nobody can — including us.
+    """
+    kit_path = RECOVERY_KIT_PATH if kit_path is None else kit_path
+    identity_strings = load_identity_strings(key_path)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    identities_block = "\n".join(identity_strings)
+    kit = f"""# Ormah Recovery Kit
+
+Generated: {now}
+
+> **Anyone with this file can read your backups; without it, nobody can —
+> including us. Store it offline** (print it, or keep it on a USB drive in a
+> drawer). Do not store it in the same cloud account it protects.
+
+## Your encryption identities (all of them — order matters, current first)
+
+```
+{identities_block}
+```
+
+## Your store id
+
+```
+{store_id}
+```
+
+## Account
+
+Email: {account_email or "<your ormah account email>"}
+
+## Restore on a fresh machine
+
+1. Install ormah, then log in:  `ormah account login`
+2. Import this kit's keys:      `ormah cloud init --import-key <path-to-this-file>`
+3. Restore your memory graph:   `ormah backup restore --cloud`
+
+That's the whole procedure. Every identity listed above is needed to read
+backups made before key rotations — never trim this list.
+"""
+    kit_path = kit_path.expanduser()
+    _atomic_write_0600(kit_path, kit)
+    return kit_path

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -160,6 +160,61 @@ def get_or_create_store_id(memory_dir: Path) -> str:
     return store_id
 
 
+def extract_store_id(source: str) -> str | None:
+    """Pull the store id out of recovery-kit material (path or raw text).
+
+    Looks for the ``store_id: <uuid>`` line the kit writes; returns None for
+    key material that carries no store id (e.g. a bare key file).
+    """
+    source_path = Path(source).expanduser()
+    try:
+        text = source_path.read_text(encoding="utf-8") if source_path.is_file() else source
+    except OSError:
+        text = source
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("store_id:"):
+            candidate = stripped.split(":", 1)[1].strip()
+            try:
+                return str(uuid.UUID(candidate))
+            except ValueError:
+                continue
+    # Older kits carried the store id as a bare UUID line.
+    for line in text.splitlines():
+        stripped = line.strip()
+        if len(stripped) == 36:
+            try:
+                return str(uuid.UUID(stripped))
+            except ValueError:
+                continue
+    return None
+
+
+def install_store_id(memory_dir: Path, store_id: str) -> str:
+    """Install a store id from a recovery kit on a fresh machine.
+
+    The store id is the remote namespace (E08 §1) — a restore that generates
+    a new one would orphan every existing backup. Fails if a *different* id
+    is already installed; installing the same id is a no-op.
+    """
+    store_id = str(uuid.UUID(store_id))  # validate
+    memory_dir = memory_dir.expanduser()
+    store_path = memory_dir / STORE_ID_NAME
+    if store_path.is_file():
+        existing = store_path.read_text(encoding="utf-8").strip()
+        if existing == store_id:
+            return store_id
+        raise CloudKeyError(
+            f"This memory store already has store id {existing}, but the recovery "
+            f"kit carries {store_id}. Refusing to overwrite — restoring into a "
+            "store that belongs to a different remote namespace would orphan its "
+            "backups. Use a fresh ORMAH_MEMORY_DIR or remove .store_id deliberately."
+        )
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(store_id + "\n", encoding="utf-8")
+    return store_id
+
+
 # --- Recovery kit ---
 
 
@@ -195,7 +250,7 @@ Generated: {now}
 ## Your store id
 
 ```
-{store_id}
+store_id: {store_id}
 ```
 
 ## Account

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -35,6 +35,11 @@ class Settings(BaseSettings):
     backup_interval_hours: int = 24
     backup_retention_count: int = 10
 
+    # Encrypted cloud backups (paid tier). Client-side keys; nothing readable
+    # ever leaves the machine. Off by default until an account is configured.
+    cloud_backup_enabled: bool = False
+    cloud_api_url: str = "https://api.ormah.dev"
+
     # Embeddings
     embedding_provider: str = "local"  # "local", "ollama", "litellm"
     embedding_model: str = "BAAI/bge-base-en-v1.5"

--- a/tests/test_cloud_bundle.py
+++ b/tests/test_cloud_bundle.py
@@ -347,3 +347,84 @@ def test_rejects_unknown_format_version(tmp_path, keypair):
     evil = _encrypted_tar(tmp_path, recipient, add)
     with pytest.raises(BundleError, match="format_version"):
         open_bundle(evil, tmp_path / "restored", [identity])
+
+
+# --- Review fixes (Codex review of PR #108) ---
+
+
+def test_rejects_nonempty_destination(tmp_path, backup_dir, keypair):
+    """A pre-populated destination (e.g. containing a planted symlink) is
+    refused outright — extraction only ever targets fresh directories."""
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+    victim = tmp_path / "victim.txt"
+    victim.write_text("do not touch")
+    dest = tmp_path / "restored"
+    (dest / "nodes").mkdir(parents=True)
+    (dest / "nodes" / "fact_alpha_abc123.md").symlink_to(victim)
+
+    with pytest.raises(BundleError, match="new or empty"):
+        open_bundle(bundle, dest, [identity])
+    assert victim.read_text() == "do not touch"
+
+
+def test_rejects_destination_that_is_a_file(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+    dest = tmp_path / "not-a-dir"
+    dest.write_text("occupied")
+    with pytest.raises(BundleError, match="new or empty"):
+        open_bundle(bundle, dest, [identity])
+
+
+def test_empty_existing_destination_is_fine(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+    dest = tmp_path / "restored"
+    dest.mkdir()
+    info = open_bundle(bundle, dest, [identity])
+    assert info.file_count == 4
+
+
+def test_rejects_unicode_normalization_collision(tmp_path, keypair):
+    """Composed vs decomposed forms of the same name must collide."""
+    identity, recipient = keypair
+    composed = "nodes/café_abc.md"          # é as single codepoint
+    decomposed = "nodes/café_abc.md"       # e + combining acute
+
+    def add(tar):
+        _reg(tar, composed, b"one")
+        _reg(tar, decomposed, b"two")
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="case-colliding"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_expansion_limit_enforced_on_actual_bytes(tmp_path, keypair):
+    """A member lying about its size cannot bypass the streamed-bytes cap."""
+    identity, recipient = keypair
+
+    def add(tar):
+        _reg(tar, "nodes/big_abc.md", b"a" * 2048)
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="expansion limit"):
+        open_bundle(evil, tmp_path / "restored", [identity], max_expanded_bytes=1024)
+
+
+def test_failed_open_leaves_no_staging_debris(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+    tampered = _rebuild_tampered(
+        bundle, identity, recipient, lambda m: m.pop("nodes/fact_beta_def456.md")
+    )
+    dest = tmp_path / "cleanup-check" / "restored"
+    with pytest.raises(BundleError):
+        open_bundle(tampered, dest, [identity])
+    parent = dest.parent
+    leftovers = [p for p in parent.iterdir() if p.name.startswith(".ormah_extract_")]
+    assert leftovers == []
+    assert not dest.exists() or not any(dest.iterdir())

--- a/tests/test_cloud_bundle.py
+++ b/tests/test_cloud_bundle.py
@@ -1,0 +1,349 @@
+"""Tests for encrypted snapshot bundles: round-trip, tamper detection,
+and the malicious-tar hardening suite."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import tarfile
+
+import pytest
+
+from ormah.cloud.bundle import (
+    MANIFEST_NAME,
+    BundleError,
+    build_bundle,
+    open_bundle,
+)
+from ormah.cloud.crypto import (
+    decrypt_bytes,
+    encrypt_bytes,
+    generate_identity,
+    recipient_for,
+)
+
+STORE_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def keypair():
+    identity = generate_identity()
+    return identity, recipient_for(identity)
+
+
+@pytest.fixture
+def backup_dir(tmp_path):
+    """A minimal finished local backup: nodes/, deleted/, backup.json."""
+    d = tmp_path / "memory_2026-07-12_12-00-00"
+    (d / "nodes").mkdir(parents=True)
+    (d / "deleted").mkdir()
+    (d / "nodes" / "fact_alpha_abc123.md").write_text(
+        "---\nid: abc123\ntype: fact\n---\nAlpha content.\n"
+    )
+    (d / "nodes" / "fact_beta_def456.md").write_text(
+        "---\nid: def456\ntype: fact\n---\nBeta content.\n"
+    )
+    (d / "deleted" / "fact_gone_9f9f9f.md").write_text(
+        "---\nid: 9f9f9f\ntype: fact\ndeleted_at: '2026-07-12T10:00:00Z'\n---\nGone.\n"
+    )
+    (d / "backup.json").write_text(json.dumps({"version": 1, "reason": "test"}) + "\n")
+    return d
+
+
+def _dir_hashes(root):
+    return {
+        p.relative_to(root).as_posix(): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(root.rglob("*"))
+        if p.is_file()
+    }
+
+
+# --- Round trip ---
+
+
+def test_roundtrip_byte_identical(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(
+        backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID, reason="test"
+    )
+    assert bundle.read_bytes().startswith(b"age-encryption.org/v1")
+
+    dest = tmp_path / "restored"
+    info = open_bundle(bundle, dest, [identity])
+
+    source = _dir_hashes(backup_dir)
+    restored = _dir_hashes(dest)
+    restored.pop(MANIFEST_NAME)  # manifest is bundle-only, not part of the backup
+    assert restored == source
+
+    assert info.store_id == STORE_ID
+    assert info.reason == "test"
+    assert info.node_count == 2
+    assert info.deleted_count == 1
+    assert info.file_count == 4
+    assert info.sync_base_snapshot_id is None
+    assert info.device_id is None
+
+
+def test_sync_fields_carried(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(
+        backup_dir,
+        tmp_path / "out.age",
+        [recipient],
+        store_id=STORE_ID,
+        sync_base_snapshot_id="01J0SNAPSHOT",
+        device_id="dev-42",
+    )
+    info = open_bundle(bundle, tmp_path / "restored", [identity])
+    assert info.sync_base_snapshot_id == "01J0SNAPSHOT"
+    assert info.device_id == "dev-42"
+
+
+def test_missing_backup_dir(tmp_path, keypair):
+    _, recipient = keypair
+    with pytest.raises(BundleError, match="not found"):
+        build_bundle(tmp_path / "nope", tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+
+# --- Tamper detection ---
+
+
+def _rebuild_tampered(bundle_path, identity, recipient, mutate):
+    """Decrypt a bundle, let `mutate` alter the member dict, re-encrypt."""
+    plaintext = decrypt_bytes(bundle_path.read_bytes(), [identity])
+    members: dict[str, bytes] = {}
+    with tarfile.open(fileobj=io.BytesIO(plaintext), mode="r:gz") as tar:
+        for member in tar:
+            members[member.name] = tar.extractfile(member).read()
+
+    mutate(members)
+
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        for name, data in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    tampered = bundle_path.parent / "tampered.age"
+    tampered.write_bytes(encrypt_bytes(buffer.getvalue(), [recipient]))
+    return tampered
+
+
+def test_flipped_byte_fails_loudly(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+    def flip(members):
+        name = "nodes/fact_alpha_abc123.md"
+        data = bytearray(members[name])
+        data[-2] ^= 0xFF
+        members[name] = bytes(data)
+
+    tampered = _rebuild_tampered(bundle, identity, recipient, flip)
+    with pytest.raises(BundleError, match="Hash mismatch"):
+        open_bundle(tampered, tmp_path / "restored", [identity])
+
+
+def test_missing_file_fails(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+    tampered = _rebuild_tampered(
+        bundle, identity, recipient, lambda m: m.pop("nodes/fact_beta_def456.md")
+    )
+    with pytest.raises(BundleError, match="missing manifest-listed"):
+        open_bundle(tampered, tmp_path / "restored", [identity])
+
+
+def test_extra_file_fails(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+    tampered = _rebuild_tampered(
+        bundle,
+        identity,
+        recipient,
+        lambda m: m.__setitem__("nodes/smuggled_ffffff.md", b"not in manifest"),
+    )
+    with pytest.raises(BundleError, match="not in the manifest"):
+        open_bundle(tampered, tmp_path / "restored", [identity])
+
+
+def test_missing_manifest_fails(tmp_path, backup_dir, keypair):
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+    tampered = _rebuild_tampered(bundle, identity, recipient, lambda m: m.pop(MANIFEST_NAME))
+    with pytest.raises(BundleError, match=f"missing {MANIFEST_NAME}"):
+        open_bundle(tampered, tmp_path / "restored", [identity])
+
+
+def test_wrong_identity_fails_cleanly(tmp_path, backup_dir, keypair):
+    from ormah.cloud.crypto import CloudCryptoError
+
+    _, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+    with pytest.raises(CloudCryptoError, match="no matching key"):
+        open_bundle(bundle, tmp_path / "restored", [generate_identity()])
+
+
+# --- Malicious tar suite ---
+
+
+def _encrypted_tar(tmp_path, recipient, add_members):
+    """Build an encrypted tar from scratch via `add_members(tar)`."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        add_members(tar)
+    path = tmp_path / "evil.age"
+    path.write_bytes(encrypt_bytes(buffer.getvalue(), [recipient]))
+    return path
+
+
+def _reg(tar, name, data=b"x"):
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "../escape.md",
+        "nodes/../../escape.md",
+        "/etc/passwd",
+        "nodes/sub/dir.md",  # nesting not allowed
+        "nodes/not-markdown.txt",
+        "secrets.json",  # not in the allowlist
+    ],
+)
+def test_rejects_unsafe_or_disallowed_paths(tmp_path, keypair, name):
+    identity, recipient = keypair
+    evil = _encrypted_tar(tmp_path, recipient, lambda tar: _reg(tar, name))
+    with pytest.raises(BundleError, match="unsafe path|disallowed member"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_rejects_symlink(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        info = tarfile.TarInfo(name="nodes/link_abc.md")
+        info.type = tarfile.SYMTYPE
+        info.linkname = "/etc/passwd"
+        tar.addfile(info)
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="non-regular"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_rejects_hardlink(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        info = tarfile.TarInfo(name="nodes/hard_abc.md")
+        info.type = tarfile.LNKTYPE
+        info.linkname = "backup.json"
+        tar.addfile(info)
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="non-regular"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_rejects_device_node(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        info = tarfile.TarInfo(name="nodes/dev_abc.md")
+        info.type = tarfile.CHRTYPE
+        info.devmajor, info.devminor = 1, 3
+        tar.addfile(info)
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="non-regular"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_rejects_directory_member(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        info = tarfile.TarInfo(name="nodes/")
+        info.type = tarfile.DIRTYPE
+        tar.addfile(info)
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="non-regular"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_rejects_duplicate_names(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        _reg(tar, "nodes/dup_abc.md", b"first")
+        _reg(tar, "nodes/dup_abc.md", b"second")
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="duplicate member"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_rejects_case_colliding_names(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        _reg(tar, "nodes/case_abc.md", b"lower")
+        _reg(tar, "nodes/CASE_abc.md", b"upper")
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="case-colliding"):
+        open_bundle(evil, tmp_path / "restored", [identity])
+
+
+def test_rejects_too_many_members(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        for i in range(5):
+            _reg(tar, f"nodes/n{i}_aaaa.md")
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="member limit"):
+        open_bundle(evil, tmp_path / "restored", [identity], max_members=3)
+
+
+def test_rejects_oversized_expansion(tmp_path, keypair):
+    identity, recipient = keypair
+
+    def add(tar):
+        _reg(tar, "nodes/big_abc.md", b"a" * 1024)
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="expansion limit"):
+        open_bundle(evil, tmp_path / "restored", [identity], max_expanded_bytes=512)
+
+
+def test_rejects_non_tar_payload(tmp_path, keypair):
+    identity, recipient = keypair
+    garbage = tmp_path / "garbage.age"
+    garbage.write_bytes(encrypt_bytes(b"this is not a tar archive", [recipient]))
+    with pytest.raises(BundleError, match="not a valid tar.gz"):
+        open_bundle(garbage, tmp_path / "restored", [identity])
+
+
+def test_rejects_unknown_format_version(tmp_path, keypair):
+    identity, recipient = keypair
+
+    manifest = json.dumps({"format_version": 99, "files": []}).encode()
+
+    def add(tar):
+        _reg(tar, MANIFEST_NAME, manifest)
+
+    evil = _encrypted_tar(tmp_path, recipient, add)
+    with pytest.raises(BundleError, match="format_version"):
+        open_bundle(evil, tmp_path / "restored", [identity])

--- a/tests/test_cloud_bundle.py
+++ b/tests/test_cloud_bundle.py
@@ -428,3 +428,26 @@ def test_failed_open_leaves_no_staging_debris(tmp_path, backup_dir, keypair):
     leftovers = [p for p in parent.iterdir() if p.name.startswith(".ormah_extract_")]
     assert leftovers == []
     assert not dest.exists() or not any(dest.iterdir())
+
+
+def test_rejects_symlinked_destination(tmp_path, backup_dir, keypair):
+    """An empty dir behind a symlink must be rejected, not followed."""
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+
+    real_target = tmp_path / "elsewhere"
+    real_target.mkdir()
+    dest = tmp_path / "restored"
+    dest.symlink_to(real_target)
+
+    with pytest.raises(BundleError, match="symlink"):
+        open_bundle(bundle, dest, [identity])
+    assert not any(real_target.iterdir())
+
+
+def test_rejects_oversized_encrypted_bundle(tmp_path, backup_dir, keypair):
+    """The encrypted input itself is capped before being read into memory."""
+    identity, recipient = keypair
+    bundle = build_bundle(backup_dir, tmp_path / "out.age", [recipient], store_id=STORE_ID)
+    with pytest.raises(BundleError, match="size limit"):
+        open_bundle(bundle, tmp_path / "restored", [identity], max_bundle_bytes=64)

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -123,3 +123,40 @@ def test_cloud_kit_without_key_fails(cloud_paths, capsys):
     with pytest.raises(SystemExit):
         _run(["cloud", "kit", "--json"])
     assert "cloud init" in capsys.readouterr().err
+
+
+def test_import_key_preserves_store_id(cloud_paths, tmp_path, capsys):
+    """Fresh-machine import must adopt the kit's store id, not mint a new one
+    — the store id is the remote namespace for all existing backups."""
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    original_store_id = json.loads(capsys.readouterr().out)["store_id"]
+    kit_copy = tmp_path / "kit-copy.md"
+    kit_copy.write_text(kit_path.read_text())
+
+    # Fresh machine: no key, no store id
+    key_path.rename(key_path.with_suffix(".bak"))
+    (memory_dir / ".store_id").unlink()
+
+    _run(["cloud", "init", "--import-key", str(kit_copy), "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["store_id"] == original_store_id
+    assert (memory_dir / ".store_id").read_text().strip() == original_store_id
+
+
+def test_import_key_refuses_store_id_conflict(cloud_paths, tmp_path, capsys):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    kit_copy = tmp_path / "kit-copy.md"
+    kit_copy.write_text(kit_path.read_text())
+
+    key_path.rename(key_path.with_suffix(".bak"))
+    (memory_dir / ".store_id").write_text("99999999-8888-7777-6666-555555555555\n")
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(kit_copy)])
+    err = capsys.readouterr().err
+    assert "orphan" in err
+    # Key material untouched by the aborted import
+    assert not key_path.exists()

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -1,0 +1,101 @@
+"""CLI tests for the `ormah cloud` group."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from ormah import cli
+from ormah.cloud import keys as cloud_keys
+
+
+@pytest.fixture
+def cloud_paths(tmp_path, monkeypatch):
+    """Point every cloud path at tmp and return the key path."""
+    key_path = tmp_path / "config" / "cloud.key"
+    kit_path = tmp_path / "config" / "ormah-recovery-kit.md"
+    memory_dir = tmp_path / "memory"
+    monkeypatch.setattr(cloud_keys, "KEY_PATH", key_path)
+    monkeypatch.setattr(cloud_keys, "RECOVERY_KIT_PATH", kit_path)
+    from ormah.config import settings
+
+    monkeypatch.setattr(settings, "memory_dir", memory_dir)
+    return key_path, kit_path, memory_dir
+
+
+def _run(argv):
+    with patch("sys.argv", ["ormah", *argv]):
+        cli.main()
+
+
+def test_cloud_init_json(cloud_paths, capsys):
+    key_path, kit_path, memory_dir = cloud_paths
+
+    _run(["cloud", "init", "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["key_path"] == str(key_path)
+    assert out["identity_count"] == 1
+    assert out["imported"] is False
+    assert out["recovery_kit"] == str(kit_path)
+    assert key_path.is_file()
+    assert kit_path.is_file()
+    assert (memory_dir / ".store_id").is_file()
+    assert out["store_id"] == (memory_dir / ".store_id").read_text().strip()
+
+
+def test_cloud_init_refuses_second_run(cloud_paths, capsys):
+    _run(["cloud", "init", "--json"])
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--json"])
+    assert "rotate-key" in capsys.readouterr().err
+
+
+def test_cloud_init_import_key(cloud_paths, tmp_path, capsys):
+    key_path, kit_path, _ = cloud_paths
+    _run(["cloud", "init", "--json"])
+    original = cloud_keys.load_identity_strings(key_path)
+    kit_copy = tmp_path / "kit-copy.md"
+    kit_copy.write_text(kit_path.read_text())
+
+    # fresh machine: move real key aside
+    key_path.rename(key_path.with_suffix(".bak"))
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", str(kit_copy), "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert out["imported"] is True
+    assert cloud_keys.load_identity_strings(key_path) == original
+
+
+def test_cloud_rotate_key_json(cloud_paths, capsys):
+    key_path, kit_path, _ = cloud_paths
+    _run(["cloud", "init", "--json"])
+    first = cloud_keys.load_identity_strings(key_path)
+    capsys.readouterr()
+
+    _run(["cloud", "rotate-key", "--yes", "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["rotated"] is True
+    assert out["identity_count"] == 2
+    strings = cloud_keys.load_identity_strings(key_path)
+    assert strings[1:] == first  # old identity retained
+    assert strings[0] in kit_path.read_text()  # kit regenerated with new key
+
+
+def test_cloud_rotate_key_requires_confirmation_non_tty(cloud_paths, capsys, monkeypatch):
+    _run(["cloud", "init", "--json"])
+    capsys.readouterr()
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    with pytest.raises(SystemExit):
+        _run(["cloud", "rotate-key"])
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_cloud_rotate_key_without_init_fails(cloud_paths, capsys):
+    with pytest.raises(SystemExit):
+        _run(["cloud", "rotate-key", "--yes"])
+    assert "cloud init" in capsys.readouterr().err

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -160,3 +160,24 @@ def test_import_key_refuses_store_id_conflict(cloud_paths, tmp_path, capsys):
     assert "orphan" in err
     # Key material untouched by the aborted import
     assert not key_path.exists()
+
+
+def test_import_key_aborts_on_damaged_kit_store_id(cloud_paths, tmp_path, capsys):
+    """A damaged store_id line must abort the whole import before any key
+    material is written — never silently mint a new namespace."""
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    damaged = tmp_path / "damaged-kit.md"
+    damaged.write_text(kit_path.read_text().replace(
+        "store_id: ", "store_id: corrupted-"
+    ))
+    key_path.rename(key_path.with_suffix(".bak"))
+    (memory_dir / ".store_id").unlink()
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(damaged)])
+
+    assert "malformed store id" in capsys.readouterr().err
+    assert not key_path.exists()  # no key material written
+    assert not (memory_dir / ".store_id").exists()  # no new namespace minted

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -99,3 +99,27 @@ def test_cloud_rotate_key_without_init_fails(cloud_paths, capsys):
     with pytest.raises(SystemExit):
         _run(["cloud", "rotate-key", "--yes"])
     assert "cloud init" in capsys.readouterr().err
+
+
+def test_cloud_kit_regenerates_after_loss(cloud_paths, capsys):
+    """`ormah cloud kit` is the recovery path when init/rotate is interrupted
+    between key commit and kit generation."""
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    kit_path.unlink()  # simulate the stranded state
+    capsys.readouterr()
+
+    _run(["cloud", "kit", "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["recovery_kit"] == str(kit_path)
+    assert out["identity_count"] == 1
+    assert kit_path.is_file()
+    current = cloud_keys.load_identity_strings(key_path)[0]
+    assert current in kit_path.read_text()
+
+
+def test_cloud_kit_without_key_fails(cloud_paths, capsys):
+    with pytest.raises(SystemExit):
+        _run(["cloud", "kit", "--json"])
+    assert "cloud init" in capsys.readouterr().err

--- a/tests/test_cloud_crypto.py
+++ b/tests/test_cloud_crypto.py
@@ -1,0 +1,80 @@
+"""Tests for age encryption wrappers."""
+
+from __future__ import annotations
+
+import pytest
+
+from ormah.cloud.crypto import (
+    AGE_HEADER,
+    CloudCryptoError,
+    decrypt_bytes,
+    encrypt_bytes,
+    generate_identity,
+    identity_from_str,
+    identity_to_str,
+    recipient_for,
+    recipient_from_str,
+)
+
+
+def test_roundtrip():
+    identity = generate_identity()
+    ciphertext = encrypt_bytes(b"secret memory graph", [recipient_for(identity)])
+
+    assert ciphertext.startswith(AGE_HEADER)
+    assert b"secret memory graph" not in ciphertext
+    assert decrypt_bytes(ciphertext, [identity]) == b"secret memory graph"
+
+
+def test_identity_string_roundtrip():
+    identity = generate_identity()
+    s = identity_to_str(identity)
+    assert s.startswith("AGE-SECRET-KEY-")
+
+    restored = identity_from_str(s)
+    ciphertext = encrypt_bytes(b"data", [recipient_for(identity)])
+    assert decrypt_bytes(ciphertext, [restored]) == b"data"
+
+
+def test_recipient_string_roundtrip():
+    identity = generate_identity()
+    recipient = recipient_from_str(str(recipient_for(identity)))
+    ciphertext = encrypt_bytes(b"data", [recipient])
+    assert decrypt_bytes(ciphertext, [identity]) == b"data"
+
+
+def test_wrong_identity_clean_error():
+    identity = generate_identity()
+    stranger = generate_identity()
+    ciphertext = encrypt_bytes(b"data", [recipient_for(identity)])
+
+    with pytest.raises(CloudCryptoError, match="no matching key"):
+        decrypt_bytes(ciphertext, [stranger])
+
+
+def test_multi_identity_decrypt_after_rotation():
+    """Bundles encrypted pre-rotation must decrypt with the full identity list."""
+    old_identity = generate_identity()
+    old_bundle = encrypt_bytes(b"pre-rotation data", [recipient_for(old_identity)])
+
+    new_identity = generate_identity()  # rotation: new current, old retained
+    identities = [new_identity, old_identity]
+
+    assert decrypt_bytes(old_bundle, identities) == b"pre-rotation data"
+
+    new_bundle = encrypt_bytes(b"post-rotation data", [recipient_for(new_identity)])
+    assert decrypt_bytes(new_bundle, identities) == b"post-rotation data"
+
+
+def test_invalid_strings_raise():
+    with pytest.raises(CloudCryptoError, match="identity"):
+        identity_from_str("not-a-key")
+    with pytest.raises(CloudCryptoError, match="recipient"):
+        recipient_from_str("not-a-recipient")
+
+
+def test_empty_lists_raise():
+    with pytest.raises(CloudCryptoError):
+        encrypt_bytes(b"data", [])
+    with pytest.raises(CloudCryptoError):
+        decrypt_bytes(b"data", [])

--- a/tests/test_cloud_keys.py
+++ b/tests/test_cloud_keys.py
@@ -194,15 +194,15 @@ def test_extract_store_id_from_kit(tmp_path, key_path):
     init_key(key_path)
     from ormah.cloud.keys import extract_store_id
 
-    kit = write_recovery_kit("33333333-4444-5555-6666-777777777777", key_path, tmp_path / "kit.md")
-    assert extract_store_id(str(kit)) == "33333333-4444-5555-6666-777777777777"
+    kit = write_recovery_kit("33333333-4444-4555-8666-777777777777", key_path, tmp_path / "kit.md")
+    assert extract_store_id(str(kit)) == "33333333-4444-4555-8666-777777777777"
 
 
 def test_extract_store_id_legacy_bare_uuid(tmp_path):
     from ormah.cloud.keys import extract_store_id
 
-    legacy = "## Your store id\n\n```\n44444444-5555-6666-7777-888888888888\n```\n"
-    assert extract_store_id(legacy) == "44444444-5555-6666-7777-888888888888"
+    legacy = "## Your store id\n\n```\n44444444-5555-4666-8777-888888888888\n```\n"
+    assert extract_store_id(legacy) == "44444444-5555-4666-8777-888888888888"
 
 
 def test_extract_store_id_absent(tmp_path):
@@ -215,7 +215,7 @@ def test_install_store_id_fresh_and_idempotent(tmp_path):
     from ormah.cloud.keys import install_store_id
 
     memory_dir = tmp_path / "memory"
-    sid = "55555555-6666-7777-8888-999999999999"
+    sid = "55555555-6666-4777-8888-999999999999"
     assert install_store_id(memory_dir, sid) == sid
     assert (memory_dir / ".store_id").read_text().strip() == sid
     assert install_store_id(memory_dir, sid) == sid  # same id: no-op
@@ -225,6 +225,30 @@ def test_install_store_id_refuses_mismatch(tmp_path):
     from ormah.cloud.keys import install_store_id
 
     memory_dir = tmp_path / "memory"
-    install_store_id(memory_dir, "55555555-6666-7777-8888-999999999999")
+    install_store_id(memory_dir, "55555555-6666-4777-8888-999999999999")
     with pytest.raises(CloudKeyError, match="orphan"):
-        install_store_id(memory_dir, "66666666-7777-8888-9999-aaaaaaaaaaaa")
+        install_store_id(memory_dir, "66666666-7777-4888-9999-aaaaaaaaaaaa")
+
+
+def test_extract_store_id_fails_closed_on_malformed(tmp_path):
+    """A kit whose store_id line is damaged must abort, not fall through to
+    minting a fresh namespace."""
+    from ormah.cloud.keys import extract_store_id
+
+    with pytest.raises(CloudKeyError, match="malformed store id"):
+        extract_store_id("store_id: not-a-uuid-at-all")
+
+
+def test_extract_store_id_fails_closed_on_non_v4(tmp_path):
+    from ormah.cloud.keys import extract_store_id
+
+    # Valid UUID, wrong version (v7) — E08 requires UUIDv4
+    with pytest.raises(CloudKeyError, match="malformed store id"):
+        extract_store_id("store_id: 018f4b2c-7a00-7000-8000-000000000000")
+
+
+def test_install_store_id_rejects_non_v4(tmp_path):
+    from ormah.cloud.keys import install_store_id
+
+    with pytest.raises(CloudKeyError, match="UUIDv4"):
+        install_store_id(tmp_path / "memory", "018f4b2c-7a00-7000-8000-000000000000")

--- a/tests/test_cloud_keys.py
+++ b/tests/test_cloud_keys.py
@@ -1,0 +1,187 @@
+"""Tests for cloud key lifecycle, store_id, and the recovery kit."""
+
+from __future__ import annotations
+
+import stat
+import uuid
+
+import pytest
+
+from ormah.cloud.bundle import build_bundle, open_bundle
+from ormah.cloud.crypto import encrypt_bytes, decrypt_bytes
+from ormah.cloud.keys import (
+    CloudKeyError,
+    current_recipient,
+    get_or_create_store_id,
+    import_key,
+    init_key,
+    key_file_exists,
+    load_identities,
+    load_identity_strings,
+    rotate_key,
+    write_recovery_kit,
+)
+
+
+@pytest.fixture
+def key_path(tmp_path):
+    return tmp_path / "config" / "cloud.key"
+
+
+# --- init ---
+
+
+def test_init_creates_key_with_0600(key_path):
+    identity_str = init_key(key_path)
+    assert identity_str.startswith("AGE-SECRET-KEY-")
+    assert key_file_exists(key_path)
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert load_identity_strings(key_path) == [identity_str]
+
+
+def test_init_refuses_overwrite_and_names_rotate_key(key_path):
+    init_key(key_path)
+    with pytest.raises(CloudKeyError, match="rotate-key"):
+        init_key(key_path)
+
+
+# --- rotation ---
+
+
+def test_rotate_retains_old_identities_and_old_bundles_decrypt(key_path):
+    init_key(key_path)
+    old_recipient = current_recipient(key_path)
+    old_bundle = encrypt_bytes(b"pre-rotation", [old_recipient])
+
+    new_str = rotate_key(key_path)
+
+    strings = load_identity_strings(key_path)
+    assert strings[0] == new_str
+    assert len(strings) == 2
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+    # Pre-rotation data decrypts with the full identity list
+    assert decrypt_bytes(old_bundle, load_identities(key_path)) == b"pre-rotation"
+    # New encryptions use the new current identity
+    new_bundle = encrypt_bytes(b"post-rotation", [current_recipient(key_path)])
+    assert decrypt_bytes(new_bundle, load_identities(key_path)) == b"post-rotation"
+
+
+def test_double_rotation_keeps_all_three(key_path):
+    first = init_key(key_path)
+    second = rotate_key(key_path)
+    third = rotate_key(key_path)
+    assert load_identity_strings(key_path) == [third, second, first]
+
+
+def test_rotate_without_key_fails(key_path):
+    with pytest.raises(CloudKeyError, match="cloud init"):
+        rotate_key(key_path)
+
+
+# --- import ---
+
+
+def test_import_key_roundtrip_from_kit(tmp_path, key_path):
+    init_key(key_path)
+    rotate_key(key_path)
+    originals = load_identity_strings(key_path)
+    kit = write_recovery_kit("store-1", key_path, tmp_path / "kit.md")
+
+    fresh_key_path = tmp_path / "fresh" / "cloud.key"
+    imported = import_key(str(kit), fresh_key_path)
+
+    assert imported == originals
+    assert load_identity_strings(fresh_key_path) == originals
+    assert stat.S_IMODE(fresh_key_path.stat().st_mode) == 0o600
+
+
+def test_import_key_from_pasted_text(tmp_path, key_path):
+    original = init_key(key_path)
+    fresh = tmp_path / "fresh.key"
+    assert import_key(f"junk\n{original}\nmore junk", fresh) == [original]
+
+
+def test_import_refuses_existing_key(tmp_path, key_path):
+    init_key(key_path)
+    with pytest.raises(CloudKeyError, match="refusing to overwrite"):
+        import_key("AGE-SECRET-KEY-1WHATEVER", key_path)
+
+
+def test_import_rejects_material_without_identities(tmp_path):
+    with pytest.raises(CloudKeyError, match="No age identities"):
+        import_key("nothing to see here", tmp_path / "fresh.key")
+
+
+def test_import_validates_before_writing(tmp_path):
+    fresh = tmp_path / "fresh.key"
+    with pytest.raises(Exception):
+        import_key("AGE-SECRET-KEY-1NOTREAL", fresh)
+    assert not fresh.exists()
+
+
+# --- store_id ---
+
+
+def test_store_id_created_and_stable(tmp_path):
+    memory_dir = tmp_path / "memory"
+    first = get_or_create_store_id(memory_dir)
+    assert uuid.UUID(first)
+    assert (memory_dir / ".store_id").read_text().strip() == first
+    assert get_or_create_store_id(memory_dir) == first
+
+
+def test_store_id_corrupt_raises(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / ".store_id").write_text("not-a-uuid\n")
+    with pytest.raises(CloudKeyError, match="Corrupt store id"):
+        get_or_create_store_id(memory_dir)
+
+
+# --- recovery kit ---
+
+
+def test_recovery_kit_contains_everything_and_no_passphrase(tmp_path, key_path):
+    init_key(key_path)
+    rotate_key(key_path)
+    strings = load_identity_strings(key_path)
+
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-5555-666666666666", key_path, tmp_path / "kit.md",
+        account_email="rishi@example.com",
+    )
+
+    text = kit_path.read_text()
+    for s in strings:
+        assert s in text
+    assert "22222222-3333-4444-5555-666666666666" in text
+    assert "rishi@example.com" in text
+    assert "ormah cloud init --import-key" in text
+    assert "ormah backup restore --cloud" in text
+    assert "including us" in text
+    assert "passphrase" not in text.lower()
+    assert stat.S_IMODE(kit_path.stat().st_mode) == 0o600
+
+
+def test_kit_keys_open_real_bundle(tmp_path, key_path):
+    """End-to-end: a bundle encrypted to the current key opens with identities
+    re-imported from the recovery kit on a 'fresh machine'."""
+    init_key(key_path)
+    store_id = get_or_create_store_id(tmp_path / "memory")
+
+    backup = tmp_path / "backup"
+    (backup / "nodes").mkdir(parents=True)
+    (backup / "nodes" / "fact_x_aaa111.md").write_text("---\nid: aaa111\n---\nX.\n")
+
+    bundle = build_bundle(
+        backup, tmp_path / "b.age", [current_recipient(key_path)], store_id=store_id
+    )
+
+    kit = write_recovery_kit(store_id, key_path, tmp_path / "kit.md")
+    fresh_key = tmp_path / "fresh" / "cloud.key"
+    import_key(str(kit), fresh_key)
+
+    info = open_bundle(bundle, tmp_path / "restored", load_identities(fresh_key))
+    assert info.store_id == store_id
+    assert (tmp_path / "restored" / "nodes" / "fact_x_aaa111.md").read_text().endswith("X.\n")

--- a/tests/test_cloud_keys.py
+++ b/tests/test_cloud_keys.py
@@ -185,3 +185,46 @@ def test_kit_keys_open_real_bundle(tmp_path, key_path):
     info = open_bundle(bundle, tmp_path / "restored", load_identities(fresh_key))
     assert info.store_id == store_id
     assert (tmp_path / "restored" / "nodes" / "fact_x_aaa111.md").read_text().endswith("X.\n")
+
+
+# --- store_id preservation on import (Codex re-review) ---
+
+
+def test_extract_store_id_from_kit(tmp_path, key_path):
+    init_key(key_path)
+    from ormah.cloud.keys import extract_store_id
+
+    kit = write_recovery_kit("33333333-4444-5555-6666-777777777777", key_path, tmp_path / "kit.md")
+    assert extract_store_id(str(kit)) == "33333333-4444-5555-6666-777777777777"
+
+
+def test_extract_store_id_legacy_bare_uuid(tmp_path):
+    from ormah.cloud.keys import extract_store_id
+
+    legacy = "## Your store id\n\n```\n44444444-5555-6666-7777-888888888888\n```\n"
+    assert extract_store_id(legacy) == "44444444-5555-6666-7777-888888888888"
+
+
+def test_extract_store_id_absent(tmp_path):
+    from ormah.cloud.keys import extract_store_id
+
+    assert extract_store_id("AGE-SECRET-KEY-1FOO\nno uuid here") is None
+
+
+def test_install_store_id_fresh_and_idempotent(tmp_path):
+    from ormah.cloud.keys import install_store_id
+
+    memory_dir = tmp_path / "memory"
+    sid = "55555555-6666-7777-8888-999999999999"
+    assert install_store_id(memory_dir, sid) == sid
+    assert (memory_dir / ".store_id").read_text().strip() == sid
+    assert install_store_id(memory_dir, sid) == sid  # same id: no-op
+
+
+def test_install_store_id_refuses_mismatch(tmp_path):
+    from ormah.cloud.keys import install_store_id
+
+    memory_dir = tmp_path / "memory"
+    install_store_id(memory_dir, "55555555-6666-7777-8888-999999999999")
+    with pytest.raises(CloudKeyError, match="orphan"):
+        install_store_id(memory_dir, "66666666-7777-8888-9999-aaaaaaaaaaaa")


### PR DESCRIPTION
## What

**E02 — Encrypted Snapshot Engine**, the zero-knowledge trust core of the paid tier (per E08 §1/§2/§5). Turns a local backup into an encrypted, uploadable, restorable blob with client-side keys.

New `src/ormah/cloud/` package:

- **`crypto.py`** — pyrage (age) wrappers: `encrypt_bytes`/`decrypt_bytes` over recipient/identity lists. Decryption always takes **all** known identities so bundles from before a key rotation stay readable forever.
- **`bundle.py`** — `build_bundle` produces `age( gzip-tar( snapshot ) )` with a `bundle-manifest.json` carrying per-file `{path, size, sha256}` plus sync fields (nullable until E06). `open_bundle` decrypts and extracts through a strict allowlist (`nodes/*.md`, `deleted/*.md`, `backup.json`, manifest only; regular files only; ≤100k members; ≤2GB expanded; duplicate + case-collision rejection) and **hard-fails on any hash/size mismatch, missing, or extra file**. Extraction writes bytes manually from `extractfile()` — tar metadata is never applied, which is strictly stronger than `filter="data"` (noted deviation from E08 §2 wording; also sidesteps the 3.11.0–3.11.3 data_filter availability question).
- **`keys.py`** — `~/.config/ormah/cloud.key` (0600 via the existing `_atomic_write` primitive): every identity ever generated, current first. `store_id` (UUIDv4) at `<memory_dir>/.store_id`. Recovery kit regeneration with all identities, restore instructions, and the "without it, nobody can — including us" warning (no passphrase exists or is mentioned). Rotation is non-destructive; **no `--force` exists**.

CLI: `ormah cloud init [--json] [--import-key PATH]` (refuses re-init, names `rotate-key`) and `ormah cloud rotate-key [--yes] [--json]`, mirroring the backup group's lazy-import/`--json`/confirmation patterns. Config: `cloud_backup_enabled` (default false), `cloud_api_url`; documented in `.env.example`. `.store_id` added to the backup manifest's excluded list.

Deps: `pyrage` (runtime), `boto3` (dev group only — `grep -rn boto3 src/` is empty; the dev-only `scripts/cloud_spike.py` is the sole consumer).

## Non-goals honored (E02 contract)

No service code, no scheduler job, no `--cloud` restore UX, no passphrase anywhere, no change to local backup behavior.

## Verification

- **1234 tests pass** (51 new), ruff clean, whisper pipeline suite untouched.
- Tamper suite: flipped byte / missing file / extra file / missing manifest / unknown format_version all fail loudly; malicious tars (traversal, absolute paths, symlink, hardlink, device node, directory member, duplicates, case collisions, member/expansion limits, non-tar payload) all rejected.
- Key lifecycle: 0600 asserted; init-refuses-overwrite; rotation retains old identities and **pre-rotation bundles still decrypt**; `--import-key` round-trip from a real recovery kit opens a real bundle.
- **Live spike against a real dev R2 bucket passed** (transcript below): the bucket only ever held ciphertext; counts and per-file hashes matched byte-identically after restore; spike object cleaned up.

```
[1] Create a scratch memory store with real nodes         5 nodes written
[2] Local backup (BackupService.create)                   memory_2026-07-12_18-46-12 (5 nodes)
[3] Generate age identity and build encrypted bundle      spike.age (1580 bytes)
[4] Presign PUT and upload with httpx                     HTTP 200
[5] Download; verify object is ciphertext                 starts with age header; no plaintext
[6] Decrypt + hash-verify + extract (open_bundle)         manifest verified: 6 files
[7] Restore into fresh memory dir; rebuild index          5 nodes
[8] Counts and per-file hashes match source               5/5 byte-identical ✓
[9] Clean up spike object                                 deleted
SPIKE OK
```

Also live on the dev machine: `ormah cloud init --json` created key/kit/store_id (0600), re-init refused, live `rotate-key` + post-rotation decryption of pre-rotation data.

## Related

- Filed #107: `ormah uninstall` deletes `~/.config/ormah`, which would destroy `cloud.key` — needs a guard before E05 ships.
- Part of the Sync v1/paid-tier chain: #105 (Step 0 mutation stamping) → **this** → E03 service → E04 accounts → E05 cloud backup → E06 sync.