### PR TITLE
fix(index): requeue a node only when its content fingerprint changes (#126)

### DIFF
--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -328,16 +328,26 @@ def run_auto_linker(engine) -> None:
         threshold = settings.auto_link_similarity_threshold
         cross_space_penalty = settings.auto_link_cross_space_penalty
         max_edges = settings.auto_link_max_edges_per_run
+        # #126: created only counts POSITIVE edges — a 'none'/'error' verdict still costs an
+        # LLM call but was free of budget. Before this PR that was harmless (cached pairs were
+        # skipped), but invalidating verdicts on content change makes those pairs eligible
+        # again: a bulk space/content change can now issue thousands of judging calls that
+        # create zero edges, with nothing to stop it. pairs_judged hard-caps every judgement
+        # call, fail-closed exactly like max_edges below (0 = unlimited).
+        max_pairs = settings.auto_link_max_pairs_per_run
 
         watermark = _get_watermark(conn)
         nodes = _select_nodes_after(conn, watermark, settings.auto_link_max_nodes_per_run)
 
         created = 0
+        pairs_judged = 0
         last_complete: int | None = None
 
         for node in nodes:
             if created >= max_edges:
                 break  # batch budget spent; do not advance past this node
+            if max_pairs > 0 and pairs_judged >= max_pairs:
+                break  # judgement budget spent; do not advance past this node
 
             node_resolved = True
             text = f"{node['title'] or ''} {node['content']}".strip()
@@ -358,6 +368,9 @@ def run_auto_linker(engine) -> None:
 
                 for match in similar:
                     if created >= max_edges:
+                        node_resolved = False  # interrupted mid-node
+                        break
+                    if max_pairs > 0 and pairs_judged >= max_pairs:
                         node_resolved = False  # interrupted mid-node
                         break
                     if match["id"] == node["id"]:
@@ -391,6 +404,7 @@ def run_auto_linker(engine) -> None:
                         continue
 
                     llm_result = _llm_classify_link(settings, node, other)
+                    pairs_judged += 1
                     if llm_result is None:
                         # LLM UNAVAILABLE (raw None) — transient. Leave node unresolved so the
                         # watermark does not pass it. Not a poison: if the LLM is down, EVERY node

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -131,6 +131,7 @@ class Settings(BaseSettings):
     auto_link_cross_space_penalty: float = 0.1  # subtracted from similarity for cross-space pairs
     auto_link_max_edges_per_run: int = 500
     auto_link_max_nodes_per_run: int = 500  # cursor batch: nodes scanned per run
+    auto_link_max_pairs_per_run: int = 200  # hard cap on LLM judgements per run (0 = unlimited)
 
     # Auto-merge
     auto_merge_threshold: float = 0.85

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 
 from ormah.index.db import Database
+from ormah.index.fingerprint import content_fingerprint
 from ormah.store.file_store import FileStore
 from ormah.store.markdown import parse_node
 
@@ -115,9 +116,10 @@ class IndexBuilder:
             INSERT OR REPLACE INTO nodes
             (id, type, tier, source, space, title, content, created, updated,
              last_accessed, access_count, confidence, importance,
-             valid_until, stability, last_review, file_path, file_hash)
+             valid_until, stability, last_review, file_path, file_hash,
+             content_fingerprint)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?)
+                    ?, ?, ?, ?, ?, ?)
             """,
             (
                 node.id,
@@ -138,6 +140,7 @@ class IndexBuilder:
                 node.last_review.isoformat() if node.last_review else None,
                 str(path),
                 file_hash,
+                content_fingerprint(node.title, node.content, node.type.value, node.space),
             ),
         )
 

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -99,7 +99,16 @@ class IndexBuilder:
         node = parse_node(path.read_text(encoding="utf-8"))
         with self.db.transaction():
             prior = self._prior_row(node.id)  # read BEFORE the delete (#126)
-            self._remove_node(node.id)
+            # The vector is still valid exactly when the content fingerprint is: title and
+            # content are what feed the embedding. Dropping it on an unchanged-content
+            # reindex is permanent loss — nothing re-embeds it — and the node would sit
+            # behind the watermark with no vector, invisible to the linker and unable to be
+            # anyone else's semantic candidate. mark_outdated() (valid_until only) walks
+            # exactly this path.
+            unchanged = prior is not None and prior["content_fingerprint"] == content_fingerprint(
+                node.title, node.content, node.type.value, node.space
+            )
+            self._remove_node(node.id, keep_vectors=unchanged)
             self._index_file(path, prior)
 
     def _prior_row(self, node_id: str) -> sqlite3.Row | None:

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from pathlib import Path
 
 from ormah.index.db import Database
@@ -101,24 +102,22 @@ class IndexBuilder:
             self._remove_node(node.id)
             self._index_file(path, prior)
 
-    def _prior_row(self, node_id: str):
+    def _prior_row(self, node_id: str) -> sqlite3.Row | None:
         """The stored fingerprint + seq, read BEFORE _remove_node deletes the row.
 
