### PR TITLE
fix(index): atomic full_rebuild + abort-on-partial (#84)

### DIFF
--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -100,8 +100,14 @@ class MemoryEngine:
         """Initialize on server start: rebuild index if empty, ensure self node."""
         count = self.db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
         if count == 0:
-            n = self.builder.full_rebuild()
-            logger.info("Initial index rebuild: %d nodes", n)
+            try:
+                n = self.builder.full_rebuild()
+                logger.info("Initial index rebuild: %d nodes", n)
+            except Exception as e:
+                # Rebuild aborted (e.g. fd exhaustion) — the index is left as-is instead of
+                # partially overwritten. Log loudly and continue; do NOT crash-loop under
+                # launchd KeepAlive.
+                logger.error("Initial index rebuild FAILED; index left as-is: %s", e)
 
         # Rebuild FTS index if tokenizer was migrated
         fts_rebuild_row = self.db.conn.execute(
@@ -109,12 +115,16 @@ class MemoryEngine:
         ).fetchone()
         if fts_rebuild_row and fts_rebuild_row["value"] == "1":
             logger.info("Rebuilding FTS index after tokenizer migration")
-            n = self.builder.full_rebuild()
-            logger.info("FTS rebuild complete: %d nodes", n)
-            with self.db.transaction() as conn:
-                conn.execute(
-                    "INSERT OR REPLACE INTO meta (key, value) VALUES ('fts_needs_rebuild', '0')"
-                )
+            try:
+                n = self.builder.full_rebuild()
+                logger.info("FTS rebuild complete: %d nodes", n)
+                with self.db.transaction() as conn:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO meta (key, value) VALUES ('fts_needs_rebuild', '0')"
+                    )
+            except Exception as e:
+                # Leave fts_needs_rebuild='1' so the next startup retries once fds recover.
+                logger.error("FTS rebuild FAILED; will retry next startup: %s", e)
 
         # Re-embed nodes if the vector store is missing entries or schema version changed
         vec_count = self.db.conn.execute("SELECT count(*) FROM node_vectors").fetchone()[0]

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -19,8 +19,17 @@ class IndexBuilder:
         self.db = db
         self.file_store = file_store
 
-    def full_rebuild(self) -> int:
-        """Drop and rebuild the entire index from markdown files. Returns node count."""
+    def full_rebuild(self, *, allow_partial: bool = False) -> int:
+        """Drop and rebuild the entire index from markdown files. Returns node count.
+
+        Atomic: DELETE + both insert passes run in ONE transaction, and the method aborts
+        (-> ROLLBACK) rather than commit a partial index when any source file fails to
+        index. A partial failure or an fd-exhaustion storm therefore preserves the prior
+        committed state instead of persisting a truncated index. Pass allow_partial=True
+        to accept a partial rebuild anyway (e.g. known-corrupt files that should be skipped).
+        """
+        paths = list(self.file_store.list_paths())
+        count = 0
         with self.db.transaction() as conn:
             conn.execute("DELETE FROM node_tags")
             conn.execute("DELETE FROM edges")
@@ -31,20 +40,28 @@ class IndexBuilder:
             except Exception:
                 pass  # table may not exist
 
-        # Mass reindex re-allocates seq from the durable counter; clear the watermark so the
-        # rebuilt store is reprocessed even if the counter was also reset (wiped meta).
-        self.db.conn.execute("DELETE FROM meta WHERE key = 'auto_link_watermark'")
+            # Mass reindex re-allocates seq from the durable counter; clear the watermark so
+            # the rebuilt store is reprocessed even if the counter was also reset (wiped meta).
+            conn.execute("DELETE FROM meta WHERE key = 'auto_link_watermark'")
 
-        # Two-pass: nodes first, then edges (to satisfy FK constraints)
-        paths = list(self.file_store.list_paths())
-        count = 0
-        with self.db.transaction():
+            # Two-pass: nodes first, then edges (to satisfy FK constraints)
             for path in paths:
                 try:
                     self._index_file_nodes_only(path)
                     count += 1
                 except Exception as e:
                     logger.warning("Failed to index %s: %s", path, e)
