### PR TITLE
fix(index): reindex wipes edges.reason — 100% of edges end up with reason=NULL

### DIFF
--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -304,7 +304,12 @@ def _apply_edge(
                     target=node_b_id,
                     edge=EdgeType(edge_type),
                     weight=round(similarity, 2),
-                    reason=reason or None,
+                    # Coerce: the LLM can return JSON-valid non-strings (reason: 123).
+                    # SQLite takes them, but Connection.reason is typed — a ValidationError
+                    # here is swallowed by the except below, and the edge would end up in
+                    # the index with no markdown connection, which the next reindex deletes
+                    # while auto_link_checked blocks reevaluation. The link would be lost.
+                    reason=str(reason) if reason else None,
                 )
                 mem_node.connections.append(md_conn)
                 mem_node.touch_updated()

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -304,6 +304,7 @@ def _apply_edge(
                     target=node_b_id,
                     edge=EdgeType(edge_type),
                     weight=round(similarity, 2),
+                    reason=reason or None,
                 )
                 mem_node.connections.append(md_conn)
                 mem_node.touch_updated()

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -269,6 +269,7 @@ def run_conflict_detection(engine) -> None:
                 target=target_id,
                 edge=EdgeType(edge_type_str),
                 weight=0.9,
+                reason=explanation or None,
             )
             dirty_nodes.setdefault(source_id, []).append(md_conn)
             edges_created += 1

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -269,7 +269,9 @@ def run_conflict_detection(engine) -> None:
                 target=target_id,
                 edge=EdgeType(edge_type_str),
                 weight=0.9,
-                reason=explanation or None,
+                # Coerce for the same reason as auto_linker: a non-string LLM explanation
+                # would raise on Connection and cost us the markdown connection.
+                reason=str(explanation) if explanation else None,
             )
             dirty_nodes.setdefault(source_id, []).append(md_conn)
             edges_created += 1

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -192,10 +192,10 @@ class IndexBuilder:
 
             conn.execute(
                 """
-                INSERT OR REPLACE INTO edges (source_id, target_id, edge_type, weight, created)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT OR REPLACE INTO edges (source_id, target_id, edge_type, weight, created, reason)
+                VALUES (?, ?, ?, ?, ?, ?)
                 """,
-                (node.id, c.target, c.edge.value, c.weight, node.created.isoformat()),
+                (node.id, c.target, c.edge.value, c.weight, node.created.isoformat(), c.reason),
             )
 
     def _remove_node(self, node_id: str, *, keep_vectors: bool = False) -> None:

--- a/src/ormah/models/node.py
+++ b/src/ormah/models/node.py
@@ -43,6 +43,7 @@ class Connection(BaseModel):
     target: str
     edge: EdgeType = EdgeType.related_to
     weight: float = Field(default=0.5, ge=0.0, le=1.0)
+    reason: str | None = None
 
 
 class MemoryNode(BaseModel):

--- a/src/ormah/store/markdown.py
+++ b/src/ormah/store/markdown.py
@@ -16,12 +16,18 @@ def parse_node(text: str) -> MemoryNode:
 
     connections = []
     for conn in meta.get("connections", []):
+        # Coerce, don't trust: YAML happily yields ints, bools and lists here, and
+        # Connection.reason is a typed str|None. A stray `reason: 123` would raise, so
+        # parse_node would fail and the WHOLE node become unreadable — and
+        # incremental_update can mistake a parse failure for a deleted file and drop the
+        # node and its edges from the index. Mirrors the coercion the writers do.
+        raw_reason = conn.get("reason")
         connections.append(
             Connection(
                 target=conn["target"],
                 edge=EdgeType(conn.get("edge", "related_to")),
                 weight=conn.get("weight", 0.5),
-                reason=conn.get("reason"),
+                reason=str(raw_reason) if raw_reason is not None else None,
             )
         )
 

--- a/src/ormah/store/markdown.py
+++ b/src/ormah/store/markdown.py
@@ -21,6 +21,7 @@ def parse_node(text: str) -> MemoryNode:
                 target=conn["target"],
                 edge=EdgeType(conn.get("edge", "related_to")),
                 weight=conn.get("weight", 0.5),
+                reason=conn.get("reason"),
             )
         )
 
@@ -83,7 +84,12 @@ def serialize_node(node: MemoryNode) -> str:
         meta["tags"] = node.tags
     if node.connections:
         meta["connections"] = [
-            {"target": c.target, "edge": c.edge.value, "weight": c.weight}
+            {
+                "target": c.target,
+                "edge": c.edge.value,
+                "weight": c.weight,
+                **({"reason": c.reason} if c.reason else {}),
+            }
             for c in node.connections
         ]
 

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -411,3 +411,15 @@ def test_checked_pairs_invalidated_on_update(engine):
         run_auto_linker(engine)
 
     assert mock_llm.call_count >= 1  # LLM was called again for this pair
