### PR TITLE
fix(engine): identity nodes stay global — space_locked so auto_cluster can't reassign the Self node (#63)

### DIFF
--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -211,6 +211,8 @@ async def _dispatch(
                 body["tags"] = _coerce_list(args["tags"])
             if args.get("about_self"):
                 body["about_self"] = True
+            if args.get("space_locked"):
+                body["space_locked"] = True
             if "confidence" in args:
                 body["confidence"] = args["confidence"]
             if args.get("links"):

--- a/src/ormah/adapters/tool_schemas.py
+++ b/src/ormah/adapters/tool_schemas.py
@@ -88,6 +88,16 @@ TOOLS = [
                     ),
                     "default": False,
                 },
+                "space_locked": {
+                    "type": "boolean",
+                    "description": (
+                        "Set to true to pin this memory's space as user-curated. A locked "
+                        "memory (typically a global one with space=null) is never reassigned "
+                        "to a project space by automatic clustering. about_self memories are "
+                        "locked automatically."
+                    ),
+                    "default": False,
+                },
                 "confidence": {
                     "type": "number",
                     "description": "Belief strength 0.0-1.0. Lower values mean less certain.",

--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -66,6 +66,7 @@ def run_auto_cluster(engine) -> None:
                     )
                 continue
             node.space = most_common
+            node.touch_updated()   # real edit -> advance `updated` for LWW sync ordering
             # ponytail: a concurrent lock landing between this recheck and save() loses to
             # last-writer here (the index UPDATE below is still guarded). Bounded: hourly job,
             # microsecond window, single-user, self-heals next run. A cross-store file<->SQLite

--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -54,9 +54,22 @@ def run_auto_cluster(engine) -> None:
             # stale, or the node may have been locked between selection and now. Never
             # reassign a locked node or the self node.
             node = engine.file_store.load(node_id)
-            if node is None or node.space_locked or node_id == engine.user_node_id:
+            if node is None or node_id == engine.user_node_id:
+                continue
+            if node.space_locked:
+                # The file (source of truth) says locked but the index selected it — heal the
+                # stale index row so this node stops resurfacing in the query every run.
+                with engine.db.transaction() as conn:
+                    conn.execute(
+                        "UPDATE nodes SET space = ?, space_locked = 1 WHERE id = ?",
+                        (node.space, node_id),
+                    )
                 continue
             node.space = most_common
+            # ponytail: a concurrent lock landing between this recheck and save() loses to
+            # last-writer here (the index UPDATE below is still guarded). Bounded: hourly job,
+            # microsecond window, single-user, self-heals next run. A cross-store file<->SQLite
+            # lock would close it but is overkill for this context.
             engine.file_store.save(node)
             updates.append((most_common, node_id))
             assigned += 1

--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -11,8 +11,12 @@ logger = logging.getLogger(__name__)
 def run_auto_cluster(engine) -> None:
     """Assign unassigned nodes to spaces based on their connections."""
     try:
+        # Skip user-curated globals (space_locked) and the self node — a None space on
+        # those means "deliberately global", not "needs a space" (#22 council follow-up).
         unassigned = engine.db.conn.execute(
-            "SELECT id FROM nodes WHERE space IS NULL OR space = ''"
+            "SELECT id FROM nodes "
+            "WHERE (space IS NULL OR space = '') AND space_locked = 0 AND id != ?",
+            (engine.user_node_id or "",),
         ).fetchall()
 
         if not unassigned:

--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from collections import Counter
 
+from ormah.models.node import normalize_space
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,19 +42,23 @@ def run_auto_cluster(engine) -> None:
             if not neighbors:
                 continue
 
-            # Majority vote
+            # Majority vote. Normalize at the source so both writes below (the raw
+            # index UPDATE and the markdown node.space assignment) stay clean — a stale
+            # neighbor with the literal 'null' string must not propagate a phantom space.
             spaces = [n["space"] for n in neighbors]
-            most_common = Counter(spaces).most_common(1)[0][0]
+            most_common = normalize_space(Counter(spaces).most_common(1)[0][0])
+            if most_common is None:
+                continue
 
-            updates.append((most_common, node_id))
-
-            # Update markdown file
+            # Re-check the source of truth (markdown) before writing: the index row may be
+            # stale, or the node may have been locked between selection and now. Never
+            # reassign a locked node or the self node.
             node = engine.file_store.load(node_id)
-            if node:
-                node.space = most_common
-                node.touch_updated()
-                engine.file_store.save(node)
-
+            if node is None or node.space_locked or node_id == engine.user_node_id:
+                continue
+            node.space = most_common
+            engine.file_store.save(node)
+            updates.append((most_common, node_id))
             assigned += 1
 
         if updates:
@@ -60,8 +66,11 @@ def run_auto_cluster(engine) -> None:
             for i in range(0, len(updates), chunk_size):
                 with engine.db.transaction() as conn:
                     for space_val, node_id in updates[i : i + chunk_size]:
