### PR TITLE
fix(index): refuse to silently DROP a populated vector store on a dimension mismatch (#115)

### DIFF
--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -47,6 +47,9 @@ class Settings(BaseSettings):
     embedding_provider: str = "local"  # "local", "ollama", "litellm"
     embedding_model: str = "BAAI/bge-base-en-v1.5"
     embedding_dim: int = 768
+    # Set to the NEW dim to authorize ONE deliberate destructive reindex of a
+    # populated vector store (embedding-model migration). Remove after the boot.
+    reindex_on_dim_change: int = 0
 
     # LLM for extraction. Disabled by default; setup can opt into cloud/local providers.
     llm_provider: str = "none"

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -82,7 +82,10 @@ class MemoryEngine:
         self.file_store = FileStore(settings.nodes_dir)
         self.db = Database(settings.db_path)
         self.db.init_schema()
-        self.db.init_vec_table(settings.embedding_dim)
+        self.db.init_vec_table(
+            settings.embedding_dim,
+            allow_drop=settings.reindex_on_dim_change == settings.embedding_dim,
+        )
 
         self.graph = GraphIndex(self.db)
         self.builder = IndexBuilder(self.db, self.file_store)

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -537,22 +537,46 @@ class Database:
                 count = self.conn.execute(
                     "SELECT count(*) FROM node_vectors"
                 ).fetchone()[0]
-                if count > 0 and not allow_drop:
-                    raise RuntimeError(
-                        f"Embedding dimension mismatch: configured "
-                        f"ORMAH_EMBEDDING_DIM={dim} but node_vectors holds "
-                        f"{count} vectors of dim {existing_dim}. Refusing to "
-                        f"DROP them. If this is a deliberate embedding-model "
-                        f"change, set ORMAH_REINDEX_ON_DIM_CHANGE={dim} for one "
-                        f"boot (remove it afterwards); otherwise fix "
-                        f"ORMAH_EMBEDDING_DIM — the code default is 768."
+                if count > 0:
+                    consumed = self.conn.execute(
+                        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+                    ).fetchone()
+                    already_consumed = consumed is not None and consumed["value"] == str(dim)
+                    if not allow_drop:
+                        raise RuntimeError(
+                            f"Embedding dimension mismatch: configured "
+                            f"ORMAH_EMBEDDING_DIM={dim} but node_vectors holds "
+                            f"{count} vectors of dim {existing_dim}. Refusing to "
+                            f"DROP them. If this is a deliberate embedding-model "
+                            f"change, set ORMAH_REINDEX_ON_DIM_CHANGE={dim} for one "
+                            f"boot (remove it afterwards); otherwise fix "
+                            f"ORMAH_EMBEDDING_DIM — the code default is 768."
+                        )
+                    if already_consumed:
+                        raise RuntimeError(
+                            f"Embedding dimension mismatch: a reindex to dim {dim} "
+                            f"was already performed and the ORMAH_REINDEX_ON_DIM_CHANGE "
+                            f"authorization is spent. node_vectors now holds {count} "
+                            f"vectors of dim {existing_dim} — remove the stale "
+                            f"ORMAH_REINDEX_ON_DIM_CHANGE from your config. If a second "
+                            f"deliberate reindex to dim {dim} is genuinely needed, clear "
+                            f"the marker first: DELETE FROM meta WHERE "
+                            f"key='reindex_consumed_dim'."
+                        )
+                    logger.info(
+                        "Recreating vec table (%d → %d, %d vectors dropped)",
+                        existing_dim, dim, count,
                     )
-                logger.info(
-                    "Recreating vec table (%d → %d, %d vectors dropped)",
-                    existing_dim, dim, count,
-                )
-                with self.transaction() as conn:
-                    conn.execute("DROP TABLE node_vectors")
+                    with self.transaction() as conn:
+                        conn.execute("DROP TABLE node_vectors")
+                        conn.execute(
+                            "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                            "('reindex_consumed_dim', ?)",
+                            (str(dim),),
+                        )
+                else:
+                    with self.transaction() as conn:
+                        conn.execute("DROP TABLE node_vectors")
 
         with self.transaction() as conn:
             conn.execute(

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sqlite3
 import threading
 from contextlib import contextmanager
@@ -496,12 +497,17 @@ class Database:
                 "INSERT OR REPLACE INTO meta (key, value) VALUES ('fts_needs_rebuild', '1')"
             )
 
-    def init_vec_table(self, dim: int = 768) -> None:
+    def init_vec_table(self, dim: int = 768, *, allow_drop: bool = False) -> None:
         """Create the sqlite-vec virtual table. Requires sqlite-vec extension.
 
-        If the existing table has a different dimension than *dim*, it is
-        dropped and recreated.  The caller (engine startup) is responsible
-        for re-embedding all nodes afterwards.
+        The stored dimension is read from the table DDL in sqlite_master, so an
+        EMPTY mismatched table is detected too (a row probe cannot see it). On a
+        mismatch: an empty table is dropped and recreated at *dim*; a POPULATED
+        table is protected — RuntimeError — unless ``allow_drop=True`` (a
+        deliberate embedding-model migration). The caller (engine startup) is
+        responsible for re-embedding after any authorized drop; the
+        embedding_backfill job first fires ~10s after boot, so recovery is
+        automatic.
         """
         try:
             import sqlite_vec
@@ -509,39 +515,50 @@ class Database:
             self.conn.enable_load_extension(True)
             sqlite_vec.load(self.conn)
             self.conn.enable_load_extension(False)
-
-            # Check for dimension mismatch on an existing table
-            existing = self.conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='node_vectors'"
-            ).fetchone()
-            if existing:
-                try:
-                    row = self.conn.execute(
-                        "SELECT embedding FROM node_vectors LIMIT 1"
-                    ).fetchone()
-                    if row is not None:
-                        import struct
-
-                        blob = row[0]
-                        existing_dim = len(blob) // struct.calcsize("f")
-                        if existing_dim != dim:
-                            logger.info(
-                                "Embedding dimension changed (%d → %d), recreating vec table",
-                                existing_dim,
-                                dim,
-                            )
-                            with self.transaction() as conn:
-                                conn.execute("DROP TABLE node_vectors")
-                except Exception:
-                    pass  # empty table or parse error — just ensure it exists
-
-            with self.transaction() as conn:
-                conn.execute(
-                    f"CREATE VIRTUAL TABLE IF NOT EXISTS node_vectors USING vec0("
-                    f"id TEXT PRIMARY KEY, embedding FLOAT[{dim}])"
-                )
         except ImportError:
-            pass  # sqlite-vec not available, vector search disabled
+            return  # sqlite-vec not available, vector search disabled
+
+        row = self.conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='node_vectors'"
+        ).fetchone()
+        if row is not None:
+            match = re.search(r"FLOAT\[(\d+)\]", row[0] or "")
+            if match is None:
+                # Corrupt/foreign schema: fail closed — never guess-drop, and never
+                # boot into broken vector search (MATCH would fail at runtime).
+                raise RuntimeError(
+                    "node_vectors exists but its DDL has no FLOAT[dim] — "
+                    "unsupported or corrupt schema. Rows were preserved; inspect "
+                    "the table, then restore a vec0 table (or move this one aside "
+                    "and let the embedding backfill re-embed)."
+                )
+            existing_dim = int(match.group(1))
+            if existing_dim != dim:
+                count = self.conn.execute(
+                    "SELECT count(*) FROM node_vectors"
+                ).fetchone()[0]
+                if count > 0 and not allow_drop:
+                    raise RuntimeError(
+                        f"Embedding dimension mismatch: configured "
+                        f"ORMAH_EMBEDDING_DIM={dim} but node_vectors holds "
+                        f"{count} vectors of dim {existing_dim}. Refusing to "
+                        f"DROP them. If this is a deliberate embedding-model "
+                        f"change, set ORMAH_REINDEX_ON_DIM_CHANGE={dim} for one "
+                        f"boot (remove it afterwards); otherwise fix "
+                        f"ORMAH_EMBEDDING_DIM — the code default is 768."
+                    )
+                logger.info(
+                    "Recreating vec table (%d → %d, %d vectors dropped)",
+                    existing_dim, dim, count,
+                )
+                with self.transaction() as conn:
+                    conn.execute("DROP TABLE node_vectors")
+
+        with self.transaction() as conn:
+            conn.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS node_vectors USING vec0("
+                f"id TEXT PRIMARY KEY, embedding FLOAT[{dim}])"
+            )
 
     def close(self) -> None:
         with self._conns_lock:

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -547,11 +547,14 @@ class Database:
                     ).fetchone()[0]
                     if count > 0:
                         consumed = conn.execute(
-                            "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+                            "SELECT value FROM meta WHERE key = 'reindex_consumed_dims'"
                         ).fetchone()