+
+
+def test_apply_edge_writes_the_reason_into_the_markdown(engine):
+    """The reason must reach the file, otherwise the next reindex erases it."""
+    from ormah.background.auto_linker import _apply_edge
+
+    id_a, id_b = _create_pair(engine)
+    _apply_edge(engine, id_a, id_b, "supports", "they agree about Python", 0.8)
+
+    node = engine.file_store.load(id_a)
+    conn = next(c for c in node.connections if c.target == id_b)
+    assert conn.reason == "they agree about Python"

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -423,3 +423,20 @@ def test_apply_edge_writes_the_reason_into_the_markdown(engine):
     node = engine.file_store.load(id_a)
     conn = next(c for c in node.connections if c.target == id_b)
     assert conn.reason == "they agree about Python"
+
+
+def test_a_non_string_llm_reason_does_not_cost_us_the_markdown_connection(engine):
+    """The LLM can return JSON-valid garbage like {"reason": 123}. SQLite accepts the int
+    and commits the edge + auto_link_checked, but Connection.reason is typed str|None, so
+    building it raises — and the broad except swallows it, leaving the edge in the index
+    with NO markdown connection. The next reindex then deletes the edge while the checked
+    pair blocks reevaluation: the link is lost for good (Codex, PR C)."""
+    from ormah.background.auto_linker import _apply_edge
+
+    id_a, id_b = _create_pair(engine)
+
+    _apply_edge(engine, id_a, id_b, "supports", 123, 0.8)   # non-string reason
+
+    conns = [c for c in engine.file_store.load(id_a).connections if c.target == id_b]
+    assert len(conns) == 1, "the edge was committed but the markdown connection was lost"
+    assert conns[0].reason == "123"

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -52,3 +52,32 @@ def test_incremental_update(db, file_store):
 
     rows = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()
     assert rows[0] == 2
+
+
+def test_reindex_preserves_the_edge_reason(engine):
+    """Reindexing a node must not wipe why its edges exist."""
+    from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
+
+    id_a, _ = engine.remember(
+        CreateNodeRequest(content="A fact.", type=NodeType.fact), agent_id="t")
+    id_b, _ = engine.remember(
+        CreateNodeRequest(content="Another fact.", type=NodeType.fact), agent_id="t")
+
+    node = engine.file_store.load(id_a)
+    node.connections.append(
+        Connection(target=id_b, edge=EdgeType.supports, weight=0.9, reason="because X")
+    )
+    engine.file_store.save(node)
+
+    # index_single takes a Path, not an id (builder.py:124) - passing the id raises
+    # before the assertion is ever reached (Codex R2, critical #4). The only helper that
+    # maps a node to its file is FileStore._path_for(node) (file_store.py:192), which
+    # takes the MemoryNode, not the id.
+    engine.builder.index_single(engine.file_store._path_for(node))
+
+    row = engine.db.conn.execute(
+        "SELECT reason FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = 'supports'",
+        (id_a, id_b),
+    ).fetchone()
+    assert row is not None
+    assert row["reason"] == "because X"

--- a/tests/test_store/test_markdown.py
+++ b/tests/test_store/test_markdown.py
@@ -74,3 +74,49 @@ def test_deleted_at_omitted_when_none():
     node = MemoryNode(type=NodeType.fact, source="agent:test", content="Live fact.")
     text = serialize_node(node)
     assert "deleted_at" not in text
+
+
+def test_connection_reason_round_trips():
+    """The reason an edge exists must survive a save/load cycle — the index is
+    rebuilt from markdown every minute, so anything not in the file is lost."""
+    from ormah.models.node import Connection, EdgeType, MemoryNode, NodeType
+    from ormah.store.markdown import parse_node, serialize_node
+
+    node = MemoryNode(
+        type=NodeType.fact,
+        content="Python is a programming language.",
+        connections=[
+            Connection(
+                target="11111111-1111-1111-1111-111111111111",
+                edge=EdgeType.supports,
+                weight=0.8,
+                reason="Both describe Python as a language.",
+            )
+        ],
+    )
+
+    reloaded = parse_node(serialize_node(node))
+
+    assert reloaded.connections[0].reason == "Both describe Python as a language."
+    assert reloaded.connections[0].edge == EdgeType.supports
+    assert reloaded.connections[0].weight == 0.8
+
+
+def test_connection_without_reason_still_parses():
+    """Files written before this change have no `reason` key — they must still load."""
+    from ormah.store.markdown import parse_node
+
+    text = """---
+id: 22222222-2222-2222-2222-222222222222
+type: fact
+created: 2026-01-01T00:00:00+00:00
+updated: 2026-01-01T00:00:00+00:00
+connections:
+  - target: 33333333-3333-3333-3333-333333333333
+    edge: related_to
+    weight: 0.7
+---
+Old file.
+"""
+    node = parse_node(text)
+    assert node.connections[0].reason is None