+                        # Guard the index write too: a concurrent lock after the recheck
+                        # above must not be clobbered.
                         conn.execute(
-                            "UPDATE nodes SET space = ? WHERE id = ?", (space_val, node_id)
+                            "UPDATE nodes SET space = ? WHERE id = ? AND space_locked = 0",
+                            (space_val, node_id),
                         )
         if assigned:
             logger.info("Auto-cluster assigned %d nodes to spaces", assigned)

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -152,14 +152,14 @@ def _apply_consolidation(
                 pass
             new_node = engine.file_store.load(new_id)
             if new_node and "about_self" not in new_node.tags:
+                from ormah.engine.memory_engine import apply_identity_space_invariants
+
                 new_node.tags.append("about_self")
-                new_node.touch_updated()
-                engine.file_store.save(new_node)
-                with engine.db.transaction() as tx_conn:
-                    tx_conn.execute(
-                        "INSERT OR IGNORE INTO node_tags (node_id, tag) VALUES (?, 'about_self')",
-                        (new_id,),
-                    )
+                # Identity is always global — force None + lock so auto_cluster never
+                # reassigns the consolidated node (the majority vote may have picked a
+                # project space). index_single syncs tags + space + space_locked.
+                apply_identity_space_invariants(new_node)
+                engine.builder.index_single(engine.file_store.save(new_node))
 
     # Create derived_from edges and demote originals to archival
     for node_id in node_ids:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -479,6 +479,7 @@ class MemoryEngine:
             tier=req.tier,
             source=req.source or f"agent:{agent_id or 'unknown'}",
             space=req.space,
+            space_locked=req.space_locked,
             tags=req.tags,
             connections=req.connections,
             title=title,
@@ -492,6 +493,8 @@ class MemoryEngine:
                 node.tags.append("about_self")
             if node.type == NodeType.person:
                 node.tier = Tier.core
+            # Identity is always global — lock its space so auto_cluster never reassigns it.
+            node.space_locked = True
 
         # Enforce core cap
         if node.tier == Tier.core:
@@ -951,6 +954,8 @@ class MemoryEngine:
         if req.space is not None:
             # Plain assignment bypasses the MemoryNode field validator, so normalize here.
             node.space = normalize_space(req.space)
+        if req.space_locked is not None:
+            node.space_locked = req.space_locked
         if req.tags is not None:
             node.tags = req.tags
         if req.title is not None:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -38,6 +38,7 @@ from ormah.models.node import (
     NodeType,
     Tier,
     UpdateNodeRequest,
+    normalize_space,
 )
 from ormah.store.file_store import FileStore
 from ormah.text.tokens import STOP_WORDS
@@ -948,7 +949,8 @@ class MemoryEngine:
         if req.tier is not None:
             node.tier = req.tier
         if req.space is not None:
-            node.space = req.space
+            # Plain assignment bypasses the MemoryNode field validator, so normalize here.
+            node.space = normalize_space(req.space)
         if req.tags is not None:
             node.tags = req.tags
         if req.title is not None:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -141,6 +141,7 @@ class MemoryEngine:
 
         self._ensure_self_node()
         self._migrate_identity_tiers()
+        self._migrate_lock_identity_spaces()
         self._seed_initial_maintenance_grace_period()
         self._warmup_embedder()
         self._warmup_reranker()
@@ -224,6 +225,7 @@ class MemoryEngine:
             tier=Tier.core,
             source="system:self",
             space=None,
+            space_locked=True,
             tags=["self", "identity"],
             title="Self",
             content="The user's identity and personal information.",
@@ -381,6 +383,38 @@ class MemoryEngine:
                     "INSERT OR REPLACE INTO meta (key, value) VALUES ('identity_edges_repaired', '1')"
                 )
 
