### PR TITLE
feat(cloud): add client account integration (E04)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ ORMAH_PORT=8787
 # plaintext. Disabled until an account is configured.
 # ORMAH_CLOUD_BACKUP_ENABLED=false
 # ORMAH_CLOUD_API_URL=https://api.ormah.dev
+# Managed by `ormah account login`; do not commit real values.
+# ORMAH_ACCOUNT_EMAIL=
+# ORMAH_ACCOUNT_TOKEN=
 
 # Embeddings model
 ORMAH_EMBEDDING_MODEL=all-MiniLM-L6-v2

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ Ormah can create timestamped local backups of the source-of-truth memory files a
 
 Read more: [Configuration Reference](https://www.ormah.me/docs/operations/configuration-reference)
 
+### Cloud Account
+
+Sign in with an emailed one-time code using `ormah account login`. Use
+`ormah account status` to inspect the cached paid-tier entitlement and
+`ormah account logout` to revoke this device token and remove local account
+credentials. Cloud entitlement checks tolerate temporary outages; they never
+gate local backups or cloud downloads.
+
 ### Agent-Agnostic Surfaces
 
 Ormah is not tied to a single agent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-httpx>=0.35.0",
+    "respx>=0.22.0",
     "ruff>=0.8.0",
 ]
 litellm = ["litellm>=1.0.0"]
@@ -53,6 +54,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-httpx>=0.35.0",
+    "respx>=0.22.0",
     "ruff>=0.8.0",
 ]
 

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -8,6 +8,9 @@ Usage:
     ormah setup             One-shot setup (hooks, MCP, server)
     ormah backup create     Create a local memory backup
     ormah backup restore    Restore a local memory backup
+    ormah account login     Sign in to Ormah Cloud
+    ormah account status    Show cached account entitlement status
+    ormah account logout    Revoke this device token and sign out
     ormah claude-md install Install shared Ormah guidance into CLAUDE.md
     ormah pi-md install     Install shared Ormah guidance into Pi AGENTS.md
     ormah uninstall         Remove all ormah integrations and data
@@ -230,6 +233,133 @@ def _backup_service():
     from ormah.config import settings
 
     return service_from_settings(settings)