+
+            # Never commit a partial index when the source-of-truth files exist. A mass or
+            # partial failure (e.g. fd exhaustion) would otherwise persist a truncated index —
+            # the exact 2026-07-05 incident. Raising here rolls the whole transaction back.
+            if paths and not allow_partial and count != len(paths):
+                failed = len(paths) - count
+                raise RuntimeError(
+                    f"full_rebuild indexed {count}/{len(paths)} files ({failed} failed); "
+                    "aborting to avoid persisting a partial index (pass allow_partial=True "
+                    "to override)"
+                )
 
             for path in paths:
                 try:

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -63,11 +63,24 @@ class IndexBuilder:
                     "to override)"
                 )
 
+            edge_failures = 0
             for path in paths:
                 try:
                     self._index_file_edges(path)
                 except Exception as e:
+                    edge_failures += 1
                     logger.warning("Failed to index edges for %s: %s", path, e)
+            if edge_failures:
+                # Edges are DERIVED (auto_linker regenerates them; the watermark was cleared above),
+                # so a per-file edge failure is best-effort and must NOT abort the rebuild the way a
+                # missing node does — aborting on one bad link would roll back every good node and
+                # could leave the store empty, the exact failure this rebuild guards against. Surface
+                # the aggregate so the loss is not swallowed silently (council-pr H1).
+                logger.error(
+                    "full_rebuild: %d/%d files failed edge indexing; nodes are complete, edges are "
+                    "best-effort and will be rebuilt by auto_linker",
+                    edge_failures, len(paths),
+                )
 
         return count
 

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -1,5 +1,7 @@
 """Tests for index builder."""
 
+import pytest
+
 from ormah.index.builder import IndexBuilder
 from ormah.models.node import MemoryNode, NodeType
 
@@ -52,3 +54,100 @@ def test_incremental_update(db, file_store):
 
     rows = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()
     assert rows[0] == 2
