### PR TITLE
fix(ci): use free-disk-space action before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,26 +10,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Free runner disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-      - name: Free runner disk space
-        run: |
-          echo "Disk before cleanup:"
-          df -h
-
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          docker system prune --all --force || true
-
-          echo "Disk after cleanup:"
-          df -h
       - name: Install
         run: uv sync --extra dev
       - name: Run tests
-        run: uv run pytest tests/ -q --durations=25
+        run: |
+          monitor_disk() {
+            while true; do
+              echo "::group::Disk usage $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+              df -h
+              df -i
+              (du -x -h -d 2 \
+                "$GITHUB_WORKSPACE" \
+                "$RUNNER_TEMP" \
+                "$UV_CACHE_DIR" \
+                "$HOME/.local/share/ormah" \
+                "$HOME/.cache" \
+                /tmp \
+                .venv 2>/dev/null || true) | sort -hr | head -100
+              echo "::endgroup::"
+              sleep 120
+            done
+          }
+
+          monitor_disk &
+          monitor_pid=$!
+          trap 'kill "$monitor_pid" 2>/dev/null || true' EXIT
+
+          uv run pytest tests/ -vv --durations=25
       - name: Report disk usage
         if: always()
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,23 @@ def prevent_tests_mutating_real_ormah_install(monkeypatch):
     monkeypatch.setattr(shutil, "rmtree", guarded_rmtree)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def isolate_fastembed_cache(tmp_path_factory):
+    """Keep model download/cache mutations outside the real Ormah install.
+
+    The deletion guard above intentionally protects ``~/.local/share/ormah``,
+    which is also FastEmbed's production cache location.  A fresh test runner
+    must therefore use a separate cache so Hugging Face can atomically replace
+    its ``*.incomplete`` downloads without tripping the guard.
+    """
+    cache_dir = tmp_path_factory.getbasetemp().parent / "ormah-fastembed-cache"
+    cache_dir.mkdir(exist_ok=True)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(cache_dir))
+        yield cache_dir
+
+
 @pytest.fixture
 def tmp_memory_dir(tmp_path):
     """Temporary memory directory."""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2599,7 +2599,8 @@ class TestRemoveFastembedCache:
         # cache_dir itself is removed when empty
         assert not tmp_path.exists()
 
-    def test_uses_default_fastembed_cache_dir(self, tmp_path):
+    def test_uses_default_fastembed_cache_dir(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("FASTEMBED_CACHE_PATH")
         cache_dir = tmp_path / ".local" / "share" / "ormah" / "models"
         model_dir = cache_dir / "models--qdrant--bge-base-en-v1.5-onnx-q"
         model_dir.mkdir(parents=True)

--- a/tests/test_test_safety.py
+++ b/tests/test_test_safety.py
@@ -1,0 +1,19 @@
+"""Regression tests for the shared pytest safety fixtures."""
+
+from pathlib import Path
+
+from ormah.embeddings.cache import get_fastembed_cache_dir
+
+
+def test_fastembed_cache_isolated_from_real_ormah_install(isolate_fastembed_cache):
+    cache_dir = get_fastembed_cache_dir()
+    real_ormah_data_dir = Path.home() / ".local" / "share" / "ormah"
+
+    assert cache_dir == isolate_fastembed_cache
+    assert not cache_dir.is_relative_to(real_ormah_data_dir)
+
+    cleanup_probe = cache_dir / ".cleanup-probe.incomplete"
+    cleanup_probe.write_text("partial download", encoding="utf-8")
+    cleanup_probe.unlink()
+
+    assert not cleanup_probe.exists()


### PR DESCRIPTION
## Problem

CI appeared to stall in pytest and eventually crashed when the Actions runner could no longer write its own diagnostic log.

The fresh-run failure was caused by the test safety fixture added in `2e76b5b`. It blocks deletion anywhere under the real `~/.local/share/ormah` tree, while FastEmbed uses `~/.local/share/ormah/models` by default. Hugging Face could download model files but could not delete/replace its `*.incomplete` temporary files. Every new test engine retried initialization, repeatedly growing partial downloads until the runner filled. Tests requiring embeddings then created no vectors or edges.

## Solution

- Use Andre's suggested `jlumbroso/free-disk-space` action before installing the test environment.
- Give each pytest session a persistent test-only FastEmbed cache under pytest's temporary root, outside the real Ormah install.
- Keep the real-install deletion guard strict.
- Add a regression test proving the test cache is isolated and temporary-file cleanup is allowed.
- Keep verbose pytest progress and periodic disk diagnostics so any future resource regression identifies the active test and growing path.

## Verification

- Fresh isolated cache: safety regression plus both formerly failing auto-linker tests passed.
- CI-ordered prefix: 100 passed in 6.79s.
- Full suite with an isolated CI-like HOME: 1,405 passed, 1 deselected in 54.42s.
- Ruff clean.
- Workflow YAML parsed successfully and `git diff --check` passed.

Follow-up to #99 and #102.
