### PR TITLE
fix(api): manual task triggers start a second concurrent run and report a dead run as success

### DIFF
--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -290,18 +290,23 @@ def _run_and_report(task_id: str, runner, engine) -> dict:
     The route used to return {"status": "completed"} unconditionally: a run that
     raised, or that returned {"error": ...}, was reported to the caller as a success.
     """
+    from ormah.background.job_tracker import failure_reason
+
     try:
         result = runner(engine)
     except Exception as e:
         logger.warning("Manual run of %s failed: %s", task_id, e)
         raise HTTPException(status_code=500, detail=str(e)) from e
 
-    stats = result if isinstance(result, dict) else None
-    if stats is not None and "error" in stats:
-        raise HTTPException(status_code=500, detail=str(stats["error"]))
+    # Same classifier the tracker uses: runners do not raise, they signal failure in the
+    # return value, and not all of them use the same shape (dict with "error", or False).
+    reason = failure_reason(result)
+    if reason is not None:
+        raise HTTPException(status_code=500, detail=reason)
+
     payload = {"status": "completed", "task": task_id}
-    if stats is not None:
-        payload["stats"] = stats
+    if isinstance(result, dict):
+        payload["stats"] = result
     return payload
 
 
@@ -326,6 +331,8 @@ def run_all_tasks(request: Request):
     """Run all background tasks sequentially in sleep-cycle order."""
     import importlib
 
+    from ormah.background.job_tracker import failure_reason
+
     engine = request.app.state.engine
     tracker = getattr(request.app.state, "job_tracker", None)
     results: dict[str, str] = {}
@@ -345,9 +352,9 @@ def run_all_tasks(request: Request):
                     module_path, func_name = _TASK_RUNNERS[task_id]
                     module = importlib.import_module(module_path)
                     runner = getattr(module, func_name)
-                    result = runner(engine)
-                    if isinstance(result, dict) and "error" in result:
-                        results[task_id] = f"error: {result['error']}"
+                    reason = failure_reason(runner(engine))
+                    if reason is not None:
+                        results[task_id] = f"error: {reason}"
                         continue
                 results[task_id] = "ok"
             except Exception as exc:
@@ -356,4 +363,9 @@ def run_all_tasks(request: Request):
     has_errors = any(v.startswith("error:") for v in results.values())
     if has_errors:
         return JSONResponse(status_code=503, content={"status": "degraded", "results": results})
+    # A skipped task is not an error, but the cycle did NOT run everything it was asked
+    # to. Reporting "completed" would tell a cron/script that the sleep cycle ran in full
+    # when part of it never started.
+    if any(v.startswith("skipped:") for v in results.values()):
+        return {"status": "partial", "results": results}
     return {"status": "completed", "results": results}

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import contextlib
+import logging
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -251,11 +256,15 @@ def resume_all_tasks(request: Request):
 def run_task(task_id: str, request: Request):
     """Manually trigger a background task by ID."""
     engine = request.app.state.engine
+    tracker = getattr(request.app.state, "job_tracker", None)
 
     # index_updater is a method on engine.builder, not a standalone function
     if task_id == "index_updater":
-        added, updated = engine.builder.incremental_update()
-        return {"status": "completed", "task": task_id, "added": added, "updated": updated}
+        with _guard(tracker, task_id) as acquired:
+            if not acquired:
+                raise HTTPException(status_code=409, detail=f"Task {task_id} is already running")
+            added, updated = engine.builder.incremental_update()
+            return {"status": "completed", "task": task_id, "added": added, "updated": updated}
 
     if task_id not in _TASK_RUNNERS:
         raise HTTPException(status_code=404, detail=f"Unknown task: {task_id}. Available: {list(_TASK_RUNNERS.keys()) + ['index_updater']}")
@@ -265,8 +274,51 @@ def run_task(task_id: str, request: Request):
     module = importlib.import_module(module_path)
     runner = getattr(module, func_name)
 
-    runner(engine)
-    return {"status": "completed", "task": task_id}
+    # This route bypasses the scheduler, so APScheduler's max_instances=1 does not
+    # apply to it. Without this guard a manual trigger during a scheduled run starts a
+    # second concurrent run over the same watermark, and the two race each other's
+    # edge writes (#117).
+    with _guard(tracker, task_id) as acquired:
+        if not acquired:
+            raise HTTPException(status_code=409, detail=f"Task {task_id} is already running")
+        return _run_and_report(task_id, runner, engine)
+
+
+def _run_and_report(task_id: str, runner, engine) -> dict:
+    """Run a task and report what actually happened.
+
+    The route used to return {"status": "completed"} unconditionally: a run that
+    raised, or that returned {"error": ...}, was reported to the caller as a success.
+    """
+    try:
+        result = runner(engine)
+    except Exception as e:
+        logger.warning("Manual run of %s failed: %s", task_id, e)
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    stats = result if isinstance(result, dict) else None
+    if stats is not None and "error" in stats:
+        raise HTTPException(status_code=500, detail=str(stats["error"]))
+    payload = {"status": "completed", "task": task_id}
+    if stats is not None:
+        payload["stats"] = stats
+    return payload
+
+
+@contextlib.contextmanager
+def _guard(tracker, task_id: str):
+    """Claim task_id for the duration of the block, or yield False if it is running.
+
+    A missing tracker (scheduler never started) means no scheduled job can be running
+    either, so there is nothing to collide with — but two concurrent HTTP requests
+    still could, so the app always builds a JobTracker (main.py), tracker=None is only
+    reachable in tests.
+    """
+    if tracker is None:
+        yield True
+        return
+    with tracker.run_guard(task_id) as acquired:
+        yield acquired
 
 
 @router.post("/tasks/run-all")
@@ -275,19 +327,33 @@ def run_all_tasks(request: Request):
     import importlib
 
     engine = request.app.state.engine
+    tracker = getattr(request.app.state, "job_tracker", None)
     results: dict[str, str] = {}
 
     for task_id in _SLEEP_CYCLE_ORDER:
-        try:
-            if task_id == "index_updater":
-                engine.builder.incremental_update()
-            elif task_id in _TASK_RUNNERS:
-                module_path, func_name = _TASK_RUNNERS[task_id]
-                module = importlib.import_module(module_path)
-                runner = getattr(module, func_name)
-                runner(engine)
-            results[task_id] = "ok"
-        except Exception as exc:
-            results[task_id] = f"error: {exc}"
+        with _guard(tracker, task_id) as acquired:
+            if not acquired:
+                # Same hole as run_task: this bypasses the scheduler, so a job already
+                # in flight would get a second concurrent run over the same watermark,
+                # racing its edge and markdown writes (#117).
+                results[task_id] = "skipped: already running"
+                continue
+            try:
+                if task_id == "index_updater":
+                    engine.builder.incremental_update()
+                elif task_id in _TASK_RUNNERS:
+                    module_path, func_name = _TASK_RUNNERS[task_id]
+                    module = importlib.import_module(module_path)
+                    runner = getattr(module, func_name)
+                    result = runner(engine)
+                    if isinstance(result, dict) and "error" in result:
+                        results[task_id] = f"error: {result['error']}"
+                        continue
+                results[task_id] = "ok"
+            except Exception as exc:
+                results[task_id] = f"error: {exc}"
 
+    has_errors = any(v.startswith("error:") for v in results.values())
+    if has_errors:
+        return JSONResponse(status_code=503, content={"status": "degraded", "results": results})
     return {"status": "completed", "results": results}

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -260,9 +260,12 @@ def _find_link_candidates(engine, limit: int = 8) -> list[dict]:
 
         return candidates
 
-    except Exception as e:
-        logger.warning("_find_link_candidates failed: %s", e)
-        return []
+    except Exception:
+        # Same reason as conflict_detector: swallowing this into an empty list turned a
+        # broken encoder/vector store into a "clean run with no candidates", which the
+        # tracker recorded as a success. Let run_auto_linker's handler report the error.
+        logger.warning("_find_link_candidates failed", exc_info=True)
+        raise
 
 
 def _apply_edge(

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -418,3 +418,4 @@ def run_auto_linker(engine) -> None:
 
     except Exception as e:
         logger.warning("Auto-linker failed: %s", e)
+        return {"error": str(e)}

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -207,9 +207,13 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
 
         return candidates
 
-    except Exception as e:
-        logger.warning("_find_conflict_candidates failed: %s", e)
-        return []
+    except Exception:
+        # Do NOT swallow into an empty list: a broken encoder, vector store or DB would
+        # look like "zero candidates, clean run", so the tracker recorded a success and
+        # /admin/health stayed green while conflict detection was silently dead. Let it
+        # reach run_conflict_detection's handler, which reports {"error": ...}.
+        logger.warning("_find_conflict_candidates failed", exc_info=True)
+        raise
 
 
 def run_conflict_detection(engine) -> None:

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -290,3 +290,4 @@ def run_conflict_detection(engine) -> None:
 
     except Exception as e:
         logger.warning("Conflict detection failed: %s", e)
+        return {"error": str(e)}

--- a/src/ormah/background/job_tracker.py
+++ b/src/ormah/background/job_tracker.py
@@ -106,9 +106,19 @@ def tracked(tracker: JobTracker, job_id: str, fn: Callable, *args: Any) -> Calla
                 logger.warning("Job %s is already running; skipping this trigger", job_id)
                 return
             try:
-                fn(*args)
+                result = fn(*args)
                 duration_ms = (time.monotonic() - t0) * 1000
-                tracker.record_success(job_id, duration_ms)
+                # The runners catch their own exceptions and signal a fatal error by
+                # RETURNING {"error": ...}. Discarding the return value recorded a dead
+                # run as a success, so /admin/health kept reporting ok (#117).
+                if isinstance(result, dict) and "error" in result:
+                    tracker.record_failure(job_id, str(result["error"]), duration_ms)
+                    logger.warning(
+                        "Job %s reported an error after %.0fms: %s",
+                        job_id, duration_ms, result["error"],
+                    )
+                else:
+                    tracker.record_success(job_id, duration_ms)
             except Exception as e:
                 duration_ms = (time.monotonic() - t0) * 1000
                 tracker.record_failure(job_id, str(e), duration_ms)

--- a/src/ormah/background/job_tracker.py
+++ b/src/ormah/background/job_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import threading
 import time
@@ -31,6 +32,7 @@ class JobTracker:
     def __init__(self) -> None:
         self._jobs: dict[str, JobStatus] = {}
         self._lock = threading.Lock()
+        self._running: set[str] = set()
 
     def record_success(self, job_id: str, duration_ms: float) -> None:
         now = datetime.now(timezone.utc)
@@ -51,6 +53,31 @@ class JobTracker:
             status.run_count += 1
             status.error_count += 1
             status.last_duration_ms = duration_ms
+
+    def is_running(self, job_id: str) -> bool:
+        with self._lock:
+            return job_id in self._running
+
+    @contextlib.contextmanager
+    def run_guard(self, job_id: str):
+        """Yield True if this caller claimed the job, False if it was already running.
+
+        An edge-writing job (auto_linker, conflict_detector) must never run twice at
+        once: both instances read the same watermark, enumerate the same candidates,
+        and race each other's edge writes (#117). APScheduler's max_instances=1 covers
+        the scheduled path; this covers the manual admin routes, which call the
+        runners directly and never touch the scheduler.
+        """
+        with self._lock:
+            acquired = job_id not in self._running
+            if acquired:
+                self._running.add(job_id)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                with self._lock:
+                    self._running.discard(job_id)
 
     def snapshot(self) -> dict[str, dict[str, Any]]:
         """Return a JSON-serialisable snapshot of all job statuses."""
@@ -74,13 +101,17 @@ def tracked(tracker: JobTracker, job_id: str, fn: Callable, *args: Any) -> Calla
 
     def _wrapper():
         t0 = time.monotonic()
-        try:
-            fn(*args)
-            duration_ms = (time.monotonic() - t0) * 1000
-            tracker.record_success(job_id, duration_ms)
-        except Exception as e:
-            duration_ms = (time.monotonic() - t0) * 1000
-            tracker.record_failure(job_id, str(e), duration_ms)
-            logger.warning("Job %s failed after %.0fms: %s", job_id, duration_ms, e)
+        with tracker.run_guard(job_id) as acquired:
+            if not acquired:
+                logger.warning("Job %s is already running; skipping this trigger", job_id)
+                return
+            try:
+                fn(*args)
+                duration_ms = (time.monotonic() - t0) * 1000
+                tracker.record_success(job_id, duration_ms)
+            except Exception as e:
+                duration_ms = (time.monotonic() - t0) * 1000
+                tracker.record_failure(job_id, str(e), duration_ms)
+                logger.warning("Job %s failed after %.0fms: %s", job_id, duration_ms, e)
 
     return _wrapper

--- a/src/ormah/background/job_tracker.py
+++ b/src/ormah/background/job_tracker.py
@@ -96,6 +96,25 @@ class JobTracker:
             return result
 
 
+def failure_reason(result: Any) -> str | None:
+    """Return why a runner's result means failure, or None if it succeeded.
+
+    Runners do not raise on failure — they signal it in the return value, and they do
+    not all use the same shape:
+      * the background jobs return ``{"error": ...}``
+      * ``run_restore_verification`` returns a plain ``False``
+
+    Treating everything that is not an error dict as a success recorded a failed run as
+    healthy, which is how the #117 outage stayed invisible for a day. ``None`` and
+    ``True`` stay successes: most runners return nothing at all.
+    """
+    if result is False:
+        return "run reported failure"
+    if isinstance(result, dict) and "error" in result:
+        return str(result["error"])
+    return None
+
+
 def tracked(tracker: JobTracker, job_id: str, fn: Callable, *args: Any) -> Callable:
     """Wrap a job function with tracking. Returns a no-arg callable for the scheduler."""
 
@@ -108,14 +127,14 @@ def tracked(tracker: JobTracker, job_id: str, fn: Callable, *args: Any) -> Calla
             try:
                 result = fn(*args)
                 duration_ms = (time.monotonic() - t0) * 1000
-                # The runners catch their own exceptions and signal a fatal error by
-                # RETURNING {"error": ...}. Discarding the return value recorded a dead
-                # run as a success, so /admin/health kept reporting ok (#117).
-                if isinstance(result, dict) and "error" in result:
-                    tracker.record_failure(job_id, str(result["error"]), duration_ms)
+                # The runners catch their own exceptions and signal failure in the RETURN
+                # value. Discarding it recorded a dead run as a success, so /admin/health
+                # kept reporting ok (#117).
+                reason = failure_reason(result)
+                if reason is not None:
+                    tracker.record_failure(job_id, reason, duration_ms)
                     logger.warning(
-                        "Job %s reported an error after %.0fms: %s",
-                        job_id, duration_ms, result["error"],
+                        "Job %s reported an error after %.0fms: %s", job_id, duration_ms, reason
                     )
                 else:
                     tracker.record_success(job_id, duration_ms)

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -68,6 +68,17 @@ async def lifespan(app: FastAPI):
     except Exception as e:
         logger.warning("Background scheduler not started: %s", e)
 
+    if not hasattr(app.state, "job_tracker"):
+        # The manual admin routes use the tracker for single-flight exclusion. It was only
+        # created inside the scheduler's try block, so a failed scheduler startup left the
+        # guard with nothing to claim against and it silently degraded to a no-op — two
+        # concurrent HTTP triggers could then run the same edge-writing job at once (#117).
+        # No scheduler means no scheduled job to collide with, but concurrent requests
+        # still collide, so the tracker must always exist.
+        from ormah.background.job_tracker import JobTracker
+
+        app.state.job_tracker = JobTracker()
+
     if not hasattr(app.state, "maintenance_manager"):
         app.state.maintenance_manager = MaintenanceManager(engine)
 

--- a/tests/test_api/test_routes_admin_run_task.py
+++ b/tests/test_api/test_routes_admin_run_task.py
@@ -1,0 +1,83 @@
+"""The manual task-trigger routes must not start a job that is already running,
+and must report what actually happened (#117)."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api.routes_admin import router as admin_router
+from ormah.background.job_tracker import JobTracker
+from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+
+
+@pytest.fixture
+def app_and_client(tmp_memory_dir):
+    settings = Settings(memory_dir=tmp_memory_dir, backup_dir=tmp_memory_dir.parent / "backups")
+    engine = MemoryEngine(settings)
+    engine.startup()
+
+    app = FastAPI()
+    app.include_router(admin_router)
+    app.state.engine = engine
+    app.state.job_tracker = JobTracker()
+
+    with TestClient(app) as c:
+        yield app, c
+
+    engine.shutdown()
+
+
+def test_run_task_rejects_a_job_that_is_already_running(app_and_client):
+    """A manual trigger during the scheduled run used to start a second concurrent
+    run over the same watermark (#117). It must 409 instead."""
+    app, client = app_and_client
+
+    with app.state.job_tracker.run_guard("auto_linker") as acquired:
+        assert acquired is True
+        resp = client.post("/admin/tasks/auto_linker/run")
+
+    assert resp.status_code == 409
+    assert "already running" in resp.json()["detail"].lower()
+
+
+def test_run_task_reports_a_failure_instead_of_completed(app_and_client, monkeypatch):
+    """The route returned {'status': 'completed'} unconditionally — a run that blew
+    up was reported to the caller as a success."""
+    _app, client = app_and_client
+    import ormah.background.auto_linker as al
+
+    def boom(_engine):
+        raise RuntimeError("watermark exploded")
+
+    monkeypatch.setattr(al, "run_auto_linker", boom)
+    resp = client.post("/admin/tasks/auto_linker/run")
+
+    assert resp.status_code == 500
+    assert "watermark exploded" in resp.json()["detail"]
+
+
+def test_run_task_returns_the_stats_on_success(app_and_client, monkeypatch):
+    _app, client = app_and_client
+    import ormah.background.auto_linker as al
+
+    monkeypatch.setattr(al, "run_auto_linker", lambda _e: None)
+    resp = client.post("/admin/tasks/auto_linker/run")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "completed"
+
+
+def test_run_all_skips_a_task_that_is_already_running(app_and_client, monkeypatch):
+    """run-all calls the runners directly too — same hole."""
+    app, client = app_and_client
+    import ormah.background.auto_linker as al
+
+    calls = []
+    monkeypatch.setattr(al, "run_auto_linker", lambda _e: calls.append(1))
+
+    with app.state.job_tracker.run_guard("auto_linker"):
+        resp = client.post("/admin/tasks/run-all")
+
+    assert calls == []                                  # never started a second run
+    assert resp.json()["results"]["auto_linker"] == "skipped: already running"

--- a/tests/test_api/test_routes_admin_run_task.py
+++ b/tests/test_api/test_routes_admin_run_task.py
@@ -81,3 +81,34 @@ def test_run_all_skips_a_task_that_is_already_running(app_and_client, monkeypatc
 
     assert calls == []                                  # never started a second run
     assert resp.json()["results"]["auto_linker"] == "skipped: already running"
+
+
+def test_lifespan_always_creates_a_job_tracker_even_if_the_scheduler_fails(tmp_memory_dir, monkeypatch):
+    """The guard is only atomic against a SHARED tracker. It was created inside the
+    scheduler's try block, so a failed scheduler startup left app.state without one and
+    _guard degraded to a no-op — two concurrent triggers could then run the same
+    edge-writing job at once (Codex, PR B)."""
+    import asyncio
+
+    from fastapi import FastAPI
+
+    import ormah.background.scheduler as sched
+    from ormah.main import lifespan
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("scheduler is down")
+
+    monkeypatch.setattr(sched, "start_scheduler", boom)
+    monkeypatch.setenv("ORMAH_MEMORY_DIR", str(tmp_memory_dir))
+    monkeypatch.setenv("ORMAH_SESSION_WATCHER_ENABLED", "false")
+
+    app = FastAPI()
+
+    async def drive():
+        async with lifespan(app):
+            return getattr(app.state, "job_tracker", None)
+
+    tracker = asyncio.run(drive())
+
+    assert tracker is not None, "no tracker -> the single-flight guard silently degrades to a no-op"
+    assert tracker.is_running("auto_linker") is False

--- a/tests/test_api/test_routes_admin_run_task.py
+++ b/tests/test_api/test_routes_admin_run_task.py
@@ -81,6 +81,7 @@ def test_run_all_skips_a_task_that_is_already_running(app_and_client, monkeypatc
 
     assert calls == []                                  # never started a second run
     assert resp.json()["results"]["auto_linker"] == "skipped: already running"
+    assert resp.json()["status"] == "partial"   # skipped work is not a completed cycle
 
 
 def test_lifespan_always_creates_a_job_tracker_even_if_the_scheduler_fails(tmp_memory_dir, monkeypatch):

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -411,3 +411,21 @@ def test_checked_pairs_invalidated_on_update(engine):
         run_auto_linker(engine)
 
     assert mock_llm.call_count >= 1  # LLM was called again for this pair
+
+
+def test_run_auto_linker_reports_a_fatal_error_instead_of_returning_none(engine, monkeypatch):
+    """A run that dies must say so in its return value — the job tracker and the admin
+    route both read it. Returning None made a dead run look like a clean one (#117)."""
+    from ormah.background import auto_linker as al
+
+    engine.settings.llm_provider = "ollama"  # llm_enabled is derived from this
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("vector store exploded")
+
+    monkeypatch.setattr(al, "_get_watermark", boom)
+
+    result = al.run_auto_linker(engine)
+
+    assert isinstance(result, dict)
+    assert "vector store exploded" in result["error"]

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -283,3 +283,24 @@ def test_project_scoped_nodes_skipped_by_default(engine):
 
     # LLM should never be called since project-scoped nodes are skipped
     mock_llm.assert_not_called()
+
+
+def test_candidate_discovery_failure_is_reported_not_swallowed(engine, monkeypatch):
+    """A broken encoder/vector store must surface as a failed run. _find_conflict_candidates
+    caught everything and returned [], so the run ended 'cleanly' with zero candidates and
+    the job tracker recorded a success — conflict detection silently disabled while
+    /admin/health stayed green (Codex, PR B)."""
+    from ormah.background import conflict_detector as cd
+
+    engine.settings.llm_provider = "ollama"
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("vector store exploded")
+
+    monkeypatch.setattr(cd, "_find_conflict_candidates", cd._find_conflict_candidates)
+    monkeypatch.setattr("ormah.embeddings.encoder.get_encoder", boom, raising=False)
+
+    result = cd.run_conflict_detection(engine)
+
+    assert isinstance(result, dict), "a broken run must report an error, not return None"
+    assert "error" in result

--- a/tests/test_background/test_job_tracker.py
+++ b/tests/test_background/test_job_tracker.py
@@ -142,3 +142,18 @@ def test_tracked_skips_a_run_when_the_job_is_already_running():
         tracked(tracker, "demo", lambda: calls.append(1))()
 
     assert calls == []   # the wrapped function never ran
+
+
+def test_tracked_records_a_failure_when_the_job_returns_an_error_dict():
+    """A runner that dies signals it by RETURNING {'error': ...} (it catches its own
+    exceptions), so tracked() must inspect the return value. Ignoring it made the job
+    tracker — and therefore /admin/health — report a dead run as a success (#117)."""
+    from ormah.background.job_tracker import JobTracker, tracked
+
+    tracker = JobTracker()
+    tracked(tracker, "demo", lambda: {"error": "watermark exploded"})()
+
+    snap = tracker.snapshot()["demo"]
+    assert snap["last_error"] == "watermark exploded"
+    assert snap["error_count"] == 1
+    assert snap["last_success"] is None

--- a/tests/test_background/test_job_tracker.py
+++ b/tests/test_background/test_job_tracker.py
@@ -87,3 +87,58 @@ def test_multiple_jobs_independent():
     snap = tracker.snapshot()
     assert snap["job_a"]["error_count"] == 0
     assert snap["job_b"]["error_count"] == 1
+
+
+def test_tracker_reports_a_job_as_running_while_it_executes():
+    from ormah.background.job_tracker import JobTracker, tracked
+
+    tracker = JobTracker()
+    seen = {}
+
+    def job():
+        seen["running_during"] = tracker.is_running("demo")
+
+    assert tracker.is_running("demo") is False
+    tracked(tracker, "demo", job)()
+    assert seen["running_during"] is True
+    assert tracker.is_running("demo") is False   # cleared after completion
+
+
+def test_tracker_clears_the_running_flag_when_the_job_raises():
+    from ormah.background.job_tracker import JobTracker, tracked
+
+    tracker = JobTracker()
+
+    def boom():
+        raise RuntimeError("nope")
+
+    tracked(tracker, "demo", boom)()
+    assert tracker.is_running("demo") is False   # a stuck flag would wedge the job forever
+
+
+def test_run_guard_refuses_a_second_concurrent_claim():
+    from ormah.background.job_tracker import JobTracker
+
+    tracker = JobTracker()
+    inner = []
+
+    with tracker.run_guard("demo") as acquired:
+        assert acquired is True
+        with tracker.run_guard("demo") as second:
+            inner.append(second)
+    assert inner == [False]
+
+    with tracker.run_guard("demo") as third:   # released -> claimable again
+        assert third is True
+
+
+def test_tracked_skips_a_run_when_the_job_is_already_running():
+    from ormah.background.job_tracker import JobTracker, tracked
+
+    tracker = JobTracker()
+    calls = []
+
+    with tracker.run_guard("demo"):
+        tracked(tracker, "demo", lambda: calls.append(1))()
+
+    assert calls == []   # the wrapped function never ran

--- a/tests/test_background/test_job_tracker.py
+++ b/tests/test_background/test_job_tracker.py
@@ -157,3 +157,28 @@ def test_tracked_records_a_failure_when_the_job_returns_an_error_dict():
     assert snap["last_error"] == "watermark exploded"
     assert snap["error_count"] == 1
     assert snap["last_success"] is None
+
+
+def test_tracked_records_a_failure_when_the_job_returns_false():
+    """run_restore_verification returns a bool — False means the restore could NOT be
+    verified. Treating every non-error-dict as success left a failed restore check green
+    in /admin/health (Codex, PR B round 2)."""
+    from ormah.background.job_tracker import JobTracker, tracked
+
+    tracker = JobTracker()
+    tracked(tracker, "restore_verification", lambda: False)()
+
+    snap = tracker.snapshot()["restore_verification"]
+    assert snap["error_count"] == 1
+    assert snap["last_success"] is None
+
+
+def test_tracked_still_treats_true_and_none_as_success():
+    from ormah.background.job_tracker import JobTracker, tracked
+
+    tracker = JobTracker()
+    tracked(tracker, "ok_bool", lambda: True)()
+    tracked(tracker, "ok_none", lambda: None)()
+
+    assert tracker.snapshot()["ok_bool"]["error_count"] == 0
+    assert tracker.snapshot()["ok_none"]["error_count"] == 0


### PR DESCRIPTION
The admin trigger routes call the job runners directly, bypassing the scheduler entirely — so APScheduler's `max_instances=1` (which is the default, and does protect the scheduled path) never applied to them.

On 2026-07-13 a manual `POST /admin/tasks/auto_linker/run` started while the scheduled `auto_linker` was ~11 minutes into its run. Both read the same (frozen) watermark, so both enumerated the same candidate pairs in the same order and raced each other's edge writes. The scheduled run died with `UNIQUE constraint failed: edges...` (#117, fixed separately).

Worse, the failure was invisible: the route answered `{"status": "completed"}` for the run that had just died, and `/admin/health` stayed green.

## Changes

**Single-flight exclusion for the manual routes**
- `JobTracker` now tracks in-flight jobs (`is_running`, `run_guard`); `tracked()` claims a job for the duration of its run and always releases, including when it raises.
- `POST /admin/tasks/{id}/run` → **409** when the job is already running. The guard also covers `index_updater`, which used to return before the tracker was consulted.
- `POST /admin/tasks/run-all` → claims each task with `run_guard` (an atomic claim, not a check-then-act) and skips the ones already in flight.
- The tracker is now created **independently of scheduler startup**. It used to be built inside the scheduler's `try` block, so a failed scheduler start left the routes' guard with nothing to claim against and it silently degraded to a no-op — two concurrent HTTP triggers could then run the same edge-writing job at once.

**One failure contract, so a dead run can no longer look healthy**
- The runners do not raise on failure; they signal it in the return value, and they did not all use the same shape. `run_auto_linker` and `run_conflict_detection` caught everything, logged, and returned `None`; `run_restore_verification` returns a plain `False`. `tracked()` treated every non-error-dict as a success.
- Both runners now return `{"error": ...}` instead of swallowing, and `failure_reason()` is the single classifier shared by `tracked()`, the manual route and `run-all`. A failed restore verification or a dead linker run is now recorded as a failure and surfaced as HTTP 500.
- `_find_conflict_candidates` and `_find_link_candidates` also caught **every** exception and returned an empty list, so a broken encoder, vector store or DB looked like "zero candidates, clean run". They now propagate to the runner's handler.
- `run-all` no longer reports `completed` when the guard skipped a task: it returns `partial`, so a cron or script is not told the sleep cycle ran in full when part of it never started.

## Not touched

`scheduler.py`. `max_instances=1` is already the APScheduler default (`BackgroundScheduler()._job_defaults == {'misfire_grace_time': 1, 'coalesce': True, 'max_instances': 1}`) and the scheduled path was never the problem.

## Known gap, deliberately out of scope

`run_cloud_backup` returns `None` both for "nothing due" and for a persisted failure, so `None` cannot be classified without changing that runner's contract (it records its own failure separately). Unifying every runner's result shape deserves its own issue.

Reviewed by an adversarial peer over two rounds; the tracker-independence, the `False` contract and the swallowed candidate-discovery failures all came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
