### PR TITLE
fix(ci): free runner disk before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,28 @@ jobs:
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
+      - name: Free runner disk space
+        run: |
+          echo "Disk before cleanup:"
+          df -h
+
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          docker system prune --all --force || true
+
+          echo "Disk after cleanup:"
+          df -h
       - name: Install
         run: uv sync --extra dev
       - name: Run tests
-        run: uv run pytest tests/ -q
+        run: uv run pytest tests/ -q --durations=25
+      - name: Report disk usage
+        if: always()
+        run: |
+          df -h
+          (du -h -d 2 "$GITHUB_WORKSPACE" "$RUNNER_TEMP" "$HOME/.cache/uv" .venv 2>/dev/null || true) | sort -hr | head -100
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- free unused hosted-runner disk space before the test job installs dependencies
- keep pytest quiet but add the slowest 25 durations for visibility
- always report disk usage after the test step so future runner exhaustion has diagnostics

## Validation

- git diff --check -- .github/workflows/ci.yml
- workflow YAML parsed successfully with PyYAML

Closes #99.
Closes #102.