### PR TITLE
fix(background): idempotent edge writes — a UNIQUE collision no longer aborts the auto_linker run (#117)

### DIFF
--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -272,15 +272,22 @@ def _apply_edge(
     edge_type: str,
     reason: str,
     similarity: float = 0.0,
-) -> None:
+) -> bool:
     """Record a link decision: write to auto_link_checked and optionally create an edge.
 
     ``edge_type="none"`` records the pair as checked without creating an edge.
+
+    Returns True only when this call actually inserted a NEW edge row. An
+    ``INSERT OR IGNORE`` that hit an existing edge inserted nothing — counting that as
+    a creation would burn the run's edge budget on a link a concurrent writer had
+    already made, and log an edge that was never created.
     """
     from ormah.models.node import Connection, EdgeType
 
     pair = tuple(sorted([node_a_id, node_b_id]))
     now = datetime.now(timezone.utc).isoformat()
+
+    edge_created = False
 
     with engine.db.transaction() as conn:
         conn.execute(
@@ -297,11 +304,12 @@ def _apply_edge(
             # already exists — the outcome we wanted. A raw INSERT turned it into an
             # IntegrityError that rolled back the auto_link_checked row above and
             # aborted the entire run (#117).
-            conn.execute(
+            cur = conn.execute(
                 "INSERT OR IGNORE INTO edges (source_id, target_id, edge_type, weight, created, reason) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
                 (node_a_id, node_b_id, edge_type, round(similarity, 3), now, reason),
             )
+            edge_created = cur.rowcount > 0
 
     if edge_type not in ("none", "error"):
         try:
@@ -328,6 +336,8 @@ def _apply_edge(
                 engine.file_store.save(mem_node)
         except Exception as e:
             logger.debug("Failed to persist connection to markdown for %s: %s", node_a_id[:8], e)
+
+    return edge_created
 
 
 def run_auto_linker(engine) -> None:
@@ -417,7 +427,7 @@ def run_auto_linker(engine) -> None:
                         continue
                     relationship = llm_result["relationship"]  # may be 'error' (invalid output)
                     try:
-                        _apply_edge(
+                        edge_created = _apply_edge(
                             engine, node["id"], match["id"], relationship,
                             llm_result.get("reason", ""), similarity,
                         )
@@ -435,7 +445,11 @@ def run_auto_linker(engine) -> None:
                         continue
                     # 'error' (poison content) is recorded in auto_link_checked by _apply_edge
                     # and the node still counts as resolved → watermark advances (council v2 crit#2).
-                    if relationship not in ("none", "error"):
+                    # Only a real insert counts: an INSERT OR IGNORE that hit an edge a
+                    # concurrent writer had already created inserted nothing, and charging it
+                    # to max_edges would spend the run's budget on work it did not do, cutting
+                    # the run short for unrelated candidates.
+                    if edge_created:
                         created += 1
 
             if not node_resolved:

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -335,7 +335,33 @@ def _apply_edge(
                 mem_node.touch_updated()
                 engine.file_store.save(mem_node)
         except Exception as e:
-            logger.debug("Failed to persist connection to markdown for %s: %s", node_a_id[:8], e)
+            # Compensate. The markdown is the source of truth — a rebuild recreates the
+            # edge table from it. Swallowing this (as the code used to) left the pair
+            # marked as checked with the connection missing from the file: the rebuild
+            # then dropped the DB-only edge, and the checked row stopped the pair from
+            # ever being judged again. The link was lost for good.
+            #
+            # Undo the marker, and undo the edge only if WE inserted it — a row a
+            # concurrent writer created is not ours to delete, and its own markdown is
+            # its own responsibility. Then propagate: the caller leaves the node
+            # unresolved, so the watermark fails closed and the pair is retried.
+            logger.warning(
+                "auto_linker: markdown persist failed for %s -> %s; undoing the checked "
+                "mark%s so the pair is retried: %s",
+                node_a_id[:8], node_b_id[:8],
+                " and the edge we inserted" if edge_created else "", e,
+            )
+            with engine.db.transaction() as conn:
+                conn.execute(
+                    "DELETE FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+                )
+                if edge_created:
+                    conn.execute(
+                        "DELETE FROM edges WHERE source_id = ? AND target_id = ? "
+                        "AND edge_type = ?",
+                        (node_a_id, node_b_id, edge_type),
+                    )
+            raise
 
     return edge_created
 

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -416,10 +416,23 @@ def run_auto_linker(engine) -> None:
                         node_resolved = False
                         continue
                     relationship = llm_result["relationship"]  # may be 'error' (invalid output)
-                    _apply_edge(
-                        engine, node["id"], match["id"], relationship,
-                        llm_result.get("reason", ""), similarity,
-                    )
+                    try:
+                        _apply_edge(
+                            engine, node["id"], match["id"], relationship,
+                            llm_result.get("reason", ""), similarity,
+                        )
+                    except Exception as e:
+                        # A single unwritable pair must never abort the run. It used to:
+                        # the exception reached the top-level handler, killed the run and
+                        # froze the watermark for the whole store (#117). Log the pair —
+                        # the old failure logged nothing, so the colliding edge was
+                        # unknowable after the fact.
+                        logger.warning(
+                            "auto_linker: edge apply failed for %s -> %s (%s): %s",
+                            node["id"][:8], match["id"][:8], relationship, e,
+                        )
+                        node_resolved = False   # fail closed: watermark stays behind this node
+                        continue
                     # 'error' (poison content) is recorded in auto_link_checked by _apply_edge
                     # and the node still counts as resolved → watermark advances (council v2 crit#2).
                     if relationship not in ("none", "error"):

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -290,8 +290,15 @@ def _apply_edge(
         )
 
         if edge_type not in ("none", "error"):
+            # OR IGNORE, not a raw INSERT: the "edge exists?" guard ran at collection
+            # time, before the LLM call. Any concurrent writer (ingest auto-link,
+            # conflict_detector, a reindex) may have created this same
+            # (source, target, type) in the meantime. Losing that race means the link
+            # already exists — the outcome we wanted. A raw INSERT turned it into an
+            # IntegrityError that rolled back the auto_link_checked row above and
+            # aborted the entire run (#117).
             conn.execute(
-                "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+                "INSERT OR IGNORE INTO edges (source_id, target_id, edge_type, weight, created, reason) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
                 (node_a_id, node_b_id, edge_type, round(similarity, 3), now, reason),
             )
@@ -299,13 +306,24 @@ def _apply_edge(
     if edge_type not in ("none", "error"):
         try:
             mem_node = engine.file_store.load(node_a_id)
-            if mem_node is not None:
-                md_conn = Connection(
-                    target=node_b_id,
-                    edge=EdgeType(edge_type),
-                    weight=round(similarity, 2),
+            # Ensure the connection is in the file, whether or not WE won the insert.
+            # The markdown is the source of truth (a reindex rebuilds edges from it) and
+            # the winner's own save is best-effort. If the winner committed the row but
+            # failed to save its file, skipping this append would let the next reindex
+            # delete the edge, while the auto_link_checked row committed above would stop
+            # the pair from ever being reconsidered — the link would be lost for good.
+            # Idempotent: adds nothing when the connection is already there.
+            if mem_node is not None and not any(
+                c.target == node_b_id and c.edge.value == edge_type
+                for c in mem_node.connections
+            ):
+                mem_node.connections.append(
+                    Connection(
+                        target=node_b_id,
+                        edge=EdgeType(edge_type),
+                        weight=round(similarity, 2),
+                    )
                 )
-                mem_node.connections.append(md_conn)
                 mem_node.touch_updated()
                 engine.file_store.save(mem_node)
         except Exception as e:

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -249,29 +249,38 @@ def run_conflict_detection(engine) -> None:
                     else:
                         newer_id, older_id = node_b["id"], node_a["id"]
 
-                    db_conn.execute(
-                        "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+                    # OR IGNORE: auto_linker also emits contradicts, and both jobs run
+                    # concurrently over overlapping pairs. A concurrent writer may have
+                    # created this exact edge while the LLM was judging — same race as #117.
+                    cur = db_conn.execute(
+                        "INSERT OR IGNORE INTO edges (source_id, target_id, edge_type, weight, created, reason) "
                         "VALUES (?, ?, 'evolved_from', 0.9, ?, ?)",
                         (newer_id, older_id, now, explanation),
                     )
                     edge_type_str = "evolved_from"
                     source_id, target_id = newer_id, older_id
                 else:
-                    db_conn.execute(
-                        "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+                    cur = db_conn.execute(
+                        "INSERT OR IGNORE INTO edges (source_id, target_id, edge_type, weight, created, reason) "
                         "VALUES (?, ?, 'contradicts', 0.9, ?, ?)",
                         (node_a["id"], node_b["id"], now, explanation),
                     )
                     edge_type_str = "contradicts"
                     source_id, target_id = node_a["id"], node_b["id"]
 
+            # Queue the markdown connection UNCONDITIONALLY, not only when we won the
+            # insert (Codex R2, critical #1 — the same data-loss path Task 1 closes).
+            # The file is the source of truth; if the writer that won the row failed to
+            # save its markdown, this is the only chance to repair it. rowcount only
+            # decides whether this run *created* an edge, i.e. the metric.
             md_conn = Connection(
                 target=target_id,
                 edge=EdgeType(edge_type_str),
                 weight=0.9,
             )
             dirty_nodes.setdefault(source_id, []).append(md_conn)
-            edges_created += 1
+            if cur.rowcount > 0:
+                edges_created += 1
 
         # Persist new connections to markdown files
         for nid, new_connections in dirty_nodes.items():
@@ -279,7 +288,13 @@ def run_conflict_detection(engine) -> None:
                 mem_node = engine.file_store.load(nid)
                 if mem_node is None:
                     continue
-                mem_node.connections.extend(new_connections)
+                existing = {(c.target, c.edge.value) for c in mem_node.connections}
+                fresh = [
+                    c for c in new_connections if (c.target, c.edge.value) not in existing
+                ]
+                if not fresh:
+                    continue
+                mem_node.connections.extend(fresh)
                 mem_node.touch_updated()
                 engine.file_store.save(mem_node)
             except Exception as e:

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -411,3 +411,87 @@ def test_checked_pairs_invalidated_on_update(engine):
         run_auto_linker(engine)
 
     assert mock_llm.call_count >= 1  # LLM was called again for this pair
+
+
+def test_apply_edge_is_idempotent_when_edge_already_exists(engine):
+    """A concurrent writer created the same edge between collection and apply.
+    _apply_edge must not raise, and must still record the pair as checked."""
+    from datetime import datetime, timezone
+    from ormah.background.auto_linker import _apply_edge
+
+    id_a, id_b = _create_pair(engine)
+    now = datetime.now(timezone.utc).isoformat()
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+            "VALUES (?, ?, 'supports', 0.9, ?, 'created by someone else')",
+            (id_a, id_b, now),
+        )
+
+    _apply_edge(engine, id_a, id_b, "supports", "auto-linker reason", 0.8)
+
+    # The pre-existing edge survives untouched; no duplicate was created.
+    rows = engine.db.conn.execute(
+        "SELECT reason FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = 'supports'",
+        (id_a, id_b),
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["reason"] == "created by someone else"
+
+    # The pair is marked checked -> it will never be re-judged. This is exactly what
+    # the rollback used to erase, which is why the pair poisoned every future run.
+    pair = tuple(sorted([id_a, id_b]))
+    assert engine.db.conn.execute(
+        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+    ).fetchone() is not None
+
+
+def test_apply_edge_does_not_duplicate_the_markdown_connection(engine):
+    """The winner of the race already wrote its Connection to the file. We must not
+    append a second one for the same (target, edge)."""
+    from datetime import datetime, timezone
+    from ormah.models.node import Connection, EdgeType
+    from ormah.background.auto_linker import _apply_edge
+
+    id_a, id_b = _create_pair(engine)
+    now = datetime.now(timezone.utc).isoformat()
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+            "VALUES (?, ?, 'supports', 0.9, ?, 'x')",
+            (id_a, id_b, now),
+        )
+    node = engine.file_store.load(id_a)          # the winner persisted its markdown
+    node.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.9))
+    engine.file_store.save(node)
+
+    _apply_edge(engine, id_a, id_b, "supports", "reason", 0.8)
+
+    node = engine.file_store.load(id_a)
+    assert len([c for c in node.connections if c.target == id_b]) == 1
+
+
+def test_apply_edge_repairs_a_markdown_connection_the_winner_failed_to_save(engine):
+    """The winner committed the DB row but crashed before saving its markdown. The
+    file is the source of truth and a reindex rebuilds edges from it — so if we skip
+    the append just because we lost the race, the next reindex deletes the edge while
+    auto_link_checked stops the pair from ever being reconsidered. The link would be
+    lost forever. We must repair the file instead. (Codex R1, critical #1.)"""
+    from datetime import datetime, timezone
+    from ormah.background.auto_linker import _apply_edge
+
+    id_a, id_b = _create_pair(engine)
+    now = datetime.now(timezone.utc).isoformat()
+    with engine.db.transaction() as conn:        # DB row exists, markdown does NOT
+        conn.execute(
+            "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+            "VALUES (?, ?, 'supports', 0.9, ?, 'winner crashed before saving md')",
+            (id_a, id_b, now),
+        )
+    assert [c for c in engine.file_store.load(id_a).connections if c.target == id_b] == []
+
+    _apply_edge(engine, id_a, id_b, "supports", "reason", 0.8)
+
+    conns = [c for c in engine.file_store.load(id_a).connections if c.target == id_b]
+    assert len(conns) == 1
+    assert conns[0].edge.value == "supports"

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -530,7 +530,6 @@ def test_a_failing_pair_does_not_block_progress_on_earlier_nodes(engine, monkeyp
     this, the fix would only be swapping one kind of total stall for another."""
     import json
     from unittest.mock import patch
-    from ormah.models.node import CreateNodeRequest, NodeType
     from ormah.background import auto_linker as al
 
     # A first pair that links cleanly, then a second pair whose apply always fails.

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -564,3 +564,27 @@ def test_a_failing_pair_does_not_block_progress_on_earlier_nodes(engine, monkeyp
     ).fetchone()
     assert row is not None, "the run made no progress at all — the failing pair stalled everything"
     assert int(row["value"]) >= good_seq, "the clean nodes before the failing pair must advance"
+
+
+def test_apply_edge_reports_whether_it_actually_created_the_edge(engine):
+    """An INSERT OR IGNORE that inserted nothing is not a creation. Counting it as one
+    burns the run's edge budget on a link someone else already made, and logs a
+    creation that never happened (Codex R2, medium)."""
+    from datetime import datetime, timezone
+    from ormah.background.auto_linker import _apply_edge
+
+    id_a, id_b = _create_pair(engine)
+
+    assert _apply_edge(engine, id_a, id_b, "supports", "r", 0.8) is True   # new edge
+
+    # Same edge again: a concurrent writer already has it -> ignored, not created.
+    now = datetime.now(timezone.utc).isoformat()
+    assert now  # keep the import honest
+    assert _apply_edge(engine, id_a, id_b, "supports", "r", 0.8) is False
+
+    # 'none' records the pair as checked without ever creating an edge.
+    id_c, id_d = _create_pair(
+        engine, title_a="Go language", content_a="Go is a systems language.",
+        title_b="Go lang", content_b="Go is a popular systems language.",
+    )
+    assert _apply_edge(engine, id_c, id_d, "none", "", 0.0) is False

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -588,3 +588,33 @@ def test_apply_edge_reports_whether_it_actually_created_the_edge(engine):
         title_b="Go lang", content_b="Go is a popular systems language.",
     )
     assert _apply_edge(engine, id_c, id_d, "none", "", 0.0) is False
+
+
+def test_a_failed_markdown_save_does_not_leave_the_pair_marked_checked(engine, monkeypatch):
+    """The markdown is the source of truth: a rebuild recreates the edge table from it.
+    If the connection cannot be persisted, the pair must NOT stay marked as checked —
+    otherwise the rebuild drops the DB-only edge and the checked row stops the pair from
+    ever being judged again. The link would be lost for good (Codex, PR A round 2)."""
+    import pytest
+    from ormah.background.auto_linker import _apply_edge
+
+    id_a, id_b = _create_pair(engine)
+
+    def boom(_node):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(engine.file_store, "save", boom)
+
+    with pytest.raises(OSError):
+        _apply_edge(engine, id_a, id_b, "supports", "r", 0.8)
+
+    pair = tuple(sorted([id_a, id_b]))
+    assert engine.db.conn.execute(
+        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+    ).fetchone() is None, "the pair stayed checked, so it will never be judged again"
+
+    # The edge WE inserted is rolled back too, or the collection guard would skip the
+    # pair forever on the strength of a row whose markdown never existed.
+    assert engine.db.conn.execute(
+        "SELECT 1 FROM edges WHERE source_id = ? AND target_id = ?", (id_a, id_b)
+    ).fetchone() is None

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -495,3 +495,73 @@ def test_apply_edge_repairs_a_markdown_connection_the_winner_failed_to_save(engi
     conns = [c for c in engine.file_store.load(id_a).connections if c.target == id_b]
     assert len(conns) == 1
     assert conns[0].edge.value == "supports"
+
+
+def test_run_survives_an_edge_apply_failure(engine, monkeypatch):
+    """A pair whose edge write blows up must not abort the whole run."""
+    import json
+    from unittest.mock import patch
+    from ormah.background import auto_linker as al
+
+    _create_pair(engine)
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("FOREIGN KEY constraint failed")
+
+    monkeypatch.setattr(al, "_apply_edge", boom)
+
+    llm_response = json.dumps({"relationship": "supports", "reason": "r"})
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=llm_response):
+        al.run_auto_linker(engine)   # must return normally, not raise
+
+    # Fail closed: the watermark must NOT have advanced past the unresolved node.
+    watermark = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'auto_link_watermark'"
+    ).fetchone()
+    assert watermark is None or int(watermark["value"]) == 0
+
+
+def test_a_failing_pair_does_not_block_progress_on_earlier_nodes(engine, monkeypatch):
+    """Progress, not just survival (Codex R1, critical #2): the failing pair parks the
+    cursor AT that node, but every node before it still advances the watermark. Without
+    this, the fix would only be swapping one kind of total stall for another."""
+    import json
+    from unittest.mock import patch
+    from ormah.models.node import CreateNodeRequest, NodeType
+    from ormah.background import auto_linker as al
+
+    # A first pair that links cleanly, then a second pair whose apply always fails.
+    good_a, good_b = _create_pair(engine)
+    bad_a, bad_b = _create_pair(
+        engine, title_a="Rust language", content_a="Rust is a systems language.",
+        title_b="Rust lang", content_b="Rust is a popular systems language.",
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+
+    real_apply = al._apply_edge
+
+    def apply_or_boom(eng, a_id, b_id, *args, **kwargs):
+        if a_id in (bad_a, bad_b):
+            raise RuntimeError("FOREIGN KEY constraint failed")
+        return real_apply(eng, a_id, b_id, *args, **kwargs)
+
+    monkeypatch.setattr(al, "_apply_edge", apply_or_boom)
+
+    good_seq = engine.db.conn.execute(
+        "SELECT seq FROM nodes WHERE id = ?", (good_b,)
+    ).fetchone()["seq"]
+
+    llm_response = json.dumps({"relationship": "supports", "reason": "r"})
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=llm_response):
+        al.run_auto_linker(engine)
+
+    row = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'auto_link_watermark'"
+    ).fetchone()
+    assert row is not None, "the run made no progress at all — the failing pair stalled everything"
+    assert int(row["value"]) >= good_seq, "the clean nodes before the failing pair must advance"

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -283,3 +283,37 @@ def test_project_scoped_nodes_skipped_by_default(engine):
 
     # LLM should never be called since project-scoped nodes are skipped
     mock_llm.assert_not_called()
+
+
+def test_conflict_edge_write_is_idempotent(engine):
+    """An edge another writer already created must not raise."""
+    from datetime import datetime, timezone
+    from ormah.models.node import CreateNodeRequest, NodeType
+
+    id_a, _ = engine.remember(
+        CreateNodeRequest(content="Coffee is good for you.", type=NodeType.fact), agent_id="t")
+    id_b, _ = engine.remember(
+        CreateNodeRequest(content="Coffee is bad for you.", type=NodeType.fact), agent_id="t")
+
+    now = datetime.now(timezone.utc).isoformat()
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+            "VALUES (?, ?, 'contradicts', 0.9, ?, 'someone else')",
+            (id_a, id_b, now),
+        )
+
+    # Writing the same contradiction again must be a no-op, not an IntegrityError,
+    # and must not overwrite the existing row.
+    with engine.db.transaction() as conn:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+            "VALUES (?, ?, 'contradicts', 0.9, ?, ?)",
+            (id_a, id_b, now, "conflict detector"),
+        )
+        assert cur.rowcount == 0
+
+    rows = engine.db.conn.execute(
+        "SELECT reason FROM edges WHERE source_id = ? AND target_id = ?", (id_a, id_b)
+    ).fetchall()
+    assert len(rows) == 1 and rows[0]["reason"] == "someone else"


### PR DESCRIPTION
Closes #117.

`auto_linker` checks whether an edge exists at **collection** time but inserts it at **apply** time, after the LLM judgment call. Any concurrent edge writer in that window (ingest auto-link, `conflict_detector`, a reindex, or a second manually-triggered run) creates the row first and the raw `INSERT` raises `IntegrityError`.

Two amplifiers turned one collision into a total outage:

- the edge insert shares a transaction with `INSERT OR IGNORE INTO auto_link_checked`, so the rollback erased the checked marker and the pair came back poisoned on every future run;
- nothing caught the exception at the call site, so it reached the top-level handler, killed a ~10 minute run and froze the watermark for the whole store. On the store where this was diagnosed the cursor sat at seq 333726 with a ~13k backlog, failing on every run.

## Changes

1. **`_apply_edge` uses `INSERT OR IGNORE`.** Losing the race means the link already exists — which is the outcome we wanted.
2. **The markdown append is idempotent and self-healing, not gated on winning the race.** This is the subtle part. The markdown file is the source of truth (a rebuild recreates the edge table from it) and the winner's own save is best-effort. If the winner committed the row but failed to save its file, skipping our append would let the next rebuild delete the edge, while the committed `auto_link_checked` row would stop the pair from ever being reconsidered — the link would be lost for good. So the connection is added whenever it is absent, whoever won.
3. **A failed markdown save is compensated, not swallowed.** It used to be logged at debug and ignored, which left the pair marked checked with the connection missing from the file — same permanent-loss path. Now the checked mark is removed, the edge is removed *only if we inserted it* (a concurrent writer's row is not ours to delete), and the error propagates so the caller leaves the node unresolved: the watermark fails closed and the pair is retried.
4. **A failing pair no longer aborts the run.** It is caught at the call site and logged **with its source/target/type** — the old failure logged nothing, so the colliding edge was unknowable after the fact.
5. **An ignored insert is not a created edge.** `_apply_edge` now reports whether it actually inserted a row; charging a no-op to `max_edges` spent the run's budget on work it did not do and logged an edge that was never created.
6. **`conflict_detector` had the same unguarded `INSERT`** for `contradicts`/`evolved_from` and runs concurrently over overlapping pairs — same fix, plus its markdown persistence loop now deduplicates instead of blindly extending.

## Ruled out, so this is not treating a symptom

- **Intra-run duplication:** impossible. The pair set is undirected and run-scoped; one candidate produces at most one insert.
- **The LLM forging IDs:** impossible. The IDs come from the collected candidate; the model only returns an integer `pair_id`, deduplicated on the way back.

## Known limitations, deliberately not fixed here

- If the concurrent writer created the **reverse** edge (`B→A`), `INSERT OR IGNORE` does not suppress our `A→B` — the primary key is directional. Pre-existing (the collection guard checks both directions, but not the apply-time window) and rare: the live store of 27,507 edges has exactly one such pair, from a week before the incident.
- A pair that fails deterministically still parks the watermark at that node. That is the existing contract of the monotonic cursor (it already parks on an unavailable LLM and on a vectorless node) and is the deferred retry/dead-letter follow-up on #109. What this PR removes is the *dominant* cause: collisions can no longer happen at all.

Reviewed by an adversarial peer over two rounds; findings 2, 3, 5 above came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
