### PR TITLE
feat(cloud): add backup, restore, and verification (E05)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ ORMAH_PORT=8787
 # with keys only you hold (see `ormah cloud init`); the service never sees
 # plaintext. Disabled until an account is configured.
 # ORMAH_CLOUD_BACKUP_ENABLED=false
+# ORMAH_CLOUD_BACKUP_INTERVAL_HOURS=24
 # ORMAH_CLOUD_API_URL=https://api.ormah.dev
 # Managed by `ormah account login`; do not commit real values.
 # ORMAH_ACCOUNT_EMAIL=

--- a/README.md
+++ b/README.md
@@ -140,6 +140,44 @@ Sign in with an emailed one-time code using `ormah account login`. Use
 credentials. Cloud entitlement checks tolerate temporary outages; they never
 gate local backups or cloud downloads.
 
+### Cloud Backup (Paid)
+
+Ormah can encrypt local memory backups on your machine and upload only the
+ciphertext to Ormah Cloud. Sign in, initialize the store key, and enable the
+scheduled uploader:
+
+```bash
+ormah account login
+ormah cloud init
+# Add ORMAH_CLOUD_BACKUP_ENABLED=true to ~/.config/ormah/.env
+ormah backup status
+```
+
+The recovery kit written by `ormah cloud init` contains every identity needed
+to decrypt current and pre-rotation snapshots, plus the store ID that locates
+them. Keep it offline and separate from the machine and cloud account it
+protects. Anyone with the kit can read the backups; without it, nobody can,
+including Ormah.
+
+Restore on a new machine with:
+
+```bash
+ormah account login
+ormah cloud init --import-key /path/to/ormah-recovery-kit.md
+ormah backup restore --cloud --yes
+```
+
+Cloud downloads remain available when a paid entitlement expires. The restore
+command verifies the encrypted bundle manifest and every file hash before it
+delegates to the normal local restore path. A weekly background job also
+downloads the latest committed snapshot, rebuilds a scratch index, and probes
+search without touching the live memory directory. `ormah backup status` and
+the admin panel report the last snapshot proven restorable.
+
+The hosted service never receives key material, plaintext, or blob bytes. It
+stores account and snapshot metadata and issues short-lived object-store URLs;
+encryption, decryption, hashing, upload, and restore all happen on the client.
+
 ### Agent-Agnostic Surfaces
 
 Ormah is not tied to a single agent.

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -26,6 +26,8 @@ _TASK_RUNNERS = {
     "importance_scorer": ("ormah.background.importance_scorer", "run_importance_scoring"),
     "consolidator": ("ormah.background.consolidator", "run_consolidation"),
     "memory_backup": ("ormah.backup", "run_auto_backup"),
+    "cloud_backup": ("ormah.cloud.jobs", "run_cloud_backup"),
+    "restore_verification": ("ormah.cloud.jobs", "run_restore_verification"),
 }
 
 _TASK_DESCRIPTIONS = {
@@ -39,6 +41,8 @@ _TASK_DESCRIPTIONS = {
     "decay_manager": "Applies time-based decay to memory importance, demoting stale unused memories.",
     "hippocampus": "Scans for structural patterns and promotes frequently accessed working memories to core.",
     "memory_backup": "Creates a local backup of memory source files when one is due.",
+    "cloud_backup": "Encrypts and uploads a due cloud backup without changing the sync head.",
+    "restore_verification": "Downloads, decrypts, rebuilds, and searches the latest cloud backup.",
 }
 
 # Order for sleep cycle (full maintenance pass)
@@ -122,6 +126,14 @@ def backup_status(request: Request):
     """Return local backup configuration and latest backup metadata."""
     settings, service = _backup_service_from_request(request)
     return _backup_status_payload(settings, service)
+
+
+@router.get("/cloud-status")
+def cloud_status(request: Request):
+    """Return per-store cloud backup and restore-verification health."""
+    from ormah.cloud.state import cloud_status_payload
+
+    return cloud_status_payload(request.app.state.engine.settings)
 
 
 @router.post("/backup/create")

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -136,6 +136,27 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
+    from ormah.cloud.jobs import run_cloud_backup, run_restore_verification
+
+    scheduler.add_job(
+        tracked(tracker, "cloud_backup", run_cloud_backup, engine),
+        "interval",
+        hours=s.cloud_backup_interval_hours,
+        id="cloud_backup",
+        name="Encrypted cloud backup",
+        next_run_time=datetime.now(timezone.utc),
+        misfire_grace_time=_MISFIRE_GRACE,
+    )
+
+    scheduler.add_job(
+        tracked(tracker, "restore_verification", run_restore_verification, engine),
+        "interval",
+        hours=168,
+        id="restore_verification",
+        name="Cloud restore verification",
+        misfire_grace_time=_MISFIRE_GRACE,
+    )
+
     scheduler.start()
     logger.info("Background scheduler started with %d jobs", len(scheduler.get_jobs()))
     return scheduler, tracker

--- a/src/ormah/backup.py
+++ b/src/ormah/backup.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 import re
 import shutil
+import threading
 
 from ormah.index.builder import IndexBuilder
 from ormah.index.db import Database
@@ -24,6 +25,7 @@ BACKUP_NAME_RE = re.compile(
 )
 MANIFEST_NAME = "backup.json"
 SOURCE_DIRS = ("nodes", "deleted")
+_BACKUP_CREATE_LOCK = threading.RLock()
 
 
 class BackupError(RuntimeError):
@@ -136,6 +138,17 @@ class BackupService:
         self.retention_count = retention_count
 
     def create(
+        self,
+        *,
+        reason: str = "manual",
+        now: datetime | None = None,
+        prune: bool = True,
+    ) -> BackupInfo:
+        """Create a timestamped backup, serialized across in-process jobs."""
+        with _BACKUP_CREATE_LOCK:
+            return self._create(reason=reason, now=now, prune=prune)
+
+    def _create(
         self,
         *,
         reason: str = "manual",

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -261,6 +261,16 @@ def _format_cache_age(seconds: int | None) -> str:
     return f"{seconds // 86400}d"
 
 
+def _format_iso_time(value: str | None) -> str:
+    if value is None:
+        return "never"
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    return _format_backup_time(parsed)
+
+
 def _cmd_account_login(args):
     from ormah.cloud.client import (
         CloudError,
@@ -418,12 +428,14 @@ def _cmd_backup_list(args):
 
 
 def _cmd_backup_status(args):
+    from ormah.cloud.state import cloud_status_payload
     from ormah.config import settings
 
     service = _backup_service()
     latest = service.latest()
     has_memory = service.has_backupable_memory()
     due = has_memory and service.backup_due(interval_hours=settings.backup_interval_hours)
+    cloud = cloud_status_payload(settings)
     status = {
         "enabled": settings.backup_enabled,
         "backup_dir": str(settings.backup_dir),
@@ -432,6 +444,7 @@ def _cmd_backup_status(args):
         "has_backupable_memory": has_memory,
         "due": due,
         "latest": _backup_to_dict(latest) if latest else None,
+        "cloud": cloud,
     }
 
     if args.json:
@@ -450,27 +463,65 @@ def _cmd_backup_status(args):
     else:
         print(f"Backup due now: {'yes' if due else 'no'}")
 
+    print("\nCloud backup:")
+    print(f"  Automatic uploads: {'enabled' if cloud['enabled'] else 'disabled'}")
+    print(f"  Entitlement: {cloud['entitlement']}")
+    if cloud["last_upload_snapshot_id"]:
+        age = _format_cache_age(cloud["last_upload_age_seconds"])
+        print(f"  Last upload: {cloud['last_upload_snapshot_id']} ({age} ago)")
+    else:
+        print("  Last upload: never")
+    if cloud["last_verify_ok"] is True:
+        print(f"  Last verified restorable: ✓ {_format_iso_time(cloud['last_verify_at'])}")
+    elif cloud["last_verify_ok"] is False:
+        reason = f" — {cloud['last_verify_error']}" if cloud["last_verify_error"] else ""
+        print(f"  Last verified restorable: ✗ {_format_iso_time(cloud['last_verify_at'])}{reason}")
+    else:
+        print("  Last verified restorable: not yet verified")
+    for warning in cloud["warnings"]:
+        print(f"  WARNING: {warning}")
+
 
 def _cmd_backup_restore(args):
     from ormah.backup import BackupError
+    from ormah.cloud.restore import CloudRestoreError, restore_cloud_snapshot
+    from ormah.config import settings
     from ormah.console import info, ok, warn
     from ormah.server_manager import is_server_running
 
     if is_server_running():
         _print_backup_error("Stop the Ormah server before restoring: ormah server stop")
 
+    cloud_requested = args.cloud is not None
+    if cloud_requested and args.backup:
+        _print_backup_error("Choose either a local backup name or --cloud, not both.")
+    if not cloud_requested and not args.backup:
+        _print_backup_error("Provide a local backup name or use --cloud [SNAPSHOT_ID].")
+
+    restore_label = (
+        f"cloud snapshot {args.cloud}" if args.cloud else "latest committed cloud snapshot"
+    ) if cloud_requested else f"backup {args.backup}"
+
     if not args.yes:
         if not sys.stdin.isatty():
             _print_backup_error("Restore needs confirmation. Re-run with --yes in non-interactive shells.")
         warn("Restore overwrites current memory files.")
-        answer = input(f"Restore backup {args.backup}? (y/N) ").strip().lower()
+        answer = input(f"Restore {restore_label}? (y/N) ").strip().lower()
         if answer not in {"y", "yes"}:
             info("Restore cancelled")
             return
 
     try:
-        result = _backup_service().restore(args.backup, rebuild_index=not args.no_rebuild)
-    except BackupError as exc:
+        if cloud_requested:
+            cloud_result = restore_cloud_snapshot(
+                settings,
+                args.cloud or None,
+                rebuild_index=not args.no_rebuild,
+            )
+            result = cloud_result.restore
+        else:
+            result = _backup_service().restore(args.backup, rebuild_index=not args.no_rebuild)
+    except (BackupError, CloudRestoreError) as exc:
         _print_backup_error(str(exc))
 
     ok(f"Restored backup: {result.restored.name}")
@@ -680,8 +731,15 @@ def main():
     backup_status.add_argument("--json", action="store_true", help="Output backup status as JSON")
     backup_status.set_defaults(func=_cmd_backup_status)
 
-    backup_restore = backup_sub.add_parser("restore", help="Restore memory files from a local backup")
-    backup_restore.add_argument("backup", help="Backup name from `ormah backup list`")
+    backup_restore = backup_sub.add_parser("restore", help="Restore memory files from a backup")
+    backup_restore.add_argument("backup", nargs="?", help="Backup name from `ormah backup list`")
+    backup_restore.add_argument(
+        "--cloud",
+        nargs="?",
+        const="",
+        metavar="SNAPSHOT_ID",
+        help="Restore the latest committed cloud snapshot, or the specified snapshot",
+    )
     backup_restore.add_argument("--yes", action="store_true", help="Skip interactive restore confirmation")
     backup_restore.add_argument("--no-rebuild", action="store_true", help="Skip search index rebuild")
     backup_restore.set_defaults(func=_cmd_backup_restore)

--- a/src/ormah/cloud/jobs.py
+++ b/src/ormah/cloud/jobs.py
@@ -1,0 +1,296 @@
+"""Scheduled encrypted cloud backup and restore-verification jobs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import logging
+from pathlib import Path
+import re
+import shutil
+import tempfile
+
+from ormah.backup import BackupInfo, service_from_settings
+from ormah.cloud.bundle import open_bundle, build_bundle
+from ormah.cloud.client import client_from_settings
+from ormah.cloud.entitlements import EntitlementStatus, check_entitlement
+from ormah.cloud.keys import (
+    STORE_ID_NAME,
+    current_recipient,
+    get_or_create_store_id,
+    key_file_exists,
+    load_identities,
+)
+from ormah.cloud.state import load_state, update_state
+from ormah.cloud.transfer import download_file, put_file, sha256_file
+from ormah.index.builder import IndexBuilder
+from ormah.index.db import Database
+from ormah.index.graph import GraphIndex
+from ormah.store.file_store import FileStore
+from ormah.store.markdown import parse_node
+
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _existing_store_id(memory_dir: Path) -> str | None:
+    memory_dir = Path(memory_dir).expanduser()
+    if not (memory_dir / STORE_ID_NAME).is_file():
+        return None
+    return get_or_create_store_id(memory_dir)
+
+
+def _safe_update(store_id: str | None, **changes) -> None:
+    if store_id is None:
+        return
+    try:
+        update_state(store_id, **changes)
+    except Exception as exc:
+        logger.warning("Could not persist Ormah Cloud state: %s", exc)
+
+
+def _record_upload_error(store_id: str | None, message: str) -> None:
+    logger.warning("Ormah Cloud backup skipped or failed: %s", message)
+    _safe_update(store_id, last_upload_error=message)
+
+
+def _snapshot_files(root: Path) -> dict[str, Path]:
+    files: dict[str, Path] = {}
+    for dirname in ("nodes", "deleted"):
+        source = Path(root) / dirname
+        if not source.is_dir():
+            continue
+        for path in source.glob("*.md"):
+            if path.is_file():
+                files[f"{dirname}/{path.name}"] = path
+    return files
+
+
+def _backup_matches_memory(backup: BackupInfo, memory_dir: Path) -> bool:
+    source_files = _snapshot_files(memory_dir)
+    backup_files = _snapshot_files(backup.path)
+    if source_files.keys() != backup_files.keys():
+        return False
+    return all(
+        source_files[name].stat().st_size == backup_files[name].stat().st_size
+        and sha256_file(source_files[name]) == sha256_file(backup_files[name])
+        for name in source_files
+    )
+
+
+def _backup_for_upload(service) -> BackupInfo:
+    latest = service.latest()
+    if latest is not None and _backup_matches_memory(latest, service.memory_dir):
+        return latest
+    return service.create(reason="cloud")
+
+
+def _upload_due(store_id: str, interval_hours: int, now: datetime) -> bool:
+    last_upload = load_state(store_id).last_upload_at
+    if last_upload is None:
+        return True
+    return now - last_upload >= timedelta(hours=interval_hours)
+
+
+def run_cloud_backup(engine) -> str | None:
+    """Upload one due encrypted backup; log and persist failures without raising."""
+    settings = engine.settings
+    store_id: str | None = None
+    client = None
+    try:
+        if not settings.cloud_backup_enabled:
+            logger.debug("Ormah Cloud backup is disabled")
+            return None
+
+        if not key_file_exists():
+            store_id = _existing_store_id(settings.memory_dir)
+            _record_upload_error(store_id, "Cloud encryption key is missing; run `ormah cloud init`.")
+            return None
+
+        store_id = _existing_store_id(settings.memory_dir)
+        if store_id is None:
+            _record_upload_error(None, "Cloud store id is missing; run `ormah cloud init`.")
+            return None
+
+        entitlement = check_entitlement(settings)
+        if entitlement not in {EntitlementStatus.ACTIVE, EntitlementStatus.GRACE}:
+            _record_upload_error(
+                store_id,
+                f"Cloud backup paused because entitlement is {entitlement.value}.",
+            )
+            return None
+
+        service = service_from_settings(settings)
+        if not service.has_backupable_memory():
+            logger.debug("Skipping Ormah Cloud backup; no memory nodes exist yet")
+            return None
+
+        now = _utc_now()
+        if not _upload_due(store_id, settings.cloud_backup_interval_hours, now):
+            logger.debug("Skipping Ormah Cloud backup; latest upload is still fresh")
+            return None
+
+        backup = _backup_for_upload(service)
+        with tempfile.TemporaryDirectory(prefix="ormah-cloud-upload-") as tmp:
+            bundle = Path(tmp) / f"{backup.name}.age"
+            build_bundle(
+                backup.path,
+                bundle,
+                [current_recipient()],
+                store_id=store_id,
+                reason="cloud-backup",
+            )
+            size = bundle.stat().st_size
+            digest = sha256_file(bundle)
+            client = client_from_settings(settings)
+            upload = client.create_upload(store_id, size, digest)
+            upload_id = upload.get("upload_id")
+            snapshot_id = upload.get("snapshot_id")
+            put_url = upload.get("put_url")
+            if not all(isinstance(value, str) and value for value in (upload_id, snapshot_id, put_url)):
+                raise RuntimeError("Cloud upload reservation response was malformed.")
+
+            put_file(put_url, bundle)
+            finalized = client.finalize_upload(store_id, upload_id)
+            finalized_snapshot = finalized.get("snapshot_id")
+            if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
+                raise RuntimeError("Cloud upload finalize response was malformed.")
+
+        _safe_update(
+            store_id,
+            last_upload_at=_utc_now(),
+            last_upload_snapshot_id=snapshot_id,
+            last_upload_error=None,
+        )
+        logger.info("Uploaded encrypted Ormah Cloud snapshot %s", snapshot_id)
+        return snapshot_id
+    except Exception as exc:
+        _record_upload_error(store_id, str(exc))
+        return None
+    finally:
+        close = getattr(client, "close", None) if client is not None else None
+        if close is not None:
+            try:
+                close()
+            except Exception:
+                pass
+
+
+def _probe_search(database: Database, nodes: list) -> None:
+    if not nodes:
+        raise RuntimeError("Restored snapshot has no active node available for a search probe.")
+    graph = GraphIndex(database)
+    for node in nodes:
+        words = re.findall(r"\w{2,}", f"{node.title or ''} {node.content}")
+        for word in sorted(words, key=len, reverse=True):
+            if any(result["id"] == node.id for result in graph.fts_search(word, limit=10)):
+                return
+    raise RuntimeError("Scratch search probe did not return a known restored node.")
+
+
+def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> int:
+    if info.store_id != expected_store_id:
+        raise RuntimeError(
+            f"Bundle store id {info.store_id!r} does not match local store {expected_store_id!r}."
+        )
+
+    active_nodes = []
+    for dirname in ("nodes", "deleted"):
+        for path in sorted((extracted / dirname).glob("*.md")):
+            node = parse_node(path.read_text(encoding="utf-8"))
+            if dirname == "nodes":
+                active_nodes.append(node)
+
+    database = Database(extracted / "scratch-index" / "index.db")
+    try:
+        database.init_schema()
+        rebuilt = IndexBuilder(database, FileStore(extracted / "nodes")).full_rebuild()
+        if rebuilt != info.node_count:
+            raise RuntimeError(
+                f"Scratch index rebuilt {rebuilt} nodes; bundle manifest declares {info.node_count}."
+            )
+        _probe_search(database, active_nodes)
+        return rebuilt
+    finally:
+        database.close()
+
+
+def run_restore_verification(engine) -> bool:
+    """Prove the latest committed snapshot decrypts, rebuilds, and searches."""
+    settings = engine.settings
+    store_id: str | None = None
+    snapshot_id: str | None = None
+    client = None
+    tmp_root: Path | None = None
+    try:
+        if not settings.cloud_backup_enabled:
+            logger.debug("Ormah Cloud restore verification is disabled")
+            return False
+        if not key_file_exists():
+            raise RuntimeError("Cloud encryption key is missing; cannot verify restore.")
+        store_id = _existing_store_id(settings.memory_dir)
+        if store_id is None:
+            raise RuntimeError("Cloud store id is missing; cannot verify restore.")
+        if not settings.account_token:
+            raise RuntimeError("Ormah Cloud login is required to verify restore.")
+
+        client = client_from_settings(settings)
+        listing = client.list_blobs(store_id)
+        blobs = listing.get("blobs")
+        if not isinstance(blobs, list) or not blobs:
+            raise RuntimeError("No committed cloud snapshot is available to verify.")
+        latest = blobs[0]
+        snapshot_id = latest.get("snapshot_id") if isinstance(latest, dict) else None
+        if not isinstance(snapshot_id, str) or not snapshot_id:
+            raise RuntimeError("Cloud snapshot listing was malformed.")
+
+        presigned = client.presign_download(store_id, snapshot_id)
+        get_url = presigned.get("get_url")
+        if not isinstance(get_url, str) or not get_url:
+            raise RuntimeError("Cloud download response was malformed.")
+
+        tmp_root = Path(tempfile.mkdtemp(prefix="ormah-restore-verify-"))
+        bundle = tmp_root / f"{snapshot_id}.age"
+        extracted = tmp_root / "snapshot"
+        download_file(get_url, bundle)
+        info = open_bundle(bundle, extracted, load_identities())
+        _verify_extracted_bundle(extracted, store_id, info)
+
+        verified_at = _utc_now()
+        _safe_update(
+            store_id,
+            last_verify_at=verified_at,
+            last_verify_ok=True,
+            last_verify_snapshot_id=snapshot_id,
+            last_verify_error=None,
+        )
+        logger.info("Verified Ormah Cloud snapshot %s is restorable", snapshot_id)
+        return True
+    except Exception as exc:
+        message = str(exc)
+        logger.warning("Ormah Cloud restore verification failed: %s", message)
+        if store_id is None:
+            try:
+                store_id = _existing_store_id(settings.memory_dir)
+            except Exception:
+                store_id = None
+        _safe_update(
+            store_id,
+            last_verify_at=_utc_now(),
+            last_verify_ok=False,
+            last_verify_snapshot_id=snapshot_id,
+            last_verify_error=message,
+        )
+        return False
+    finally:
+        close = getattr(client, "close", None) if client is not None else None
+        if close is not None:
+            try:
+                close()
+            except Exception:
+                pass
+        if tmp_root is not None:
+            shutil.rmtree(tmp_root, ignore_errors=True)

--- a/src/ormah/cloud/restore.py
+++ b/src/ormah/cloud/restore.py
@@ -1,0 +1,115 @@
+"""Reusable cloud snapshot discovery and full restore workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Any
+
+from ormah.backup import RestoreResult, service_from_settings
+from ormah.cloud.bundle import open_bundle
+from ormah.cloud.client import client_from_settings
+from ormah.cloud.keys import (
+    STORE_ID_NAME,
+    get_or_create_store_id,
+    key_file_exists,
+    load_identities,
+)
+from ormah.cloud.transfer import download_file
+
+
+class CloudRestoreError(RuntimeError):
+    """Raised when a committed cloud snapshot cannot be restored."""
+
+
+@dataclass(frozen=True)
+class CloudRestoreResult:
+    snapshot_id: str
+    restore: RestoreResult
+
+
+def _existing_store_id(memory_dir: Path) -> str:
+    memory_dir = Path(memory_dir).expanduser()
+    if not (memory_dir / STORE_ID_NAME).is_file():
+        raise CloudRestoreError("Cloud store id is missing; import a recovery kit first.")
+    return get_or_create_store_id(memory_dir)
+
+
+def _committed_blobs(client, store_id: str) -> list[dict[str, Any]]:
+    payload = client.list_blobs(store_id)
+    blobs = payload.get("blobs")
+    if not isinstance(blobs, list):
+        raise CloudRestoreError("Cloud snapshot listing was malformed.")
+    return [blob for blob in blobs if isinstance(blob, dict)]
+
+
+def _select_snapshot(blobs: list[dict[str, Any]], requested: str | None) -> str:
+    if not blobs:
+        raise CloudRestoreError("No committed cloud snapshots are available for this store.")
+    if requested:
+        if any(blob.get("snapshot_id") == requested for blob in blobs):
+            return requested
+        raise CloudRestoreError(f"Cloud snapshot not found: {requested}")
+    snapshot_id = blobs[0].get("snapshot_id")
+    if not isinstance(snapshot_id, str) or not snapshot_id:
+        raise CloudRestoreError("Cloud snapshot listing was malformed.")
+    return snapshot_id
+
+
+def restore_cloud_snapshot(
+    settings,
+    snapshot_id: str | None = None,
+    *,
+    rebuild_index: bool = True,
+) -> CloudRestoreResult:
+    """Download a verified cloud bundle and delegate replacement to BackupService."""
+    if not settings.account_token:
+        raise CloudRestoreError("Ormah Cloud login is required; run `ormah account login`.")
+    if not key_file_exists():
+        raise CloudRestoreError("Cloud encryption key is missing; import a recovery kit first.")
+
+    store_id = _existing_store_id(settings.memory_dir)
+    service = service_from_settings(settings)
+    service.backup_dir.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=".ormah-cloud-restore-", dir=str(service.backup_dir))
+    )
+    client = None
+    try:
+        client = client_from_settings(settings)
+        chosen = _select_snapshot(_committed_blobs(client, store_id), snapshot_id)
+        presigned = client.presign_download(store_id, chosen)
+        get_url = presigned.get("get_url")
+        if not isinstance(get_url, str) or not get_url:
+            raise CloudRestoreError("Cloud download response was malformed.")
+
+        encrypted = staging / f"{chosen}.age"
+        extracted = staging / "extracted"
+        download_file(get_url, encrypted)
+        info = open_bundle(encrypted, extracted, load_identities())
+        if info.store_id != store_id:
+            raise CloudRestoreError(
+                f"Cloud bundle belongs to store {info.store_id!r}, not local store {store_id!r}."
+            )
+
+        name = service._unique_backup_name(datetime.now(timezone.utc))
+        installed_backup = service.backup_dir / name
+        os.replace(extracted, installed_backup)
+        restored = service.restore(name, rebuild_index=rebuild_index)
+        return CloudRestoreResult(snapshot_id=chosen, restore=restored)
+    except CloudRestoreError:
+        raise
+    except Exception as exc:
+        raise CloudRestoreError(str(exc)) from exc
+    finally:
+        close = getattr(client, "close", None) if client is not None else None
+        if close is not None:
+            try:
+                close()
+            except Exception:
+                pass
+        shutil.rmtree(staging, ignore_errors=True)

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -1,0 +1,220 @@
+"""Per-store cloud backup state and health derivation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields, replace
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+from typing import Any
+import threading
+import uuid
+
+
+CLOUD_STATE_DIR = Path.home() / ".local" / "share" / "ormah" / "cloud"
+_STATE_LOCK = threading.RLock()
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("cloud state timestamps must be ISO-8601 strings")
+    return _as_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+
+
+def _validate_store_id(store_id: str) -> str:
+    try:
+        parsed = uuid.UUID(store_id)
+    except (ValueError, AttributeError) as exc:
+        raise ValueError("store_id must be an RFC 4122 UUIDv4") from exc
+    if parsed.version != 4 or parsed.variant != uuid.RFC_4122:
+        raise ValueError("store_id must be an RFC 4122 UUIDv4")
+    return str(parsed)
+
+
+@dataclass(frozen=True)
+class CloudState:
+    """Durable client state for one memory store."""
+
+    last_upload_at: datetime | None = None
+    last_upload_snapshot_id: str | None = None
+    last_upload_error: str | None = None
+    last_verify_at: datetime | None = None
+    last_verify_ok: bool | None = None
+    last_verify_snapshot_id: str | None = None
+    last_verify_error: str | None = None
+    extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = dict(self.extra)
+        payload.update(
+            {
+                "last_upload_at": (
+                    _as_utc(self.last_upload_at).isoformat()
+                    if self.last_upload_at is not None
+                    else None
+                ),
+                "last_upload_snapshot_id": self.last_upload_snapshot_id,
+                "last_upload_error": self.last_upload_error,
+                "last_verify_at": (
+                    _as_utc(self.last_verify_at).isoformat()
+                    if self.last_verify_at is not None
+                    else None
+                ),
+                "last_verify_ok": self.last_verify_ok,
+                "last_verify_snapshot_id": self.last_verify_snapshot_id,
+                "last_verify_error": self.last_verify_error,
+            }
+        )
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> CloudState:
+        if not isinstance(payload, dict):
+            raise ValueError("cloud state must be a JSON object")
+        allowed = {item.name for item in fields(cls)} - {"extra"}
+        values = {key: value for key, value in payload.items() if key in allowed}
+        values["last_upload_at"] = _parse_time(values.get("last_upload_at"))
+        values["last_verify_at"] = _parse_time(values.get("last_verify_at"))
+        for key in (
+            "last_upload_snapshot_id",
+            "last_upload_error",
+            "last_verify_snapshot_id",
+            "last_verify_error",
+        ):
+            value = values.get(key)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"{key} must be a string or null")
+        verify_ok = values.get("last_verify_ok")
+        if verify_ok is not None and not isinstance(verify_ok, bool):
+            raise ValueError("last_verify_ok must be a boolean or null")
+        extra = {key: value for key, value in payload.items() if key not in allowed}
+        return cls(**values, extra=extra)
+
+
+def state_path(store_id: str, *, state_dir: Path | None = None) -> Path:
+    store_id = _validate_store_id(store_id)
+    return (state_dir or CLOUD_STATE_DIR).expanduser() / f"{store_id}.json"
+
+
+def load_state(store_id: str, *, state_dir: Path | None = None) -> CloudState:
+    """Load one store's state; missing or corrupt files start empty."""
+    path = state_path(store_id, state_dir=state_dir)
+    try:
+        return CloudState.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        return CloudState()
+
+
+def save_state(
+    store_id: str,
+    state: CloudState,
+    *,
+    state_dir: Path | None = None,
+) -> CloudState:
+    """Atomically persist one store's state with owner-only permissions."""
+    path = state_path(store_id, state_dir=state_dir)
+
+    from ormah.setup import _atomic_write
+
+    with _STATE_LOCK:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write(
+            str(path),
+            json.dumps(state.to_dict(), indent=2, sort_keys=True) + "\n",
+            mode=0o600,
+        )
+    return state
+
+
+def update_state(
+    store_id: str,
+    *,
+    state_dir: Path | None = None,
+    **changes: Any,
+) -> CloudState:
+    """Update selected fields while preserving the rest of one store's state."""
+    with _STATE_LOCK:
+        state = replace(load_state(store_id, state_dir=state_dir), **changes)
+        return save_state(store_id, state, state_dir=state_dir)
+
+
+def _existing_store_id(memory_dir: Path) -> str | None:
+    from ormah.cloud.keys import STORE_ID_NAME, get_or_create_store_id
+
+    if not (Path(memory_dir).expanduser() / STORE_ID_NAME).is_file():
+        return None
+    return get_or_create_store_id(Path(memory_dir))
+
+
+def cloud_status_payload(
+    settings,
+    *,
+    entitlement: str | None = None,
+    now: datetime | None = None,
+    state_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Return state plus derived ages and warnings for CLI/API/UI consumers."""
+    now = _as_utc(now or datetime.now(timezone.utc))
+    store_error = None
+    try:
+        store_id = _existing_store_id(settings.memory_dir)
+    except Exception as exc:
+        store_id = None
+        store_error = str(exc)
+    state = load_state(store_id, state_dir=state_dir) if store_id else CloudState()
+
+    if entitlement is None:
+        from ormah.cloud.entitlements import check_entitlement
+
+        entitlement = check_entitlement(settings).value
+
+    upload_age = None
+    if state.last_upload_at is not None:
+        upload_age = max(now - state.last_upload_at, timedelta(0))
+
+    warnings: list[str] = []
+    if store_error is not None:
+        warnings.append(f"Cloud store identity is invalid: {store_error}")
+    if settings.cloud_backup_enabled:
+        if store_id is None and store_error is None:
+            warnings.append("Cloud backup is enabled but this memory store is not initialized.")
+        elif upload_age is not None and upload_age > timedelta(
+            hours=settings.cloud_backup_interval_hours * 2
+        ):
+            warnings.append(
+                "Cloud backup is stale: the last successful upload is older than "
+                f"{settings.cloud_backup_interval_hours * 2} hours."
+            )
+    if state.last_verify_ok is False:
+        detail = f": {state.last_verify_error}" if state.last_verify_error else "."
+        warnings.append(f"Cloud restore verification failed{detail}")
+
+    return {
+        "enabled": settings.cloud_backup_enabled,
+        "store_id": store_id,
+        "interval_hours": settings.cloud_backup_interval_hours,
+        "entitlement": entitlement,
+        "last_upload_at": (
+            state.last_upload_at.isoformat() if state.last_upload_at is not None else None
+        ),
+        "last_upload_snapshot_id": state.last_upload_snapshot_id,
+        "last_upload_error": state.last_upload_error,
+        "last_upload_age_seconds": (
+            int(upload_age.total_seconds()) if upload_age is not None else None
+        ),
+        "last_verify_at": (
+            state.last_verify_at.isoformat() if state.last_verify_at is not None else None
+        ),
+        "last_verify_ok": state.last_verify_ok,
+        "last_verify_snapshot_id": state.last_verify_snapshot_id,
+        "last_verify_error": state.last_verify_error,
+        "warnings": warnings,
+    }

--- a/src/ormah/cloud/transfer.py
+++ b/src/ormah/cloud/transfer.py
@@ -1,0 +1,34 @@
+"""Data-plane transfers for service-issued presigned URLs."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import httpx
+
+
+TRANSFER_TIMEOUT = httpx.Timeout(300.0, connect=10.0)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def put_file(url: str, path: Path) -> None:
+    """PUT an encrypted bundle to a presigned object URL."""
+    response = httpx.put(url, content=path.read_bytes(), timeout=TRANSFER_TIMEOUT)
+    response.raise_for_status()
+
+
+def download_file(url: str, path: Path) -> None:
+    """Stream a presigned object download to disk."""
+    with httpx.stream("GET", url, timeout=TRANSFER_TIMEOUT) as response:
+        response.raise_for_status()
+        with path.open("wb") as destination:
+            for chunk in response.iter_bytes(1024 * 1024):
+                destination.write(chunk)

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     # Encrypted cloud backups (paid tier). Client-side keys; nothing readable
     # ever leaves the machine. Off by default until an account is configured.
     cloud_backup_enabled: bool = False
+    cloud_backup_interval_hours: int = 24
     cloud_api_url: str = "https://api.ormah.dev"
     account_token: str | None = None
     account_email: str | None = None
@@ -398,6 +399,13 @@ class Settings(BaseSettings):
     def _backup_interval_hours_positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError(f"backup_interval_hours must be >= 1, got {v}")
+        return v
+
+    @field_validator("cloud_backup_interval_hours")
+    @classmethod
+    def _cloud_backup_interval_hours_positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(f"cloud_backup_interval_hours must be >= 1, got {v}")
         return v
 
     @field_validator("backup_retention_count")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -68,6 +69,22 @@ def test_retention_keeps_latest_ten_backups(tmp_path):
     assert backups[-1].name == "memory_2026-04-26_20-00-02"
     assert not (backup_dir / "memory_2026-04-26_20-00-00").exists()
     assert not (backup_dir / "memory_2026-04-26_20-00-01").exists()
+
+
+def test_concurrent_backup_creates_use_distinct_atomic_directories(tmp_path):
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    _save_node(memory_dir, "Memory", "Content")
+    service = _service(memory_dir, backup_dir)
+    created_at = datetime(2026, 4, 26, 20, 0, 0, tzinfo=timezone.utc)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        backups = list(pool.map(lambda _: service.create(now=created_at), range(2)))
+
+    assert {backup.name for backup in backups} == {
+        "memory_2026-04-26_20-00-00",
+        "memory_2026-04-26_20-00-00_01",
+    }
 
 
 def test_restore_replaces_memory_files_and_rebuilds_index(tmp_path):

--- a/tests/test_cli_cloud_backup.py
+++ b/tests/test_cli_cloud_backup.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import shutil
+from types import SimpleNamespace
+from unittest.mock import patch
+import uuid
+
+import pytest
+
+from ormah.backup import BackupInfo, RestoreResult, service_from_settings
+from ormah.cloud.bundle import build_bundle
+from ormah.cloud.crypto import generate_identity
+from ormah.cloud.restore import CloudRestoreResult, restore_cloud_snapshot
+from ormah.config import Settings
+from ormah.models.node import MemoryNode, NodeType
+from ormah.store.file_store import FileStore
+
+
+def _save_node(memory_dir: Path, title: str, content: str) -> MemoryNode:
+    node = MemoryNode(type=NodeType.fact, title=title, content=content)
+    FileStore(memory_dir / "nodes").save(node)
+    return node
+
+
+class RestoreClient:
+    def __init__(self):
+        self.closed = False
+
+    def list_blobs(self, store_id):
+        return {
+            "blobs": [
+                {
+                    "snapshot_id": "01RESTORE",
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                    "size_bytes": 100,
+                }
+            ]
+        }
+
+    def presign_download(self, store_id, snapshot_id):
+        return {"get_url": "https://objects.example/restore"}
+
+    def close(self):
+        self.closed = True
+
+
+def test_restore_cloud_snapshot_verifies_then_uses_backup_service(tmp_path, monkeypatch):
+    from ormah.cloud import restore
+
+    store_id = str(uuid.uuid4())
+    source_memory = tmp_path / "source-memory"
+    expected = _save_node(source_memory, "Recovered node", "Recovered cloud content")
+    source_settings = Settings(
+        memory_dir=source_memory,
+        backup_dir=tmp_path / "source-backups",
+    )
+    backup = service_from_settings(source_settings).create(reason="cloud-fixture")
+    identity = generate_identity()
+    bundle = tmp_path / "snapshot.age"
+    build_bundle(
+        backup.path,
+        bundle,
+        [identity.to_public()],
+        store_id=store_id,
+        reason="cloud-backup",
+    )
+
+    target_memory = tmp_path / "target-memory"
+    target_memory.mkdir()
+    (target_memory / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    replaced = _save_node(target_memory, "Old local node", "This should be replaced")
+    settings = Settings(
+        memory_dir=target_memory,
+        backup_dir=tmp_path / "target-backups",
+        account_token="test-token",
+    )
+    client = RestoreClient()
+    monkeypatch.setattr(restore, "key_file_exists", lambda: True)
+    monkeypatch.setattr(restore, "load_identities", lambda: [identity])
+    monkeypatch.setattr(restore, "client_from_settings", lambda settings: client)
+    monkeypatch.setattr(restore, "download_file", lambda url, path: shutil.copyfile(bundle, path))
+
+    result = restore_cloud_snapshot(settings)
+
+    assert result.snapshot_id == "01RESTORE"
+    assert result.restore.rebuilt_nodes == 1
+    assert list((target_memory / "nodes").glob(f"*_{expected.short_id}.md"))
+    assert not list((target_memory / "nodes").glob(f"*_{replaced.short_id}.md"))
+    assert result.restore.safety_backup is not None
+    assert client.closed is True
+
+
+def test_cloud_restore_does_not_check_entitlement(tmp_path, monkeypatch):
+    from ormah.cloud import restore
+    from ormah.cloud import entitlements
+
+    store_id = str(uuid.uuid4())
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    settings = Settings(
+        memory_dir=memory_dir,
+        backup_dir=tmp_path / "backups",
+        account_token="test-token",
+    )
+    monkeypatch.setattr(restore, "key_file_exists", lambda: True)
+    monkeypatch.setattr(
+        entitlements,
+        "check_entitlement",
+        lambda settings: (_ for _ in ()).throw(AssertionError("restore gated entitlement")),
+    )
+    monkeypatch.setattr(
+        restore,
+        "client_from_settings",
+        lambda settings: SimpleNamespace(
+            list_blobs=lambda store_id: {"blobs": []},
+            close=lambda: None,
+        ),
+    )
+
+    with pytest.raises(restore.CloudRestoreError, match="No committed"):
+        restore_cloud_snapshot(settings)
+
+
+def _local_status_service():
+    return SimpleNamespace(
+        latest=lambda: None,
+        has_backupable_memory=lambda: False,
+        backup_due=lambda interval_hours: True,
+    )
+
+
+def _cloud_status(*, warning=False):
+    return {
+        "enabled": True,
+        "store_id": str(uuid.uuid4()),
+        "interval_hours": 24,
+        "entitlement": "active",
+        "last_upload_at": "2026-07-13T10:00:00+00:00",
+        "last_upload_snapshot_id": "01LATEST",
+        "last_upload_error": None,
+        "last_upload_age_seconds": 7200,
+        "last_verify_at": "2026-07-13T11:00:00+00:00",
+        "last_verify_ok": not warning,
+        "last_verify_snapshot_id": "01LATEST",
+        "last_verify_error": "hash mismatch" if warning else None,
+        "warnings": ["Cloud restore verification failed: hash mismatch"] if warning else [],
+    }
+
+
+def test_backup_status_json_contains_cloud_section(capsys):
+    from ormah.cli import main
+
+    with (
+        patch("sys.argv", ["ormah", "backup", "status", "--json"]),
+        patch("ormah.cli._backup_service", return_value=_local_status_service()),
+        patch("ormah.cloud.state.cloud_status_payload", return_value=_cloud_status()),
+    ):
+        main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["cloud"]["last_upload_snapshot_id"] == "01LATEST"
+    assert payload["cloud"]["last_verify_ok"] is True
+    assert "account_token" not in json.dumps(payload)
+
+
+def test_backup_status_prints_loud_verification_warning(capsys):
+    from ormah.cli import main
+
+    with (
+        patch("sys.argv", ["ormah", "backup", "status"]),
+        patch("ormah.cli._backup_service", return_value=_local_status_service()),
+        patch("ormah.cloud.state.cloud_status_payload", return_value=_cloud_status(warning=True)),
+    ):
+        main()
+
+    output = capsys.readouterr().out
+    assert "Last verified restorable: ✗" in output
+    assert "WARNING: Cloud restore verification failed" in output
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_snapshot"),
+    [
+        (["ormah", "backup", "restore", "--cloud", "--yes"], None),
+        (["ormah", "backup", "restore", "--cloud", "01CHOSEN", "--yes"], "01CHOSEN"),
+    ],
+)
+def test_cli_cloud_restore_delegates_to_reusable_workflow(
+    tmp_path, capsys, argv, expected_snapshot
+):
+    from ormah.cli import main
+
+    backup = BackupInfo(
+        name="memory_2026-07-13_12-00-00",
+        path=tmp_path / "backups" / "memory_2026-07-13_12-00-00",
+        created_at=datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc),
+        node_count=3,
+        deleted_count=1,
+        size_bytes=100,
+    )
+    result = CloudRestoreResult(
+        snapshot_id=expected_snapshot or "01LATEST",
+        restore=RestoreResult(restored=backup, safety_backup=None, rebuilt_nodes=3),
+    )
+
+    with (
+        patch("sys.argv", argv),
+        patch("ormah.server_manager.is_server_running", return_value=False),
+        patch("ormah.cloud.restore.restore_cloud_snapshot", return_value=result) as restore_call,
+    ):
+        main()
+
+    assert restore_call.call_args.args[1] == expected_snapshot
+    assert "Restored backup: memory_2026-07-13_12-00-00" in capsys.readouterr().out
+
+
+def test_cli_restore_rejects_missing_source(capsys):
+    from ormah.cli import main
+
+    with (
+        patch("sys.argv", ["ormah", "backup", "restore", "--yes"]),
+        patch("ormah.server_manager.is_server_running", return_value=False),
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+    assert "Provide a local backup name or use --cloud" in capsys.readouterr().err

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import shutil
+from types import SimpleNamespace
+import uuid
+
+import pytest
+
+from ormah.backup import run_auto_backup, service_from_settings
+from ormah.cloud.bundle import build_bundle
+from ormah.cloud.crypto import generate_identity
+from ormah.cloud.entitlements import EntitlementStatus
+from ormah.cloud.state import load_state, save_state, CloudState
+from ormah.config import Settings
+from ormah.models.node import MemoryNode, NodeType
+from ormah.store.file_store import FileStore
+
+
+NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeCloudClient:
+    def __init__(self, *, bundle: Path | None = None):
+        self.bundle = bundle
+        self.created: list[tuple[str, int, str]] = []
+        self.finalized: list[tuple] = []
+        self.closed = False
+
+    def create_upload(self, store_id, size, sha256):
+        self.created.append((store_id, size, sha256))
+        return {
+            "upload_id": "upload-1",
+            "snapshot_id": "01SNAPSHOT",
+            "put_url": "https://objects.example/put",
+        }
+
+    def finalize_upload(self, *args):
+        self.finalized.append(args)
+        return {"snapshot_id": "01SNAPSHOT", "status": "committed", "head": {"seq": 0}}
+
+    def list_blobs(self, store_id):
+        return {
+            "blobs": [
+                {"snapshot_id": "01SNAPSHOT", "created_at": NOW.isoformat(), "size_bytes": 1}
+            ]
+        }
+
+    def presign_download(self, store_id, snapshot_id):
+        return {"get_url": "https://objects.example/get"}
+
+    def close(self):
+        self.closed = True
+
+
+def _save_node(memory_dir: Path, title: str = "Cloud proof") -> MemoryNode:
+    node = MemoryNode(
+        type=NodeType.fact,
+        title=title,
+        content="Cloud restore verification finds this durable memory.",
+    )
+    FileStore(memory_dir / "nodes").save(node)
+    return node
+
+
+def _settings(tmp_path: Path, *, with_node: bool = True) -> tuple[Settings, str]:
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir(parents=True)
+    store_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    if with_node:
+        _save_node(memory_dir)
+    return (
+        Settings(
+            memory_dir=memory_dir,
+            backup_dir=tmp_path / "backups",
+            cloud_backup_enabled=True,
+            cloud_backup_interval_hours=24,
+            account_token="test-token",
+        ),
+        store_id,
+    )
+
+
+@pytest.fixture
+def cloud_state_dir(tmp_path, monkeypatch):
+    from ormah.cloud import state
+
+    path = tmp_path / "cloud-state"
+    monkeypatch.setattr(state, "CLOUD_STATE_DIR", path)
+    return path
+
+
+def _patch_upload_prerequisites(monkeypatch, client: FakeCloudClient):
+    from ormah.cloud import jobs
+
+    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
+    monkeypatch.setattr(jobs, "check_entitlement", lambda settings: EntitlementStatus.ACTIVE)
+    monkeypatch.setattr(jobs, "current_recipient", lambda: object())
+    monkeypatch.setattr(jobs, "client_from_settings", lambda settings: client)
+    monkeypatch.setattr(jobs, "_utc_now", lambda: NOW)
+
+    def fake_bundle(backup_dir, out_path, recipients, **kwargs):
+        out_path.write_bytes(b"age-encrypted-bundle")
+        return out_path
+
+    monkeypatch.setattr(jobs, "build_bundle", fake_bundle)
+    monkeypatch.setattr(jobs, "put_file", lambda url, path: None)
+
+
+def test_cloud_backup_disabled_is_first_guard(tmp_path, monkeypatch):
+    from ormah.cloud import jobs
+
+    settings, _ = _settings(tmp_path)
+    settings.cloud_backup_enabled = False
+    monkeypatch.setattr(
+        jobs,
+        "key_file_exists",
+        lambda: (_ for _ in ()).throw(AssertionError("key guard should not run")),
+    )
+
+    assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
+
+
+def test_cloud_backup_missing_key_records_error(tmp_path, monkeypatch, cloud_state_dir):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    monkeypatch.setattr(jobs, "key_file_exists", lambda: False)
+
+    assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
+    assert "key is missing" in load_state(store_id).last_upload_error
+
+
+def test_cloud_backup_missing_store_short_circuits_entitlement(tmp_path, monkeypatch):
+    from ormah.cloud import jobs
+
+    settings, _ = _settings(tmp_path)
+    (settings.memory_dir / ".store_id").unlink()
+    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
+    monkeypatch.setattr(
+        jobs,
+        "check_entitlement",
+        lambda settings: (_ for _ in ()).throw(AssertionError("entitlement should not run")),
+    )
+
+    assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
+    assert not (settings.memory_dir / ".store_id").exists()
+
+
+def test_expired_entitlement_skips_cloud_but_not_local_backup(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
+    monkeypatch.setattr(jobs, "check_entitlement", lambda settings: EntitlementStatus.EXPIRED)
+    monkeypatch.setattr(
+        jobs,
+        "build_bundle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("upload should not run")),
+    )
+
+    assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
+    assert "expired" in load_state(store_id).last_upload_error
+    assert run_auto_backup(SimpleNamespace(settings=settings)) is not None
+
+
+def test_cloud_backup_empty_store_short_circuits_bundle(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, _ = _settings(tmp_path, with_node=False)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    monkeypatch.setattr(
+        jobs,
+        "build_bundle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("bundle should not build")),
+    )
+
+    assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
+    assert client.created == []
+
+
+def test_cloud_backup_fresh_upload_short_circuits_bundle(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    save_state(store_id, CloudState(last_upload_at=NOW - timedelta(hours=23)))
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    monkeypatch.setattr(
+        jobs,
+        "build_bundle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("bundle should not build")),
+    )
+
+    assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
+    assert client.created == []
+
+
+def test_failed_put_records_error_and_never_finalizes(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    monkeypatch.setattr(jobs, "put_file", lambda url, path: (_ for _ in ()).throw(OSError("PUT failed")))
+
+    assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
+    assert client.finalized == []
+    assert "PUT failed" in load_state(store_id).last_upload_error
+    assert client.closed is True
+
+
+def test_successful_upload_finalizes_without_advancing_sync_head(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+
+    result = jobs.run_cloud_backup(SimpleNamespace(settings=settings))
+
+    assert result == "01SNAPSHOT"
+    assert client.finalized == [(store_id, "upload-1")]
+    state = load_state(store_id)
+    assert state.last_upload_at == NOW
+    assert state.last_upload_snapshot_id == "01SNAPSHOT"
+    assert state.last_upload_error is None
+
+
+def test_cloud_backup_never_reuses_newer_safety_backup_with_different_contents(tmp_path):
+    from ormah.cloud import jobs
+
+    settings, _ = _settings(tmp_path)
+    service = service_from_settings(settings)
+    stale = service.create(reason="pre-restore", prune=False)
+    for path in (stale.path / "nodes").glob("*.md"):
+        path.unlink()
+
+    selected = jobs._backup_for_upload(service)
+
+    assert selected.name != stale.name
+    assert selected.node_count == 1
+    assert len(list((selected.path / "nodes").glob("*.md"))) == 1
+
+
+def test_two_stores_upload_under_their_own_ids(tmp_path, monkeypatch, cloud_state_dir):
+    from ormah.cloud import jobs
+
+    first_settings, first_id = _settings(tmp_path / "first")
+    second_settings, second_id = _settings(tmp_path / "second")
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+
+    jobs.run_cloud_backup(SimpleNamespace(settings=first_settings))
+    jobs.run_cloud_backup(SimpleNamespace(settings=second_settings))
+
+    assert [call[0] for call in client.created] == [first_id, second_id]
+    assert load_state(first_id).last_upload_snapshot_id == "01SNAPSHOT"
+    assert load_state(second_id).last_upload_snapshot_id == "01SNAPSHOT"
+
+
+def _verification_bundle(tmp_path: Path, settings: Settings, store_id: str):
+    service = service_from_settings(settings)
+    backup = service.create(reason="verification-fixture")
+    identity = generate_identity()
+    bundle = tmp_path / "snapshot.age"
+    build_bundle(
+        backup.path,
+        bundle,
+        [identity.to_public()],
+        store_id=store_id,
+        reason="cloud-backup",
+    )
+    return bundle, identity
+
+
+def _patch_verification(monkeypatch, client, bundle: Path, identity):
+    from ormah.cloud import jobs
+
+    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
+    monkeypatch.setattr(jobs, "client_from_settings", lambda settings: client)
+    monkeypatch.setattr(jobs, "load_identities", lambda: [identity])
+    monkeypatch.setattr(jobs, "_utc_now", lambda: NOW)
+    monkeypatch.setattr(jobs, "download_file", lambda url, path: shutil.copyfile(bundle, path))
+
+
+def test_restore_verification_rebuilds_search_and_leaves_live_store_untouched(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    live_files = {
+        path: (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in settings.memory_dir.rglob("*")
+        if path.is_file()
+    }
+
+    assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is True
+
+    state = load_state(store_id)
+    assert state.last_verify_ok is True
+    assert state.last_verify_snapshot_id == "01SNAPSHOT"
+    assert state.last_verify_error is None
+    assert {
+        path: (path.read_bytes(), path.stat().st_mtime_ns) for path in live_files
+    } == live_files
+
+
+def test_restore_verification_search_probe_supports_unicode_nodes(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path, with_node=False)
+    _save_node(settings.memory_dir, title="Mémoire récupérée")
+    node_path = next((settings.memory_dir / "nodes").glob("*.md"))
+    text = node_path.read_text(encoding="utf-8")
+    node_path.write_text(
+        text.replace(
+            "Cloud restore verification finds this durable memory.",
+            "Récupération chiffrée réussie.",
+        ),
+        encoding="utf-8",
+    )
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+
+    assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is True
+    assert load_state(store_id).last_verify_ok is True
+
+
+@pytest.mark.parametrize("failure", ["truncated", "hash-mismatch"])
+def test_restore_verification_records_bundle_failures(
+    tmp_path, monkeypatch, cloud_state_dir, failure
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    if failure == "truncated":
+        bundle.write_bytes(bundle.read_bytes()[:20])
+    else:
+        monkeypatch.setattr(
+            jobs,
+            "open_bundle",
+            lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Hash mismatch")),
+        )
+
+    assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is False
+
+    state = load_state(store_id)
+    assert state.last_verify_ok is False
+    assert state.last_verify_snapshot_id == "01SNAPSHOT"
+    expected = "Hash mismatch" if failure == "hash-mismatch" else "decrypt"
+    assert expected.lower() in state.last_verify_error.lower()
+
+
+def test_restore_verification_cleans_temporary_tree_on_failure(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    root = tmp_path / "known-verification-root"
+    real_mkdtemp = jobs.tempfile.mkdtemp
+
+    def controlled_mkdtemp(*args, prefix=None, **kwargs):
+        if prefix == "ormah-restore-verify-":
+            root.mkdir()
+            return str(root)
+        return real_mkdtemp(*args, prefix=prefix, **kwargs)
+
+    monkeypatch.setattr(jobs.tempfile, "mkdtemp", controlled_mkdtemp)
+    monkeypatch.setattr(
+        jobs,
+        "open_bundle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("verification stopped")),
+    )
+
+    assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is False
+    assert not root.exists()
+
+
+def test_scheduler_registers_cloud_backup_and_weekly_verification(tmp_path, monkeypatch):
+    from ormah.background import scheduler as scheduler_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.jobs = []
+
+        def add_job(self, func, trigger, **kwargs):
+            self.jobs.append({"func": func, "trigger": trigger, **kwargs})
+
+        def start(self):
+            pass
+
+        def get_jobs(self):
+            return self.jobs
+
+    monkeypatch.setattr(scheduler_module, "BackgroundScheduler", FakeScheduler)
+    settings = Settings(
+        memory_dir=tmp_path / "memory",
+        backup_dir=tmp_path / "backups",
+        cloud_backup_interval_hours=36,
+    )
+    engine = SimpleNamespace(
+        settings=settings,
+        builder=SimpleNamespace(incremental_update=lambda: (0, 0)),
+    )
+
+    scheduler, _tracker = scheduler_module.start_scheduler(engine)
+
+    cloud = next(job for job in scheduler.jobs if job["id"] == "cloud_backup")
+    verify = next(job for job in scheduler.jobs if job["id"] == "restore_verification")
+    assert cloud["trigger"] == "interval"
+    assert cloud["hours"] == 36
+    assert cloud["next_run_time"] is not None
+    assert verify["trigger"] == "interval"
+    assert verify["hours"] == 168

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import stat
+from types import SimpleNamespace
+import uuid
+
+from ormah.cloud.state import (
+    CloudState,
+    cloud_status_payload,
+    load_state,
+    save_state,
+    state_path,
+    update_state,
+)
+from ormah.config import Settings
+
+
+def test_state_round_trip_is_atomic_and_owner_only(tmp_path):
+    store_id = str(uuid.uuid4())
+    now = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    state = CloudState(
+        last_upload_at=now,
+        last_upload_snapshot_id="01UPLOAD",
+        last_verify_at=now + timedelta(hours=1),
+        last_verify_ok=False,
+        last_verify_snapshot_id="01VERIFY",
+        last_verify_error="hash mismatch",
+    )
+
+    save_state(store_id, state, state_dir=tmp_path)
+
+    path = state_path(store_id, state_dir=tmp_path)
+    assert load_state(store_id, state_dir=tmp_path) == state
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_update_preserves_unmodified_fields(tmp_path):
+    store_id = str(uuid.uuid4())
+    save_state(
+        store_id,
+        CloudState(last_upload_snapshot_id="old", last_verify_ok=True),
+        state_dir=tmp_path,
+    )
+
+    updated = update_state(
+        store_id,
+        state_dir=tmp_path,
+        last_upload_error="offline",
+    )
+
+    assert updated.last_upload_snapshot_id == "old"
+    assert updated.last_verify_ok is True
+    assert updated.last_upload_error == "offline"
+
+
+def test_update_preserves_future_state_fields(tmp_path):
+    store_id = str(uuid.uuid4())
+    path = state_path(store_id, state_dir=tmp_path)
+    path.write_text(
+        json.dumps({"last_synced_snapshot_id": "future-e06", "last_verify_ok": True}),
+        encoding="utf-8",
+    )
+
+    update_state(store_id, state_dir=tmp_path, last_upload_error="retrying")
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["last_synced_snapshot_id"] == "future-e06"
+    assert payload["last_upload_error"] == "retrying"
+
+
+def test_two_stores_never_share_state(tmp_path):
+    first = str(uuid.uuid4())
+    second = str(uuid.uuid4())
+
+    update_state(first, state_dir=tmp_path, last_upload_snapshot_id="first")
+    update_state(second, state_dir=tmp_path, last_upload_snapshot_id="second")
+
+    assert load_state(first, state_dir=tmp_path).last_upload_snapshot_id == "first"
+    assert load_state(second, state_dir=tmp_path).last_upload_snapshot_id == "second"
+    assert state_path(first, state_dir=tmp_path) != state_path(second, state_dir=tmp_path)
+
+
+def test_missing_or_malformed_state_loads_empty(tmp_path):
+    store_id = str(uuid.uuid4())
+    assert load_state(store_id, state_dir=tmp_path) == CloudState()
+    state_path(store_id, state_dir=tmp_path).write_text("{not-json", encoding="utf-8")
+    assert load_state(store_id, state_dir=tmp_path) == CloudState()
+
+
+def test_state_path_rejects_path_traversal(tmp_path):
+    try:
+        state_path("../outside", state_dir=tmp_path)
+    except ValueError as exc:
+        assert "UUIDv4" in str(exc)
+    else:
+        raise AssertionError("invalid store id was accepted")
+
+
+def test_cloud_status_derives_stale_and_verification_warnings(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    now = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    save_state(
+        store_id,
+        CloudState(
+            last_upload_at=now - timedelta(hours=49),
+            last_upload_snapshot_id="01OLD",
+            last_verify_at=now - timedelta(days=1),
+            last_verify_ok=False,
+            last_verify_error="bundle truncated",
+        ),
+        state_dir=tmp_path / "state",
+    )
+    settings = Settings(
+        memory_dir=memory_dir,
+        cloud_backup_enabled=True,
+        cloud_backup_interval_hours=24,
+    )
+
+    payload = cloud_status_payload(
+        settings,
+        entitlement="expired",
+        now=now,
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["store_id"] == store_id
+    assert payload["last_upload_age_seconds"] == 49 * 3600
+    assert payload["entitlement"] == "expired"
+    assert any("stale" in warning for warning in payload["warnings"])
+    assert any("bundle truncated" in warning for warning in payload["warnings"])
+
+
+def test_cloud_state_json_contains_only_plain_metadata(tmp_path):
+    store_id = str(uuid.uuid4())
+    save_state(store_id, CloudState(last_upload_snapshot_id="01SAFE"), state_dir=tmp_path)
+
+    payload = json.loads(state_path(store_id, state_dir=tmp_path).read_text(encoding="utf-8"))
+
+    assert payload["last_upload_snapshot_id"] == "01SAFE"
+    assert set(payload) == {
+        "last_upload_at",
+        "last_upload_snapshot_id",
+        "last_upload_error",
+        "last_verify_at",
+        "last_verify_ok",
+        "last_verify_snapshot_id",
+        "last_verify_error",
+    }
+
+
+def test_admin_cloud_status_is_thin_wrapper(monkeypatch):
+    from ormah.api import routes_admin
+
+    settings = SimpleNamespace(memory_dir=Path("/tmp/memory"))
+    expected = {"last_verify_ok": True, "warnings": []}
+    monkeypatch.setattr("ormah.cloud.state.cloud_status_payload", lambda value: expected)
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(engine=SimpleNamespace(settings=settings))))
+
+    assert routes_admin.cloud_status(request) == expected
+    assert any(route.path == "/admin/cloud-status" for route in routes_admin.router.routes)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,6 +114,11 @@ def test_backup_interval_zero():
         _settings(backup_interval_hours=0)
 
 
+def test_cloud_backup_interval_zero():
+    with pytest.raises(ValidationError, match="cloud_backup_interval_hours must be >= 1"):
+        _settings(cloud_backup_interval_hours=0)
+
+
 def test_backup_retention_zero():
     with pytest.raises(ValidationError, match="backup_retention_count must be >= 1"):
         _settings(backup_retention_count=0)

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -82,12 +82,32 @@ export interface BackupStatus {
   latest: BackupInfo | null;
 }
 
+export interface CloudStatus {
+  enabled: boolean;
+  store_id: string | null;
+  interval_hours: number;
+  entitlement: "active" | "grace" | "expired" | "none";
+  last_upload_at: string | null;
+  last_upload_snapshot_id: string | null;
+  last_upload_error: string | null;
+  last_upload_age_seconds: number | null;
+  last_verify_at: string | null;
+  last_verify_ok: boolean | null;
+  last_verify_snapshot_id: string | null;
+  last_verify_error: string | null;
+  warnings: string[];
+}
+
 export function fetchAdminTasks(): Promise<{ tasks: AdminTask[] }> {
   return get("/admin/tasks");
 }
 
 export function fetchBackupStatus(): Promise<BackupStatus> {
   return get("/admin/backup");
+}
+
+export function fetchCloudStatus(): Promise<CloudStatus> {
+  return get("/admin/cloud-status");
 }
 
 export function createBackup(): Promise<{

--- a/ui/src/components/AdminPanel.tsx
+++ b/ui/src/components/AdminPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   createBackup,
   fetchBackupStatus,
+  fetchCloudStatus,
   fetchAdminTasks,
   runAdminTask,
   runAllTasks,
@@ -11,7 +12,7 @@ import {
   resumeAllTasks,
   updateBackupSettings,
 } from "../api";
-import type { AdminTask, BackupStatus } from "../api";
+import type { AdminTask, BackupStatus, CloudStatus } from "../api";
 
 interface Props {
   open: boolean;
@@ -22,6 +23,7 @@ interface Props {
 export default function AdminPanel({ open, onClose, onToast }: Props) {
   const [tasks, setTasks] = useState<AdminTask[]>([]);
   const [backupStatus, setBackupStatus] = useState<BackupStatus | null>(null);
+  const [cloudStatus, setCloudStatus] = useState<CloudStatus | null>(null);
   const [backupStatusLoaded, setBackupStatusLoaded] = useState(false);
   const [backupSettingsOpen, setBackupSettingsOpen] = useState(false);
   const [backupDirInput, setBackupDirInput] = useState("");
@@ -41,6 +43,7 @@ export default function AdminPanel({ open, onClose, onToast }: Props) {
       .then(setBackupStatus)
       .catch(() => setBackupStatus(null))
       .finally(() => setBackupStatusLoaded(true));
+    fetchCloudStatus().then(setCloudStatus).catch(() => setCloudStatus(null));
   }, [open]);
 
   useEffect(() => {
@@ -201,6 +204,27 @@ export default function AdminPanel({ open, onClose, onToast }: Props) {
             </div>
             {!backupStatus.has_backupable_memory && (
               <div className="admin-backup-note">no memory nodes to auto-backup yet</div>
+            )}
+            {cloudStatus && (
+              <div
+                className={`admin-cloud-verification ${
+                  cloudStatus.last_verify_ok === true
+                    ? "ok"
+                    : cloudStatus.last_verify_ok === false
+                      ? "failed"
+                      : "unknown"
+                }`}
+                title={cloudStatus.last_verify_error || undefined}
+              >
+                <span>Last verified restorable:</span>
+                <strong>
+                  {cloudStatus.last_verify_ok === true
+                    ? `✓ ${cloudStatus.last_verify_at ? formatDate(cloudStatus.last_verify_at) : "date unavailable"}`
+                    : cloudStatus.last_verify_ok === false
+                      ? `✗ ${cloudStatus.last_verify_at ? formatDate(cloudStatus.last_verify_at) : "date unavailable"}`
+                      : "not yet verified"}
+                </strong>
+              </div>
             )}
             <button
               className="review-btn approve admin-backup-button"

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -978,6 +978,37 @@ body.in-app .node-detail.tier-core {
   font-size: 11px;
 }
 
+.admin-cloud-verification {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 8px 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+}
+
+.admin-cloud-verification span {
+  color: var(--text-muted);
+}
+
+.admin-cloud-verification strong {
+  text-align: right;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.admin-cloud-verification.ok strong {
+  color: var(--edge-supports);
+}
+
+.admin-cloud-verification.failed strong {
+  color: var(--edge-contradicts);
+}
+
 .admin-backup-button {
   width: 100%;
   margin-top: 4px;


### PR DESCRIPTION
## Summary

Implements E05 Cloud Backup, Restore & Verification on top of the merged E02, E03, and E04 milestones.

- adds atomic `0600` per-store cloud state with forward-compatible fields and centralized health warnings
- adds entitlement-aware scheduled encrypted uploads using create, presigned PUT, and finalize without `advance_head`
- adds weekly full restore verification: download, decrypt, manifest hashes, markdown parsing, scratch index rebuild, manifest count assertion, and Unicode-aware search probe
- adds reusable committed-snapshot restore logic and `ormah backup restore --cloud [SNAPSHOT_ID]`
- extends backup status JSON/text, adds `/admin/cloud-status`, and shows the minimal admin verification badge
- adds cloud interval config, README recovery-kit/fresh-machine guidance, and scheduler registration
- serializes in-process local backup creation so the immediate local/cloud scheduler jobs cannot collide

## Behavioral contracts

- upload guards run in order: enabled, key/store identity, entitlement, memory, due
- only `active` and `grace` upload; `expired` and `none` record a warning and return without raising
- uploads finalize only after a successful object PUT and never move the sync head
- local backup reuse requires exact file-set, size, and SHA-256 equality with the live source files
- restore and downloads never check entitlement
- cloud restore installs the verified bundle as a normal local backup, then delegates replacement and safety backup handling to `BackupService.restore()`
- verification uses only temporary extraction/index paths and cleans them in `finally`; live source files are never opened for write
- state updates preserve future E06 fields and are serialized against coincident upload/verification schedules
- no token, plaintext, recovery key, or blob content is exposed through status or the admin endpoint

## Configuration

Adds `ORMAH_CLOUD_BACKUP_INTERVAL_HOURS` with a minimum value of 1. Cloud backup remains disabled by default.

## Verification

- `87 passed` across E05 cloud jobs/state/CLI plus backup/config regression files
- `1,245 passed, 1 deselected` in the broad suite excluding the five known TestClient portal-timeout files
- the five socket/cache environment failures from that sandbox split pass separately (`5 passed`), giving 1,250 runnable non-TestClient tests on the final tree
- `make lint` passes
- `npm run build` passes; Vite reports only the existing bundle-size warning
- `uv tool install . --reinstall` succeeds
- installed `ormah backup status --json` includes the cloud section and no credentials

A single uninterrupted `make test` result is not claimed: the five pre-existing TestClient-heavy files (`test_routes`, `test_routes_concurrency`, `test_stats`, `test_submit_feedback`, `test_whisper_context`) hit the already-known AnyIO blocking-portal timeout in this environment.

## Local service + real R2 walkthrough

Ran `ormah-cloud` locally in development mode with a fresh SQLite database and the real dev R2 credentials. The temporary test account was set to `active` in that local database after console OTP login.

```text
$ ormah account login --email e05-e2e@example.com
[ok] Signed in as e05-e2e@example.com
Plan status: active
Cloud backup entitlement: active

$ ormah cloud init --json
{"identity_count": 1, "store_id": "d843ba10-...", "imported": false}

$ force run_cloud_backup
snapshot_id: 01KXE08NTE3FPRV7GZETY97600
committed blobs: 1
sync head: {"snapshot_id": null, "seq": 0}

$ inspect store-specific R2 prefix
count: 1
suffix: .age
age header: true
plaintext memory content present: false

$ fresh-home ormah account login
[ok] Signed in as e05-e2e@example.com
Plan status: active

$ ormah cloud init --import-key <recovery-kit> --json
{"identity_count": 1, "store_id": "d843ba10-...", "imported": true}

$ ormah backup restore --cloud --yes
[ok] Restored backup: memory_2026-07-13_15-08-30
[..] Safety backup of previous memory: memory_2026-07-13_15-08-30_01
[..] Rebuilt search index from 1 nodes

$ force run_restore_verification
{"verified": true}

$ diff -r source-memory/nodes restored-memory/nodes
# no differences
```

The exact test object was deleted from dev R2 after the walkthrough. Fly staging remains pending the E03 deployment credentials and is not required for this local code review.