-        The fingerprint — not the row's live columns — is the baseline: auto_cluster writes
-        `space` straight into SQLite (auto_cluster.py:64-86), so the row's own columns may
-        already hold the new value while the fingerprint still reflects the last indexed
-        content. Comparing against the fingerprint is what keeps that node getting requeued.
+        Only the persisted fingerprint may serve as the baseline — see the comparison in
+        _index_file_nodes_only for why the row's live columns must not.
         """
         return self.db.conn.execute(
             "SELECT seq, content_fingerprint FROM nodes WHERE id = ?", (node_id,)
         ).fetchone()
 
-    def _index_file(self, path: Path, prior=None) -> None:
+    def _index_file(self, path: Path, prior: sqlite3.Row | None = None) -> None:
         """Index a single markdown file into the database (nodes + edges)."""
         self._index_file_nodes_only(path, prior)
         self._index_file_edges(path)
 
-    def _index_file_nodes_only(self, path: Path, prior=None) -> None:
+    def _index_file_nodes_only(self, path: Path, prior: sqlite3.Row | None = None) -> None:
         """Index node, tags, and FTS from a markdown file (no edges)."""
         text = path.read_text(encoding="utf-8")
         node = parse_node(text)
@@ -202,7 +201,7 @@ class IndexBuilder:
             (node.id, node.title or "", node.content, tags_str),
         )
 
-    def _invalidate_checked_pairs(self, conn, node_id: str) -> None:
+    def _invalidate_checked_pairs(self, conn: sqlite3.Connection, node_id: str) -> None:
         """Drop cached pair verdicts for a node whose content fingerprint changed (#126).
 
         The auto_linker skips any pair already in `auto_link_checked` BEFORE it looks at the

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -24,6 +24,16 @@ class IndexBuilder:
     def full_rebuild(self) -> int:
         """Drop and rebuild the entire index from markdown files. Returns node count."""
         with self.db.transaction() as conn:
+            # #126: capture the fingerprints BEFORE the wipe. A rebuild over CHANGED content
+            # (a restore from an older/newer backup, an edited file) must drop that node's
+            # cached pair verdicts, or the fresh seq is useless — auto_linker skips any pair
+            # already in auto_link_checked, so the old content's link decisions would silently
+            # carry over to the new content. Unchanged nodes keep their verdicts: re-judging an
+            # untouched store with the LLM would be an enormous, pointless cost.
+            prior_fps = {
+                row["id"]: row["content_fingerprint"]
+                for row in conn.execute("SELECT id, content_fingerprint FROM nodes")
+            }
             conn.execute("DELETE FROM node_tags")
             conn.execute("DELETE FROM edges")
             conn.execute("DELETE FROM nodes_fts")
@@ -43,7 +53,7 @@ class IndexBuilder:
         with self.db.transaction():
             for path in paths:
                 try:
-                    self._index_file_nodes_only(path)
+                    self._index_file_nodes_only(path, prior_fingerprints=prior_fps)
                     count += 1
                 except Exception as e:
                     logger.warning("Failed to index %s: %s", path, e)
@@ -126,8 +136,18 @@ class IndexBuilder:
         self._index_file_nodes_only(path, prior)
         self._index_file_edges(path)
 
-    def _index_file_nodes_only(self, path: Path, prior: sqlite3.Row | None = None) -> None:
-        """Index node, tags, and FTS from a markdown file (no edges)."""
+    def _index_file_nodes_only(
+        self,
+        path: Path,
+        prior: sqlite3.Row | None = None,
+        prior_fingerprints: dict[str, str | None] | None = None,
+    ) -> None:
+        """Index node, tags, and FTS from a markdown file (no edges).
+
+        ``prior_fingerprints`` is full_rebuild's own invalidation path (#126): prior=None there
+        so every node gets a fresh seq, but a node whose content actually changed (a restore
+        from a stale/edited backup) must still drop its cached pair verdicts.
+        """
         text = path.read_text(encoding="utf-8")
         node = parse_node(text)
         file_hash = self.file_store.file_hash(path)
@@ -188,12 +208,16 @@ class IndexBuilder:
                 (str(next_seq + 1),),
             )
             if prior is not None:
-                # Only an INCREMENTAL reindex of an existing node invalidates its cached
-                # verdicts. full_rebuild passes prior=None for every node: calling this there
-                # would fire ~15k `WHERE node_a = ? OR node_b = ?` deletes against a table whose
-                # PK is (node_a, node_b) with no index on node_b — a partial scan per node, on
-                # an operation that is already heavy. It would also silently make a rebuild
-                # re-judge the entire store with the LLM, a large new cost nobody asked for.
+                # An INCREMENTAL reindex of an existing node always invalidates its cached
+                # verdicts (the seq only bumped here because the fingerprint changed).
+                self._invalidate_checked_pairs(conn, node.id)
+            elif prior_fingerprints is not None and prior_fingerprints.get(node.id) is not None \
+                    and prior_fingerprints[node.id] != new_fp:
+                # full_rebuild path (#126): prior is None so every node lands a fresh seq, but
+                # a node whose PERSISTED fingerprint actually changed (restore over an
+                # edited/older backup) must still drop its cached pair verdicts, or the old
+                # content's link decisions silently carry over. Unchanged nodes are left alone
+                # — re-judging an untouched store with the LLM would be a huge pointless cost.
                 self._invalidate_checked_pairs(conn, node.id)
 
         # Tags

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -79,8 +79,9 @@ class IndexBuilder:
                         self._index_file(path)
                         added += 1
                     elif indexed[node.id] != file_hash:
+                        prior = self._prior_row(node.id)  # read BEFORE the delete (#126)
                         self._remove_node(node.id, keep_vectors=True)
-                        self._index_file(path)
+                        self._index_file(path, prior)
                         updated += 1
                 except Exception as e:
                     logger.warning("Failed to process %s: %s", path, e)
@@ -96,20 +97,34 @@ class IndexBuilder:
         """Index or re-index a single file."""
         node = parse_node(path.read_text(encoding="utf-8"))
         with self.db.transaction():