+
+
+def _cloud_client():
+    from ormah.cloud.client import client_from_settings
+    from ormah.config import settings
+
+    return client_from_settings(settings)
+
+
+def _print_account_error(message: str) -> None:
+    from ormah.console import fail
+
+    fail(message)
+    sys.exit(1)
+
+
+def _format_cache_age(seconds: int | None) -> str:
+    if seconds is None:
+        return "none"
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _cmd_account_login(args):
+    from ormah.cloud.client import (
+        CloudError,
+        get_device_name,
+        get_or_create_device_id,
+        persist_account_credentials,
+    )
+    from ormah.cloud.entitlements import refresh_entitlements, status_from_cache
+    from ormah.config import settings
+    from ormah.console import info, ok, warn
+
+    email = (args.email or input("Email: ")).strip().lower()
+    if not email:
+        _print_account_error("Email is required.")
+
+    client = None
+    try:
+        client = _cloud_client()
+        client.request_code(email)
+        info(f"Sign-in code requested for {email}")
+        code = (args.code or input("Sign-in code: ")).strip()
+        device_id = get_or_create_device_id()
+        device_name = get_device_name()
+        token = client.verify_code(email, code, device_id, device_name)
+        persist_account_credentials(token, email)
+        try:
+            cache = refresh_entitlements(settings, client=client)
+        except Exception:
+            cache = None
+    except (CloudError, OSError) as exc:
+        _print_account_error(str(exc))
+    finally:
+        close = getattr(client, "close", None) if client is not None else None
+        if close:
+            close()
+
+    ok(f"Signed in as {email}")
+    if cache is None:
+        warn("Entitlement status is unavailable while offline; it will refresh later.")
+        return
+    print(f"Plan status: {cache.plan_status or 'unknown'}")
+    print(f"Cloud backup entitlement: {status_from_cache(cache).value}")
+
+
+def _cmd_account_status(args):
+    from ormah.cloud.client import get_device_name
+    from ormah.cloud.entitlements import check_entitlement, load_entitlement_cache
+    from ormah.config import settings
+
+    state = check_entitlement(settings)
+    cache = load_entitlement_cache()
+    age_seconds = int(cache.age().total_seconds()) if cache is not None else None
+    result = {
+        "cache_age_seconds": age_seconds,
+        "device_name": get_device_name(),
+        "email": settings.account_email,
+        "entitlement": state.value,
+        "plan_status": cache.plan_status if cache is not None else None,
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return
+
+    print(f"Account: {settings.account_email or 'not signed in'}")
+    print(f"Entitlement: {state.value}")
+    print(f"Plan status: {result['plan_status'] or 'unknown'}")
+    print(f"Cache age: {_format_cache_age(age_seconds)}")
+    print(f"Device: {result['device_name']}")
+
+
+def _cmd_account_logout(args):
+    from ormah.cloud.client import remove_account_credentials
+    from ormah.cloud.entitlements import clear_entitlement_cache
+    from ormah.config import settings
+    from ormah.console import info, ok, warn
+
+    if not args.yes:
+        if not sys.stdin.isatty():
+            _print_account_error("Logout needs confirmation. Re-run with --yes in non-interactive shells.")
+        answer = input("Revoke this device token and sign out? (y/N) ").strip().lower()
+        if answer not in {"y", "yes"}:
+            info("Logout cancelled")
+            return
+
+    if settings.account_token:
+        client = None
+        try:
+            client = _cloud_client()
+            client.revoke_token()
+        except Exception as exc:
+            warn(f"Could not revoke the server token while offline: {exc}")
+        finally:
+            close = getattr(client, "close", None) if client is not None else None
+            if close:
+                close()
+
+    remove_account_credentials()
+    clear_entitlement_cache()
+    ok("Signed out locally")
 
 
 def _print_backup_error(message: str) -> None:
@@ -555,6 +685,23 @@ def main():
     backup_restore.add_argument("--yes", action="store_true", help="Skip interactive restore confirmation")
     backup_restore.add_argument("--no-rebuild", action="store_true", help="Skip search index rebuild")
     backup_restore.set_defaults(func=_cmd_backup_restore)
+
+    # --- account ---
+    account_p = sub.add_parser("account", help="Manage the Ormah Cloud account")
+    account_sub = account_p.add_subparsers(dest="account_cmd", required=True)
+
+    account_login = account_sub.add_parser("login", help="Sign in with an emailed one-time code")
+    account_login.add_argument("--email", help="Account email (otherwise prompted)")
+    account_login.add_argument("--code", help="One-time code (otherwise prompted)")
+    account_login.set_defaults(func=_cmd_account_login)
+
+    account_status = account_sub.add_parser("status", help="Show account and entitlement status")
+    account_status.add_argument("--json", action="store_true", help="Output status as JSON")
+    account_status.set_defaults(func=_cmd_account_status)
+
+    account_logout = account_sub.add_parser("logout", help="Revoke this device token and sign out")
+    account_logout.add_argument("--yes", action="store_true", help="Skip interactive confirmation")
+    account_logout.set_defaults(func=_cmd_account_logout)
 
     # --- cloud ---
     cloud_p = sub.add_parser("cloud", help="Encrypted cloud backup keys and store identity")

--- a/src/ormah/cloud/client.py
+++ b/src/ormah/cloud/client.py
@@ -1,0 +1,257 @@
+"""HTTP client and local account identity for the Ormah Cloud service."""
+
+from __future__ import annotations
+
+import socket
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+DATA_DIR = Path.home() / ".local" / "share" / "ormah"
+DEVICE_ID_PATH = DATA_DIR / "device_id"
+ACCOUNT_TOKEN_KEY = "ORMAH_ACCOUNT_TOKEN"
+ACCOUNT_EMAIL_KEY = "ORMAH_ACCOUNT_EMAIL"
+
+
+class CloudError(RuntimeError):
+    """A network, protocol, or non-success response from Ormah Cloud."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        payload: Any = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.payload = payload
+
+
+def _uuid4(value: str, path: Path) -> str:
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError as exc:
+        raise CloudError(f"Invalid device id at {path}; expected UUIDv4.") from exc
+    if parsed.version != 4 or parsed.variant != uuid.RFC_4122:
+        raise CloudError(f"Invalid device id at {path}; expected UUIDv4.")
+    return str(parsed)
+
+
+def get_or_create_device_id(path: Path | None = None) -> str:
+    """Return this installation's stable UUIDv4, creating it with mode 0600."""
+    path = (DEVICE_ID_PATH if path is None else path).expanduser()
+    if path.is_file():
+        return _uuid4(path.read_text(encoding="utf-8").strip(), path)
+
+    from ormah.setup import _atomic_write
+
+    device_id = str(uuid.uuid4())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(str(path), device_id + "\n", mode=0o600)
+    return device_id
+
+
+def get_device_name() -> str:
+    """Human-readable name attached to server-side device tokens."""
+    return (socket.gethostname().strip() or "unknown-device")[:200]
+
+
+def persist_account_credentials(token: str, email: str) -> None:
+    """Persist account credentials without dropping unrelated environment keys."""
+    from ormah.setup import _read_env_file, _write_env_file
+
+    env = _read_env_file()
+    env[ACCOUNT_TOKEN_KEY] = token
+    env[ACCOUNT_EMAIL_KEY] = email.strip().lower()
+    _write_env_file(env)
+
+
+def remove_account_credentials() -> None:
+    """Remove only Ormah account credentials from the global environment file."""
+    from ormah.setup import _read_env_file, _write_env_file
+
+    env = _read_env_file()
+    changed = ACCOUNT_TOKEN_KEY in env or ACCOUNT_EMAIL_KEY in env
+    env.pop(ACCOUNT_TOKEN_KEY, None)
+    env.pop(ACCOUNT_EMAIL_KEY, None)
+    if changed:
+        _write_env_file(env)
+
+
+class CloudClient:
+    """Small synchronous client for the metadata-only Ormah Cloud API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str | None = None,
+        *,
+        timeout: float = 10.0,
+        device_id: str | None = None,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/") + "/"
+        self.token = token
+        self.device_id = device_id
+        self._http = httpx.Client(
+            base_url=self.base_url,
+            timeout=httpx.Timeout(timeout),
+            transport=transport,
+        )
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> CloudClient:
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+    def _headers(self) -> dict[str, str]:
+        if not self.token:
+            return {}
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def _request_json(
+        self,
+        method: str,
+        path: str,
+        *,
+        authenticated: bool = True,
+        **kwargs,
+    ) -> dict[str, Any]:
+        try:
+            response = self._http.request(
+                method,
+                path,
+                headers=self._headers() if authenticated else {},
+                **kwargs,
+            )
+        except httpx.HTTPError as exc:
+            raise CloudError(f"Could not reach Ormah Cloud: {exc}") from exc
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise CloudError(
+                "Ormah Cloud returned an invalid JSON response.",
+                status_code=response.status_code,
+            ) from exc
+
+        if not response.is_success:
+            detail = payload.get("detail") if isinstance(payload, dict) else payload
+            raise CloudError(
+                f"Ormah Cloud request failed ({response.status_code}): {detail}",
+                status_code=response.status_code,
+                payload=payload,
+            )
+        if not isinstance(payload, dict):
+            raise CloudError(
+                "Ormah Cloud returned an invalid response shape.",
+                status_code=response.status_code,
+                payload=payload,
+            )
+        return payload
+
+    def request_code(self, email: str) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "auth/request-code",
+            authenticated=False,
+            json={"email": email.strip().lower()},
+        )
+
+    def verify_code(
+        self,
+        email: str,
+        code: str,
+        device_id: str,
+        device_name: str,
+    ) -> str:
+        payload = self._request_json(
+            "POST",
+            "auth/verify",
+            authenticated=False,
+            json={
+                "email": email.strip().lower(),
+                "code": code.strip(),
+                "device_id": device_id,
+                "device_name": device_name,
+            },
+        )
+        token = payload.get("token")
+        if not isinstance(token, str) or not token:
+            raise CloudError("Ormah Cloud verification response did not include a token.")
+        self.token = token
+        self.device_id = device_id
+        return token
+
+    def get_entitlements(self) -> dict[str, Any]:
+        return self._request_json("GET", "me/entitlements")
+
+    def revoke_token(self) -> dict[str, Any]:
+        device_id = self.device_id or get_or_create_device_id()
+        payload = self._request_json("GET", "me/tokens")
+        tokens = payload.get("tokens")
+        if not isinstance(tokens, list):
+            raise CloudError("Ormah Cloud token-list response was malformed.")
+        token_id = next(
+            (
+                item.get("token_id")
+                for item in tokens
+                if isinstance(item, dict)
+                and item.get("device_id") == device_id
+                and isinstance(item.get("token_id"), str)
+            ),
+            None,
+        )
+        if token_id is None:
+            raise CloudError("No server token was found for this device.")
+        return self._request_json("POST", "me/tokens/revoke", json={"token_id": token_id})
+
+    def create_upload(self, store_id: str, size: int, sha256: str) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            f"stores/{store_id}/uploads",
+            json={"size_bytes": size, "sha256": sha256},
+        )
+
+    def finalize_upload(
+        self,
+        store_id: str,
+        upload_id: str,
+        advance_head: dict[str, int] | None = None,
+    ) -> dict[str, Any]:
+        body = {"advance_head": advance_head} if advance_head is not None else {}
+        try:
+            return self._request_json(
+                "POST",
+                f"stores/{store_id}/uploads/{upload_id}/finalize",
+                json=body,
+            )
+        except CloudError as exc:
+            detail = exc.payload.get("detail") if isinstance(exc.payload, dict) else None
+            if exc.status_code == 409 and isinstance(detail, dict) and "head" in detail:
+                return detail
+            raise
+
+    def list_blobs(self, store_id: str) -> dict[str, Any]:
+        return self._request_json("GET", f"stores/{store_id}/blobs")
+
+    def presign_download(self, store_id: str, snapshot_id: str) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            f"stores/{store_id}/presign-download",
+            json={"snapshot_id": snapshot_id},
+        )
+
+    def get_head(self, store_id: str) -> dict[str, Any]:
+        return self._request_json("GET", f"stores/{store_id}/head")
+
+
+def client_from_settings(settings) -> CloudClient:
+    return CloudClient(settings.cloud_api_url, settings.account_token)

--- a/src/ormah/cloud/entitlements.py
+++ b/src/ormah/cloud/entitlements.py
@@ -1,0 +1,154 @@
+"""Offline-tolerant advisory entitlement policy from E08 section 6.
+
+=================  ================================  =========  =========
+State              Condition                         Uploads    Downloads
+=================  ================================  =========  =========
+``active``         fresh <=24h and ``backup: true``  run        run
+``grace``          stale <=7d, last backup true      run        run
+``expired``        fresh false/malformed or >7d      pause      run
+``none``           no account token or cache         n/a        n/a
+=================  ================================  =========  =========
+
+This policy is advisory UX. The service enforces uploads at presign/finalize;
+downloads and local backups are never gated here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from ormah.cloud.client import CloudClient, client_from_settings
+
+logger = logging.getLogger(__name__)
+
+ENTITLEMENT_CACHE_PATH = Path.home() / ".local" / "share" / "ormah" / "entitlements.json"
+FRESH_FOR = timedelta(hours=24)
+GRACE_FOR = timedelta(days=7)
+
+
+class EntitlementStatus(str, Enum):
+    ACTIVE = "active"
+    GRACE = "grace"
+    EXPIRED = "expired"
+    NONE = "none"
+
+
+@dataclass(frozen=True)
+class EntitlementCache:
+    entitlements: dict[str, Any]
+    fetched_at: datetime
+
+    def age(self, now: datetime | None = None) -> timedelta:
+        now = _as_utc(now or datetime.now(timezone.utc))
+        return max(now - self.fetched_at, timedelta(0))
+
+    @property
+    def plan_status(self) -> str | None:
+        value = self.entitlements.get("plan_status")
+        return value if isinstance(value, str) else None
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def load_entitlement_cache(path: Path | None = None) -> EntitlementCache | None:
+    path = (ENTITLEMENT_CACHE_PATH if path is None else path).expanduser()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return None
+        fetched_raw = payload.pop("fetched_at", None)
+        if not isinstance(fetched_raw, str):
+            return None
+        fetched_at = _as_utc(datetime.fromisoformat(fetched_raw.replace("Z", "+00:00")))
+    except (OSError, ValueError, TypeError):
+        return None
+    return EntitlementCache(entitlements=payload, fetched_at=fetched_at)
+
+
+def cache_entitlements(
+    entitlements: dict[str, Any],
+    *,
+    fetched_at: datetime | None = None,
+    path: Path | None = None,
+) -> EntitlementCache:
+    """Atomically cache the raw server response plus its fetch timestamp."""
+    if not isinstance(entitlements, dict):
+        raise ValueError("Entitlements response must be a JSON object.")
+    path = (ENTITLEMENT_CACHE_PATH if path is None else path).expanduser()
+    fetched_at = _as_utc(fetched_at or datetime.now(timezone.utc))
+    payload = {**entitlements, "fetched_at": fetched_at.isoformat()}
+
+    from ormah.setup import _atomic_write
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(str(path), json.dumps(payload, indent=2, sort_keys=True) + "\n", mode=0o600)
+    return EntitlementCache(entitlements=dict(entitlements), fetched_at=fetched_at)
+
+
+def clear_entitlement_cache(path: Path | None = None) -> None:
+    path = (ENTITLEMENT_CACHE_PATH if path is None else path).expanduser()
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def refresh_entitlements(
+    settings,
+    *,
+    client: CloudClient | None = None,
+    now: datetime | None = None,
+) -> EntitlementCache:
+    """Fetch and cache current entitlements, raising on refresh failure."""
+    owned_client = client is None
+    client = client or client_from_settings(settings)
+    try:
+        entitlements = client.get_entitlements()
+        return cache_entitlements(entitlements, fetched_at=now)
+    finally:
+        if owned_client:
+            client.close()
+
+
+def status_from_cache(
+    cache: EntitlementCache, *, now: datetime | None = None
+) -> EntitlementStatus:
+    """Classify one cached response using the canonical E08 policy."""
+    now = _as_utc(now or datetime.now(timezone.utc))
+    age = cache.age(now)
+    backup_enabled = cache.entitlements.get("backup") is True
+    if age <= FRESH_FOR:
+        return EntitlementStatus.ACTIVE if backup_enabled else EntitlementStatus.EXPIRED
+    if age <= GRACE_FOR and backup_enabled:
+        return EntitlementStatus.GRACE
+    return EntitlementStatus.EXPIRED
+
+
+def check_entitlement(settings, *, now: datetime | None = None) -> EntitlementStatus:
+    """Return ``active|grace|expired|none`` without propagating refresh failures."""
+    now = _as_utc(now or datetime.now(timezone.utc))
+    cache = load_entitlement_cache()
+    if not settings.account_token:
+        return EntitlementStatus.NONE
+
+    if cache is not None and cache.age(now) <= FRESH_FOR:
+        return status_from_cache(cache, now=now)
+
+    try:
+        cache = refresh_entitlements(settings, now=now)
+    except Exception as exc:
+        logger.debug("Could not refresh Ormah Cloud entitlements; using cache: %s", exc)
+
+    if cache is None:
+        return EntitlementStatus.NONE
+    return status_from_cache(cache, now=now)

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -39,6 +39,8 @@ class Settings(BaseSettings):
     # ever leaves the machine. Off by default until an account is configured.
     cloud_backup_enabled: bool = False
     cloud_api_url: str = "https://api.ormah.dev"
+    account_token: str | None = None
+    account_email: str | None = None
 
     # Embeddings
     embedding_provider: str = "local"  # "local", "ollama", "litellm"

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -1117,7 +1117,11 @@ def _write_env_file(env: dict[str, str]) -> None:
         if stripped and not stripped.startswith("#") and "=" in stripped:
             key = stripped.partition("=")[0].strip()
             if key in env and key not in seen:
-                out.append(f"{key}={env[key]}")
+                original_value = stripped.partition("=")[2].strip()
+                if env[key] == original_value:
+                    out.append(line)
+                else:
+                    out.append(f"{key}={env[key]}")
                 seen.add(key)
             # key removed by caller -> drop the line
         else:

--- a/tests/test_cli_account.py
+++ b/tests/test_cli_account.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+import stat
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from ormah import cli
+from ormah.cloud import client as cloud_client
+from ormah.cloud import entitlements
+from ormah.cloud.client import CloudError
+from ormah.config import Settings, settings
+
+
+class FakeClient:
+    def __init__(self, *, entitlement=None, revoke_error=None, before_revoke=None):
+        self.entitlement = entitlement or {
+            "backup": True,
+            "founding": False,
+            "plan_status": "active",
+        }
+        self.revoke_error = revoke_error
+        self.before_revoke = before_revoke
+        self.calls = []
+        self.closed = False
+
+    def request_code(self, email):
+        self.calls.append(("request_code", email))
+
+    def verify_code(self, email, code, device_id, device_name):
+        self.calls.append(("verify_code", email, code, device_id, device_name))
+        return "secret-account-token"
+
+    def get_entitlements(self):
+        self.calls.append(("get_entitlements",))
+        if isinstance(self.entitlement, Exception):
+            raise self.entitlement
+        return self.entitlement
+
+    def revoke_token(self):
+        self.calls.append(("revoke_token",))
+        if self.before_revoke:
+            self.before_revoke()
+        if self.revoke_error:
+            raise self.revoke_error
+        return {"revoked": True}
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def account_paths(tmp_path, monkeypatch):
+    env_path = tmp_path / "config" / ".env"
+    device_path = tmp_path / "data" / "device_id"
+    cache_path = tmp_path / "data" / "entitlements.json"
+    monkeypatch.setattr("ormah.setup.ENV_PATH", env_path)
+    monkeypatch.setattr("ormah.setup.ENV_DIR", env_path.parent)
+    monkeypatch.setattr(cloud_client, "DEVICE_ID_PATH", device_path)
+    monkeypatch.setattr(entitlements, "ENTITLEMENT_CACHE_PATH", cache_path)
+    monkeypatch.setattr(settings, "account_token", None)
+    monkeypatch.setattr(settings, "account_email", None)
+    monkeypatch.setattr(settings, "cloud_api_url", "https://cloud.test")
+    return env_path, device_path, cache_path
+
+
+def _run(argv, client):
+    with (
+        patch("sys.argv", ["ormah", *argv]),
+        patch("ormah.cli._cloud_client", return_value=client),
+    ):
+        cli.main()
+
+
+def test_login_persists_credentials_without_rewriting_unrelated_lines(
+    account_paths, capsys
+):
+    env_path, device_path, cache_path = account_paths
+    original = "# user comment\nMANUAL = spaced  # keep exactly\n\nORMAH_LLM_PROVIDER=none\n"
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text(original)
+    fake = FakeClient()
+
+    _run(
+        ["account", "login", "--email", "Person@Example.com", "--code", "123456"],
+        fake,
+    )
+
+    text = env_path.read_text()
+    assert text.startswith(original)
+    assert "ORMAH_ACCOUNT_TOKEN=secret-account-token\n" in text
+    assert "ORMAH_ACCOUNT_EMAIL=person@example.com\n" in text
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(device_path.stat().st_mode) == 0o600
+    assert cache_path.is_file()
+    assert [call[0] for call in fake.calls] == [
+        "request_code",
+        "verify_code",
+        "get_entitlements",
+    ]
+    verify_call = fake.calls[1]
+    assert uuid.UUID(verify_call[3]).version == 4
+    assert verify_call[4]
+    output = capsys.readouterr().out
+    assert "Plan status: active" in output
+    assert "secret-account-token" not in output
+
+
+def test_login_keeps_credentials_when_entitlement_refresh_is_offline(
+    account_paths, capsys
+):
+    env_path, _, cache_path = account_paths
+    fake = FakeClient(entitlement=CloudError("offline"))
+
+    _run(
+        ["account", "login", "--email", "person@example.com", "--code", "123456"],
+        fake,
+    )
+
+    assert "ORMAH_ACCOUNT_TOKEN=secret-account-token" in env_path.read_text()
+    assert not cache_path.exists()
+    assert "unavailable while offline" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("offline", [False, True])
+def test_logout_revokes_before_local_deletion_and_preserves_other_keys(
+    account_paths, capsys, monkeypatch, offline
+):
+    env_path, _, cache_path = account_paths
+    original = (
+        "# header\n"
+        "MANUAL = spaced  # keep exactly\n"
+        "ORMAH_ACCOUNT_TOKEN=secret-account-token\n"
+        "ORMAH_X=1\n"
+        "ORMAH_ACCOUNT_EMAIL=person@example.com\n"
+        "# footer\n"
+    )
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text(original)
+    entitlements.cache_entitlements(
+        {"backup": True, "plan_status": "active"},
+    )
+    monkeypatch.setattr(settings, "account_token", "secret-account-token")
+    monkeypatch.setattr(settings, "account_email", "person@example.com")
+
+    def assert_local_state_still_exists():
+        assert "ORMAH_ACCOUNT_TOKEN" in env_path.read_text()
+        assert cache_path.is_file()
+
+    fake = FakeClient(
+        revoke_error=CloudError("offline") if offline else None,
+        before_revoke=assert_local_state_still_exists,
+    )
+
+    _run(["account", "logout", "--yes"], fake)
+
+    assert fake.calls[0] == ("revoke_token",)
+    assert env_path.read_text() == (
+        "# header\n"
+        "MANUAL = spaced  # keep exactly\n"
+        "ORMAH_X=1\n"
+        "# footer\n"
+    )
+    assert not cache_path.exists()
+    output = capsys.readouterr().out
+    assert "Signed out locally" in output
+    assert ("Could not revoke" in output) is offline
+
+
+def test_status_json_contains_no_token(account_paths, capsys, monkeypatch):
+    _, _, _ = account_paths
+    entitlements.cache_entitlements(
+        {"backup": True, "founding": True, "plan_status": "trialing"}
+    )
+    monkeypatch.setattr(settings, "account_token", "secret-account-token")
+    monkeypatch.setattr(settings, "account_email", "person@example.com")
+
+    _run(["account", "status", "--json"], FakeClient())
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert payload["email"] == "person@example.com"
+    assert payload["entitlement"] == "active"
+    assert payload["plan_status"] == "trialing"
+    assert payload["device_name"]
+    assert "token" not in output.lower()
+
+
+def test_logout_requires_confirmation_in_noninteractive_shell(account_paths, monkeypatch, capsys):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    with pytest.raises(SystemExit):
+        _run(["account", "logout"], FakeClient())
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_logout_still_clears_locally_when_client_construction_fails(
+    account_paths, monkeypatch, capsys
+):
+    env_path, _, cache_path = account_paths
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text(
+        "KEEP=exact\n"
+        "ORMAH_ACCOUNT_TOKEN=secret-account-token\n"
+        "ORMAH_ACCOUNT_EMAIL=person@example.com\n"
+    )
+    entitlements.cache_entitlements({"backup": True})
+    monkeypatch.setattr(settings, "account_token", "secret-account-token")
+    monkeypatch.setattr(settings, "account_email", "person@example.com")
+
+    with (
+        patch("sys.argv", ["ormah", "account", "logout", "--yes"]),
+        patch("ormah.cli._cloud_client", side_effect=ValueError("bad URL")),
+    ):
+        cli.main()
+
+    assert env_path.read_text() == "KEEP=exact\n"
+    assert not cache_path.exists()
+    output = capsys.readouterr().out
+    assert "Could not revoke" in output
+    assert "Signed out locally" in output
+
+
+def test_account_settings_are_loaded_from_environment(monkeypatch):
+    monkeypatch.setenv("ORMAH_ACCOUNT_TOKEN", "configured-token")
+    monkeypatch.setenv("ORMAH_ACCOUNT_EMAIL", "person@example.com")
+    configured = Settings(memory_dir="/tmp/ormah-e04-config-test")
+    assert configured.account_token == "configured-token"
+    assert configured.account_email == "person@example.com"

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import stat
+import uuid
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import respx
+
+from ormah.cloud.client import (
+    CloudClient,
+    CloudError,
+    client_from_settings,
+    get_or_create_device_id,
+)
+
+BASE_URL = "https://cloud.test"
+TOKEN = "opaque-account-token"
+
+
+@respx.mock
+def test_auth_and_entitlement_requests_match_service_shapes():
+    request_route = respx.post(f"{BASE_URL}/auth/request-code").mock(
+        return_value=httpx.Response(202, json={"message": "sent"})
+    )
+    verify_route = respx.post(f"{BASE_URL}/auth/verify").mock(
+        return_value=httpx.Response(200, json={"token": TOKEN, "token_type": "bearer"})
+    )
+    entitlement_route = respx.get(f"{BASE_URL}/me/entitlements").mock(
+        return_value=httpx.Response(
+            200,
+            json={"backup": True, "founding": False, "plan_status": "active"},
+        )
+    )
+    device_id = str(uuid.uuid4())
+
+    with CloudClient(BASE_URL) as client:
+        client.request_code("Person@Example.com")
+        assert client.verify_code(
+            "Person@Example.com", "123456", device_id, "Test laptop"
+        ) == TOKEN
+        assert client.get_entitlements()["plan_status"] == "active"
+
+    assert request_route.calls[0].request.content == b'{"email":"person@example.com"}'
+    assert "authorization" not in request_route.calls[0].request.headers
+    assert b'"device_id"' in verify_route.calls[0].request.content
+    assert "authorization" not in verify_route.calls[0].request.headers
+    assert entitlement_route.calls[0].request.headers["authorization"] == f"Bearer {TOKEN}"
+
+
+@respx.mock
+def test_revoke_resolves_server_token_id_from_device():
+    device_id = str(uuid.uuid4())
+    respx.get(f"{BASE_URL}/me/tokens").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "tokens": [
+                    {
+                        "token_id": "server-side-hmac-id",
+                        "device_id": device_id,
+                        "device_name": "Laptop",
+                    }
+                ]
+            },
+        )
+    )
+    revoke_route = respx.post(f"{BASE_URL}/me/tokens/revoke").mock(
+        return_value=httpx.Response(200, json={"revoked": True})
+    )
+
+    with CloudClient(BASE_URL, TOKEN, device_id=device_id) as client:
+        assert client.revoke_token() == {"revoked": True}
+
+    assert revoke_route.calls[0].request.content == b'{"token_id":"server-side-hmac-id"}'
+    assert TOKEN.encode() not in revoke_route.calls[0].request.content
+
+
+@respx.mock
+def test_upload_blob_and_head_methods_match_service_shapes():
+    store_id = str(uuid.uuid4())
+    create_route = respx.post(f"{BASE_URL}/stores/{store_id}/uploads").mock(
+        return_value=httpx.Response(
+            201,
+            json={"upload_id": "upload", "snapshot_id": "snapshot", "put_url": "https://put"},
+        )
+    )
+    finalize_route = respx.post(
+        f"{BASE_URL}/stores/{store_id}/uploads/upload/finalize"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "snapshot_id": "snapshot",
+                "status": "committed",
+                "head": {"snapshot_id": "snapshot", "seq": 4},
+            },
+        )
+    )
+    respx.get(f"{BASE_URL}/stores/{store_id}/blobs").mock(
+        return_value=httpx.Response(200, json={"blobs": [{"snapshot_id": "snapshot"}]})
+    )
+    download_route = respx.post(f"{BASE_URL}/stores/{store_id}/presign-download").mock(
+        return_value=httpx.Response(200, json={"get_url": "https://get"})
+    )
+    respx.get(f"{BASE_URL}/stores/{store_id}/head").mock(
+        return_value=httpx.Response(200, json={"snapshot_id": "snapshot", "seq": 4})
+    )
+
+    with CloudClient(BASE_URL, TOKEN) as client:
+        client.create_upload(store_id, 42, "a" * 64)
+        client.finalize_upload(store_id, "upload", {"expected_seq": 3})
+        assert client.list_blobs(store_id)["blobs"][0]["snapshot_id"] == "snapshot"
+        assert client.presign_download(store_id, "snapshot") == {"get_url": "https://get"}
+        assert client.get_head(store_id) == {"snapshot_id": "snapshot", "seq": 4}
+
+    assert create_route.calls[0].request.content == (
+        b'{"size_bytes":42,"sha256":"' + b"a" * 64 + b'"}'
+    )
+    assert finalize_route.calls[0].request.content == b'{"advance_head":{"expected_seq":3}}'
+    assert download_route.calls[0].request.content == b'{"snapshot_id":"snapshot"}'
+
+
+@respx.mock
+def test_finalize_cas_conflict_returns_current_head_payload():
+    store_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/stores/{store_id}/uploads/upload/finalize").mock(
+        return_value=httpx.Response(
+            409,
+            json={
+                "detail": {
+                    "message": "Sync head changed.",
+                    "snapshot_id": "loser",
+                    "status": "committed",
+                    "head": {"snapshot_id": "winner", "seq": 2},
+                }
+            },
+        )
+    )
+
+    with CloudClient(BASE_URL, TOKEN) as client:
+        result = client.finalize_upload(store_id, "upload", {"expected_seq": 1})
+
+    assert result["status"] == "committed"
+    assert result["head"] == {"snapshot_id": "winner", "seq": 2}
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 500])
+@respx.mock
+def test_non_success_responses_raise_cloud_error(status_code):
+    respx.get(f"{BASE_URL}/me/entitlements").mock(
+        return_value=httpx.Response(status_code, json={"detail": "denied"})
+    )
+
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError) as exc_info:
+            client.get_entitlements()
+
+    assert exc_info.value.status_code == status_code
+    assert TOKEN not in str(exc_info.value)
+
+
+@respx.mock
+def test_non_cas_conflict_still_raises():
+    store_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/stores/{store_id}/uploads/upload/finalize").mock(
+        return_value=httpx.Response(409, json={"detail": "Uploaded object is not available."})
+    )
+
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="not available"):
+            client.finalize_upload(store_id, "upload")
+
+
+@respx.mock
+def test_network_errors_are_wrapped():
+    respx.get(f"{BASE_URL}/me/entitlements").mock(
+        side_effect=httpx.ConnectError("offline")
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="Could not reach"):
+            client.get_entitlements()
+
+
+def test_device_id_is_stable_uuid4_and_mode_0600(tmp_path):
+    path = tmp_path / "device_id"
+    first = get_or_create_device_id(path)
+    second = get_or_create_device_id(path)
+
+    assert first == second
+    assert uuid.UUID(first).version == 4
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_corrupt_device_id_fails_closed(tmp_path):
+    path = tmp_path / "device_id"
+    path.write_text("not-a-uuid\n")
+
+    with pytest.raises(CloudError, match="expected UUIDv4"):
+        get_or_create_device_id(path)
+
+
+def test_client_factory_reads_settings():
+    client = client_from_settings(
+        SimpleNamespace(cloud_api_url=BASE_URL, account_token=TOKEN)
+    )
+    try:
+        assert client.base_url == f"{BASE_URL}/"
+        assert client.token == TOKEN
+    finally:
+        client.close()

