### PR TITLE
fix(db): retire per-thread SQLite connections on thread death — FD leak (#83)

### DIFF
--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+import weakref
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -48,6 +49,11 @@ class Database:
             pass  # sqlite-vec not installed — vector search disabled
         with self._conns_lock:
             self._all_conns.append(conn)
+        # Auto-close this connection when its OWNING thread is garbage-collected. Without this,
+        # an ephemeral thread (e.g. a maintenance phase thread) leaks its connection — and its
+        # ~3 WAL fds — for the whole process lifetime, until [Errno 24]. finalize fires at most
+        # once; close() (shutdown) also handles any still-live threads' connections.
+        weakref.finalize(threading.current_thread(), self._retire_connection, conn)
         return conn
 
     @property
@@ -542,6 +548,18 @@ class Database:
                 )
         except ImportError:
             pass  # sqlite-vec not available, vector search disabled
+
+    def _retire_connection(self, conn: sqlite3.Connection) -> None:
+        """Drop a dead thread's connection from the registry and close it."""
+        with self._conns_lock:
+            try:
+                self._all_conns.remove(conn)
+            except ValueError:
+                pass  # already retired by close()
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001
+            pass
 
     def close(self) -> None:
         with self._conns_lock:

--- a/tests/test_index/test_db_fd_lifecycle.py
+++ b/tests/test_index/test_db_fd_lifecycle.py
@@ -1,0 +1,29 @@
+"""Ephemeral threads must not leak their per-thread SQLite connection (FD-leak regression)."""
+from __future__ import annotations
+
+import gc
+import threading
+
+from ormah.index.db import Database
+
+
+def test_ephemeral_thread_connection_is_retired(tmp_path):
+    db = Database(tmp_path / "t.db")
+    db.init_schema()  # opens the main-thread connection
+    baseline = len(db._all_conns)
+
+    def worker():
+        db.conn.execute("SELECT 1").fetchone()  # forces a new per-thread connection
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # `t` still holds a strong ref to the last thread after the loop above (the loop
+    # variable outlives the loop) — drop it explicitly, or that one thread never dies.
+    del threads, t
+    gc.collect()  # run the weakref finalizers for the now-dead threads
+
+    assert len(db._all_conns) <= baseline


### PR DESCRIPTION
## Problem

Per-thread SQLite connections were created but **never released**. Under a long-running server, worker threads come and go while their connections stay open, leaking file descriptors until `[Errno 24] Too many open files`.

## Fix

Register `weakref.finalize(threading.current_thread(), self._retire_connection, conn)` on every new per-thread connection. When the owning thread is garbage-collected, `_retire_connection` closes the connection and drops it from `_all_conns`. Bounded FD usage regardless of thread churn.

## Verification

`pytest tests/test_index/test_db_fd_lifecycle.py` → 1 passed (`test_ephemeral_thread_connection_is_retired`).

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)