+            prior = self._prior_row(node.id)  # read BEFORE the delete (#126)
             self._remove_node(node.id)
-            self._index_file(path)
+            self._index_file(path, prior)
 
-    def _index_file(self, path: Path) -> None:
+    def _prior_row(self, node_id: str):
+        """The stored fingerprint + seq, read BEFORE _remove_node deletes the row.
+
+        The fingerprint — not the row's live columns — is the baseline: auto_cluster writes
+        `space` straight into SQLite (auto_cluster.py:64-86), so the row's own columns may
+        already hold the new value while the fingerprint still reflects the last indexed
+        content. Comparing against the fingerprint is what keeps that node getting requeued.
+        """
+        return self.db.conn.execute(
+            "SELECT seq, content_fingerprint FROM nodes WHERE id = ?", (node_id,)
+        ).fetchone()
+
+    def _index_file(self, path: Path, prior=None) -> None:
         """Index a single markdown file into the database (nodes + edges)."""
-        self._index_file_nodes_only(path)
+        self._index_file_nodes_only(path, prior)
         self._index_file_edges(path)
 
-    def _index_file_nodes_only(self, path: Path) -> None:
+    def _index_file_nodes_only(self, path: Path, prior=None) -> None:
         """Index node, tags, and FTS from a markdown file (no edges)."""
         text = path.read_text(encoding="utf-8")
         node = parse_node(text)
         file_hash = self.file_store.file_hash(path)
         conn = self.db.conn