--- a/tests/test_entitlements.py
+++ b/tests/test_entitlements.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import stat
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from ormah.cloud import entitlements
+from ormah.cloud.entitlements import EntitlementStatus
+
+NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeClient:
+    def __init__(self, response=None, error: Exception | None = None):
+        self.response = response
+        self.error = error
+        self.calls = 0
+        self.closed = False
+
+    def get_entitlements(self):
+        self.calls += 1
+        if self.error:
+            raise self.error
+        return self.response
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def cache_path(tmp_path, monkeypatch):
+    path = tmp_path / "entitlements.json"
+    monkeypatch.setattr(entitlements, "ENTITLEMENT_CACHE_PATH", path)
+    return path
+
+
+def _settings(token="opaque-token"):
+    return SimpleNamespace(
+        account_token=token,
+        cloud_api_url="https://cloud.test",
+    )
+
+
+@pytest.mark.parametrize(
+    ("age", "payload", "expected"),
+    [
+        (timedelta(hours=1), {"backup": True, "plan_status": "active"}, EntitlementStatus.ACTIVE),
+        (timedelta(hours=24), {"backup": True}, EntitlementStatus.ACTIVE),
+        (timedelta(hours=24, microseconds=1), {"backup": True}, EntitlementStatus.GRACE),
+        (timedelta(days=2), {"backup": True, "plan_status": "active"}, EntitlementStatus.GRACE),
+        (timedelta(days=7), {"backup": True}, EntitlementStatus.GRACE),
+        (timedelta(days=7, microseconds=1), {"backup": True}, EntitlementStatus.EXPIRED),
+        (timedelta(days=8), {"backup": True, "plan_status": "active"}, EntitlementStatus.EXPIRED),
+        (timedelta(hours=1), {"backup": False, "plan_status": "none"}, EntitlementStatus.EXPIRED),
+        (timedelta(hours=1), {"plan_status": "active"}, EntitlementStatus.EXPIRED),
+        (timedelta(hours=1), {"backup": "true"}, EntitlementStatus.EXPIRED),
+    ],
+)
+def test_cached_entitlement_states(age, payload, expected, monkeypatch):
+    entitlements.cache_entitlements(payload, fetched_at=NOW - age)
+    offline = FakeClient(error=OSError("offline"))
+    monkeypatch.setattr(entitlements, "client_from_settings", lambda settings: offline)
+
+    assert entitlements.check_entitlement(_settings(), now=NOW) is expected
+    if age <= timedelta(hours=24):
+        assert offline.calls == 0
+    else:
+        assert offline.calls == 1
+
+
+def test_no_token_returns_none_without_refresh(monkeypatch):
+    client = FakeClient(response={"backup": True})
+    monkeypatch.setattr(entitlements, "client_from_settings", lambda settings: client)
+
+    assert entitlements.check_entitlement(_settings(token=None), now=NOW) is EntitlementStatus.NONE
+    assert client.calls == 0
+
+
+def test_no_cache_offline_returns_none_and_never_raises(monkeypatch):
+    offline = FakeClient(error=OSError("offline"))
+    monkeypatch.setattr(entitlements, "client_from_settings", lambda settings: offline)
+
+    assert entitlements.check_entitlement(_settings(), now=NOW) is EntitlementStatus.NONE
+    assert offline.closed is True
+
+
+def test_missing_cache_refreshes_to_active(monkeypatch):
+    client = FakeClient(
+        response={"backup": True, "founding": False, "plan_status": "past_due"}
+    )
+    monkeypatch.setattr(entitlements, "client_from_settings", lambda settings: client)
+
+    assert entitlements.check_entitlement(_settings(), now=NOW) is EntitlementStatus.ACTIVE
+    cache = entitlements.load_entitlement_cache()
+    assert cache is not None
+    assert cache.plan_status == "past_due"
+    assert cache.fetched_at == NOW
+
+
+def test_successful_malformed_refresh_can_never_be_active(monkeypatch):
+    entitlements.cache_entitlements(
+        {"backup": True, "plan_status": "active"},
+        fetched_at=NOW - timedelta(days=2),
+    )
+    client = FakeClient(response={"plan_status": "active"})
+    monkeypatch.setattr(entitlements, "client_from_settings", lambda settings: client)
+
+    assert entitlements.check_entitlement(_settings(), now=NOW) is EntitlementStatus.EXPIRED
+    assert entitlements.load_entitlement_cache().entitlements.get("backup") is None
+
+
+def test_cache_is_raw_response_plus_timestamp_and_mode_0600(cache_path):
+    raw = {"backup": True, "founding": True, "plan_status": "trialing", "future": "kept"}
+    entitlements.cache_entitlements(raw, fetched_at=NOW)
+
+    text = cache_path.read_text()
+    assert '"future": "kept"' in text
+    assert '"fetched_at": "2026-07-13T12:00:00+00:00"' in text
+    assert stat.S_IMODE(cache_path.stat().st_mode) == 0o600
+
+
+def test_corrupt_cache_is_ignored(monkeypatch, cache_path):
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text("not-json")
+    offline = FakeClient(error=OSError("offline"))
+    monkeypatch.setattr(entitlements, "client_from_settings", lambda settings: offline)
+
+    assert entitlements.check_entitlement(_settings(), now=NOW) is EntitlementStatus.NONE
+
+
+def test_clear_cache_is_idempotent(cache_path):
+    entitlements.cache_entitlements({"backup": True}, fetched_at=NOW)
+    entitlements.clear_entitlement_cache()
+    entitlements.clear_entitlement_cache()
+    assert not cache_path.exists()


