### PR TITLE
test: the suite reads the developer's real environment — make it hermetic (#106)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest bootstrap — runs before tests/conftest.py, and before anything
+imports ormah.
+
+`ormah.config` builds its `Settings()` singleton at module import time, and
+`Settings` reads `~/.config/ormah/.env` plus every `ORMAH_*` variable in the
+environment. On a developer machine that runs ormah, those describe the live
+install, not the test tree: a provider this branch does not accept aborts
+collection outright, and a non-default embedding model silently changes what
+the cache tests look for.
+
+Point HOME at an empty directory and drop the ORMAH_* variables here, before
+that import happens. This also keeps `Settings.memory_dir` — which defaults
+under `Path.home()` — away from the developer's real store.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+for _key in [k for k in os.environ if k.startswith("ORMAH_")]:
+    del os.environ[_key]
+
+os.environ["HOME"] = tempfile.mkdtemp(prefix="ormah-test-home-")

--- a/src/ormah/adapters/space_detect.py
+++ b/src/ormah/adapters/space_detect.py
@@ -14,8 +14,11 @@ def detect_space_from_dir(path: str) -> str | None:
     """
     path = os.path.realpath(path)
 
-    # Don't auto-detect space for home directory or root
-    home = os.path.expanduser("~")
+    # Don't auto-detect space for home directory or root. realpath both sides:
+    # `path` is already resolved above, so comparing it against an unresolved
+    # $HOME misses the home directory whenever $HOME traverses a symlink, and
+    # the caller silently gets the home's basename as a space instead of None.
+    home = os.path.realpath(os.path.expanduser("~"))
     if path == home or path == "/":
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -69,6 +71,19 @@ def prevent_tests_mutating_real_ormah_install(monkeypatch):
 
     monkeypatch.setattr(Path, "unlink", guarded_unlink)
     monkeypatch.setattr(shutil, "rmtree", guarded_rmtree)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_settings_from_global_env(monkeypatch, tmp_path):
+    """Stop the global ~/.config/ormah/.env and stray ORMAH_* OS vars from
+    leaking into bare Settings() during tests (env pollution, not regressions).
+    """
+    empty_env = tmp_path / "empty.env"
+    empty_env.write_text("")
+    monkeypatch.setitem(Settings.model_config, "env_file", str(empty_env))
+    for key in list(os.environ):
+        if key.startswith("ORMAH_"):
+            monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -808,7 +808,7 @@ class TestConfigureClaudeDesktop:
 class TestConfigureCodexMcp:
     def test_writes_mcp_config_to_codex_toml(self, tmp_path):
         with (
-            patch("ormah.setup.shutil.which", return_value=None),
+            patch("ormah.setup._find_binary", return_value=None),
             patch("ormah.setup.subprocess.run") as mock_run,
             patch("ormah.setup.Path.home", return_value=tmp_path),
         ):
@@ -832,7 +832,7 @@ class TestConfigureCodexMcp:
         )
 
         with (
-            patch("ormah.setup.shutil.which", return_value=None),
+            patch("ormah.setup._find_binary", return_value=None),
             patch("ormah.setup.subprocess.run") as mock_run,
             patch("ormah.setup.Path.home", return_value=tmp_path),
         ):
@@ -857,7 +857,7 @@ class TestConfigureCodexMcp:
         )
 
         with (
-            patch("ormah.setup.shutil.which", return_value=None),
+            patch("ormah.setup._find_binary", return_value=None),
             patch("ormah.setup.subprocess.run") as mock_run,
             patch("ormah.setup.Path.home", return_value=tmp_path),
         ):
@@ -3327,10 +3327,14 @@ class TestRemoveFastembedCache:
         assert "manually" in captured.out.lower()
 
     def test_removes_cache_dir_when_empty_after_cleanup(self, tmp_path, monkeypatch):
-        model_dir = tmp_path / "models--qdrant--bge-base-en-v1.5-onnx-q"
-        model_dir.mkdir()
+        # A dedicated subdirectory, not tmp_path itself: the autouse
+        # _isolate_settings_from_global_env fixture writes empty.env into tmp_path,
+        # so the "cache dir is now empty" assertion below would never hold on it.
+        cache_dir = tmp_path / "cache"
+        model_dir = cache_dir / "models--qdrant--bge-base-en-v1.5-onnx-q"
+        model_dir.mkdir(parents=True)
 
-        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(tmp_path))
+        monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(cache_dir))
 
         fake_embed_models = [{"model": "BAAI/bge-base-en-v1.5", "sources": {"hf": "qdrant/bge-base-en-v1.5-onnx-q"}}]
 
@@ -3341,7 +3345,7 @@ class TestRemoveFastembedCache:
             _remove_fastembed_cache()
 
         # cache_dir itself is removed when empty
-        assert not tmp_path.exists()
+        assert not cache_dir.exists()
 
     def test_uses_default_fastembed_cache_dir(self, tmp_path, monkeypatch):
         monkeypatch.delenv("FASTEMBED_CACHE_PATH")


### PR DESCRIPTION
Fixes #106.

On a machine that actually runs ormah, the test suite does not describe the tree under test — it describes the developer's install. Three separate leaks, one of which stops collection entirely.

## 1. `Settings()` is built at import time

`ormah/config.py` instantiates its singleton when the module loads, reading `~/.config/ormah/.env` and every `ORMAH_*` variable. `tests/conftest.py` imports it at line 12, so no fixture can get in front of it — a provider this branch does not accept aborts the run before a single test executes.

Two layers fix it: a root `conftest.py`, which loads before `tests/conftest.py` and is therefore the only place that can act before that import (it drops `ORMAH_*` and points `HOME` at an empty directory), and the autouse fixture in `tests/conftest.py` for `Settings()` instances built later during a test.

Pointing `HOME` away has a second benefit: `Settings.memory_dir` defaults under `Path.home()`, so the whole run stays off the developer's real memory store.

## 2. `shutil.which` is not where the binary is found

`TestConfigureCodexMcp` arranges "no codex binary" by patching `shutil.which`, but `configure_codex_mcp` calls `_find_binary` — and `shutil.which` is only its first lookup, followed by the mise shims, nvm bins, `~/.local/bin`, `/usr/local/bin` and `/opt/homebrew/bin`. Anyone with the Codex CLI installed fails these three tests on `main` today. `TestEnsureCodexHooksEnabled` in the same file already patches `_find_binary`; this makes the three consistent with it.

## 3. `$HOME` compared unresolved (one production line)

`detect_space_from_dir` realpaths its argument, then compares it against a raw `expanduser("~")`. When `$HOME` traverses a symlink the two never match, the home-directory guard does not fire, and the caller gets the home's basename as a space instead of `None`.

## Verification

From a worktree cut off `main`, on a machine with the Codex CLI installed and a populated `~/.config/ormah/.env`:

| | before | after |
|---|---|---|
| developer's real environment | collection aborts (exit 4) | **2008 passed**, exit 0 |
| `HOME=$(mktemp -d)` | 4 failed | **2008 passed**, exit 0 |

`ruff check src/ tests/ conftest.py` clean. Everything is test scaffolding except the single `realpath` line in `space_detect.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)