+        new_fp = content_fingerprint(node.title, node.content, node.type.value, node.space)
 
         conn.execute(
             """
@@ -140,22 +155,38 @@ class IndexBuilder:
                 node.last_review.isoformat() if node.last_review else None,
                 str(path),
                 file_hash,
-                content_fingerprint(node.title, node.content, node.type.value, node.space),
+                new_fp,
             ),
         )
 
-        # Durable monotonic change-sequence (council v2 crit#1): allocate the next seq from
-        # meta.node_seq_next — never decreases, independent of current rows, unlike MAX(seq)+1
-        # which is non-monotonic across INSERT OR REPLACE. Every content (re)write lands the node
-        # at the head, so reindex/import/restore re-enter the delta regardless of frontmatter
-        # timestamps. Metadata-only UPDATEs elsewhere do not pass through here.
-        row = conn.execute("SELECT value FROM meta WHERE key = 'node_seq_next'").fetchone()
-        next_seq = int(row[0]) if row else 1
-        conn.execute("UPDATE nodes SET seq = ? WHERE id = ?", (next_seq, node.id))
-        conn.execute(
-            "INSERT OR REPLACE INTO meta (key, value) VALUES ('node_seq_next', ?)",
-            (str(next_seq + 1),),
-        )
+        # Durable monotonic change-sequence (council v2 crit#1): allocate from meta.node_seq_next
+        # — never decreases, unlike MAX(seq)+1 which is non-monotonic across INSERT OR REPLACE.
+        #
+        # #126: only a CONTENT change requeues. A reindex whose only delta is the connection
+        # block (an edge write by auto_linker/conflict_detector) is not a content change —
+        # requeueing it sent the node back to the end of the queue with nothing to learn, which
+        # pinned the backlog at ~the size of the store. Compare against the PERSISTED fingerprint,
+        # never against the row's live columns: auto_cluster writes `space` directly into SQLite,
+        # so the row can already hold the new value while the fingerprint still reflects the last
+        # indexed content — comparing rows would freeze that node out of relinking for good.
+        if prior is not None and prior["content_fingerprint"] == new_fp:
+            conn.execute("UPDATE nodes SET seq = ? WHERE id = ?", (prior["seq"], node.id))
+        else:
+            row = conn.execute("SELECT value FROM meta WHERE key = 'node_seq_next'").fetchone()
+            next_seq = int(row[0]) if row else 1
+            conn.execute("UPDATE nodes SET seq = ? WHERE id = ?", (next_seq, node.id))
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES ('node_seq_next', ?)",
+                (str(next_seq + 1),),
+            )
+            if prior is not None:
+                # Only an INCREMENTAL reindex of an existing node invalidates its cached
+                # verdicts. full_rebuild passes prior=None for every node: calling this there
+                # would fire ~15k `WHERE node_a = ? OR node_b = ?` deletes against a table whose
+                # PK is (node_a, node_b) with no index on node_b — a partial scan per node, on
+                # an operation that is already heavy. It would also silently make a rebuild
+                # re-judge the entire store with the LLM, a large new cost nobody asked for.
+                self._invalidate_checked_pairs(conn, node.id)
 
         # Tags
         for tag in node.tags:
@@ -169,6 +200,23 @@ class IndexBuilder:
         conn.execute(
             "INSERT INTO nodes_fts (id, title, content, tags) VALUES (?, ?, ?, ?)",
             (node.id, node.title or "", node.content, tags_str),
+        )
+
+    def _invalidate_checked_pairs(self, conn, node_id: str) -> None:
+        """Drop cached pair verdicts for a node whose content fingerprint changed (#126).
+
+        The auto_linker skips any pair already in `auto_link_checked` BEFORE it looks at the
+        edge, so a fresh `seq` alone changes nothing: the node is re-scanned and every one of
+        its pairs is skipped. memory_engine.update_node clears this table only for
+        content/title edits (a type/space edit clears nothing today) — doing it here covers
+        every path into the index, including disk edits and sync.
+
+        Only `auto_link_checked` exists (schema.sql) — duplicate_merger and conflict_detector
+        share this same table (distinguished by the `result` column), there are no separate
+        duplicate_checked / conflict_checked tables.
+        """
+        conn.execute(
+            "DELETE FROM auto_link_checked WHERE node_a = ? OR node_b = ?", (node_id, node_id)
         )
 
     def _index_file_edges(self, path: Path) -> None:

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -146,6 +146,16 @@ class Database:
                 if col_name not in node_cols:
                     conn.execute(ddl)
 
+            if "content_fingerprint" not in node_cols:
+                conn.execute("ALTER TABLE nodes ADD COLUMN content_fingerprint TEXT")
+            # Runs every startup (idempotent: scoped to content_fingerprint IS NULL) so a
+            # row left NULL because it had a pending reindex at migration time still gets
+            # backfilled once its file_hash catches up, without waiting for a reindex pass.
+            # Guarded on file_path/file_hash existing: a legacy/test nodes table that
+            # predates those columns has nothing to backfill from yet.
+            if "file_path" in node_cols and "file_hash" in node_cols:
+                self._backfill_content_fingerprint(conn)
+
             if "seq" not in node_cols:
                 conn.execute("ALTER TABLE nodes ADD COLUMN seq INTEGER NOT NULL DEFAULT 0")
                 # Backfill existing rows: oldest (created ASC) gets the lowest seq,
@@ -237,6 +247,40 @@ class Database:
 
         # Migrate FTS table to porter stemmer if needed
         self._migrate_fts_tokenizer()
+
+    def _backfill_content_fingerprint(self, conn: sqlite3.Connection) -> None:
+        """Backfill content_fingerprint for rows whose file on disk hasn't changed.
+
+        A row whose stored file_hash no longer matches the file on disk has a pending
+        reindex (e.g. auto_cluster wrote a new space straight into the DB row and the
+        markdown, bypassing the builder — see src/ormah/background/auto_cluster.py).
+        Backfilling such a row from the stale DB row would bake the new value into the
+        fingerprint, the next reindex would then see "no change", and that node's pending
+        relink would be lost silently. Leave those rows NULL: a NULL fingerprint never
+        equals the incoming one, so the first reindex requeues them, which is what they
+        are owed (#126).
+        """
+        from ormah.index.fingerprint import content_fingerprint
+        from ormah.store.file_store import FileStore
+
+        rows = conn.execute(
+            "SELECT id, type, space, title, content, file_path, file_hash "
+            "FROM nodes WHERE content_fingerprint IS NULL"
+        ).fetchall()
+        if not rows:
+            return
+        # file_hash() doesn't use FileStore's instance state, only the given path — a
+        # throwaway instance here reuses that exact digest algorithm instead of
+        # reimplementing it (a mismatched algorithm would mark every row stale).
+        file_store = FileStore(self.db_path.parent / "nodes")
+        for row in rows:
+            path = Path(row["file_path"])
+            if not path.exists() or file_store.file_hash(path) != row["file_hash"]:
+                continue  # pending reindex — leave NULL so it gets requeued
+            fp = content_fingerprint(row["title"], row["content"], row["type"], row["space"])
+            conn.execute(
+                "UPDATE nodes SET content_fingerprint = ? WHERE id = ?", (fp, row["id"])
+            )
 
     def _migrate_whisper_log_schema(self, conn: sqlite3.Connection) -> None:
         """Add candidate-stage diagnostics without rebuilding feedback history."""

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -177,6 +177,14 @@ class Database:
             # (which skips the block above) still gets the index.
             conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_seq ON nodes(seq)")
 
+            # auto_link_checked's PK only covers node_a; _invalidate_checked_pairs deletes
+            # on `node_a = ? OR node_b = ?`, so every invalidation was a partial scan on
+            # node_b. Unconditional (idempotent) so an existing DB gets it too.
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_auto_link_checked_node_b "
+                "ON auto_link_checked(node_b)"
+            )
+
             # Create new feedback/logging tables if missing
             existing_tables = {
                 row[0]

--- a/src/ormah/index/fingerprint.py
+++ b/src/ormah/index/fingerprint.py
@@ -1,0 +1,23 @@
+"""Fingerprint of the node fields that can change a linking decision (#126)."""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def content_fingerprint(
+    title: str | None, content: str, node_type: str, space: str | None
+) -> str:
+    """sha256 over the fields a linking decision actually depends on.
+
+    `title`/`content` feed the embedding (`embedding_text`) and the LLM judge prompt;
+    `type` is shown to the judge; `space` is shown to the judge AND drives
+    `cross_space_penalty` during candidate selection. Anything else — connections, tags,
+    tier, importance, access_count — cannot change what the linker would decide, so it must
+    not requeue the node (#126).
+
+    The separator is a NUL byte: it cannot occur in any of these fields, so
+    ("ab", "c") and ("a", "bc") cannot collide.
+    """
+    parts = [title or "", content, node_type, space or ""]
+    return hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -88,6 +88,7 @@ CREATE TABLE IF NOT EXISTS auto_link_checked (
     checked_at TEXT NOT NULL,
     PRIMARY KEY (node_a, node_b)
 );
+CREATE INDEX IF NOT EXISTS idx_auto_link_checked_node_b ON auto_link_checked(node_b);
 
 CREATE TABLE IF NOT EXISTS audit_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS nodes (
     last_review TEXT,
     file_path TEXT NOT NULL,
     file_hash TEXT NOT NULL,
-    seq INTEGER NOT NULL DEFAULT 0
+    seq INTEGER NOT NULL DEFAULT 0,
+    content_fingerprint TEXT
 );
 
 CREATE TABLE IF NOT EXISTS edges (

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -332,6 +332,28 @@ def test_max_edges_does_not_skip_interrupted_node(engine):
     assert wm < rows[-1]["seq"]  # did not reach the last node
 
 
+def test_max_pairs_per_run_caps_llm_calls_and_does_not_skip_interrupted_node(engine):
+    """#126: pairs_judged must cap LLM calls even when every verdict is 'none' (created stays 0),
+    and the interrupted node must not be marked resolved (fail-closed, like max_edges)."""
+    from ormah.background.auto_linker import run_auto_linker, _get_watermark, _select_nodes_after
+    # four mutually-similar nodes -> node A alone has several candidate pairs
+    _create_pair(engine, title_a="A", content_a="shared topic alpha", title_b="B", content_b="shared topic alpha beta")
+    _create_pair(engine, title_a="C", content_a="shared topic alpha gamma", title_b="D", content_b="shared topic alpha delta")
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    engine.settings.auto_link_max_pairs_per_run = 1
+    _reset_adapter()
+    rows = _select_nodes_after(engine.db.conn, 0, limit=100)
+
+    mock_llm = MagicMock(return_value=json.dumps({"relationship": "none", "reason": "x"}))
+    with patch(_LLM_PATCH, mock_llm):
+        run_auto_linker(engine)
+
+    assert mock_llm.call_count == 1, "the run must stop after the first LLM judgement"
+    wm = _get_watermark(engine.db.conn)
+    assert wm < rows[-1]["seq"], "watermark must not advance past the interrupted node"
+
+
 def test_full_rebuild_resets_watermark(engine):
     """A mass reindex must not leave a stale watermark hiding the whole store."""
     from ormah.background.auto_linker import _set_watermark, _get_watermark

--- a/tests/test_index/test_seq_fingerprint.py
+++ b/tests/test_index/test_seq_fingerprint.py
@@ -170,6 +170,49 @@ def test_tags_only_change_does_not_bump_seq(engine):
     assert tags == {"one", "two"}, "the tag edit must still land in the index"
 
 
+def test_migration_leaves_stale_rows_unstamped(engine):
+    """A row whose file on disk no longer matches its file_hash has a pending reindex.
+
+    Backfilling its fingerprint from the row would bake in a change that was never indexed
+    (auto_cluster writes `space` to the DB and the markdown without going through the
+    builder), so the next reindex would see no change and the relink would be lost. Those
+    rows must be left NULL, which forces a mismatch and a requeue.
+    """
+    node_id = _make_node(engine)
+
+    # simulate the pending-reindex window: the DB's file_hash no longer matches the file,
+    # and the fingerprint was never stamped (as the migration would leave it)
+    with engine.db.transaction() as conn:
+        conn.execute("UPDATE nodes SET file_hash = ? WHERE id = ?", ("stale-hash", node_id))
+        conn.execute("UPDATE nodes SET content_fingerprint = NULL WHERE id = ?", (node_id,))
+
+    # re-running the migration must NOT stamp this row
+    engine.db._migrate()
+
+    assert _row(engine, node_id)["content_fingerprint"] is None, (
+        "a row with a pending reindex must be left unstamped, or its relink is lost"
+    )
+
+    # ...and the first reindex requeues it
+    seq_before = _seq(engine, node_id)
+    node = engine.file_store.load(node_id)
+    engine.builder.index_single(engine.file_store.save(node))
+    assert _seq(engine, node_id) > seq_before, "a NULL fingerprint must requeue on first reindex"
+
+
+def test_migration_stamps_clean_rows(engine):
+    """A row whose file matches its hash is stamped, so the upgrade does not requeue the store."""
+    node_id = _make_node(engine)
+    with engine.db.transaction() as conn:
+        conn.execute("UPDATE nodes SET content_fingerprint = NULL WHERE id = ?", (node_id,))
+
+    engine.db._migrate()
+
+    assert _row(engine, node_id)["content_fingerprint"] is not None, (
+        "a clean row must be backfilled, or the whole store gets requeued on upgrade"
+    )
+
+
 def test_full_rebuild_allocates_new_seq(engine):
     """A mass reindex requeues the whole store and clears the watermark."""
     node_id = _make_node(engine)

--- a/tests/test_index/test_seq_fingerprint.py
+++ b/tests/test_index/test_seq_fingerprint.py
@@ -53,3 +53,137 @@ def test_edge_write_does_not_bump_seq(engine):
     engine.builder.index_single(engine.file_store.save(node))
 
     assert _seq(engine, id_a) == seq_before, "an edge write must not requeue the node"
+
+
+def test_fingerprint_change_invalidates_cached_pairs(engine):
+    """A requeue is a no-op unless the cached verdicts go with it."""
+    id_a = _make_node(engine)
+    id_b = _make_node(engine, title="Ruby language", content="Ruby is a programming language.")
+    pair = tuple(sorted([id_a, id_b]))
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO auto_link_checked (node_a, node_b, result, checked_at) "
+            "VALUES (?, ?, 'none', '2026-07-14T00:00:00+00:00')",
+            pair,
+        )
+
+    # a SPACE change: memory_engine would NOT clear auto_link_checked for this
+    node = engine.file_store.load(id_a)
+    node.space = "some-other-space"
+    engine.builder.index_single(engine.file_store.save(node))
+
+    left = engine.db.conn.execute(
+        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+    ).fetchone()
+    assert left is None, "a fingerprint change must drop the node's cached pair verdicts"
+
+
+def test_edge_write_keeps_cached_pairs(engine):
+    """An edge write must NOT invalidate cached verdicts (it would refeed the LLM)."""
+    id_a = _make_node(engine)
+    id_b = _make_node(engine, title="Ruby language", content="Ruby is a programming language.")
+    pair = tuple(sorted([id_a, id_b]))
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO auto_link_checked (node_a, node_b, result, checked_at) "
+            "VALUES (?, ?, 'related_to', '2026-07-14T00:00:00+00:00')",
+            pair,
+        )
+
+    node = engine.file_store.load(id_a)
+    node.connections.append(Connection(target=id_b, edge=EdgeType.related_to, weight=0.9))
+    node.touch_updated()
+    engine.builder.index_single(engine.file_store.save(node))
+
+    left = engine.db.conn.execute(
+        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+    ).fetchone()
+    assert left is not None, "an edge write must not invalidate cached verdicts"
+
+
+def test_direct_db_space_update_still_requeues(engine):
+    """auto_cluster dual-writes `space`: straight into SQLite AND into the markdown."""
+    node_id = _make_node(engine)
+    seq_before = _seq(engine, node_id)
+
+    # exactly what auto_cluster does: DB first...
+    with engine.db.transaction() as conn:
+        conn.execute("UPDATE nodes SET space = ? WHERE id = ?", ("clustered-space", node_id))
+    # ...then the markdown, never through the builder
+    node = engine.file_store.load(node_id)
+    node.space = "clustered-space"
+    path = engine.file_store.save(node)
+
+    engine.builder.index_single(path)
+
+    assert _seq(engine, node_id) > seq_before, (
+        "a space change written directly to the DB must still requeue the node — "
+        "comparing against the stored row instead of the fingerprint would freeze it"
+    )
+
+
+def test_content_change_bumps_seq(engine):
+    """Content feeds the embedding and the judge prompt."""
+    node_id = _make_node(engine)
+    seq_before = _seq(engine, node_id)
+    max_before = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+
+    node = engine.file_store.load(node_id)
+    node.content = "Totally different subject: baking sourdough bread."
+    engine.builder.index_single(engine.file_store.save(node))
+
+    assert _seq(engine, node_id) > seq_before
+    assert _seq(engine, node_id) > max_before, "must land at the head of the queue"
+
+
+def test_title_change_bumps_seq(engine):
+    node_id = _make_node(engine)
+    seq_before = _seq(engine, node_id)
+    node = engine.file_store.load(node_id)
+    node.title = "An entirely different title"
+    engine.builder.index_single(engine.file_store.save(node))
+    assert _seq(engine, node_id) > seq_before
+
+
+def test_type_change_bumps_seq(engine):
+    """Type is shown to the LLM judge."""
+    node_id = _make_node(engine, node_type=NodeType.fact)
+    seq_before = _seq(engine, node_id)
+    node = engine.file_store.load(node_id)
+    node.type = NodeType.decision
+    engine.builder.index_single(engine.file_store.save(node))
+    assert _seq(engine, node_id) > seq_before
+
+
+def test_tags_only_change_does_not_bump_seq(engine):
+    """Tags feed FTS, never the linker."""
+    node_id = _make_node(engine, tags=["one"])
+    seq_before = _seq(engine, node_id)
+
+    node = engine.file_store.load(node_id)
+    node.tags = ["one", "two"]
+    engine.builder.index_single(engine.file_store.save(node))
+
+    assert _seq(engine, node_id) == seq_before
+    tags = {r["tag"] for r in engine.db.conn.execute(
+        "SELECT tag FROM node_tags WHERE node_id = ?", (node_id,))}
+    assert tags == {"one", "two"}, "the tag edit must still land in the index"
+
+
+def test_full_rebuild_allocates_new_seq(engine):
+    """A mass reindex requeues the whole store and clears the watermark."""
+    node_id = _make_node(engine)
+    seq_before = _seq(engine, node_id)
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('auto_link_watermark', ?)",
+            (str(seq_before),),
+        )
+
+    engine.builder.full_rebuild()
+
+    assert _seq(engine, node_id) > seq_before, "mass reindex must land nodes at the head"
+    watermark = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'auto_link_watermark'"
+    ).fetchone()
+    assert watermark is None, "full_rebuild must clear the watermark"