### PR DESCRIPTION
## Summary

Implements E04 client account integration against the merged `ormah-cloud` service.

- adds a reusable `CloudClient` for OTP auth, entitlements, token revocation, uploads, blobs, downloads, and sync-head operations
- adds persistent UUIDv4 device identity and device-aware server token revocation
- centralizes the E08 entitlement policy with an offline-tolerant 24-hour cache and seven-day grace window
- adds `ormah account login|status|logout`, including scriptable login and JSON status output
- adds account settings and preserves unrelated env-file entries during credential updates
- adds focused HTTP, entitlement-policy, CLI, permissions, and env-round-trip coverage

## Security and behavior

- bearer tokens are never printed or included in status JSON
- device ID, entitlement cache, and env credentials are written with mode `0600`
- login and logout use full-dictionary env-file read/modify/write operations
- logout revokes the matching device token before local deletion and still clears local credentials when offline
- `finalize_upload` returns the server head payload for CAS conflicts while other non-2xx responses raise `CloudError`
- entitlement refresh failures never block callers and always fall back to cache policy
- missing or non-boolean `backup` values can never produce `active`

## Configuration

Adds `ORMAH_ACCOUNT_TOKEN` and `ORMAH_ACCOUNT_EMAIL`. They are managed by the account CLI; no secrets are committed.