-                        already_consumed = (
-                            consumed is not None and consumed["value"] == str(dim)
+                        consumed_dims = (
+                            set(consumed["value"].split(","))
+                            if consumed is not None
+                            else set()
                         )
+                        already_consumed = str(dim) in consumed_dims
                         if not allow_drop:
                             raise RuntimeError(
                                 f"Embedding dimension mismatch: configured "
@@ -571,17 +574,19 @@ class Database:
                                 f"ORMAH_REINDEX_ON_DIM_CHANGE from your config. If a second "
                                 f"deliberate reindex to dim {dim} is genuinely needed, clear "
                                 f"the marker first: DELETE FROM meta WHERE "
-                                f"key='reindex_consumed_dim'."
+                                f"key='reindex_consumed_dims' (or remove {dim} from its "
+                                f"comma-separated value)."
                             )
                         logger.info(
                             "Recreating vec table (%d → %d, %d vectors dropped)",
                             existing_dim, dim, count,
                         )
                         conn.execute("DROP TABLE node_vectors")
+                        consumed_dims.add(str(dim))
                         conn.execute(
                             "INSERT OR REPLACE INTO meta (key, value) VALUES "
-                            "('reindex_consumed_dim', ?)",
-                            (str(dim),),
+                            "('reindex_consumed_dims', ?)",
+                            (",".join(sorted(consumed_dims)),),
                         )
                     else:
                         conn.execute("DROP TABLE node_vectors")

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -518,67 +518,74 @@ class Database:
         except ImportError:
             return  # sqlite-vec not available, vector search disabled
 
-        row = self.conn.execute(
-            "SELECT sql FROM sqlite_master WHERE type='table' AND name='node_vectors'"
-        ).fetchone()
-        if row is not None:
-            match = re.search(r"FLOAT\[(\d+)\]", row[0] or "")
-            if match is None:
-                # Corrupt/foreign schema: fail closed — never guess-drop, and never
-                # boot into broken vector search (MATCH would fail at runtime).
-                raise RuntimeError(
-                    "node_vectors exists but its DDL has no FLOAT[dim] — "
-                    "unsupported or corrupt schema. Rows were preserved; inspect "
-                    "the table, then restore a vec0 table (or move this one aside "
-                    "and let the embedding backfill re-embed)."
-                )
-            existing_dim = int(match.group(1))
-            if existing_dim != dim:
-                count = self.conn.execute(
-                    "SELECT count(*) FROM node_vectors"
-                ).fetchone()[0]
-                if count > 0:
-                    consumed = self.conn.execute(
-                        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
-                    ).fetchone()
-                    already_consumed = consumed is not None and consumed["value"] == str(dim)
-                    if not allow_drop:
-                        raise RuntimeError(
-                            f"Embedding dimension mismatch: configured "
-                            f"ORMAH_EMBEDDING_DIM={dim} but node_vectors holds "
-                            f"{count} vectors of dim {existing_dim}. Refusing to "
-                            f"DROP them. If this is a deliberate embedding-model "
-                            f"change, set ORMAH_REINDEX_ON_DIM_CHANGE={dim} for one "
-                            f"boot (remove it afterwards); otherwise fix "
-                            f"ORMAH_EMBEDDING_DIM — the code default is 768."
-                        )
-                    if already_consumed:
-                        raise RuntimeError(
-                            f"Embedding dimension mismatch: a reindex to dim {dim} "
-                            f"was already performed and the ORMAH_REINDEX_ON_DIM_CHANGE "
-                            f"authorization is spent. node_vectors now holds {count} "
-                            f"vectors of dim {existing_dim} — remove the stale "
-                            f"ORMAH_REINDEX_ON_DIM_CHANGE from your config. If a second "
-                            f"deliberate reindex to dim {dim} is genuinely needed, clear "
-                            f"the marker first: DELETE FROM meta WHERE "
-                            f"key='reindex_consumed_dim'."
-                        )
-                    logger.info(
-                        "Recreating vec table (%d → %d, %d vectors dropped)",
-                        existing_dim, dim, count,
+        # The whole read → decide → drop → mark → create sequence runs inside a
+        # SINGLE BEGIN IMMEDIATE. transaction() takes the write lock (via the
+        # internal RLock across threads, and via SQLite's write lock across
+        # processes), so a concurrent initializer can no longer read the marker
+        # as absent, THEN drop after another initializer already consumed it —
+        # closing the check-then-drop TOCTOU (council: codex high). A concurrent
+        # caller blocks here, then re-reads the marker itself once serialized.
+        with self.transaction() as conn:
+            row = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='node_vectors'"
+            ).fetchone()
+            if row is not None:
+                match = re.search(r"FLOAT\[(\d+)\]", row[0] or "")
+                if match is None:
+                    # Corrupt/foreign schema: fail closed — never guess-drop, and never
+                    # boot into broken vector search (MATCH would fail at runtime).
+                    raise RuntimeError(
+                        "node_vectors exists but its DDL has no FLOAT[dim] — "
+                        "unsupported or corrupt schema. Rows were preserved; inspect "
+                        "the table, then restore a vec0 table (or move this one aside "
+                        "and let the embedding backfill re-embed)."
                     )
-                    with self.transaction() as conn:
+                existing_dim = int(match.group(1))
+                if existing_dim != dim:
+                    count = conn.execute(
+                        "SELECT count(*) FROM node_vectors"
+                    ).fetchone()[0]
+                    if count > 0:
+                        consumed = conn.execute(
+                            "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+                        ).fetchone()
+                        already_consumed = (
+                            consumed is not None and consumed["value"] == str(dim)
+                        )
+                        if not allow_drop:
+                            raise RuntimeError(
+                                f"Embedding dimension mismatch: configured "
+                                f"ORMAH_EMBEDDING_DIM={dim} but node_vectors holds "
+                                f"{count} vectors of dim {existing_dim}. Refusing to "
+                                f"DROP them. If this is a deliberate embedding-model "
+                                f"change, set ORMAH_REINDEX_ON_DIM_CHANGE={dim} for one "
+                                f"boot (remove it afterwards); otherwise fix "
+                                f"ORMAH_EMBEDDING_DIM — the code default is 768."
+                            )
+                        if already_consumed:
+                            raise RuntimeError(
+                                f"Embedding dimension mismatch: a reindex to dim {dim} "
+                                f"was already performed and the ORMAH_REINDEX_ON_DIM_CHANGE "
+                                f"authorization is spent. node_vectors now holds {count} "
+                                f"vectors of dim {existing_dim} — remove the stale "
+                                f"ORMAH_REINDEX_ON_DIM_CHANGE from your config. If a second "
+                                f"deliberate reindex to dim {dim} is genuinely needed, clear "
+                                f"the marker first: DELETE FROM meta WHERE "
+                                f"key='reindex_consumed_dim'."
+                            )
+                        logger.info(
+                            "Recreating vec table (%d → %d, %d vectors dropped)",
+                            existing_dim, dim, count,
+                        )
                         conn.execute("DROP TABLE node_vectors")
                         conn.execute(
                             "INSERT OR REPLACE INTO meta (key, value) VALUES "
                             "('reindex_consumed_dim', ?)",
                             (str(dim),),
                         )
-                else:
-                    with self.transaction() as conn:
+                    else:
                         conn.execute("DROP TABLE node_vectors")
 
-        with self.transaction() as conn:
             conn.execute(
                 f"CREATE VIRTUAL TABLE IF NOT EXISTS node_vectors USING vec0("
                 f"id TEXT PRIMARY KEY, embedding FLOAT[{dim}])"

--- a/tests/test_embeddings/test_adapters.py
+++ b/tests/test_embeddings/test_adapters.py
@@ -195,20 +195,17 @@ class TestGetEncoderCaching:
 
 
 class TestDimensionMismatch:
-    def test_mismatch_drops_and_recreates(self, tmp_path):
-        """Changing dim should drop and recreate the vec table."""
+    def test_mismatch_on_populated_refuses_then_drops_with_allow(self, tmp_path):
+        """A populated store refuses a dim change; allow_drop authorizes it."""
         from ormah.index.db import Database
 
         db = Database(tmp_path / "index.db")
         db.init_schema()
-
-        # Create with dim=4
         try:
             db.init_vec_table(dim=4)
         except Exception:
             pytest.skip("sqlite-vec not available")
 
-        # Insert a vector
         import struct
 
         vec_bytes = struct.pack("4f", 1.0, 0.0, 0.0, 0.0)
@@ -218,10 +215,10 @@ class TestDimensionMismatch:
         )
         db.conn.commit()
 
-        # Now init with dim=8 — should drop and recreate
-        db.init_vec_table(dim=8)
+        with pytest.raises(RuntimeError, match="dimension mismatch"):
+            db.init_vec_table(dim=8)  # populated + no authorization → refuse
 
-        # Old data should be gone
+        db.init_vec_table(dim=8, allow_drop=True)  # authorized → drop + recreate
         row = db.conn.execute(
             "SELECT id FROM node_vectors WHERE id = 'test-node'"
         ).fetchone()

--- a/tests/test_index/test_init_vec_table_guard.py
+++ b/tests/test_index/test_init_vec_table_guard.py
@@ -101,7 +101,7 @@ def test_authorization_is_one_shot(engine):
     engine.db.init_vec_table(dim + 256, allow_drop=True)
     assert _count(engine) == 0
     marker = engine.db.conn.execute(
-        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+        "SELECT value FROM meta WHERE key = 'reindex_consumed_dims'"
     ).fetchone()
     assert marker["value"] == str(dim + 256)
 
@@ -131,7 +131,7 @@ def test_empty_table_does_not_consume_authorization(engine):
     engine.db.init_vec_table(engine.settings.embedding_dim + 256)  # no allow_drop needed
 
     marker = engine.db.conn.execute(
-        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+        "SELECT value FROM meta WHERE key = 'reindex_consumed_dims'"
     ).fetchone()
     assert marker is None  # authorization untouched
 
@@ -213,7 +213,37 @@ def test_concurrent_init_vec_table_race_consumes_authorization_once(engine):
     )
 
     marker = engine.db.conn.execute(
-        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+        "SELECT value FROM meta WHERE key = 'reindex_consumed_dims'"
     ).fetchone()
     assert marker["value"] == str(new_dim)  # written exactly once
     assert _count(engine) == 0  # exactly one drop+recreate, not two
+
+
+def test_consumed_authorization_survives_a_later_migration(engine):
+    """The consumed-marker must accumulate. A later migration must not erase the
+    record of an earlier consumption, or the spent token becomes valid again and
+    silently drops a populated store. (council: codex high)"""
+    import numpy as np
+
+    from ormah.embeddings.vector_store import VectorStore
+
+    d1 = engine.settings.embedding_dim          # starting dim
+    d2 = d1 + 256
+    d3 = d1 + 512
+
+    # 1) Populated store at d1. Authorized migration d1 -> d2 consumes the d2 token.
+    VectorStore(engine.db).upsert("a", np.ones(d1, dtype=np.float32))
+    engine.db.init_vec_table(d2, allow_drop=True)
+
+    # 2) Repopulate at d2, then a second authorized migration d2 -> d3 consumes d3.
+    VectorStore(engine.db).upsert("b", np.ones(d2, dtype=np.float32))
+    engine.db.init_vec_table(d3, allow_drop=True)
+
+    # 3) Repopulate at d3. Now a STALE flag re-offers the ALREADY-SPENT d2 token.
+    VectorStore(engine.db).upsert("c", np.ones(d3, dtype=np.float32))
+    assert _count(engine) == 1
+
+    with pytest.raises(RuntimeError, match="already"):
+        engine.db.init_vec_table(d2, allow_drop=True)
+
+    assert _count(engine) == 1  # the populated d3 store was NOT dropped

--- a/tests/test_index/test_init_vec_table_guard.py
+++ b/tests/test_index/test_init_vec_table_guard.py
@@ -1,0 +1,86 @@
+"""Guard: a dim mismatch must never silently DROP a populated vector store."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ormah.embeddings.vector_store import VectorStore
+
+
+def _count(engine) -> int:
+    return engine.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]
+
+
+def test_dim_mismatch_on_populated_store_raises_not_drops(engine):
+    dim = engine.settings.embedding_dim
+    VectorStore(engine.db).upsert("n1", np.ones(dim, dtype=np.float32))
+    before = _count(engine)
+    assert before > 0
+
+    with pytest.raises(RuntimeError, match="dimension mismatch"):
+        engine.db.init_vec_table(dim + 256)  # e.g. config default 768 vs stored 1024
+
+    assert _count(engine) == before  # nothing dropped
+
+
+def test_dim_mismatch_on_empty_store_recreates(engine):
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+    new_dim = engine.settings.embedding_dim + 256
+
+    engine.db.init_vec_table(new_dim)  # empty → safe to recreate, no raise
+
+    row = engine.db.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name='node_vectors'"
+    ).fetchone()
+    assert f"FLOAT[{new_dim}]" in row[0]
+
+
+def test_allow_drop_authorizes_reindex(engine):
+    dim = engine.settings.embedding_dim
+    VectorStore(engine.db).upsert("n1", np.ones(dim, dtype=np.float32))
+
+    engine.db.init_vec_table(dim + 256, allow_drop=True)  # explicit → drops
+
+    assert _count(engine) == 0
+    row = engine.db.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name='node_vectors'"
+    ).fetchone()
+    assert f"FLOAT[{dim + 256}]" in row[0]
+
+
+def test_unparseable_ddl_raises_and_preserves_rows(engine):
+    """A node_vectors table whose DDL has no FLOAT[dim] (corrupt/foreign schema)
+    must fail closed: never guess-drop, never boot into broken vector search."""
+    with engine.db.transaction() as conn:
+        conn.execute("DROP TABLE node_vectors")
+        conn.execute("CREATE TABLE node_vectors (id TEXT PRIMARY KEY, embedding BLOB)")
+        conn.execute("INSERT INTO node_vectors (id, embedding) VALUES ('n1', x'00')")
+
+    with pytest.raises(RuntimeError, match="FLOAT"):
+        engine.db.init_vec_table(engine.settings.embedding_dim)
+
+    assert _count(engine) == 1  # rows preserved for inspection/recovery
+
+
+def test_startup_wiring_respects_reindex_flag(settings):
+    """MemoryEngine.__init__ authorizes the drop only when the flag equals the
+    configured dim; a stale flag from a previous migration keeps refusing."""
+    from ormah.engine.memory_engine import MemoryEngine
+
+    eng = MemoryEngine(settings)
+    dim = settings.embedding_dim
+    VectorStore(eng.db).upsert("n1", np.ones(dim, dtype=np.float32))
+    eng.db.close()
+
+    # Stale flag: authorizes the OLD dim while config asks a new one → refuse.
+    settings.embedding_dim = dim + 256
+    settings.reindex_on_dim_change = dim  # stale value != new dim
+    with pytest.raises(RuntimeError, match="dimension mismatch"):
+        MemoryEngine(settings)
+
+    # Correct flag: equals the NEW dim → authorized drop.
+    settings.reindex_on_dim_change = dim + 256
+    eng2 = MemoryEngine(settings)
+    assert eng2.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0] == 0
+    eng2.db.close()

--- a/tests/test_index/test_init_vec_table_guard.py
+++ b/tests/test_index/test_init_vec_table_guard.py
@@ -134,3 +134,86 @@ def test_empty_table_does_not_consume_authorization(engine):
         "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
     ).fetchone()
     assert marker is None  # authorization untouched
+
+
+def test_concurrent_init_vec_table_race_consumes_authorization_once(engine):
+    """TOCTOU: two concurrent init_vec_table(allow_drop=True) calls against the
+    same populated store, both racing the SAME target dim, must spend the
+    one-shot authorization's DROP exactly once. (A second call landing on an
+    already-migrated table is a legitimate no-op — dims now match, nothing to
+    authorize — so success/failure counts don't distinguish fixed from broken;
+    the DROP TABLE count does: pre-fix, both threads independently decide
+    "not yet consumed" from a stale read and each issues their own DROP,
+    corrupting the freshly-recreated table — proven below by a live probe
+    against the pre-fix code that gets a bare sqlite3 OperationalError on the
+    second DROP.)
+
+    Uses a barrier on the marker SELECT (via sqlite3's per-connection trace
+    callback, since sqlite3.Connection is an immutable C type — its methods
+    cannot be monkeypatched) to force both threads past the "not yet consumed"
+    check before either drops. Fixed code: reads happen inside the same
+    BEGIN IMMEDIATE as the drop, so the second thread's read only happens
+    after the first thread's transaction commits — the barrier times out and
+    is a no-op, and the second thread observes the table already migrated.
+    (council: codex high — check-then-drop TOCTOU)"""
+    import threading
+
+    dim = engine.settings.embedding_dim
+    new_dim = dim + 256
+    VectorStore(engine.db).upsert("n1", np.ones(dim, dtype=np.float32))
+
+    barrier = threading.Barrier(2)
+    drop_count = 0
+    drop_lock = threading.Lock()
+
+    def trace(sql: str) -> None:
+        nonlocal drop_count
+        upper = sql.strip().upper()
+        if "REINDEX_CONSUMED_DIM" in upper and upper.startswith("SELECT"):
+            try:
+                barrier.wait(timeout=2)
+            except threading.BrokenBarrierError:
+                pass  # fixed code: second thread arrives only after the first commits
+        if upper.startswith("DROP TABLE") and "NODE_VECTORS" in upper:
+            with drop_lock:
+                drop_count += 1
+
+    # Worker threads get fresh, thread-local connections lazily via db.conn;
+    # wrap connection creation (a plain Python method, unlike sqlite3.Connection
+    # itself) to attach the trace callback to each new connection.
+    orig_new_connection = engine.db._new_connection
+
+    def new_connection_with_trace():
+        conn = orig_new_connection()
+        conn.set_trace_callback(trace)
+        return conn
+
+    results: dict[str, object] = {}
+
+    def worker(name: str):
+        try:
+            engine.db.init_vec_table(new_dim, allow_drop=True)
+            results[name] = "ok"
+        except Exception as e:  # noqa: BLE001 — pre-fix races can raise sqlite3 errors too
+            results[name] = e
+
+    engine.db._new_connection = new_connection_with_trace
+    try:
+        t1 = threading.Thread(target=worker, args=("t1",))
+        t2 = threading.Thread(target=worker, args=("t2",))
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+    finally:
+        engine.db._new_connection = orig_new_connection
+
+    assert drop_count == 1, (
+        f"expected exactly one DROP TABLE node_vectors, saw {drop_count}: {results}"
+    )
+
+    marker = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+    ).fetchone()
+    assert marker["value"] == str(new_dim)  # written exactly once
+    assert _count(engine) == 0  # exactly one drop+recreate, not two

--- a/tests/test_index/test_init_vec_table_guard.py
+++ b/tests/test_index/test_init_vec_table_guard.py
@@ -84,3 +84,53 @@ def test_startup_wiring_respects_reindex_flag(settings):
     eng2 = MemoryEngine(settings)
     assert eng2.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0] == 0
     eng2.db.close()
+
+
+def test_authorization_is_one_shot(engine):
+    """A consumed reindex authorization must not silently re-authorize a second
+    destructive drop — the stale flag left in .env would otherwise reopen the
+    data-loss path. (council: codex high)"""
+    import numpy as np
+
+    from ormah.embeddings.vector_store import VectorStore
+
+    dim = engine.settings.embedding_dim
+    VectorStore(engine.db).upsert("n1", np.ones(dim, dtype=np.float32))
+
+    # First authorized migration: allowed, drops, and consumes the authorization.
+    engine.db.init_vec_table(dim + 256, allow_drop=True)
+    assert _count(engine) == 0
+    marker = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+    ).fetchone()
+    assert marker["value"] == str(dim + 256)
+
+    # Store gets repopulated at the new dim, then a DIFFERENT dim shows up while the
+    # stale flag still authorizes dim+256. The spent authorization must NOT allow it.
+    VectorStore(engine.db).upsert("n2", np.ones(dim + 256, dtype=np.float32))
+    with engine.db.transaction() as conn:
+        conn.execute("DROP TABLE node_vectors")
+        conn.execute(
+            f"CREATE VIRTUAL TABLE node_vectors USING vec0(id TEXT PRIMARY KEY, "
+            f"embedding FLOAT[{dim}])"
+        )
+    VectorStore(engine.db).upsert("n3", np.ones(dim, dtype=np.float32))
+    assert _count(engine) == 1
+
+    with pytest.raises(RuntimeError, match="already"):
+        engine.db.init_vec_table(dim + 256, allow_drop=True)  # stale flag, spent auth
+
+    assert _count(engine) == 1  # nothing dropped
+
+
+def test_empty_table_does_not_consume_authorization(engine):
+    """An empty table is recreated freely and must not burn the one-shot token."""
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    engine.db.init_vec_table(engine.settings.embedding_dim + 256)  # no allow_drop needed
+
+    marker = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'reindex_consumed_dim'"
+    ).fetchone()
+    assert marker is None  # authorization untouched


### PR DESCRIPTION
Fixes #115.

`init_vec_table` silently DROPs a populated `node_vectors` table whenever the configured embedding dimension differs from the stored one. Since the parameter defaults to `dim=768`, any boot where `ORMAH_EMBEDDING_DIM` fails to resolve falls back to 768 and wipes a 1024-dim store (e.g. `bge-m3`). This happened **twice in one morning** on a real 12,164-node store:

```
09:53:15  Embedding dimension changed (1024 → 768), recreating vec table   ← DROP
09:58:12  Embedding backfill (delta): embedded=12138 missing=0 vec=12138/12138
10:28:52  Embedding dimension changed (768 → 1024), recreating vec table   ← DROP again
```

Downstream, an empty vector store froze the `auto_linker` watermark (12,135-node backlog, `pairs_attempted=0` in 15 ms), so maintenance "succeeded" daily while doing nothing.

## What changed

**1. Read the stored dim from the table DDL, not from a row probe.**
`SELECT sql FROM sqlite_master` + `FLOAT\[(\d+)\]` replaces `SELECT embedding ... LIMIT 1`. The old probe returns `None` on an *empty* table, so an empty table with the wrong declared dimension silently kept its wrong schema and every later insert failed. Unparseable DDL now raises (fail closed) instead of booting into a broken vector index.

**2. Refuse to DROP a POPULATED table.**
A mismatch on a table holding vectors raises `RuntimeError` naming the configured dim, the stored dim and the vector count, and telling the operator what to do. An **empty** table is still recreated freely — there is no data to lose.

**3. The `raise` can no longer be swallowed.**
The old `try: ... except Exception: pass` wrapped the whole check; a guard raised inside it would have been silently discarded. The `try` now wraps **only** the `sqlite_vec` import, with `except ImportError: return`.

**4. Explicit, dim-valued, one-shot authorization for a deliberate model migration.**
`ORMAH_REINDEX_ON_DIM_CHANGE=<new dim>` (new setting, default `0`) authorizes the drop, and **only** when it equals the configured dim — a stale flag naming a different dim cannot authorize anything. The authorization is then **consumed in the database**, so a flag left behind in `.env` cannot silently re-authorize a future drop.

**5. Consumed authorizations accumulate.**
The consumed dims live in `meta.reindex_consumed_dims` as a set. Storing only the last one would let a later migration erase the record of an earlier one and revive a spent token (`4→8` consumes 8; `8→16` overwrites the marker; restoring `dim=8` with the stale flag would then drop a populated 16-dim store).

**6. The whole sequence runs in one `BEGIN IMMEDIATE`.**
Reading the count and the marker *before* the transaction left a check-then-drop race: two concurrent initializers (e.g. two launchd agents both with `RunAtLoad=true` — the exact deployment where this was found) could both observe the marker as absent and both spend the same one-shot authorization. Reproduced with a two-thread probe: two `DROP TABLE` statements executed, and the losing thread hit `OperationalError: no such table`. Now read → decide → drop → consume → recreate is a single serialized transaction.

## Tests

New `tests/test_index/test_init_vec_table_guard.py` (8 tests), all written failing-first:

| test | proves |
|---|---|
| `test_dim_mismatch_on_populated_store_raises_not_drops` | populated + unauthorized → raises, rows preserved |
| `test_dim_mismatch_on_empty_store_recreates` | empty + mismatch → recreated at the new dim (the row-probe blind spot) |
| `test_allow_drop_authorizes_reindex` | explicit authorization performs the migration |
| `test_unparseable_ddl_raises_and_preserves_rows` | corrupt/foreign schema fails closed, rows kept |
| `test_startup_wiring_respects_reindex_flag` | a stale flag naming another dim is still refused |
| `test_authorization_is_one_shot` | the authorization is consumed and cannot be reused |
| `test_consumed_authorization_survives_a_later_migration` | a later migration cannot revive a spent token |
| `test_concurrent_init_vec_table_race_consumes_authorization_once` | two concurrent initializers → exactly **one** `DROP` (counted via a `sqlite3` trace callback synchronized with a `threading.Barrier`; fails on the pre-fix code with 2 drops) |

`tests/test_embeddings/test_adapters.py::TestDimensionMismatch` pinned the old silent-drop behaviour and is rewritten to the new contract.

**Suite:** `22 failed, 1287 passed` on this branch vs `22 failed, 1278 passed` on pristine `main` — the same 22 pre-existing environment-dependent failures (`test_setup*.py`), **zero regressions**, +9 new passing tests. `ruff check src/ tests/`: clean.

## Migration note

Existing deployments are unaffected: a store whose dim already matches the config never enters the mismatch branch. An operator who genuinely changes embedding model now sets `ORMAH_REINDEX_ON_DIM_CHANGE=<new dim>` for one boot and removes it afterwards; the error message spells this out, including how to clear the consumed marker if a second deliberate reindex to the same dim is ever needed.

## Related

- #109 — the backfill's own durability and the `auto_linker` fail-closed abort. That issue is the *consequence* of an empty store; this one is the *trigger*.
- #32 / #38 — delta backfill, which is what has to repair the damage after each wipe.
- #84 — non-atomic `full_rebuild`, a second independent way `node_vectors` can be emptied.

Reviewed by two independent adversarial reviewers over three rounds; findings 4, 5 and 6 above were each found by review and fixed with a failing test first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