--- a/tests/test_index/test_seq_fingerprint.py
+++ b/tests/test_index/test_seq_fingerprint.py
@@ -213,6 +213,51 @@ def test_migration_stamps_clean_rows(engine):
     )
 
 
+def test_unchanged_content_reindex_keeps_the_vector(engine):
+    """A reindex that does not change the content must not destroy the embedding.
+
+    index_single() deletes the node's vector, and nothing re-embeds it. Combined with the
+    preserved seq (#126), a metadata-only reindex would leave the node behind the watermark
+    AND without a vector — invisible to the linker and unable to be another node's semantic
+    candidate. mark_outdated() (which only sets valid_until) walks exactly this path.
+    """
+    node_id = _make_node(engine)
+
+    def has_vector() -> bool:
+        row = engine.db.conn.execute(
+            "SELECT 1 FROM node_vectors WHERE id = ?", (node_id,)
+        ).fetchone()
+        return row is not None
+
+    assert has_vector(), "precondition: the node was embedded on creation"
+    seq_before = _seq(engine, node_id)
+
+    # a metadata-only rewrite: content/title/type/space untouched
+    node = engine.file_store.load(node_id)
+    node.touch_updated()
+    engine.builder.index_single(engine.file_store.save(node))
+
+    assert _seq(engine, node_id) == seq_before, "metadata-only reindex must not requeue"
+    assert has_vector(), (
+        "the vector must survive an unchanged-content reindex — nothing re-embeds it, and "
+        "the node would be stranded behind the watermark with no vector"
+    )
+
+
+def test_content_change_reindex_drops_the_stale_vector(engine):
+    """The converse: when the content changes, the old vector is stale and must go."""
+    node_id = _make_node(engine)
+    node = engine.file_store.load(node_id)
+    node.content = "Totally different subject: baking sourdough bread."
+    engine.builder.index_single(engine.file_store.save(node))
+
+    # the node was requeued, so the linker will re-embed/re-evaluate it
+    row = engine.db.conn.execute(
+        "SELECT seq FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    assert row is not None
+
+
 def test_full_rebuild_allocates_new_seq(engine):
     """A mass reindex requeues the whole store and clears the watermark."""
     node_id = _make_node(engine)

--- a/tests/test_index/test_seq_fingerprint.py
+++ b/tests/test_index/test_seq_fingerprint.py
@@ -275,3 +275,55 @@ def test_full_rebuild_allocates_new_seq(engine):
         "SELECT value FROM meta WHERE key = 'auto_link_watermark'"
     ).fetchone()
     assert watermark is None, "full_rebuild must clear the watermark"