--- a/tests/test_store/test_markdown.py
+++ b/tests/test_store/test_markdown.py
@@ -120,3 +120,33 @@ Old file.
 """
     node = parse_node(text)
     assert node.connections[0].reason is None
+
+
+def test_a_non_string_reason_in_the_yaml_does_not_make_the_whole_node_unparsable():
+    """The parser feeds `reason` straight into a typed pydantic field. A hand-edited or
+    stray `reason: 123` would raise ValidationError, so parse_node fails and the WHOLE
+    node becomes unreadable — incremental_update can then take the parse failure for a
+    deleted file and drop the node and its edges from the index (Codex, PR C round 2)."""
+    from ormah.store.markdown import parse_node
+
+    text = """---
+id: 44444444-4444-4444-4444-444444444444
+type: fact
+created: 2026-01-01T00:00:00+00:00
+updated: 2026-01-01T00:00:00+00:00
+connections:
+  - target: 55555555-5555-5555-5555-555555555555
+    edge: supports
+    weight: 0.7
+    reason: 123
+  - target: 66666666-6666-6666-6666-666666666666
+    edge: related_to
+    weight: 0.5
+    reason: false
+---
+Node with non-string reasons.
+"""
+    node = parse_node(text)   # must not raise
+
+    assert node.connections[0].reason == "123"
+    assert node.connections[1].reason == "False"


### PR DESCRIPTION
On the store where this was found, **100% of 27,507 edges have `reason = NULL`** — including the 432 whose types (`supports`, `part_of`, `depends_on`, `evolved_from`, `contradicts`) only `auto_linker` and `conflict_detector` can create. Both of those writers *do* pass a reason. So the reasons are written and then erased.

## Why an SQL fix cannot work

The markdown file is the source of truth; the SQLite index is derived. `Connection` had only `target`, `edge`, `weight` — **no `reason`** — and `markdown.py` serialized exactly those three keys. Reindexing a node deletes its edges and recreates them from the markdown, which never carried the reason. The index updater runs **every minute**, so any reason had a lifetime of about a minute.

The fix therefore has to make `reason` part of the file format. `edges.reason` already exists in `schema.sql`, so there is **no DB migration**.

## Changes

- `Connection.reason` (optional, defaults to `None`).
- Round-trips through the YAML frontmatter. The key is **omitted when empty**, so existing files are not churned, and files without it still parse.
- `builder._index_file_edges` writes `reason` when rebuilding edges from markdown.
- `auto_linker` and `conflict_detector` put the reason on the `Connection` they persist.

## Robustness against non-string reasons (both directions)

An LLM can return JSON-valid garbage like `{"relationship": "supports", "reason": 123}`. SQLite accepts the integer, but `Connection.reason` is typed:

- **On write:** the writers coerce. Without this, building the `Connection` raised, the broad `except` swallowed it, the markdown was never saved, and the edge existed only in the index — the next rebuild deleted it while `auto_link_checked` blocked reevaluation. The link was lost.
- **On read:** the parser coerces. Without this, a stray `reason: 123` in the YAML raised a `ValidationError`, `parse_node` failed, and the **whole node** became unreadable — and `incremental_update` can mistake a parse failure for a deleted file and drop the node and its edges from the index.

## Not fixed here — a pre-existing bug worth its own issue

`_remove_node` deletes edges where the reindexed node is **source or target**, but `_index_file_edges` only recreates the connections stored in *that node's own* markdown. So reindexing node **B** deletes an incoming `A→B` edge and cannot restore it — the connection lives in A's file, and A is not revisited. Preserving `reason` on the outbound rebuild does not address this; the fix is to stop deleting incoming edges on an update and reserve the full cascade for actual node deletion. That is a rewrite of incremental reindexing, not a rider on a file-format change.

## Backfill note

This stops the bleeding but does not recover the reasons already lost — they were never written to a file. A future run of each job regenerates reasons only for pairs not already recorded in `auto_link_checked` / `conflict_checked`, so most existing edges keep `reason = NULL` unless those tables are selectively cleared. That is a separate decision.

Reviewed by an adversarial peer over two rounds; both coercions came out of that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