## Verification

- `37 passed` in `tests/test_cloud_client.py tests/test_entitlements.py tests/test_cli_account.py`
- `uv run ruff check src/ tests/` passes
- `uv tool install . --reinstall` succeeds
- `1,215` tests outside the five existing TestClient-heavy files pass collectively; those five files hit the already-known AnyIO blocking-portal timeout in this environment, so a single uninterrupted `make test` result is not claimed
- staging verification remains deferred until the E03 service is deployed to Fly

## Local service walkthrough

Ran the installed CLI against the real `ormah-cloud` app locally with the development console OTP backend and an isolated HOME:

```text
$ ormah account login --email e04-local@example.com --code <console-otp>
[..] Sign-in code requested for e04-local@example.com
[ok] Signed in as e04-local@example.com
Plan status: none
Cloud backup entitlement: expired

$ ormah account status --json
{
  "cache_age_seconds": 9,
  "device_name": "r2205",
  "email": "e04-local@example.com",
  "entitlement": "expired",
  "plan_status": "none"
}

$ ormah account logout --yes
[ok] Signed out locally
```

The service recorded `GET /me/tokens` followed by a successful revoke request. After logout there were zero active tokens, the local entitlement cache was removed, account env keys were removed, unrelated env content remained intact, and the persistent device ID remained available for future logins.