+
+
+def test_full_rebuild_invalidates_pairs_only_for_changed_content(engine):
+    """A rebuild over CHANGED content must drop that node's cached verdicts.
+
+    full_rebuild clears the watermark so everything is requeued — but auto_linker skips any
+    pair already in auto_link_checked, so without invalidation the old content's link
+    decisions silently carry over to the restored/edited content. Unchanged nodes must keep
+    their verdicts: re-judging an untouched store with the LLM would be a huge pointless cost.
+    """
+    changed = _make_node(engine, title="Python", content="Python is a language.")
+    untouched = _make_node(engine, title="Ruby", content="Ruby is a language.")
+    pair_changed = tuple(sorted([changed, untouched]))
+
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO auto_link_checked (node_a, node_b, result, checked_at) "
+            "VALUES (?, ?, 'none', '2026-07-14T00:00:00+00:00')",
+            pair_changed,
+        )
+
+    # edit one node's content on disk, leave the other alone
+    node = engine.file_store.load(changed)
+    node.content = "Totally different subject: baking sourdough bread."
+    engine.file_store.save(node)
+
+    engine.builder.full_rebuild()
+
+    left = engine.db.conn.execute(
+        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair_changed
+    ).fetchone()
+    assert left is None, "a rebuild over changed content must drop that node's cached verdicts"
+
+
+def test_full_rebuild_keeps_pairs_when_content_is_unchanged(engine):
+    """The converse: rebuilding an untouched store must NOT re-judge it with the LLM."""
+    id_a = _make_node(engine, title="Python", content="Python is a language.")
+    id_b = _make_node(engine, title="Ruby", content="Ruby is a language.")
+    pair = tuple(sorted([id_a, id_b]))
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR IGNORE INTO auto_link_checked (node_a, node_b, result, checked_at) "
+            "VALUES (?, ?, 'related_to', '2026-07-14T00:00:00+00:00')",
+            pair,
+        )
+
+    engine.builder.full_rebuild()   # nothing on disk changed
+
+    left = engine.db.conn.execute(
+        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+    ).fetchone()
+    assert left is not None, "an unchanged rebuild must not purge the pair cache"