+
+
+def test_full_rebuild_aborts_and_preserves_data_on_total_failure(db, file_store, monkeypatch):
+    """A rebuild where every file fails to index must NOT persist a truncated index —
+    it must ROLLBACK, preserving whatever was committed before (the nodes-empty incident)."""
+    for i in range(3):
+        node = MemoryNode(
+            type=NodeType.fact,
+            source="agent:test",
+            content=f"Fact {i} for indexing.",
+            title=f"Fact {i}",
+        )
+        file_store.save(node)
+
+    builder = IndexBuilder(db, file_store)
+    builder.full_rebuild()  # seed the index from the fixture store
+    before = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    assert before == 3
+
+    def boom(_path):
+        raise OSError(24, "Too many open files")
+
+    monkeypatch.setattr(builder, "_index_file_nodes_only", boom)
+
+    with pytest.raises(RuntimeError, match=r"0/3 files"):
+        builder.full_rebuild()
+
+    after = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    assert after == before  # ROLLBACK preserved the prior committed state
+
+
+def test_full_rebuild_aborts_and_preserves_data_on_partial_failure(db, file_store, monkeypatch):
+    """One file succeeding out of many must still abort the rebuild (not just count==0) —
+    a partial index committed as "complete" is the exact silent-degradation risk the
+    count==0 guard misses."""
+    for i in range(3):
+        node = MemoryNode(
+            type=NodeType.fact,
+            source="agent:test",
+            content=f"Fact {i} for indexing.",
+            title=f"Fact {i}",
+        )
+        file_store.save(node)
+
+    builder = IndexBuilder(db, file_store)
+    builder.full_rebuild()  # seed the index from the fixture store
+    before = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    assert before == 3
+
+    original = builder._index_file_nodes_only
+    calls = {"n": 0}
+
+    def flaky(path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return original(path)
+        raise OSError(24, "Too many open files")
+
+    monkeypatch.setattr(builder, "_index_file_nodes_only", flaky)
+
+    with pytest.raises(RuntimeError, match=r"1/3 files"):
+        builder.full_rebuild()
+
+    after = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    assert after == before  # ROLLBACK preserved the prior committed state, not a 1-node index
+
+
+def test_full_rebuild_allow_partial_accepts_incomplete_pass(db, file_store, monkeypatch):
+    """allow_partial=True is the explicit opt-out: a partial pass is committed instead of
+    raising, for callers that intentionally tolerate known-corrupt files."""
+    for i in range(3):
+        node = MemoryNode(
+            type=NodeType.fact,
+            source="agent:test",
+            content=f"Fact {i} for indexing.",
+            title=f"Fact {i}",
+        )
+        file_store.save(node)
+
+    builder = IndexBuilder(db, file_store)
+
+    original = builder._index_file_nodes_only
+    calls = {"n": 0}
+
+    def flaky(path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return original(path)
+        raise OSError(24, "Too many open files")
+
+    monkeypatch.setattr(builder, "_index_file_nodes_only", flaky)
+
+    count = builder.full_rebuild(allow_partial=True)
+    assert count == 1
+
+    rows = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()
+    assert rows[0] == 1

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -151,3 +151,36 @@ def test_full_rebuild_allow_partial_accepts_incomplete_pass(db, file_store, monk
 
     rows = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()
     assert rows[0] == 1
+
+
+def test_full_rebuild_edge_failure_does_not_abort_but_is_surfaced(db, file_store, monkeypatch, caplog):
+    """A per-file edge-indexing failure must NOT abort the rebuild (edges are derived and
+    self-healing; aborting on one bad link would roll back every good node and risk an empty
+    store). But the aggregate failure must be surfaced, not swallowed silently (council-pr H1)."""
+    import logging
+
+    for i in range(3):
+        node = MemoryNode(
+            type=NodeType.fact,
+            source="agent:test",
+            content=f"Fact {i} for indexing.",
+            title=f"Fact {i}",
+        )
+        file_store.save(node)
+
+    builder = IndexBuilder(db, file_store)
+    original = builder._index_file_edges
+
+    def flaky_edges(path):
+        if "Fact 1" in path.read_text(encoding="utf-8"):
+            raise RuntimeError("bad link")
+        return original(path)
+
+    monkeypatch.setattr(builder, "_index_file_edges", flaky_edges)
+
+    with caplog.at_level(logging.ERROR, logger="ormah.index.builder"):
+        count = builder.full_rebuild()
+
+    assert count == 3  # all nodes committed despite the edge failure
+    assert db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0] == 3
+    assert any("failed edge indexing" in r.message for r in caplog.records)  # surfaced, not silent


### PR DESCRIPTION
## Problem

`full_rebuild` was non-atomic: it `DELETE`d the nodes table and reinserted in **separate transactions**, so a failure mid-pass could persist an **empty** nodes table. The startup "rebuild-if-empty" path would then loop. Edge-indexing failures during the rebuild were also swallowed.

## Fix

- Wrap the DELETE + both insert passes in a **single** `db.transaction()`.
- **Abort-on-partial**: if `paths and not allow_partial and count != len(paths)`, `raise` → the whole rebuild rolls back rather than committing a truncated index. `allow_partial` is the explicit opt-in for an incomplete pass.
- Startup tolerates a rebuild failure instead of persisting an empty table.
- Surface edge-indexing failures in `full_rebuild` instead of swallowing them (council-pr H1).

## Verification

`pytest tests/test_index/test_builder.py` → 6 passed, including:
- `test_full_rebuild_aborts_and_preserves_data_on_total_failure`
- `test_full_rebuild_aborts_and_preserves_data_on_partial_failure`
- `test_full_rebuild_allow_partial_accepts_incomplete_pass`
- `test_full_rebuild_edge_failure_does_not_abort_but_is_surfaced`

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)