### PR TITLE
fix(cloud): preserve recovery material on uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ including Ormah.
 
 `ormah uninstall` removes local data and account configuration, but it always
 preserves `~/.config/ormah/cloud.key` and
-`~/.config/ormah/ormah-recovery-kit.md`. Deleting those files manually can make
+`~/.config/ormah/ormah-recovery-kit.md`. Before deleting anything, uninstall
+verifies that the kit contains the current encryption identities and store ID,
+and safely refreshes a missing or stale kit when the local key and store ID are
+available. If complete recovery cannot be guaranteed, uninstall stops without
+removing data or integrations. Deleting the preserved files manually can make
 encrypted cloud backups permanently unreadable.
 
 Restore on a new machine with:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ them. Keep it offline and separate from the machine and cloud account it
 protects. Anyone with the kit can read the backups; without it, nobody can,
 including Ormah.
 
+`ormah uninstall` removes local data and account configuration, but it always
+preserves `~/.config/ormah/cloud.key` and
+`~/.config/ormah/ormah-recovery-kit.md`. Deleting those files manually can make
+encrypted cloud backups permanently unreadable.
+
 Restore on a new machine with:
 
 ```bash

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -13,7 +13,7 @@ Usage:
     ormah account logout    Revoke this device token and sign out
     ormah claude-md install Install shared Ormah guidance into CLAUDE.md
     ormah pi-md install     Install shared Ormah guidance into Pi AGENTS.md
-    ormah uninstall         Remove all ormah integrations and data
+    ormah uninstall         Remove integrations and local data; preserve cloud recovery files
     ormah mcp               Run MCP stdio server
     ormah recall <query>    Search memories
     ormah remember <text>   Store a memory
@@ -799,7 +799,10 @@ def main():
     setup_p.set_defaults(func=_cmd_setup)
 
     # --- uninstall ---
-    uninstall_p = sub.add_parser("uninstall", help="Remove all ormah integrations and data")
+    uninstall_p = sub.add_parser(
+        "uninstall",
+        help="Remove integrations and local data; preserve cloud recovery files",
+    )
     uninstall_p.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts")
     uninstall_p.set_defaults(func=_cmd_uninstall)
 

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -1934,6 +1934,160 @@ def _cloud_recovery_paths(config_dir: Path) -> tuple[Path, ...]:
     )
 
 
+class CloudRecoveryPreflightError(RuntimeError):
+    """Raised when uninstall cannot prove cloud backups remain recoverable."""
+
+
+@dataclass(frozen=True)
+class CloudRecoveryPreflight:
+    """Recovery artifacts verified before destructive uninstall work begins."""
+
+    paths: tuple[Path, ...]
+    kit_regenerated: bool = False
+
+
+def _store_id_for_uninstall(memory_dirs: list[Path]) -> str | None:
+    """Return the single store id uninstall is about to remove, if present."""
+    from ormah.cloud.keys import CloudKeyError, extract_store_id
+
+    store_ids: dict[str, list[Path]] = {}
+    for memory_dir in dict.fromkeys(memory_dirs):
+        store_path = memory_dir / ".store_id"
+        if not store_path.is_file():
+            continue
+        try:
+            value = store_path.read_text(encoding="utf-8").strip()
+            store_id = extract_store_id(f"store_id: {value}")
+        except (CloudKeyError, OSError) as exc:
+            raise CloudRecoveryPreflightError(
+                f"Cannot validate cloud store identity at {store_path}: {exc}"
+            ) from exc
+        if store_id is None:  # Defensive: an explicit store_id line must parse or raise.
+            raise CloudRecoveryPreflightError(
+                f"Cannot validate cloud store identity at {store_path}."
+            )
+        store_ids.setdefault(store_id, []).append(store_path)
+
+    if len(store_ids) > 1:
+        paths = ", ".join(str(path) for found in store_ids.values() for path in found)
+        raise CloudRecoveryPreflightError(
+            "Multiple cloud store IDs would be deleted, but one recovery kit can only "
+            f"represent one store: {paths}"
+        )
+    return next(iter(store_ids), None)
+
+
+def _validated_identity_strings(path: Path) -> list[str]:
+    """Read and cryptographically validate every age identity in a file."""
+    from ormah.cloud.keys import load_identities, load_identity_strings
+
+    strings = load_identity_strings(path)
+    load_identities(path)
+    return strings
+
+
+def _prepare_cloud_recovery(
+    config_dir: Path,
+    memory_dirs: list[Path],
+) -> CloudRecoveryPreflight:
+    """Ensure uninstall leaves a complete key + store-id recovery path.
+
+    A valid kit is left byte-for-byte untouched. A missing or stale kit is
+    regenerated only when the current key and one authoritative store id are
+    both available. Valid mismatched store ids fail closed because overwriting
+    that kit could orphan a different store.
+    """
+    from ormah.cloud.crypto import CloudCryptoError
+    from ormah.cloud.keys import CloudKeyError, extract_store_id, write_recovery_kit
+
+    paths = _cloud_recovery_paths(config_dir)
+    if not paths:
+        return CloudRecoveryPreflight(())
+
+    key_path = config_dir / "cloud.key"
+    kit_path = config_dir / "ormah-recovery-kit.md"
+    expected_store_id = _store_id_for_uninstall(memory_dirs)
+
+    key_identities: list[str] | None = None
+    if key_path.exists() or key_path.is_symlink():
+        if not key_path.is_file():
+            raise CloudRecoveryPreflightError(
+                f"Cloud key is not a readable file: {key_path}"
+            )
+        try:
+            key_identities = _validated_identity_strings(key_path)
+        except (CloudKeyError, CloudCryptoError, OSError) as exc:
+            raise CloudRecoveryPreflightError(
+                f"Cloud key validation failed at {key_path}: {exc}"
+            ) from exc
+
+    kit_identities: list[str] | None = None
+    kit_store_id: str | None = None
+    kit_error: Exception | None = None
+    if kit_path.exists() or kit_path.is_symlink():
+        if not kit_path.is_file():
+            kit_error = CloudRecoveryPreflightError(
+                f"Recovery kit is not a readable file: {kit_path}"
+            )
+        else:
+            try:
+                kit_identities = _validated_identity_strings(kit_path)
+            except (CloudKeyError, CloudCryptoError, OSError) as exc:
+                kit_error = exc
+            try:
+                kit_store_id = extract_store_id(str(kit_path))
+            except (CloudKeyError, OSError) as exc:
+                kit_error = exc
+
+    if (
+        kit_identities
+        and kit_store_id
+        and (key_identities is None or kit_identities == key_identities)
+        and (expected_store_id is None or kit_store_id == expected_store_id)
+    ):
+        return CloudRecoveryPreflight(_cloud_recovery_paths(config_dir))
+
+    if key_identities is None:
+        detail = f": {kit_error}" if kit_error else ""
+        raise CloudRecoveryPreflightError(
+            "No valid cloud key is available to repair the incomplete recovery "
+            f"kit at {kit_path}{detail}"
+        )
+    if (
+        expected_store_id is not None
+        and kit_store_id is not None
+        and kit_store_id != expected_store_id
+    ):
+        raise CloudRecoveryPreflightError(
+            f"Recovery kit store ID {kit_store_id} does not match the store being "
+            f"removed ({expected_store_id}); refusing to overwrite either store's kit."
+        )
+    target_store_id = expected_store_id or kit_store_id
+    if target_store_id is None:
+        raise CloudRecoveryPreflightError(
+            "The cloud key exists, but no store ID is available in either the "
+            "recovery kit or the memory store. Uninstall cannot guarantee recovery."
+        )
+
+    try:
+        write_recovery_kit(
+            target_store_id,
+            key_path=key_path,
+            kit_path=kit_path,
+        )
+        regenerated_identities = _validated_identity_strings(kit_path)
+        regenerated_store_id = extract_store_id(str(kit_path))
+    except (CloudKeyError, CloudCryptoError, OSError) as exc:
+        raise CloudRecoveryPreflightError(
+            f"Could not create a complete recovery kit at {kit_path}: {exc}"
+        ) from exc
+    if regenerated_identities != key_identities or regenerated_store_id != target_store_id:
+        raise CloudRecoveryPreflightError(
+            f"Recovery-kit verification failed after writing {kit_path}."
+        )
+    return CloudRecoveryPreflight(_cloud_recovery_paths(config_dir), kit_regenerated=True)
+
+
 def _remove_config_preserving_cloud_recovery(config_dir: Path) -> tuple[Path, ...]:
     """Delete Ormah config while retaining zero-knowledge recovery material."""
     preserved = _cloud_recovery_paths(config_dir)
@@ -2000,6 +2154,29 @@ def run_uninstall(yes: bool = False) -> None:
     # that resolves differently depending on the invoking binary's config).
     live_data_dir = _get_running_server_data_dir()
 
+    from ormah.config import settings as _settings
+
+    config_mem_dir = _settings.memory_dir
+    if not config_mem_dir.is_absolute():
+        config_mem_dir = Path.home() / config_mem_dir
+    config_mem_dir = config_mem_dir.resolve()
+
+    if recovery_paths:
+        step("Verifying cloud recovery")
+        try:
+            recovery = _prepare_cloud_recovery(
+                config_dir,
+                list(filter(None, [live_data_dir, config_mem_dir])),
+            )
+        except CloudRecoveryPreflightError as exc:
+            warn(str(exc))
+            warn("Uninstall cancelled before removing any data or integrations.")
+            return
+        if recovery.kit_regenerated:
+            ok(f"Recovery kit refreshed and verified: {config_dir / 'ormah-recovery-kit.md'}")
+        else:
+            ok("Cloud recovery material is complete and verified")
+
     # a. Stop daemon
     step("Stopping server")
     from ormah.server_manager import uninstall_autostart
@@ -2043,12 +2220,6 @@ def run_uninstall(yes: bool = False) -> None:
 
     # Add the live server's actual data dir if it falls outside the XDG tree.
     # Also add the config-derived path as a safety net (handles custom ORMAH_MEMORY_DIR).
-    from ormah.config import settings as _settings
-    config_mem_dir = _settings.memory_dir
-    if not config_mem_dir.is_absolute():
-        config_mem_dir = Path.home() / config_mem_dir
-    config_mem_dir = config_mem_dir.resolve()
-
     for candidate in filter(None, [live_data_dir, config_mem_dir]):
         if not any(candidate == d or str(candidate).startswith(str(d) + "/")
                    for d in xdg_dirs):

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -68,6 +68,7 @@ def _find_binary(name: str) -> str | None:
     return None
 ENV_PATH = ENV_DIR / ".env"
 WRAPPER_PATH = ENV_DIR / "ormah-server"
+CLOUD_RECOVERY_FILENAMES = frozenset({"cloud.key", "ormah-recovery-kit.md"})
 
 CLAUDE_MD_SENTINEL_START = "<!-- ormah:start -->"
 CLAUDE_MD_SENTINEL_END = "<!-- ormah:end -->"
@@ -1924,9 +1925,55 @@ def _remove_uv_tool_install_files() -> bool:
     return removed
 
 
+def _cloud_recovery_paths(config_dir: Path) -> tuple[Path, ...]:
+    """Return recovery artifacts that uninstall must never delete."""
+    return tuple(
+        path
+        for name in sorted(CLOUD_RECOVERY_FILENAMES)
+        if (path := config_dir / name).exists() or path.is_symlink()
+    )
+
+
+def _remove_config_preserving_cloud_recovery(config_dir: Path) -> tuple[Path, ...]:
+    """Delete Ormah config while retaining zero-knowledge recovery material."""
+    preserved = _cloud_recovery_paths(config_dir)
+    if not preserved:
+        shutil.rmtree(config_dir)
+        return ()
+
+    preserved_names = {path.name for path in preserved}
+    for child in config_dir.iterdir():
+        if child.name in preserved_names:
+            continue
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+
+    ok(f"Deleted Ormah config from {config_dir}")
+    for path in preserved:
+        warn(f"Preserved cloud recovery material: {path}")
+    return preserved
+
+
 def run_uninstall(yes: bool = False) -> None:
-    """Remove all ormah integrations, data, and optionally the package itself."""
-    print("This will remove all ormah integrations and data.\n")
+    """Remove Ormah while preserving zero-knowledge cloud recovery material."""
+    print(
+        "This will remove Ormah integrations, local memory, caches, and account "
+        "configuration. Cloud recovery files are preserved.\n"
+    )
+
+    config_dir = Path.home() / ".config" / "ormah"
+    recovery_paths = _cloud_recovery_paths(config_dir)
+    if recovery_paths:
+        warn("Cloud recovery material detected; uninstall will not delete it:")
+        for path in recovery_paths:
+            warn(f"  {path}")
+        warn(
+            "Keep these files safe. Deleting them can make encrypted cloud backups "
+            "permanently unreadable."
+        )
+        print()
 
     if not yes:
         try:
@@ -1990,7 +2037,7 @@ def run_uninstall(yes: bool = False) -> None:
     xdg_dirs = [
         Path.home() / ".local" / "share" / "ormah",
         Path.home() / ".cache" / "ormah",
-        Path.home() / ".config" / "ormah",
+        config_dir,
     ]
     data_dirs: list[Path] = list(xdg_dirs)
 
@@ -2010,8 +2057,13 @@ def run_uninstall(yes: bool = False) -> None:
 
     for d in data_dirs:
         if d.exists():
-            shutil.rmtree(d)
-            ok(f"Deleted {d}")
+            if d == config_dir:
+                preserved = _remove_config_preserving_cloud_recovery(d)
+                if not preserved:
+                    ok(f"Deleted {d}")
+            else:
+                shutil.rmtree(d)
+                ok(f"Deleted {d}")
         else:
             info(f"{d} not found — skipping")
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -38,6 +38,7 @@ from ormah.setup import (
     _remove_codex_hooks,
     _remove_codex_md_block,
     _remove_codex_mcp_config,
+    _remove_config_preserving_cloud_recovery,
     _read_env_file,
     _remove_codex_agents,
     _remove_claude_hooks,
@@ -2446,6 +2447,92 @@ class TestRunUninstall:
         assert not share_dir.exists()
         assert not cache_dir.exists()
         assert not config_dir.exists()
+
+    @pytest.mark.parametrize("filename", ["cloud.key", "ormah-recovery-kit.md"])
+    def test_config_cleanup_preserves_each_cloud_recovery_file(self, tmp_path, filename):
+        config_dir = tmp_path / ".config" / "ormah"
+        config_dir.mkdir(parents=True)
+        recovery_file = config_dir / filename
+        recovery_file.write_text("recovery material\n")
+        recovery_file.chmod(0o600)
+        (config_dir / ".env").write_text("ORMAH_ACCOUNT_TOKEN=secret\n")
+        nested = config_dir / "generated"
+        nested.mkdir()
+        (nested / "state.json").write_text("{}\n")
+
+        preserved = _remove_config_preserving_cloud_recovery(config_dir)
+
+        assert preserved == (recovery_file,)
+        assert recovery_file.read_text() == "recovery material\n"
+        assert stat.S_IMODE(recovery_file.stat().st_mode) == 0o600
+        assert list(config_dir.iterdir()) == [recovery_file]
+
+    def test_uninstall_preserves_cloud_recovery_material_with_yes(self, tmp_path, capsys):
+        share_dir = tmp_path / ".local" / "share" / "ormah"
+        cache_dir = tmp_path / ".cache" / "ormah"
+        config_dir = tmp_path / ".config" / "ormah"
+        for directory in (share_dir, cache_dir, config_dir):
+            directory.mkdir(parents=True)
+
+        key_path = config_dir / "cloud.key"
+        kit_path = config_dir / "ormah-recovery-kit.md"
+        key_content = "AGE-SECRET-KEY-TEST\n"
+        kit_content = "# Ormah Recovery Kit\nstore_id: test\n"
+        key_path.write_text(key_content)
+        kit_path.write_text(kit_content)
+        key_path.chmod(0o600)
+        kit_path.chmod(0o600)
+        (config_dir / ".env").write_text("ORMAH_ACCOUNT_TOKEN=secret\n")
+
+        with (
+            patch("ormah.server_manager.uninstall_autostart"),
+            patch("ormah.setup._remove_claude_hooks"),
+            patch("ormah.setup._remove_codex_hooks"),
+            patch("ormah.setup._remove_mcp_registration"),
+            patch("ormah.setup._remove_pi_extension"),
+            patch("ormah.setup._remove_claude_md_block"),
+            patch("ormah.setup._remove_codex_md_block"),
+            patch("ormah.setup._remove_codex_agents"),
+            patch("ormah.setup._remove_claude_agents"),
+            patch("ormah.setup._remove_claude_commands"),
+            patch("ormah.setup._remove_pi_md_block"),
+            patch("ormah.setup._remove_pi_agents"),
+            patch("ormah.setup._remove_fastembed_cache"),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+        ):
+            run_uninstall(yes=True)
+
+        assert not share_dir.exists()
+        assert not cache_dir.exists()
+        assert key_path.read_text() == key_content
+        assert kit_path.read_text() == kit_content
+        assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(kit_path.stat().st_mode) == 0o600
+        assert {path.name for path in config_dir.iterdir()} == {
+            "cloud.key",
+            "ormah-recovery-kit.md",
+        }
+        output = capsys.readouterr().out.lower()
+        assert "preserved cloud recovery material" in output
+        assert "permanently unreadable" in output
+
+    def test_warns_about_cloud_key_before_interactive_confirmation(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        config_dir = tmp_path / ".config" / "ormah"
+        config_dir.mkdir(parents=True)
+        key_path = config_dir / "cloud.key"
+        key_path.write_text("AGE-SECRET-KEY-TEST\n")
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+
+        with patch("ormah.server_manager.uninstall_autostart") as mock_daemon:
+            run_uninstall(yes=False)
+
+        mock_daemon.assert_not_called()
+        assert key_path.exists()
+        output = capsys.readouterr().out.lower()
+        assert "uninstall will not delete it" in output
+        assert "permanently unreadable" in output
 
     def test_graceful_uv_failure(self, capsys):
         with (

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -21,6 +21,7 @@ from ormah.server_manager import (
     is_server_running,
 )
 from ormah.setup import (
+    CloudRecoveryPreflightError,
     CODEX_AGENTS_SENTINEL_END,
     CODEX_AGENTS_SENTINEL_START,
     CLAUDE_MD_SENTINEL_END,
@@ -35,6 +36,7 @@ from ormah.setup import (
     _pi_is_wired,
     _preload_local_models,
     _print_setup_summary,
+    _prepare_cloud_recovery,
     _remove_codex_hooks,
     _remove_codex_md_block,
     _remove_codex_mcp_config,
@@ -2474,14 +2476,16 @@ class TestRunUninstall:
         for directory in (share_dir, cache_dir, config_dir):
             directory.mkdir(parents=True)
 
+        from ormah.cloud.keys import get_or_create_store_id, init_key, write_recovery_kit
+
         key_path = config_dir / "cloud.key"
         kit_path = config_dir / "ormah-recovery-kit.md"
-        key_content = "AGE-SECRET-KEY-TEST\n"
-        kit_content = "# Ormah Recovery Kit\nstore_id: test\n"
-        key_path.write_text(key_content)
-        kit_path.write_text(kit_content)
-        key_path.chmod(0o600)
-        kit_path.chmod(0o600)
+        memory_dir = share_dir / "memory"
+        init_key(key_path)
+        store_id = get_or_create_store_id(memory_dir)
+        write_recovery_kit(store_id, key_path=key_path, kit_path=kit_path)
+        key_content = key_path.read_text()
+        kit_content = kit_path.read_text()
         (config_dir / ".env").write_text("ORMAH_ACCOUNT_TOKEN=secret\n")
 
         with (
@@ -2515,6 +2519,130 @@ class TestRunUninstall:
         output = capsys.readouterr().out.lower()
         assert "preserved cloud recovery material" in output
         assert "permanently unreadable" in output
+
+    def test_recovery_preflight_regenerates_missing_kit(self, tmp_path):
+        from ormah.cloud.keys import (
+            extract_store_id,
+            get_or_create_store_id,
+            init_key,
+            load_identity_strings,
+        )
+
+        config_dir = tmp_path / ".config" / "ormah"
+        key_path = config_dir / "cloud.key"
+        kit_path = config_dir / "ormah-recovery-kit.md"
+        memory_dir = tmp_path / "memory"
+        init_key(key_path)
+        store_id = get_or_create_store_id(memory_dir)
+
+        result = _prepare_cloud_recovery(config_dir, [memory_dir])
+
+        assert result.kit_regenerated is True
+        assert result.paths == (key_path, kit_path)
+        assert load_identity_strings(kit_path) == load_identity_strings(key_path)
+        assert extract_store_id(str(kit_path)) == store_id
+        assert stat.S_IMODE(kit_path.stat().st_mode) == 0o600
+
+    def test_recovery_preflight_refreshes_stale_kit_after_rotation(self, tmp_path):
+        from ormah.cloud.keys import (
+            get_or_create_store_id,
+            init_key,
+            load_identity_strings,
+            rotate_key,
+            write_recovery_kit,
+        )
+
+        config_dir = tmp_path / ".config" / "ormah"
+        key_path = config_dir / "cloud.key"
+        kit_path = config_dir / "ormah-recovery-kit.md"
+        memory_dir = tmp_path / "memory"
+        init_key(key_path)
+        store_id = get_or_create_store_id(memory_dir)
+        write_recovery_kit(store_id, key_path=key_path, kit_path=kit_path)
+        rotate_key(key_path)
+
+        result = _prepare_cloud_recovery(config_dir, [memory_dir])
+
+        assert result.kit_regenerated is True
+        assert load_identity_strings(kit_path) == load_identity_strings(key_path)
+
+    def test_recovery_preflight_accepts_complete_kit_without_key_file(self, tmp_path):
+        from ormah.cloud.keys import get_or_create_store_id, init_key, write_recovery_kit
+
+        config_dir = tmp_path / ".config" / "ormah"
+        key_path = config_dir / "cloud.key"
+        kit_path = config_dir / "ormah-recovery-kit.md"
+        memory_dir = tmp_path / "memory"
+        init_key(key_path)
+        store_id = get_or_create_store_id(memory_dir)
+        write_recovery_kit(store_id, key_path=key_path, kit_path=kit_path)
+        original = kit_path.read_bytes()
+        key_path.unlink()
+
+        result = _prepare_cloud_recovery(config_dir, [memory_dir])
+
+        assert result.paths == (kit_path,)
+        assert result.kit_regenerated is False
+        assert kit_path.read_bytes() == original
+
+    def test_recovery_preflight_refuses_key_without_store_id(self, tmp_path):
+        from ormah.cloud.keys import init_key
+
+        config_dir = tmp_path / ".config" / "ormah"
+        init_key(config_dir / "cloud.key")
+
+        with pytest.raises(CloudRecoveryPreflightError, match="no store ID"):
+            _prepare_cloud_recovery(config_dir, [tmp_path / "memory"])
+
+    def test_recovery_preflight_refuses_mismatched_store(self, tmp_path):
+        from ormah.cloud.keys import get_or_create_store_id, init_key, write_recovery_kit
+
+        config_dir = tmp_path / ".config" / "ormah"
+        key_path = config_dir / "cloud.key"
+        kit_path = config_dir / "ormah-recovery-kit.md"
+        memory_a = tmp_path / "memory-a"
+        memory_b = tmp_path / "memory-b"
+        init_key(key_path)
+        store_a = get_or_create_store_id(memory_a)
+        store_b = get_or_create_store_id(memory_b)
+        write_recovery_kit(store_b, key_path=key_path, kit_path=kit_path)
+        original = kit_path.read_bytes()
+
+        with pytest.raises(CloudRecoveryPreflightError, match="does not match"):
+            _prepare_cloud_recovery(config_dir, [memory_a])
+
+        assert store_a != store_b
+        assert kit_path.read_bytes() == original
+
+    def test_recovery_preflight_refuses_multiple_store_ids(self, tmp_path):
+        from ormah.cloud.keys import get_or_create_store_id, init_key
+
+        config_dir = tmp_path / ".config" / "ormah"
+        init_key(config_dir / "cloud.key")
+        memory_a = tmp_path / "memory-a"
+        memory_b = tmp_path / "memory-b"
+        get_or_create_store_id(memory_a)
+        get_or_create_store_id(memory_b)
+
+        with pytest.raises(CloudRecoveryPreflightError, match="Multiple cloud store IDs"):
+            _prepare_cloud_recovery(config_dir, [memory_a, memory_b])
+
+    def test_uninstall_aborts_before_changes_when_recovery_is_incomplete(
+        self, tmp_path, capsys
+    ):
+        from ormah.cloud.keys import init_key
+
+        config_dir = tmp_path / ".config" / "ormah"
+        key_path = config_dir / "cloud.key"
+        init_key(key_path)
+
+        with patch("ormah.server_manager.uninstall_autostart") as mock_daemon:
+            run_uninstall(yes=True)
+
+        mock_daemon.assert_not_called()
+        assert key_path.is_file()
+        output = capsys.readouterr().out
+        assert "Uninstall cancelled before removing any data or integrations" in output
 
     def test_warns_about_cloud_key_before_interactive_confirmation(
         self, tmp_path, monkeypatch, capsys


### PR DESCRIPTION
## Problem

`ormah uninstall` recursively deleted `~/.config/ormah`, including the age identities and recovery kit required to decrypt zero-knowledge cloud backups. A normal uninstall could therefore make every remote backup permanently unreadable.

Closes #107.

## Changes

- Preserve `cloud.key` and `ormah-recovery-kit.md` unconditionally, including with `--yes`.
- Remove unrelated account configuration and generated files from the same directory.
- Before removing anything, cryptographically validate the key and kit plus the store ID that uninstall would delete.
- Atomically regenerate a missing or rotation-stale kit when one authoritative store ID is available.
- Fail closed before stopping the server or removing integrations for corrupt, mismatched, or ambiguous multi-store recovery states.
- Warn about recovery material before interactive confirmation and report each preserved path.
- Document the guarantee in CLI help, the uninstall prompt, and the cloud-backup README section.
- Add regression coverage for either file alone, both files, byte/mode preservation, kit regeneration, rotation staleness, mismatched/multiple stores, unrelated config removal, `--yes`, and the pre-confirmation warning.

## Verification

- `uv run pytest tests/test_setup.py -q` — 214 passed
- `uv run pytest tests/test_setup.py::TestRunUninstall -q` — 19 passed
- `uv run ruff check src/ tests/` — passed
- Full suite — 1414 passed; the sole failure was the known environment-dependent `tests/test_config.py::test_llm_provider_defaults_to_none` (#106), which passes with an isolated `HOME`

A complete recovery kit remains byte-for-byte untouched. Uninstall only rewrites the kit when it can prove that the current validated key and authoritative store ID can safely repair it.