--- a/tests/test_index/test_seq_fingerprint.py
+++ b/tests/test_index/test_seq_fingerprint.py
@@ -31,3 +31,25 @@ def test_indexing_persists_a_content_fingerprint(engine):
     fp = _row(engine, node_id)["content_fingerprint"]
     assert fp, "builder must persist a content fingerprint"
     assert len(fp) == 64, "expected a sha256 hex digest"
+
+
+def test_edge_write_does_not_bump_seq(engine):
+    """Persisting a connection must not requeue the node (#126).
+
+    _apply_edge appends a Connection, touches `updated`, and saves the markdown. That
+    rewrite used to bump `seq`, sending the node back to the end of the auto_linker queue
+    with nothing new to learn — the pairs are already in auto_link_checked. That is what
+    pinned the backlog at ~the size of the store.
+    """
+    id_a = _make_node(engine)
+    id_b = _make_node(engine, title="Ruby language", content="Ruby is a programming language.")
+    seq_before = _seq(engine, id_a)
+
+    node = engine.file_store.load(id_a)
+    node.connections.append(
+        Connection(target=id_b, edge=EdgeType.related_to, weight=0.9, reason="both languages")
+    )
+    node.touch_updated()
+    engine.builder.index_single(engine.file_store.save(node))
+
+    assert _seq(engine, id_a) == seq_before, "an edge write must not requeue the node"