+    def _migrate_lock_identity_spaces(self) -> None:
+        """One-time: lock the identity cluster's space as global so auto_cluster never
+        reassigns it (#22). On an upgraded store, legacy identity memories carry
+        space_locked=0; without this they could be re-swept into a project space in the
+        window before `migrations repair-identity` is run by hand.
+        """
+        migrated = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'identity_space_locked_migrated'"
+        ).fetchone()
+        if migrated and migrated["value"] == "1":
+            return
+
+        if self.user_node_id:
+            uid = self.user_node_id
+            edged = self.db.conn.execute(
+                "SELECT DISTINCT CASE WHEN source_id = ? THEN target_id ELSE source_id END "
+                "FROM edges WHERE source_id = ? OR target_id = ?",
+                (uid, uid, uid),
+            ).fetchall()
+            for nid in {uid} | {r[0] for r in edged}:
+                node = self.file_store.load(nid)
+                if node and (node.space is not None or not node.space_locked):
+                    node.space = None
+                    node.space_locked = True
+                    self.builder.index_single(self.file_store.save(node))
+
+        with self.db.transaction() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) "
+                "VALUES ('identity_space_locked_migrated', '1')"
+            )
+
     def _warmup_embedder(self) -> None:
         """Load the embedding model now so the first request doesn't stall.
 
@@ -493,7 +527,9 @@ class MemoryEngine:
                 node.tags.append("about_self")
             if node.type == NodeType.person:
                 node.tier = Tier.core
-            # Identity is always global — lock its space so auto_cluster never reassigns it.
+            # Identity is always global — force None (a default_space may have leaked into
+            # req.space upstream) and lock it so auto_cluster never reassigns it.
+            node.space = None
             node.space_locked = True
 
         # Enforce core cap

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -75,6 +75,15 @@ _EDGE_TYPE_FACTORS: dict[str, float] = {
 }
 
 
+def apply_identity_space_invariants(node: MemoryNode) -> None:
+    """Identity (about_self) memories are always global: force space=None + lock so no
+    write path (remember, update_node, consolidator) can leave them project-scoped or
+    unlocked for auto_cluster to reassign (#22)."""
+    if "about_self" in node.tags:
+        node.space = None
+        node.space_locked = True
+
+
 class MemoryEngine:
     """Main facade: remember(), recall(), connect(), context()."""
 
@@ -527,10 +536,8 @@ class MemoryEngine:
                 node.tags.append("about_self")
             if node.type == NodeType.person:
                 node.tier = Tier.core
-            # Identity is always global — force None (a default_space may have leaked into
-            # req.space upstream) and lock it so auto_cluster never reassigns it.
-            node.space = None
-            node.space_locked = True
+            # Identity is always global (a default_space may have leaked into req.space).
+            apply_identity_space_invariants(node)
 
         # Enforce core cap
         if node.tier == Tier.core:
@@ -1003,6 +1010,10 @@ class MemoryEngine:
         if req.add_connections:
             node.connections.extend(req.add_connections)
             changed_fields.append("connections")
+
+        # Re-assert the identity invariant: an about_self node must stay global + locked
+        # regardless of any space/space_locked the request tried to set.
+        apply_identity_space_invariants(node)
 
         # No-op guard: a request that changed nothing must not advance
         # `updated`, or it could beat a real remote edit under LWW sync.

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -113,10 +113,10 @@ class IndexBuilder:
         conn.execute(
             """
             INSERT OR REPLACE INTO nodes
-            (id, type, tier, source, space, title, content, created, updated,
+            (id, type, tier, source, space, space_locked, title, content, created, updated,
              last_accessed, access_count, confidence, importance,
              valid_until, stability, last_review, file_path, file_hash)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?)
             """,
             (
@@ -125,6 +125,7 @@ class IndexBuilder:
                 node.tier.value,
                 node.source,
                 node.space,
+                int(node.space_locked),
                 node.title,
                 node.content,
                 node.created.isoformat(),

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -141,6 +141,7 @@ class Database:
                 ("valid_until", "ALTER TABLE nodes ADD COLUMN valid_until TEXT"),
                 ("stability", "ALTER TABLE nodes ADD COLUMN stability REAL DEFAULT 1.0"),
                 ("last_review", "ALTER TABLE nodes ADD COLUMN last_review TEXT"),
+                ("space_locked", "ALTER TABLE nodes ADD COLUMN space_locked INTEGER NOT NULL DEFAULT 0"),
             ]
             for col_name, ddl in enrichment_migrations:
                 if col_name not in node_cols:

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     tier TEXT NOT NULL DEFAULT 'working',
     source TEXT NOT NULL,
     space TEXT,
+    space_locked INTEGER NOT NULL DEFAULT 0,
     title TEXT,
     content TEXT,
     created TEXT NOT NULL,

--- a/src/ormah/models/node.py
+++ b/src/ormah/models/node.py
@@ -6,7 +6,21 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# Placeholder strings that mean "no space" but get persisted as a literal space
+# when None is JSON/string-serialized upstream (e.g. an agent passing the string
+# "null"). Coerced to None at the persistence boundary so they never form a
+# phantom space group. See tests/test_store/test_space_normalization.py (#22).
+_SPACE_PLACEHOLDERS = {"null", "none", ""}
+
+
+def normalize_space(space: str | None) -> str | None:
+    """Map placeholder space strings ('null', 'none', '', whitespace) to None."""
+    if space is None:
+        return None
+    stripped = space.strip()
+    return None if stripped.lower() in _SPACE_PLACEHOLDERS else stripped
 
 
 class NodeType(str, Enum):
@@ -65,6 +79,10 @@ class MemoryNode(BaseModel):
     connections: list[Connection] = Field(default_factory=list)
     title: str | None = None
     content: str = ""
+
+    _normalize_space = field_validator("space", mode="before")(
+        lambda cls, v: normalize_space(v)
+    )
 
     @property
     def short_id(self) -> str:

--- a/src/ormah/models/node.py
+++ b/src/ormah/models/node.py
@@ -75,6 +75,7 @@ class MemoryNode(BaseModel):
     valid_until: datetime | None = None
     deleted_at: datetime | None = None  # tombstone stamp; ordering for sync merges uses this, never `updated`
     space: str | None = None
+    space_locked: bool = False  # user-curated space: auto_cluster must not reassign (#22)
     tags: list[str] = Field(default_factory=list)
     connections: list[Connection] = Field(default_factory=list)
     title: str | None = None
@@ -100,6 +101,7 @@ class CreateNodeRequest(BaseModel):
     tier: Tier = Tier.working
     source: str | None = None
     space: str | None = None
+    space_locked: bool = False  # mark this memory's space as user-curated (global-safe)
     tags: list[str] = Field(default_factory=list)
     connections: list[Connection] = Field(default_factory=list)
     title: str | None = None
@@ -112,6 +114,7 @@ class UpdateNodeRequest(BaseModel):
     type: NodeType | None = None
     tier: Tier | None = None
     space: str | None = None
+    space_locked: bool | None = None
     tags: list[str] | None = None
     add_connections: list[Connection] | None = None
     title: str | None = None

--- a/src/ormah/store/markdown.py
+++ b/src/ormah/store/markdown.py
@@ -46,6 +46,7 @@ def parse_node(text: str) -> MemoryNode:
         valid_until=valid_until,
         deleted_at=deleted_at,
         space=meta.get("space"),
+        space_locked=meta.get("space_locked", False),
         tags=meta.get("tags", []),
         connections=connections,
         title=meta.get("title"),
@@ -79,6 +80,8 @@ def serialize_node(node: MemoryNode) -> str:
         meta["title"] = node.title
     if node.space:
         meta["space"] = node.space
+    if node.space_locked:
+        meta["space_locked"] = True
     if node.tags:
         meta["tags"] = node.tags
     if node.connections:

--- a/src/ormah/store/migrations.py
+++ b/src/ormah/store/migrations.py
@@ -41,19 +41,59 @@ def migrate_null_space(nodes_dir: Path, db_path: Path) -> tuple[int, int]:
     return fixed, reindexed
 
 
+def repair_global_identity(nodes_dir: Path, db_path: Path) -> tuple[int, int]:
+    """Lock the identity cluster as global so auto_cluster never reassigns it (#22).
+
+    The self node and everything edged to it (about_self memories) are global by
+    definition. Earlier auto_cluster runs swept some into a project space once their
+    placeholder 'null' was migrated to a real None. Reset those to space=None and pin
+    them with space_locked=True. Idempotent.
+
+    Returns ``(files_fixed, nodes_reindexed)``.
+    """
+    fs = FileStore(nodes_dir)
+    db = Database(db_path)
+    db.init_schema()
+    row = db.conn.execute("SELECT value FROM meta WHERE key = 'user_node_id'").fetchone()
+    if row is None:
+        return 0, IndexBuilder(db, fs).full_rebuild()
+    uid = row[0]
+    edged = db.conn.execute(
+        "SELECT DISTINCT CASE WHEN source_id = ? THEN target_id ELSE source_id END "
+        "FROM edges WHERE source_id = ? OR target_id = ?",
+        (uid, uid, uid),
+    ).fetchall()
+    ids = {uid} | {r[0] for r in edged}
+
+    fixed = 0
+    for nid in ids:
+        node = fs.load(nid)
+        if node and (node.space is not None or not node.space_locked):
+            node.space = None
+            node.space_locked = True
+            fs.save(node)
+            fixed += 1
+    return fixed, IndexBuilder(db, fs).full_rebuild()
+
+
 def main(argv: list[str] | None = None) -> None:
     import sys
 
     from ormah.config import Settings
 
     args = argv if argv is not None else sys.argv[1:]
-    if args != ["null-space"]:
-        print("usage: python -m ormah.store.migrations null-space")
+    cmd = args[0] if args else None
+    if cmd not in ("null-space", "repair-identity"):
+        print("usage: python -m ormah.store.migrations {null-space|repair-identity}")
         raise SystemExit(2)
 
     settings = Settings()
-    fixed, reindexed = migrate_null_space(settings.nodes_dir, settings.db_path)
-    print(f"migrated {fixed} file(s); reindexed {reindexed} node(s)")
+    if cmd == "null-space":
+        fixed, reindexed = migrate_null_space(settings.nodes_dir, settings.db_path)
+        print(f"migrated {fixed} file(s); reindexed {reindexed} node(s)")
+    else:
+        fixed, reindexed = repair_global_identity(settings.nodes_dir, settings.db_path)
+        print(f"locked {fixed} identity node(s); reindexed {reindexed} node(s)")
 
 
 if __name__ == "__main__":

--- a/src/ormah/store/migrations.py
+++ b/src/ormah/store/migrations.py
@@ -1,0 +1,60 @@
+"""One-shot data migrations for the markdown store.
+
+Run a migration against your configured store:
+    python -m ormah.store.migrations null-space
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import frontmatter
+
+from ormah.index.builder import IndexBuilder
+from ormah.index.db import Database
+from ormah.models.node import normalize_space
+from ormah.store.file_store import FileStore
+from ormah.store.markdown import parse_node
+
+
+def migrate_null_space(nodes_dir: Path, db_path: Path) -> tuple[int, int]:
+    """Coerce literal 'null'/'none'/'' space strings to None (#22).
+
+    A handful of stored nodes carried the placeholder string ``space='null'``
+    (not SQL NULL), landing them in a phantom "null" space group. The write-path
+    guard (``MemoryNode`` field validator) prevents new ones; this cleans the
+    existing files and rebuilds the index. Idempotent.
+
+    Returns ``(files_fixed, nodes_reindexed)``.
+    """
+    fs = FileStore(nodes_dir)
+    fixed = 0
+    for path in fs.list_paths():
+        raw = frontmatter.loads(path.read_text(encoding="utf-8")).metadata.get("space")
+        if isinstance(raw, str) and normalize_space(raw) != raw:
+            # parse_node runs the validator (normalizes); save re-serializes clean.
+            fs.save(parse_node(path.read_text(encoding="utf-8")))
+            fixed += 1
+    db = Database(db_path)
+    db.init_schema()  # no-op on an existing DB; creates tables on a fresh one
+    reindexed = IndexBuilder(db, fs).full_rebuild()
+    return fixed, reindexed
+
+
+def main(argv: list[str] | None = None) -> None:
+    import sys
+
+    from ormah.config import Settings
+
+    args = argv if argv is not None else sys.argv[1:]
+    if args != ["null-space"]:
+        print("usage: python -m ormah.store.migrations null-space")
+        raise SystemExit(2)
+
+    settings = Settings()
+    fixed, reindexed = migrate_null_space(settings.nodes_dir, settings.db_path)
+    print(f"migrated {fixed} file(s); reindexed {reindexed} node(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_background/test_auto_cluster.py
+++ b/tests/test_background/test_auto_cluster.py
@@ -81,6 +81,53 @@ def test_auto_cluster_skips_self_node(engine):
     assert engine.file_store.load(uid).space is None
 
 
+def test_auto_cluster_rechecks_stale_index_lock(engine):
+    """Markdown is source of truth: a node locked in the file but stale-unlocked in the
+    index must not be reassigned (#22 council B)."""
+    a, _ = engine.remember(
+        CreateNodeRequest(content="global pref", type=NodeType.preference, space_locked=True)
+    )
+    b, _ = engine.remember(
+        CreateNodeRequest(content="neighbor", type=NodeType.fact, space="work")
+    )
+    _connect(engine, a, b)
+    # Simulate a stale index row: file says locked, index says unlocked + no space.
+    with engine.db.transaction() as conn:
+        conn.execute("UPDATE nodes SET space_locked = 0, space = NULL WHERE id = ?", (a,))
+
+    run_auto_cluster(engine)
+
+    node = engine.file_store.load(a)
+    assert node.space is None
+    assert node.space_locked is True
+
+
+def test_migrate_lock_identity_spaces_relocks_legacy(engine):
+    """Startup migration re-locks legacy identity memories once (#22 council C)."""
+    sid, _ = engine.remember(
+        CreateNodeRequest(content="André is stoic.", type=NodeType.preference, about_self=True)
+    )
+    # Simulate a legacy/upgraded node: swept into a project space, unlocked, in file + index.
+    n = engine.file_store.load(sid)
+    n.space = "ormah"
+    n.space_locked = False
+    engine.file_store.save(n)
+    with engine.db.transaction() as conn:
+        conn.execute("UPDATE nodes SET space = 'ormah', space_locked = 0 WHERE id = ?", (sid,))
+        conn.execute("DELETE FROM meta WHERE key = 'identity_space_locked_migrated'")
+
+    engine._migrate_lock_identity_spaces()
+
+    node = engine.file_store.load(sid)
+    assert node.space is None
+    assert node.space_locked is True
+    # Idempotent: the guard meta key is set, a second run is a no-op.
+    row = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'identity_space_locked_migrated'"
+    ).fetchone()
+    assert row["value"] == "1"
+
+
 def test_repair_global_identity_relocks_swept_cluster(engine):
     """The repair resets a swept identity cluster back to global + locked."""
     from ormah.store.migrations import repair_global_identity

--- a/tests/test_background/test_auto_cluster.py
+++ b/tests/test_background/test_auto_cluster.py
@@ -1,0 +1,105 @@
+"""auto_cluster must not propagate the placeholder 'null' space (#22 council follow-up).
+
+auto_cluster assigns unassigned nodes the majority space of their neighbors, writing
+both the index (raw SQL UPDATE) and the markdown file (node.space). Both writes must
+stay clean if a stale neighbor still carries the literal 'null' string.
+"""
+
+from __future__ import annotations
+
+from ormah.background.auto_cluster import run_auto_cluster
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType
+
+
+def _connect(engine, a, b):
+    engine.connect(ConnectRequest(source_id=a, target_id=b, edge=EdgeType.related_to))
+
+
+def test_auto_cluster_assigns_real_neighbor_space(engine):
+    """Happy path still works: an unassigned node inherits a real neighbor space."""
+    a, _ = engine.remember(CreateNodeRequest(content="unassigned", type=NodeType.fact))
+    b, _ = engine.remember(
+        CreateNodeRequest(content="neighbor", type=NodeType.fact, space="work")
+    )
+    _connect(engine, a, b)
+
+    run_auto_cluster(engine)
+
+    assert engine.file_store.load(a).space == "work"
+
+
+def test_auto_cluster_does_not_propagate_placeholder_space(engine):
+    a, _ = engine.remember(CreateNodeRequest(content="unassigned", type=NodeType.fact))
+    b, _ = engine.remember(
+        CreateNodeRequest(content="neighbor", type=NodeType.fact, space="work")
+    )
+    _connect(engine, a, b)
+    # Simulate a stale, pre-migration neighbor carrying the literal placeholder.
+    with engine.db.transaction() as conn:
+        conn.execute("UPDATE nodes SET space = 'null' WHERE id = ?", (b,))
+
+    run_auto_cluster(engine)
+
+    # The unassigned node stays unassigned — it must not inherit the phantom 'null'.
+    assert engine.file_store.load(a).space is None
+    index_space = engine.db.conn.execute(
+        "SELECT space FROM nodes WHERE id = ?", (a,)
+    ).fetchone()[0]
+    assert index_space is None
+    # auto_cluster added no new 'null' rows (only the one we injected on b remains).
+    nulls = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE space = 'null'"
+    ).fetchone()[0]
+    assert nulls == 1
+
+
+def test_auto_cluster_skips_space_locked_node(engine):
+    """A user-curated global (space_locked) keeps its None space despite project neighbors."""
+    a, _ = engine.remember(
+        CreateNodeRequest(content="global pref", type=NodeType.preference, space_locked=True)
+    )
+    b, _ = engine.remember(
+        CreateNodeRequest(content="neighbor", type=NodeType.fact, space="work")
+    )
+    _connect(engine, a, b)
+
+    run_auto_cluster(engine)
+
+    assert engine.file_store.load(a).space is None
+
+
+def test_auto_cluster_skips_self_node(engine):
+    """The self/identity node is never swept into a project space."""
+    uid = engine.user_node_id
+    b, _ = engine.remember(
+        CreateNodeRequest(content="neighbor", type=NodeType.fact, space="work")
+    )
+    _connect(engine, uid, b)
+
+    run_auto_cluster(engine)
+
+    assert engine.file_store.load(uid).space is None
+
+
+def test_repair_global_identity_relocks_swept_cluster(engine):
+    """The repair resets a swept identity cluster back to global + locked."""
+    from ormah.store.migrations import repair_global_identity
+
+    uid = engine.user_node_id
+    sid, _ = engine.remember(
+        CreateNodeRequest(content="André runs triathlons.", type=NodeType.fact, about_self=True)
+    )
+    # Simulate the pre-fix damage: both pulled into a project space, unlocked.
+    for nid in (uid, sid):
+        n = engine.file_store.load(nid)
+        n.space = "ormah"
+        n.space_locked = False
+        engine.file_store.save(n)
+
+    fixed, _ = repair_global_identity(engine.settings.nodes_dir, engine.settings.db_path)
+
+    assert fixed >= 2
+    for nid in (uid, sid):
+        n = engine.file_store.load(nid)
+        assert n.space is None
+        assert n.space_locked is True

--- a/tests/test_background/test_auto_cluster.py
+++ b/tests/test_background/test_auto_cluster.py
@@ -100,6 +100,11 @@ def test_auto_cluster_rechecks_stale_index_lock(engine):
     node = engine.file_store.load(a)
     assert node.space is None
     assert node.space_locked is True
+    # The stale index row is healed so the node stops resurfacing in the unassigned query.
+    healed = engine.db.conn.execute(
+        "SELECT space_locked FROM nodes WHERE id = ?", (a,)
+    ).fetchone()[0]
+    assert healed == 1
 
 
 def test_migrate_lock_identity_spaces_relocks_legacy(engine):

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -131,6 +131,15 @@ def test_update_node(engine):
     assert "Updated" in text
 
 
+def test_update_node_normalizes_placeholder_space(engine):
+    """Updating space to the placeholder string 'null' persists as None (#22)."""
+    node_id, _ = engine.remember(
+        CreateNodeRequest(content="x", type=NodeType.fact, space="work")
+    )
+    engine.update_node(node_id, UpdateNodeRequest(space="null"))
+    assert engine.file_store.load(node_id).space is None
+
+
 def test_connect(engine):
     req1 = CreateNodeRequest(content="Node A.", type=NodeType.fact)
     req2 = CreateNodeRequest(content="Node B.", type=NodeType.fact)

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -147,6 +147,33 @@ def test_remember_about_self_locks_space(engine):
     assert engine.file_store.load(node_id).space_locked is True
 
 
+def test_apply_identity_space_invariants_helper():
+    """about_self nodes are forced global+locked; others are untouched (#22 council)."""
+    from ormah.engine.memory_engine import apply_identity_space_invariants
+    from ormah.models.node import MemoryNode
+
+    identity = MemoryNode(type=NodeType.fact, space="work", tags=["about_self"])
+    apply_identity_space_invariants(identity)
+    assert identity.space is None
+    assert identity.space_locked is True
+
+    plain = MemoryNode(type=NodeType.fact, space="work", tags=["misc"])
+    apply_identity_space_invariants(plain)
+    assert plain.space == "work"
+    assert plain.space_locked is False
+
+
+def test_update_node_cannot_unlock_identity(engine):
+    """An about_self memory stays global+locked even if update tries to set a project space."""
+    node_id, _ = engine.remember(
+        CreateNodeRequest(content="André is stoic.", type=NodeType.fact, about_self=True)
+    )
+    engine.update_node(node_id, UpdateNodeRequest(space="work", space_locked=False))
+    node = engine.file_store.load(node_id)
+    assert node.space is None
+    assert node.space_locked is True
+
+
 def test_remember_about_self_forces_global_space(engine):
     """about_self is global even if a default_space leaked into req.space (#22 council A)."""
     node_id, _ = engine.remember(

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -131,6 +131,41 @@ def test_update_node(engine):
     assert "Updated" in text
 
 
+def test_remember_normalizes_placeholder_space(engine):
+    """Creating a node with the placeholder string 'null' persists as None (#22)."""
+    node_id, _ = engine.remember(
+        CreateNodeRequest(content="x", type=NodeType.fact, space="null")
+    )
+    assert engine.file_store.load(node_id).space is None
+
+
+def test_remember_about_self_locks_space(engine):
+    """Identity nodes are global by definition — about_self locks the space (#22)."""
+    node_id, _ = engine.remember(
+        CreateNodeRequest(content="André is a triathlete.", type=NodeType.fact, about_self=True)
+    )
+    assert engine.file_store.load(node_id).space_locked is True
+
+
+def test_remember_explicit_space_locked(engine):
+    """A caller can pin a non-identity global (e.g. a cross-project preference)."""
+    node_id, _ = engine.remember(
+        CreateNodeRequest(
+            content="Always open previews in Brave.",
+            type=NodeType.preference,
+            space_locked=True,
+        )
+    )
+    assert engine.file_store.load(node_id).space_locked is True
+
+
+def test_update_node_can_lock_space(engine):
+    """update_node can flip space_locked on an existing node."""
+    node_id, _ = engine.remember(CreateNodeRequest(content="x", type=NodeType.fact))
+    engine.update_node(node_id, UpdateNodeRequest(space_locked=True))
+    assert engine.file_store.load(node_id).space_locked is True
+
+
 def test_update_node_normalizes_placeholder_space(engine):
     """Updating space to the placeholder string 'null' persists as None (#22)."""
     node_id, _ = engine.remember(

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -147,6 +147,26 @@ def test_remember_about_self_locks_space(engine):
     assert engine.file_store.load(node_id).space_locked is True
 
 
+def test_remember_about_self_forces_global_space(engine):
+    """about_self is global even if a default_space leaked into req.space (#22 council A)."""
+    node_id, _ = engine.remember(
+        CreateNodeRequest(
+            content="André runs triathlons.",
+            type=NodeType.fact,
+            about_self=True,
+            space="ormah",  # simulates default_space applied at the API boundary
+        )
+    )
+    node = engine.file_store.load(node_id)
+    assert node.space is None
+    assert node.space_locked is True
+
+
+def test_self_node_is_space_locked(engine):
+    """The self node is created locked, not relying solely on the id != user_node_id guard."""
+    assert engine.file_store.load(engine.user_node_id).space_locked is True
+
+
 def test_remember_explicit_space_locked(engine):
     """A caller can pin a non-identity global (e.g. a cross-project preference)."""
     node_id, _ = engine.remember(

--- a/tests/test_store/test_space_locked.py
+++ b/tests/test_store/test_space_locked.py
@@ -1,0 +1,43 @@
+"""space_locked: user-curated spaces survive auto_cluster (#22 council follow-up).
+
+A node marked space_locked is global/curated on purpose; the persistence layer must
+round-trip the flag through markdown and the SQLite index.
+"""
+
+from ormah.index.builder import IndexBuilder
+from ormah.index.db import Database
+from ormah.models.node import MemoryNode
+from ormah.store.file_store import FileStore
+from ormah.store.markdown import parse_node, serialize_node
+
+
+def test_model_default_is_unlocked():
+    assert MemoryNode(type="fact").space_locked is False
+
+
+def test_markdown_roundtrip_preserves_lock():
+    node = MemoryNode(type="fact", content="x", space_locked=True)
+    text = serialize_node(node)
+    assert "space_locked: true" in text
+    assert parse_node(text).space_locked is True
+
+
+def test_markdown_omits_flag_when_unlocked():
+    node = MemoryNode(type="fact", content="x")
+    assert "space_locked" not in serialize_node(node)
+
+
+def test_index_persists_space_locked(tmp_path):
+    fs = FileStore(tmp_path / "nodes")
+    locked = MemoryNode(type="fact", content="locked", space_locked=True)
+    fs.save(locked)
+    fs.save(MemoryNode(type="fact", content="plain"))
+
+    db = Database(tmp_path / "index.db")
+    db.init_schema()
+    IndexBuilder(db, fs).full_rebuild()
+
+    row = db.conn.execute(
+        "SELECT space_locked FROM nodes WHERE id = ?", (locked.id,)
+    ).fetchone()
+    assert row[0] == 1

--- a/tests/test_store/test_space_normalization.py
+++ b/tests/test_store/test_space_normalization.py
@@ -1,0 +1,71 @@
+"""Space normalization: placeholder strings persist as None, not literal 'null' (#22).
+
+A handful of stored nodes carried the literal string ``space='null'`` (not SQL NULL),
+landing them in a phantom "null" space group. Root cause: no write-path guard coerced
+the placeholder to None. The fix normalizes at the MemoryNode boundary (every persisted
+node) plus the update path.
+"""
+
+import pytest
+
+from ormah.index.db import Database
+from ormah.models.node import MemoryNode, normalize_space
+from ormah.store.file_store import FileStore
+from ormah.store.markdown import parse_node, serialize_node
+from ormah.store.migrations import migrate_null_space
+
+
+@pytest.mark.parametrize("raw", ["null", "none", "NULL", "None", " null ", "", "   "])
+def test_placeholder_space_becomes_none(raw):
+    assert MemoryNode(type="fact", space=raw).space is None
+
+
+@pytest.mark.parametrize("raw", ["work", "AndreMartins", "global", "ormah"])
+def test_real_space_is_preserved(raw):
+    assert MemoryNode(type="fact", space=raw).space == raw
+
+
+def test_none_space_stays_none():
+    assert MemoryNode(type="fact", space=None).space is None
+
+
+def test_real_space_is_stripped():
+    assert MemoryNode(type="fact", space="  work  ").space == "work"
+
+
+def test_normalize_space_helper():
+    assert normalize_space("null") is None
+    assert normalize_space("") is None
+    assert normalize_space(None) is None
+    assert normalize_space("work") == "work"
+
+
+def test_markdown_roundtrip_drops_placeholder_space():
+    """A file corrupted with the literal string 'null' parses back to None."""
+    node = MemoryNode(type="fact", space="work", content="x")
+    corrupted = serialize_node(node).replace("space: work", "space: 'null'")
+    assert parse_node(corrupted).space is None
+
+
+def test_migration_cleans_placeholder_space_in_files_and_index(tmp_path):
+    """End-to-end migration on a throwaway store: files and index both cleaned."""
+    nodes_dir = tmp_path / "nodes"
+    fs = FileStore(nodes_dir)
+
+    fs.save(MemoryNode(type="fact", space="work", content="clean"))  # untouched
+    dirty = MemoryNode(type="fact", space="work", content="dirty")
+    path = fs.save(dirty)
+    path.write_text(
+        serialize_node(dirty).replace("space: work", "space: 'null'"), encoding="utf-8"
+    )
+    assert "space: 'null'" in path.read_text(encoding="utf-8")  # sanity
+
+    fixed, reindexed = migrate_null_space(nodes_dir, tmp_path / "index.db")
+
+    assert fixed == 1
+    assert reindexed == 2
+    assert FileStore(nodes_dir).load(dirty.id).space is None  # source of truth cleaned
+    db = Database(tmp_path / "index.db")
+    spaces = {r[0] for r in db.conn.execute("SELECT space FROM nodes").fetchall()}
+    assert "null" not in spaces
+    assert spaces == {None, "work"}


### PR DESCRIPTION
## Problem

The Self / identity node is created with `space=None`, but nothing kept it there: `auto_cluster` selects every `space IS NULL` node and reassigns it to its neighbours' most-common space (`auto_cluster.py`), so the global Self node — and any `about_self` memory — gets pulled into an active project space (`'subagents'`, `'ormah'`, …). Creating it global is not enough; the graph never *keeps* it global.

## Fix — `space_locked` + a single enforced invariant

- **`space_locked` flag** on the node model + a one-shot `ALTER TABLE nodes ADD COLUMN space_locked` migration. `auto_cluster` skips locked nodes (and the user node) and heals the stale index row so they stop resurfacing in the unassigned query every run.
- **`apply_identity_space_invariants(node)`** — `about_self` ⇒ `space=None` + `space_locked=True`, applied on **every** write path: `remember()`, `update_node()` (can't unlock/re-scope an identity memory), and the `consolidator` (a majority-vote consolidation can't pick a project space). `index_single` syncs tags + space + space_locked.
- **Placeholder-space normalization**: the literal string `"null"`/`""` persists as `None` (create + update).

## Verification

`pytest tests/test_store/test_space_locked.py tests/test_store/test_space_normalization.py tests/test_background/test_auto_cluster.py tests/test_engine/test_memory_engine.py tests/test_index/test_builder.py` → **77 passed**, incl. `test_self_node_is_space_locked`, `test_remember_about_self_forces_global_space`, `test_update_node_can_lock_space`, and the auto_cluster skip-locked cases.

## Notes for the merge

Reconstructed from the Beta (`local-main`) as the ordered chain afe8e90 → f0ce0c4 → 7d467ae → 1b982f0 (#22 council rounds), rebased onto current `main`. These commits were authored atop #28's `archived_at` column; that column was intentionally **excluded** here (it belongs to #31), so the `enrichment_migrations` list and the `nodes` INSERT touch only `space_locked`. If #31 (bounded forgetting) merges first, expect a trivial textual conflict in both spots — resolve by keeping both columns.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)