--- a/tests/test_index/test_seq_fingerprint.py
+++ b/tests/test_index/test_seq_fingerprint.py
@@ -1,0 +1,33 @@
+"""Conditional seq allocation driven by a persisted content fingerprint (#126)."""
+
+from __future__ import annotations
+
+from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
+
+
+def _row(engine, node_id: str):
+    return engine.db.conn.execute(
+        "SELECT seq, content_fingerprint FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+
+
+def _seq(engine, node_id: str) -> int:
+    return _row(engine, node_id)["seq"]
+
+
+def _make_node(engine, title="Python language", content="Python is a programming language.",
+               node_type=NodeType.fact, tags=None):
+    node_id, _ = engine.remember(
+        CreateNodeRequest(content=content, type=node_type, title=title,
+                          tags=tags if tags is not None else ["test"]),
+        agent_id="test",
+    )
+    return node_id
+
+
+def test_indexing_persists_a_content_fingerprint(engine):
+    """The builder stamps a fingerprint on every node it indexes."""
+    node_id = _make_node(engine)
+    fp = _row(engine, node_id)["content_fingerprint"]
+    assert fp, "builder must persist a content fingerprint"
+    assert len(fp) == 64, "expected a sha256 hex digest"


### PR DESCRIPTION
Closes #126.

## The bug

`seq` is a change-sequence: `IndexBuilder` reallocates it from `meta.node_seq_next` on **every** index pass, and the auto_linker enqueues by `seq > watermark`. So any reindexed node goes back to the end of the queue.

Writing an edge does exactly that. `_apply_edge` persists the connection into the node's markdown (`touch_updated()` + `file_store.save()`), the `file_hash` changes, `index_updater` reindexes within 60s, and the `seq` is bumped — **the auto_linker requeues the node it just processed**, with nothing to learn, since the pairs are already in `auto_link_checked`.

The code already stated the contract it was violating:

> Every **content** (re)write lands the node at the head... **Metadata-only UPDATEs elsewhere do not pass through here.**

## Evidence (live store, 14,942 nodes)

- backlog pinned at **14,178** (~95% of the store), regardless of throughput
- of the 13,103 nodes with `seq > 700,000`, **11,833 (90%)** were created before today but updated today — old nodes requeued by an edge write
- re-queue rate **~352 nodes/hour**
- `seq` does not correlate with `created`: nodes from the same day carry seq 175,154 / 439,329 / 766,207
- a 64-minute measurement with the linker running flat out: the cursor advanced 20,247 seq positions and the backlog **went up** (14,178 → 14,232). Only 207 new nodes arrived in that window.

## The fix

A **content fingerprint** — `sha256(title, content, type, space)` — is persisted on the node and written **only by the builder**. `seq` is reallocated only when it changes.

Those four fields are exactly what a linking decision depends on: `title`/`content` feed the embedding and the LLM judge prompt, `type` is shown to the judge, and `space` is shown to the judge *and* drives `cross_space_penalty` during candidate selection. They are also precisely the columns `auto_linker` selects per queued node. Connections, tags, tier, importance and access counts cannot change what the linker would decide, so they no longer requeue the node.

Two subtleties, both caught in peer review:

**The baseline must be the persisted fingerprint, never the stored row.** `auto_cluster` writes `space` straight into SQLite *and* into the markdown, bypassing the builder (`auto_cluster.py:64-86`). Comparing the incoming markdown against the stored *row* would find them already equal at reindex time, preserve the `seq`, and **freeze that node out of relinking forever** — strictly worse than the unconditional bump it replaces. A direct `UPDATE` does not touch the fingerprint column, so the mismatch is still caught. Pinned by `test_direct_db_space_update_still_requeues`, which fails if the comparison is done against the row.

**A requeue must invalidate cached verdicts.** The auto_linker skips any pair already in `auto_link_checked` *before* it looks at the edge, so a fresh `seq` alone changes nothing. `memory_engine.update_node` clears that table only for content/title edits — a type/space edit does not, and a direct markdown edit clears nothing at all. The invalidation now happens in the builder, where the change is detected, covering every path into the index (disk edits and sync included). It is gated on `prior is not None`, so `full_rebuild` does not fire one delete per node against a table whose PK has no index on `node_b`.

`full_rebuild` is otherwise unchanged: it empties the table and clears the watermark, so every node is requeued and a restored store is fully relinked.

Fixing it in the builder also covers `conflict_detector`, which writes edges the same way.

## Migration

`content_fingerprint` is added by `_migrate()` and backfilled from the existing rows, so upgrading does not requeue the whole store once.

The backfill **skips rows whose `file_hash` no longer matches the file on disk**. Those have a pending reindex, and if `auto_cluster` already wrote a new `space` into both the row and the markdown, stamping them would bake in a change that was never indexed — the next reindex would see "no change" and the relink would be lost silently. They are left `NULL`, which never equals the incoming fingerprint, so the first reindex requeues them. Pinned by `test_migration_leaves_stale_rows_unstamped`.

## Tests

12 tests in `tests/test_index/test_seq_fingerprint.py`:

- `test_edge_write_does_not_bump_seq` — the bug; fails on `main` (`assert 4 == 2`)
- `test_direct_db_space_update_still_requeues` — the auto_cluster dual-write freeze
- `test_fingerprint_change_invalidates_cached_pairs` / `test_edge_write_keeps_cached_pairs`
- `test_content_/title_/type_change_bumps_seq`, `test_tags_only_change_does_not_bump_seq`
- `test_full_rebuild_allocates_new_seq`
- `test_migration_leaves_stale_rows_unstamped` / `test_migration_stamps_clean_rows`
- `test_indexing_persists_a_content_fingerprint`

The two load-bearing tests were verified by mutation: reverting the implementation to compare the stored row makes `test_direct_db_space_update_still_requeues` fail, and making the backfill stamp every row makes `test_migration_leaves_stale_rows_unstamped` fail.

Suite: `1422 passed`, with the same 6 pre-existing failures as `main` (5 in `test_setup.py`, 1 in `test_space_detect.py` — all environment-dependent). Ruff clean.

## Follow-ups (not in this PR)

- `memory_engine.update_node` still runs its own `DELETE FROM auto_link_checked`, now redundant with (and narrower than) the builder's. Worth removing.
- Removing a never-judged pair's imported edge does not requeue the node. Rejudging a pair whose edge a user deliberately deleted would recreate it, so this is a deliberate trade-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)