### PR TITLE
perf(background): delta-select dedup + conflict seeds by seq watermark (#81)

### DIFF
--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -182,12 +182,13 @@ def _find_conflict_candidates(
                 drained_seeds.append((node["id"], node["seq"]))
                 continue
 
-            # FAIL-CLOSED (overview invariant, mirrors upstream auto_linker.py):
-            # a seed with text but no persisted vector must NOT drain — an
-            # empty/backfilling index would return zero neighbors and the
-            # cursor would pass pairs that were never derived.
+            # FAIL-CLOSED BARRIER (overview invariant, mirrors upstream
+            # auto_linker.py): a seed with text but no persisted vector stops
+            # the batch here. `break`, not `continue` — a later seed must not
+            # drain and advance the watermark past this hole, or this seed's
+            # pairs are permanently skipped once its vector is backfilled.
             if delta and vec_store.get(node["id"]) is None:
-                continue  # NOT appended to drained_seeds
+                break
 
             query_vec = stored_or_encoded(
                 vec_store,

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -191,6 +191,12 @@ def _find_conflict_candidates(
             # not `break`: later seeds are still PROCESSED (liveness, mirrors
             # auto_linker) but no further seed drains once the barrier is hit.
             if delta and vec_store.get(node["id"]) is None:
+                if not barrier_hit:
+                    logger.warning(
+                        "conflict delta stalled: node %s has no persisted vector (embedding "
+                        "backfill pending?); cursor parked at seq %s until it embeds",
+                        node["id"][:8], node["seq"],
+                    )
                 barrier_hit = True
                 continue
 

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -281,6 +281,18 @@ def run_conflict_detection(engine) -> None:
             CONFLICT_WATERMARK_KEY, get_watermark, set_watermark,
         )
 
+        # Durably reset the cursor on a scope change BEFORE selection — so an
+        # expanded scope re-examines older nodes even if THIS run cannot
+        # drain the first seed (vectorless barrier) or the finder returns
+        # empty on a transient error. Persisting here (not just ephemerally
+        # in the finder) is what makes the reset survive to the next run:
+        # the advance loop below reloads the persisted watermark.
+        _stamp = engine.db.conn.execute(
+            "SELECT value FROM meta WHERE key = ?", (CONFLICT_SCOPE_STAMP_KEY,)
+        ).fetchone()
+        if _stamp is not None and _stamp["value"] != _conflict_scope_value(settings):
+            set_watermark(engine, CONFLICT_WATERMARK_KEY, 0)
+
         candidates, drained_seeds = _find_conflict_candidates(
             engine, limit=10_000, delta=True,
         )

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -276,7 +276,14 @@ def run_conflict_detection(engine) -> None:
             logger.debug("Conflict detection skipped: LLM not enabled")
             return
 
-        candidates = _find_conflict_candidates(engine, limit=10000)
+        from ormah.background.watermark import (
+            CONFLICT_WATERMARK_KEY, get_watermark, set_watermark,
+        )
+
+        candidates, drained_seeds = _find_conflict_candidates(
+            engine, limit=10_000, delta=True,
+        )
+        failed_seed_seqs: set[int] = set()
         edges_created = 0
         dirty_nodes: dict[str, list[Connection]] = {}
 
@@ -286,6 +293,7 @@ def run_conflict_detection(engine) -> None:
 
             llm_result = _llm_check_conflict(settings, node_a, node_b)
             if llm_result is None:
+                failed_seed_seqs.add(candidate["seed_seq"])
                 continue
             if not llm_result.get("conflict"):
                 continue
@@ -342,6 +350,21 @@ def run_conflict_detection(engine) -> None:
 
         if edges_created:
             logger.info("Conflict detector created %d edges", edges_created)
+
+        # ponytail: contiguous-prefix advance; a deterministically failing seed
+        # parks the cursor — dead-letter escape hatch is upstream #122.
+        new_watermark = get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY)
+        for _seed_id, seed_seq in drained_seeds:  # ascending seq
+            if seed_seq in failed_seed_seqs:
+                break
+            new_watermark = seed_seq
+        set_watermark(engine, CONFLICT_WATERMARK_KEY, new_watermark)
+        # Stamp the scope this cursor was advanced under (finder resets on mismatch)
+        with engine.db.transaction() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                (CONFLICT_SCOPE_STAMP_KEY, _conflict_scope_value(settings)),
+            )
 
     except Exception as e:
         logger.warning("Conflict detection failed: %s", e)

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -100,15 +100,39 @@ def _llm_check_conflict(settings, node_row, other_row) -> dict | None:
 
 _BELIEF_TYPES = ('preference', 'fact', 'observation', 'goal')
 
+CONFLICT_SCOPE_STAMP_KEY = "conflict_check_watermark_scope"
 
-def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
+
+def _conflict_scope_value(settings) -> str:
+    return "all" if settings.conflict_check_all_spaces else "global"
+
+
+def _find_conflict_candidates(
+    engine,
+    limit: int = 8,
+    *,
+    max_seeds: int | None = None,
+    delta: bool = False,
+):
     """Find node pairs that might contradict each other.
 
-    Returns up to *limit* pairs as
-    ``[{"node_a": {...}, "node_b": {...}, "similarity": float}]``.
-    Node dicts include ``created`` so they can be passed directly to the
-    LLM conflict-check prompt.  Does NOT call the LLM.
+    ``delta=False`` (default — the agent/two-call path): today's selection,
+    unchanged: full ``ORDER BY RANDOM()`` fetch, returns a candidate list.
+
+    ``delta=True`` (background run only, #81): seeds are nodes with ``seq``
+    above the ``conflict_check_watermark``, oldest-first, bounded by
+    *max_seeds* (default: ``conflict_check_max_nodes_per_run``). Vector
+    neighbors are NOT filtered by age — a new seed pairs against neighbors of
+    any age. Returns ``(candidates, drained_seeds)``; ``drained_seeds`` is
+    ``[(node_id, seq), ...]`` ascending, containing only seeds whose neighbor
+    loop completed (a seed cut short by the pair *limit* is excluded so the
+    cursor never passes it). Candidates each carry ``seed_seq``. A scope-stamp
+    mismatch (``conflict_check_all_spaces`` changed since the last advance)
+    treats the watermark as 0. Only ``run_conflict_detection`` advances the
+    watermark; this function never writes it. ``limit`` stays pair-denominated
+    in both modes.
     """
+    drained_seeds: list[tuple[str, int]] = []
     try:
         from ormah.embeddings.encoder import get_encoder
         from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
@@ -117,16 +141,32 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
         encoder = get_encoder(settings)
         vec_store = VectorStore(engine.db)
 
-        if settings.conflict_check_all_spaces:
+        space_filter = "" if settings.conflict_check_all_spaces else \
+            "AND (space IS NULL OR space = 'null') "
+
+        if delta:
+            from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark
+
+            if max_seeds is None:
+                max_seeds = settings.conflict_check_max_nodes_per_run
+            watermark = get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY)
+            stamp = engine.db.conn.execute(
+                "SELECT value FROM meta WHERE key = ?", (CONFLICT_SCOPE_STAMP_KEY,)
+            ).fetchone()
+            if stamp is not None and stamp["value"] != _conflict_scope_value(settings):
+                watermark = 0  # scope changed: older nodes are newly in scope
+
             nodes = engine.db.conn.execute(
-                "SELECT id, content, title, type, created, space FROM nodes "
-                "WHERE type IN (?, ?, ?, ?) ORDER BY RANDOM()",
-                _BELIEF_TYPES,
+                "SELECT id, content, title, type, created, space, seq FROM nodes "
+                f"WHERE type IN (?, ?, ?, ?) {space_filter}AND seq > ? "
+                "ORDER BY seq ASC LIMIT ?",
+                (*_BELIEF_TYPES, watermark, max_seeds),
             ).fetchall()
         else:
+            # Legacy selection — byte-for-byte today's queries (agent path).
             nodes = engine.db.conn.execute(
-                "SELECT id, content, title, type, created, space FROM nodes "
-                "WHERE type IN (?, ?, ?, ?) AND (space IS NULL OR space = 'null') ORDER BY RANDOM()",
+                "SELECT id, content, title, type, created, space, seq FROM nodes "
+                f"WHERE type IN (?, ?, ?, ?) {space_filter}ORDER BY RANDOM()",
                 _BELIEF_TYPES,
             ).fetchall()
 
@@ -135,11 +175,19 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
 
         for node in nodes:
             if len(candidates) >= limit:
-                break
+                break  # pair budget hit before this seed: not drained
 
             text = f"{node['title'] or ''} {node['content']}".strip()
             if not text:
+                drained_seeds.append((node["id"], node["seq"]))
                 continue
+
+            # FAIL-CLOSED (overview invariant, mirrors upstream auto_linker.py):
+            # a seed with text but no persisted vector must NOT drain — an
+            # empty/backfilling index would return zero neighbors and the
+            # cursor would pass pairs that were never derived.
+            if delta and vec_store.get(node["id"]) is None:
+                continue  # NOT appended to drained_seeds
 
             query_vec = stored_or_encoded(
                 vec_store,
@@ -203,13 +251,20 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
                     "node_a": _nd(node),
                     "node_b": _nd(other),
                     "similarity": round(similarity, 3),
+                    "seed_seq": node["seq"],
                 })
 
+            if len(candidates) >= limit:
+                break  # pair budget hit mid-seed: possibly partial, not drained
+            drained_seeds.append((node["id"], node["seq"]))
+
+        if delta:
+            return candidates, drained_seeds
         return candidates
 
     except Exception as e:
         logger.warning("_find_conflict_candidates failed: %s", e)
-        return []
+        return ([], []) if delta else []
 
 
 def run_conflict_detection(engine) -> None:

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -172,6 +172,7 @@ def _find_conflict_candidates(
 
         checked: set[tuple[str, str]] = set()
         candidates: list[dict] = []
+        barrier_hit = False
 
         for node in nodes:
             if len(candidates) >= limit:
@@ -179,16 +180,19 @@ def _find_conflict_candidates(
 
             text = f"{node['title'] or ''} {node['content']}".strip()
             if not text:
-                drained_seeds.append((node["id"], node["seq"]))
+                if not barrier_hit:
+                    drained_seeds.append((node["id"], node["seq"]))
                 continue
 
-            # FAIL-CLOSED BARRIER (overview invariant, mirrors upstream
-            # auto_linker.py): a seed with text but no persisted vector stops
-            # the batch here. `break`, not `continue` — a later seed must not
-            # drain and advance the watermark past this hole, or this seed's
-            # pairs are permanently skipped once its vector is backfilled.
+            # DRAIN BARRIER (overview invariant, mirrors upstream
+            # auto_linker.py): a seed with text but no persisted vector must
+            # not let the cursor advance past it — its pairs would be
+            # permanently skipped once the vector is backfilled. `continue`,
+            # not `break`: later seeds are still PROCESSED (liveness, mirrors
+            # auto_linker) but no further seed drains once the barrier is hit.
             if delta and vec_store.get(node["id"]) is None:
-                break
+                barrier_hit = True
+                continue
 
             query_vec = stored_or_encoded(
                 vec_store,
@@ -257,7 +261,8 @@ def _find_conflict_candidates(
 
             if len(candidates) >= limit:
                 break  # pair budget hit mid-seed: possibly partial, not drained
-            drained_seeds.append((node["id"], node["seq"]))
+            if not barrier_hit:
+                drained_seeds.append((node["id"], node["seq"]))
 
         if delta:
             return candidates, drained_seeds

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -132,15 +132,29 @@ def _llm_check_duplicate(settings, node_row, other_row) -> dict | None:
         return None
 
 
-def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
+def _find_merge_candidates(
+    engine,
+    limit: int = 8,
+    *,
+    max_seeds: int | None = None,
+    delta: bool = False,
+):
     """Find node pairs that might be duplicates.
 
-    Returns up to *limit* pairs as
-    ``[{"node_a": {...}, "node_b": {...}, "similarity": float, "score": float,
-        "embedding_sim": float, "title_sim": float, "token_sim": float}]``.
+    ``delta=False`` (default — agent path): today's ``ORDER BY RANDOM()``
+    selection, unchanged; returns a candidate list.
+
+    ``delta=True`` (background run only, #81): seeds are nodes with ``seq``
+    above the ``duplicate_check_watermark``, oldest-first, bounded by
+    *max_seeds* (default: ``duplicate_check_max_nodes_per_run``). Vector
+    neighbors are NOT age-filtered. Returns ``(candidates, drained_seeds)``;
+    candidates carry ``seed_seq``. Only ``run_duplicate_detection`` advances
+    the watermark. ``limit`` stays pair-denominated in both modes.
+
     Does NOT call the LLM — just applies the same pre-filters as
     ``run_duplicate_detection`` (same type, composite score threshold).
     """
+    drained_seeds: list[tuple[str, int]] = []
     try:
         from ormah.embeddings.encoder import get_encoder
         from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
@@ -148,21 +162,46 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
         settings = engine.settings
         encoder = get_encoder(settings)
         vec_store = VectorStore(engine.db)
-
         user_node_id = getattr(engine, "user_node_id", None)
-        nodes = engine.db.conn.execute("SELECT id, content, title, type FROM nodes ORDER BY RANDOM()").fetchall()
+
+        if delta:
+            from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark
+
+            if max_seeds is None:
+                max_seeds = settings.duplicate_check_max_nodes_per_run
+            watermark = get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY)
+            nodes = engine.db.conn.execute(
+                "SELECT id, content, title, type, seq FROM nodes "
+                "WHERE seq > ? ORDER BY seq ASC LIMIT ?",
+                (watermark, max_seeds),
+            ).fetchall()
+        else:
+            # Legacy selection — byte-for-byte today's query (agent path).
+            nodes = engine.db.conn.execute(
+                "SELECT id, content, title, type, seq FROM nodes ORDER BY RANDOM()"
+            ).fetchall()
+
         checked: set[tuple[str, str]] = set()
         candidates: list[dict] = []
 
         for node in nodes:
             if len(candidates) >= limit:
-                break
+                break  # pair budget hit before this seed: not drained
             if node["id"] == user_node_id:
+                drained_seeds.append((node["id"], node["seq"]))
                 continue
 
             text = f"{node['title'] or ''} {node['content']}".strip()
             if not text:
+                drained_seeds.append((node["id"], node["seq"]))
                 continue
+
+            # FAIL-CLOSED (overview invariant, mirrors upstream auto_linker.py):
+            # a seed with text but no persisted vector must NOT drain — an
+            # empty/backfilling index would return zero neighbors and the
+            # cursor would pass pairs that were never derived.
+            if delta and vec_store.get(node["id"]) is None:
+                continue  # NOT appended to drained_seeds
 
             query_vec = stored_or_encoded(
                 vec_store,
@@ -228,13 +267,20 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
                     "embedding_sim": round(embedding_sim, 3),
                     "title_sim": round(title_sim, 3),
                     "token_sim": round(token_sim, 3),
+                    "seed_seq": node["seq"],
                 })
 
+            if len(candidates) >= limit:
+                break  # pair budget hit mid-seed: possibly partial, not drained
+            drained_seeds.append((node["id"], node["seq"]))
+
+        if delta:
+            return candidates, drained_seeds
         return candidates
 
     except Exception as e:
         logger.warning("_find_merge_candidates failed: %s", e)
-        return []
+        return ([], []) if delta else []
 
 
 def run_duplicate_detection(engine) -> None:

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -213,6 +213,12 @@ def _find_merge_candidates(
             # not `break`: later seeds are still PROCESSED (liveness, mirrors
             # auto_linker) but no further seed drains once the barrier is hit.
             if delta and vec_store.get(node["id"]) is None:
+                if not barrier_hit:
+                    logger.warning(
+                        "duplicate delta stalled: node %s has no persisted vector (embedding "
+                        "backfill pending?); cursor parked at seq %s until it embeds",
+                        node["id"][:8], node["seq"],
+                    )
                 barrier_hit = True
                 continue
 

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -138,6 +138,7 @@ def _find_merge_candidates(
     *,
     max_seeds: int | None = None,
     delta: bool = False,
+    respect_checked: bool = True,
 ):
     """Find node pairs that might be duplicates.
 
@@ -150,6 +151,12 @@ def _find_merge_candidates(
     neighbors are NOT age-filtered. Returns ``(candidates, drained_seeds)``;
     candidates carry ``seed_seq``. Only ``run_duplicate_detection`` advances
     the watermark. ``limit`` stays pair-denominated in both modes.
+
+    ``respect_checked`` (default ``True``): skip pairs already present in
+    ``auto_link_checked``. Background dedup (``run_duplicate_detection``)
+    passes ``False`` — that table records auto_linker's LINK decisions
+    (including "no link"), not dedup verdicts, and relies on its own
+    seq-watermark for convergence instead.
 
     Does NOT call the LLM — just applies the same pre-filters as
     ``run_duplicate_detection`` (same type, composite score threshold).
@@ -183,26 +190,31 @@ def _find_merge_candidates(
 
         checked: set[tuple[str, str]] = set()
         candidates: list[dict] = []
+        barrier_hit = False
 
         for node in nodes:
             if len(candidates) >= limit:
                 break  # pair budget hit before this seed: not drained
             if node["id"] == user_node_id:
-                drained_seeds.append((node["id"], node["seq"]))
+                if not barrier_hit:
+                    drained_seeds.append((node["id"], node["seq"]))
                 continue
 
             text = f"{node['title'] or ''} {node['content']}".strip()
             if not text:
-                drained_seeds.append((node["id"], node["seq"]))
+                if not barrier_hit:
+                    drained_seeds.append((node["id"], node["seq"]))
                 continue
 
-            # FAIL-CLOSED BARRIER (overview invariant, mirrors upstream
-            # auto_linker.py): a seed with text but no persisted vector stops
-            # the batch here. `break`, not `continue` — a later seed must not
-            # drain and advance the watermark past this hole, or this seed's
-            # pairs are permanently skipped once its vector is backfilled.
+            # DRAIN BARRIER (overview invariant, mirrors upstream
+            # auto_linker.py): a seed with text but no persisted vector must
+            # not let the cursor advance past it — its pairs would be
+            # permanently skipped once the vector is backfilled. `continue`,
+            # not `break`: later seeds are still PROCESSED (liveness, mirrors
+            # auto_linker) but no further seed drains once the barrier is hit.
             if delta and vec_store.get(node["id"]) is None:
-                break
+                barrier_hit = True
+                continue
 
             query_vec = stored_or_encoded(
                 vec_store,
@@ -227,11 +239,12 @@ def _find_merge_candidates(
                     continue
                 checked.add(pair)
 
-                already_checked = engine.db.conn.execute(
-                    "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
-                ).fetchone()
-                if already_checked:
-                    continue
+                if respect_checked:
+                    already_checked = engine.db.conn.execute(
+                        "SELECT 1 FROM auto_link_checked WHERE node_a = ? AND node_b = ?", pair
+                    ).fetchone()
+                    if already_checked:
+                        continue
 
                 embedding_sim = match["similarity"]
                 if embedding_sim < 0.25:
@@ -273,7 +286,8 @@ def _find_merge_candidates(
 
             if len(candidates) >= limit:
                 break  # pair budget hit mid-seed: possibly partial, not drained
-            drained_seeds.append((node["id"], node["seq"]))
+            if not barrier_hit:
+                drained_seeds.append((node["id"], node["seq"]))
 
         if delta:
             return candidates, drained_seeds
@@ -304,7 +318,7 @@ def run_duplicate_detection(engine) -> None:
         )
 
         candidates, drained_seeds = _find_merge_candidates(
-            engine, limit=10_000, delta=True,
+            engine, limit=10_000, delta=True, respect_checked=False,
         )
         failed_seed_seqs: set[int] = set()
         proposals_created = 0

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -292,141 +292,119 @@ def run_duplicate_detection(engine) -> None:
     saying ``is_duplicate: true``.
     """
     try:
-        from ormah.embeddings.encoder import get_encoder
-        from ormah.embeddings.vector_store import VectorStore, stored_or_encoded
-
         settings = engine.settings
-        encoder = get_encoder(settings)
-        vec_store = VectorStore(engine.db)
 
         if not settings.llm_enabled:
             logger.debug("Duplicate detection skipped: LLM not enabled")
             return
 
-        user_node_id = getattr(engine, "user_node_id", None)
+        from ormah.background.watermark import (
+            DUPLICATE_WATERMARK_KEY, get_watermark, set_watermark,
+        )
 
-        nodes = engine.db.conn.execute("SELECT id, content, title, type FROM nodes").fetchall()
-        checked = set()
+        candidates, drained_seeds = _find_merge_candidates(
+            engine, limit=10_000, delta=True,
+        )
+        failed_seed_seqs: set[int] = set()
         proposals_created = 0
 
-        for node in nodes:
-            if node["id"] == user_node_id:
+        for cand in candidates:
+            # Re-fetch FULL rows: finder previews are truncated to 400 chars and
+            # merged_content must never be generated from truncated text.
+            node = engine.db.conn.execute(
+                "SELECT id, content, title, type FROM nodes WHERE id = ?",
+                (cand["node_a"]["id"],),
+            ).fetchone()
+            other = engine.db.conn.execute(
+                "SELECT id, content, title, type FROM nodes WHERE id = ?",
+                (cand["node_b"]["id"],),
+            ).fetchone()
+            if node is None or other is None:
+                continue  # merged/deleted earlier in this same run: drained
+
+            embedding_sim = cand["embedding_sim"]
+            title_sim = cand["title_sim"]
+            token_sim = cand["token_sim"]
+            score = cand["score"]
+
+            # --- LLM confirmation (mandatory) ---
+            llm_result = _llm_check_duplicate(settings, node, other)
+            if llm_result is None:
+                # LLM unavailable for this pair — skip, park the seed
+                failed_seed_seqs.add(cand["seed_seq"])
                 continue
-            text = f"{node['title'] or ''} {node['content']}".strip()
-            if not text:
+            if not llm_result.get("is_duplicate"):
+                logger.debug(
+                    "LLM rejected duplicate for %s / %s: %s",
+                    node["id"][:8], other["id"][:8],
+                    llm_result.get("reason", ""),
+                )
                 continue
 
-            query_vec = stored_or_encoded(
-                vec_store,
-                encoder,
-                node["id"],
-                node["title"],
-                node["content"],
-                settings.embedding_max_content_chars,
-            )
-            # Fetch more candidates since we use a lower embedding pre-filter
-            similar = vec_store.search(query_vec, limit=6)
+            # Extract LLM-generated merge content
+            merged_content = llm_result.get("merged_content")
+            merged_title = llm_result.get("merged_title")
+            reason = llm_result.get("reason", "LLM confirmed duplicate")
+            reason += f" (score={score:.3f}, embed={embedding_sim:.2f}, title={title_sim:.2f}, token={token_sim:.2f})"
 
-            for match in similar:
-                if match["id"] == node["id"]:
-                    continue
-                if match["id"] == user_node_id:
-                    continue
-
-                pair = tuple(sorted([node["id"], match["id"]]))
-                if pair in checked:
-                    continue
-                checked.add(pair)
-
-                embedding_sim = match["similarity"]
-                # Pre-filter: skip very dissimilar pairs to avoid wasted work
-                if embedding_sim < 0.25:
-                    continue
-
-                # Same type only
-                other = engine.db.conn.execute(
-                    "SELECT type, title, content FROM nodes WHERE id = ?", (match["id"],)
-                ).fetchone()
-                if other is None or other["type"] != node["type"]:
-                    continue
-
-                # Compute multi-signal score
-                title_sim = _title_similarity(node["title"], other["title"])
-                other_text = f"{other['title'] or ''} {other['content']}".strip()
-                token_sim = _token_overlap(text, other_text)
-                score = _composite_score(embedding_sim, title_sim, token_sim)
-
-                if score < _COMPOSITE_THRESHOLD:
-                    continue
-
-                # --- LLM confirmation (mandatory) ---
-                llm_result = _llm_check_duplicate(settings, node, other)
-                if llm_result is None:
-                    # LLM unavailable for this pair — skip
-                    continue
-                if not llm_result.get("is_duplicate"):
-                    logger.debug(
-                        "LLM rejected duplicate for %s / %s: %s",
-                        node["id"][:8], match["id"][:8],
-                        llm_result.get("reason", ""),
+            # Auto-merge for high-confidence duplicates
+            if score >= engine.settings.auto_merge_threshold:
+                try:
+                    result = engine.execute_merge(
+                        node["id"], other["id"],
+                        merged_content=merged_content,
+                        merged_title=merged_title,
                     )
+                    logger.info("Auto-merged: %s", result)
+                    proposals_created += 1
                     continue
+                except Exception as e:
+                    logger.warning("Auto-merge failed for %s / %s: %s",
+                                   node["id"][:8], other["id"][:8], e)
 
-                # Extract LLM-generated merge content
-                merged_content = llm_result.get("merged_content")
-                merged_title = llm_result.get("merged_title")
-                reason = llm_result.get("reason", "LLM confirmed duplicate")
-                reason += f" (score={score:.3f}, embed={embedding_sim:.2f}, title={title_sim:.2f}, token={token_sim:.2f})"
+            # Check no existing merge proposal
+            existing = engine.db.conn.execute(
+                "SELECT 1 FROM proposals WHERE type = 'merge' AND status = 'pending' "
+                "AND (source_nodes LIKE ? OR source_nodes LIKE ?)",
+                (f"%{node['id']}%", f"%{other['id']}%"),
+            ).fetchone()
 
-                # Auto-merge for high-confidence duplicates
-                if score >= engine.settings.auto_merge_threshold:
-                    try:
-                        result = engine.execute_merge(
-                            node["id"], match["id"],
-                            merged_content=merged_content,
-                            merged_title=merged_title,
-                        )
-                        logger.info("Auto-merged: %s", result)
-                        proposals_created += 1
-                        continue
-                    except Exception as e:
-                        logger.warning("Auto-merge failed for %s / %s: %s",
-                                       node["id"][:8], match["id"][:8], e)
+            if existing:
+                continue
 
-                # Check no existing merge proposal
-                existing = engine.db.conn.execute(
-                    "SELECT 1 FROM proposals WHERE type = 'merge' AND status = 'pending' "
-                    "AND (source_nodes LIKE ? OR source_nodes LIKE ?)",
-                    (f"%{node['id']}%", f"%{match['id']}%"),
-                ).fetchone()
+            # Build proposed_action — include merged content preview when available
+            proposed_action = f"Merge two {node['type']} memories into one"
+            if merged_content is not None:
+                proposed_action += (
+                    f"\n\nMerged content preview:\n---\n"
+                    f"{merged_title or ''}\n{merged_content}\n---"
+                )
 
-                if existing:
-                    continue
-
-                # Build proposed_action — include merged content preview when available
-                proposed_action = f"Merge two {node['type']} memories into one"
-                if merged_content is not None:
-                    proposed_action += (
-                        f"\n\nMerged content preview:\n---\n"
-                        f"{merged_title or ''}\n{merged_content}\n---"
-                    )
-
-                proposal_id = str(uuid.uuid4())
-                with engine.db.transaction() as conn:
-                    conn.execute(
-                        "INSERT INTO proposals (id, type, status, source_nodes, proposed_action, reason, created) "
-                        "VALUES (?, 'merge', 'pending', ?, ?, ?, ?)",
-                        (
-                            proposal_id,
-                            json.dumps([node["id"], match["id"]]),
-                            proposed_action,
-                            reason,
-                            datetime.now(timezone.utc).isoformat(),
-                        ),
-                    )
-                proposals_created += 1
+            proposal_id = str(uuid.uuid4())
+            with engine.db.transaction() as conn:
+                conn.execute(
+                    "INSERT INTO proposals (id, type, status, source_nodes, proposed_action, reason, created) "
+                    "VALUES (?, 'merge', 'pending', ?, ?, ?, ?)",
+                    (
+                        proposal_id,
+                        json.dumps([node["id"], other["id"]]),
+                        proposed_action,
+                        reason,
+                        datetime.now(timezone.utc).isoformat(),
+                    ),
+                )
+            proposals_created += 1
         if proposals_created:
             logger.info("Duplicate merger created %d proposals/auto-merges", proposals_created)
+
+        # ponytail: contiguous-prefix advance; deterministic failure parks the
+        # cursor — dead-letter escape hatch is upstream #122.
+        new_watermark = get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY)
+        for _seed_id, seed_seq in drained_seeds:  # ascending seq
+            if seed_seq in failed_seed_seqs:
+                break
+            new_watermark = seed_seq
+        set_watermark(engine, DUPLICATE_WATERMARK_KEY, new_watermark)
 
     except Exception as e:
         logger.warning("Duplicate detection failed: %s", e)

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -196,12 +196,13 @@ def _find_merge_candidates(
                 drained_seeds.append((node["id"], node["seq"]))
                 continue
 
-            # FAIL-CLOSED (overview invariant, mirrors upstream auto_linker.py):
-            # a seed with text but no persisted vector must NOT drain — an
-            # empty/backfilling index would return zero neighbors and the
-            # cursor would pass pairs that were never derived.
+            # FAIL-CLOSED BARRIER (overview invariant, mirrors upstream
+            # auto_linker.py): a seed with text but no persisted vector stops
+            # the batch here. `break`, not `continue` — a later seed must not
+            # drain and advance the watermark past this hole, or this seed's
+            # pairs are permanently skipped once its vector is backfilled.
             if delta and vec_store.get(node["id"]) is None:
-                continue  # NOT appended to drained_seeds
+                break
 
             query_vec = stored_or_encoded(
                 vec_store,

--- a/src/ormah/background/watermark.py
+++ b/src/ormah/background/watermark.py
@@ -1,0 +1,32 @@
+"""Shared seq-watermark helpers for incremental background jobs (#81).
+
+Generalizes the pattern auto_linker introduced in #26: a job records the seq
+of the last fully-processed node under a key in ``meta`` and selects only
+``seq > watermark`` on the next run. auto_linker still uses its private copy
+(kept untouched to avoid conflicts with queued PRs); migrating it here is a
+follow-up.
+"""
+
+from __future__ import annotations
+
+DUPLICATE_WATERMARK_KEY = "duplicate_check_watermark"
+CONFLICT_WATERMARK_KEY = "conflict_check_watermark"
+
+
+def get_watermark(conn, key: str) -> int:
+    """Return the seq of the last fully-processed node for *key*, or 0."""
+    row = conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
+    if row is None:
+        return 0
+    try:
+        return int(row["value"])
+    except (TypeError, ValueError):
+        return 0
+
+
+def set_watermark(engine, key: str, seq: int) -> None:
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            (key, str(seq)),
+        )

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -131,6 +131,8 @@ class Settings(BaseSettings):
     auto_link_cross_space_penalty: float = 0.1  # subtracted from similarity for cross-space pairs
     auto_link_max_edges_per_run: int = 500
     auto_link_max_nodes_per_run: int = 500  # cursor batch: nodes scanned per run
+    duplicate_check_max_nodes_per_run: int = 500  # seed batch per dedup run (#81)
+    conflict_check_max_nodes_per_run: int = 500   # seed batch per conflict run (#81)
 
     # Auto-merge
     auto_merge_threshold: float = 0.85

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -33,9 +33,12 @@ class IndexBuilder:
 
         # Mass reindex re-allocates seq from the durable counter; clear the watermark so the
         # rebuilt store is reprocessed even if the counter was also reset (wiped meta).
+        # Also clear the conflict scope-stamp so post-rebuild state is fully coherent
+        # (the stamp would otherwise linger and describe a scope for a watermark of 0).
         self.db.conn.execute(
             "DELETE FROM meta WHERE key IN "
-            "('auto_link_watermark', 'duplicate_check_watermark', 'conflict_check_watermark')"
+            "('auto_link_watermark', 'duplicate_check_watermark', 'conflict_check_watermark', "
+            "'conflict_check_watermark_scope')"
         )
 
         # Two-pass: nodes first, then edges (to satisfy FK constraints)

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -33,7 +33,10 @@ class IndexBuilder:
 
         # Mass reindex re-allocates seq from the durable counter; clear the watermark so the
         # rebuilt store is reprocessed even if the counter was also reset (wiped meta).
-        self.db.conn.execute("DELETE FROM meta WHERE key = 'auto_link_watermark'")
+        self.db.conn.execute(
+            "DELETE FROM meta WHERE key IN "
+            "('auto_link_watermark', 'duplicate_check_watermark', 'conflict_check_watermark')"
+        )
 
         # Two-pass: nodes first, then edges (to satisfy FK constraints)
         paths = list(self.file_store.list_paths())

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -489,6 +489,31 @@ def test_conflict_run_llm_disabled_does_not_advance_watermark(engine):
     assert get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY) == 0
 
 
+def test_conflict_run_vectorless_seed_blocks_watermark(engine):
+    """A vectorless seed must be a barrier: no later seed may drain past it,
+    or the watermark jumps a hole and the vectorless seed's pairs are never
+    re-checked once vectors are restored (#81 regression)."""
+    from ormah.background.conflict_detector import run_conflict_detection
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark
+
+    id_a, seq_a = _make_belief(engine, "Vectorless claim", "A statement whose vector went missing.")
+    id_b, seq_b = _make_belief(engine, "Second claim", "A second, unrelated statement.")
+    assert seq_a < seq_b
+
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (id_a,))  # only the LOWER-seq seed loses its vector
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_conflict_response()):
+        run_conflict_detection(engine)
+
+    # The vectorless seed (seq_a) is the lowest-seq selected node: with the
+    # `break` fix the finder stops there and drains nothing, so the
+    # watermark must stay at 0 (never jump the hole to seq_b).
+    assert get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY) == 0
+
+
 def test_run_with_no_new_nodes_is_a_noop(engine):
     from ormah.background.conflict_detector import run_conflict_detection
     from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark, set_watermark

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -422,6 +422,41 @@ def test_scope_toggle_resets_delta_selection(engine):
     assert (node_id, seq) in seeds  # stamp mismatch -> watermark treated as 0
 
 
+def test_scope_toggle_run_persists_watermark_reset_on_vectorless_barrier(engine):
+    """A scope flip must persist the watermark reset during THIS run, even if
+    the run itself drains nothing (vectorless barrier) — otherwise the reset
+    is lost and the next run's stamp already matches (#81 regression)."""
+    from ormah.background.conflict_detector import (
+        CONFLICT_SCOPE_STAMP_KEY, run_conflict_detection,
+    )
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark, set_watermark
+
+    engine.settings.conflict_check_all_spaces = False
+    lowest_id, lowest_seq = _make_belief(engine, "Global claim", "A plain global-space statement.")
+    _make_belief(engine, "Another global claim", "A second plain global-space statement.")
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+    # Simulate: already advanced under scope=global
+    set_watermark(engine, CONFLICT_WATERMARK_KEY, max_seq)
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            (CONFLICT_SCOPE_STAMP_KEY, "global"),
+        )
+
+    engine.settings.conflict_check_all_spaces = True  # operator flips the flag
+    # Vectorless barrier: the first newly-eligible seed has no vector
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (lowest_id,))
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_conflict_response()):
+        run_conflict_detection(engine)
+
+    # Nothing drained this run, but the reset must persist for next run.
+    assert get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY) == 0
+
+
 def _conflict_response():
     return json.dumps({
         "conflict": True, "same_subject": True, "relationship": "tension",

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -283,3 +283,140 @@ def test_project_scoped_nodes_skipped_by_default(engine):
 
     # LLM should never be called since project-scoped nodes are skipped
     mock_llm.assert_not_called()
+
+
+# --- #81 delta-selection ---
+
+def _make_belief(engine, title, content):
+    """Create a belief-type node without auto-linking; return (id, seq)."""
+    original = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        node_id, _ = engine.remember(
+            CreateNodeRequest(content=content, type=NodeType.fact, title=title, tags=["test"]),
+            agent_id="test",
+        )
+    finally:
+        engine.settings.auto_link_similarity_threshold = original
+    seq = engine.db.conn.execute("SELECT seq FROM nodes WHERE id = ?", (node_id,)).fetchone()["seq"]
+    return node_id, seq
+
+
+def test_delta_finder_skips_seeds_at_or_below_watermark(engine):
+    from ormah.background.conflict_detector import _find_conflict_candidates
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, set_watermark
+
+    _, seq_a = _make_belief(engine, "Coffee is healthy", "Coffee improves focus and health.")
+    _make_belief(engine, "Coffee is unhealthy", "Coffee harms sleep and health.")
+
+    # Watermark past ALL nodes -> no seeds -> no candidates
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+    set_watermark(engine, CONFLICT_WATERMARK_KEY, max_seq)
+    candidates, seeds = _find_conflict_candidates(engine, limit=100, delta=True)
+    assert candidates == [] and seeds == []
+
+    # Watermark below the pair -> pair found again
+    set_watermark(engine, CONFLICT_WATERMARK_KEY, seq_a - 1)
+    candidates, _ = _find_conflict_candidates(engine, limit=100, delta=True)
+    assert len(candidates) >= 1
+
+
+def test_legacy_mode_ignores_watermark(engine):
+    """Default call (agent path) keeps today's selection: nodes below the
+    watermark are still reachable and the return shape is a plain list."""
+    from ormah.background.conflict_detector import _find_conflict_candidates
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, set_watermark
+
+    _make_belief(engine, "Milk is good", "Milk strengthens bones at any age.")
+    _make_belief(engine, "Milk is bad", "Milk weakens bones at any age.")
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+    set_watermark(engine, CONFLICT_WATERMARK_KEY, max_seq)
+
+    candidates = _find_conflict_candidates(engine, limit=100)  # no delta kwarg
+    assert isinstance(candidates, list)
+    assert len(candidates) >= 1
+
+
+def test_new_seed_pairs_with_old_neighbor(engine):
+    """Neighbors are age-unfiltered: an OLD node below the watermark is still
+    reachable as the neighbor of a NEW seed."""
+    from ormah.background.conflict_detector import _find_conflict_candidates
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, set_watermark
+
+    old_id, old_seq = _make_belief(engine, "Tabs are best", "The project uses tabs for indentation.")
+    set_watermark(engine, CONFLICT_WATERMARK_KEY, old_seq)  # old node is below the cursor
+
+    new_id, _ = _make_belief(engine, "Spaces are best", "The project uses spaces for indentation.")
+
+    candidates, _ = _find_conflict_candidates(engine, limit=100, delta=True)
+    pair_ids = {(c["node_a"]["id"], c["node_b"]["id"]) for c in candidates}
+    assert any(old_id in p and new_id in p for p in pair_ids)
+
+
+def test_finder_respects_max_seeds_and_seq_order(engine):
+    from ormah.background.conflict_detector import _find_conflict_candidates
+
+    ids = [_make_belief(engine, f"Fact {i}", f"The sky color observation number {i} is blue.")
+           for i in range(3)]
+    candidates, seeds = _find_conflict_candidates(engine, limit=100, max_seeds=2, delta=True)
+    # Only the 2 lowest-seq nodes were seeds, in ascending order
+    assert [s[0] for s in seeds] == [ids[0][0], ids[1][0]]
+    assert [s[1] for s in seeds] == sorted(s[1] for s in seeds)
+    for c in candidates:
+        assert c["seed_seq"] in {ids[0][1], ids[1][1]}
+
+
+def test_finder_never_advances_watermark(engine):
+    """Agent path calls the finder directly; the cursor must not move."""
+    from ormah.background.conflict_detector import _find_conflict_candidates
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark
+
+    _make_belief(engine, "Bikes are green", "Cycling is an eco-friendly transport choice.")
+    _find_conflict_candidates(engine, limit=8)              # legacy mode
+    _find_conflict_candidates(engine, limit=8, delta=True)  # delta mode
+    assert get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY) == 0
+
+
+def test_empty_vector_index_does_not_advance_conflict_selection(engine):
+    """Fail-closed (overview invariant): a seed with text but NO persisted
+    vector must not drain — mirrors test_empty_vector_index_does_not_advance_watermark
+    in test_auto_linker.py."""
+    from ormah.background.conflict_detector import _find_conflict_candidates
+
+    node_id, seq = _make_belief(engine, "Vectorless claim", "A statement whose vector is missing.")
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")  # simulate rebuild-before-backfill window
+
+    _, seeds = _find_conflict_candidates(engine, limit=100, delta=True)
+    assert (node_id, seq) not in seeds  # not drained -> cursor cannot pass it
+
+
+def test_seedless_nodes_are_still_drained(engine):
+    """A seed whose pairs are all prefiltered still appears in the drained list
+    (it must not block the cursor)."""
+    from ormah.background.conflict_detector import _find_conflict_candidates
+
+    node_id, seq = _make_belief(engine, "Lone fact", "A completely unrelated singleton statement.")
+    _, seeds = _find_conflict_candidates(engine, limit=100, delta=True)
+    assert (node_id, seq) in seeds
+
+
+def test_scope_toggle_resets_delta_selection(engine):
+    """Nodes ingested while conflict_check_all_spaces was OFF must become
+    reachable when it turns ON, even if the cursor already passed them."""
+    from ormah.background.conflict_detector import _find_conflict_candidates
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, set_watermark
+
+    engine.settings.conflict_check_all_spaces = False
+    node_id, seq = _make_belief(engine, "Global claim", "A plain global-space statement.")
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+    set_watermark(engine, CONFLICT_WATERMARK_KEY, max_seq)
+    with engine.db.transaction() as conn:  # stamp as if advanced under scope=global
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES "
+            "('conflict_check_watermark_scope', 'global')"
+        )
+
+    engine.settings.conflict_check_all_spaces = True  # operator flips the flag
+    _, seeds = _find_conflict_candidates(engine, limit=100, delta=True)
+    assert (node_id, seq) in seeds  # stamp mismatch -> watermark treated as 0

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -420,3 +420,88 @@ def test_scope_toggle_resets_delta_selection(engine):
     engine.settings.conflict_check_all_spaces = True  # operator flips the flag
     _, seeds = _find_conflict_candidates(engine, limit=100, delta=True)
     assert (node_id, seq) in seeds  # stamp mismatch -> watermark treated as 0
+
+
+def _conflict_response():
+    return json.dumps({
+        "conflict": True, "same_subject": True, "relationship": "tension",
+        "reason": "Opposing claims.",
+    })
+
+
+def test_clean_run_advances_watermark_past_all_seeds(engine):
+    from ormah.background.conflict_detector import run_conflict_detection
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark
+
+    _make_belief(engine, "Tea is calming", "Tea makes the user calm in the evening.")
+    _make_belief(engine, "Tea is agitating", "Tea makes the user agitated in the evening.")
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_conflict_response()):
+        run_conflict_detection(engine)
+
+    assert get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY) == max_seq
+
+
+def test_llm_failure_parks_watermark_before_failed_seed(engine):
+    """Seed A succeeds, seed B's LLM check returns None -> cursor stops at A;
+    the next run re-selects B."""
+    from ormah.background.conflict_detector import (
+        _find_conflict_candidates, run_conflict_detection,
+    )
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark
+
+    _make_belief(engine, "Cats are aloof", "The cat ignores everyone at home.")
+    _make_belief(engine, "Cats are clingy", "The cat follows everyone at home.")
+    b_id, b_seq = _make_belief(engine, "Dogs bark a lot", "The dog barks at everything.")
+    _make_belief(engine, "Dogs are silent", "The dog never barks at anything.")
+
+    def llm_fails_for_b(settings, prompt, *args, **kwargs):
+        if "barks" in prompt:
+            return None          # seed involving the dog pair fails
+        return _conflict_response()
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, side_effect=llm_fails_for_b):
+        run_conflict_detection(engine)
+
+    wm = get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY)
+    assert wm < b_seq  # cursor did not pass the failed seed
+
+    # next run re-selects the failed seed
+    candidates = _find_conflict_candidates(engine, limit=100)
+    assert any(b_id in (c["node_a"]["id"], c["node_b"]["id"]) for c in candidates)
+
+
+def test_conflict_run_llm_disabled_does_not_advance_watermark(engine):
+    """The llm_enabled guard must run BEFORE selection: a disabled-LLM run
+    must not move the cursor (guard-reorder regression trap)."""
+    from ormah.background.conflict_detector import run_conflict_detection
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark
+
+    _make_belief(engine, "Any claim", "A statement that would otherwise be a seed.")
+    engine.settings.llm_provider = "none"
+    _reset_adapter()
+    run_conflict_detection(engine)
+    assert get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY) == 0
+
+
+def test_run_with_no_new_nodes_is_a_noop(engine):
+    from ormah.background.conflict_detector import run_conflict_detection
+    from ormah.background.watermark import CONFLICT_WATERMARK_KEY, get_watermark, set_watermark
+
+    _make_belief(engine, "Solo fact", "One isolated statement about nothing else.")
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+    set_watermark(engine, CONFLICT_WATERMARK_KEY, max_seq)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    llm = MagicMock(return_value=_conflict_response())
+    with patch(_LLM_PATCH, llm):
+        run_conflict_detection(engine)
+
+    llm.assert_not_called()
+    assert get_watermark(engine.db.conn, CONFLICT_WATERMARK_KEY) == max_seq

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -374,6 +374,65 @@ def test_dedup_run_vectorless_seed_blocks_watermark(engine):
     assert get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY) < seq_a
 
 
+def test_dedup_run_judges_pair_already_in_auto_link_checked(engine):
+    """Background dedup must not skip a pair merely because auto_linker
+    already recorded a link decision for it (#81 regression: auto_link_checked
+    is a LINK-decision log, not a dedup-skip list)."""
+    from datetime import datetime, timezone
+
+    from ormah.background.duplicate_merger import run_duplicate_detection
+
+    engine.settings.auto_merge_threshold = 999.0  # force proposal path
+    id_a, _ = _make_fact(engine, "Editor choice", "The user edits everything in neovim.")
+    id_b, _ = _make_fact(engine, "Editor pick", "The user does all editing in neovim.")
+
+    pair = tuple(sorted([id_a, id_b]))
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO auto_link_checked (node_a, node_b, result, checked_at) "
+            "VALUES (?, ?, ?, ?)",
+            (*pair, "none", datetime.now(timezone.utc).isoformat()),
+        )
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_duplicate_response()):
+        run_duplicate_detection(engine)
+
+    proposals = engine.db.conn.execute(
+        "SELECT 1 FROM proposals WHERE type = 'merge' AND status = 'pending'"
+    ).fetchall()
+    assert len(proposals) >= 1
+
+
+def test_dedup_run_processes_seeds_after_vectorless_barrier(engine):
+    """A vectorless barrier parks the cursor but must not stop later seeds
+    from being judged (liveness, mirrors upstream auto_linker)."""
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark
+
+    engine.settings.auto_merge_threshold = 999.0  # force proposal path
+    barrier_id, barrier_seq = _make_fact(engine, "Vectorless note", "A note whose vector went missing.")
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (barrier_id,))
+
+    id_a, _ = _make_fact(engine, "Editor choice", "The user edits everything in neovim.")
+    id_b, _ = _make_fact(engine, "Editor pick", "The user does all editing in neovim.")
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_duplicate_response()):
+        run_duplicate_detection(engine)
+
+    proposals = engine.db.conn.execute(
+        "SELECT 1 FROM proposals WHERE type = 'merge' AND status = 'pending'"
+    ).fetchall()
+    assert len(proposals) >= 1, "later seeds past the barrier must still be judged"
+
+    wm = get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY)
+    assert wm < barrier_seq  # cursor still parked before the barrier
+
+
 def test_auto_merge_survivor_requeues_into_delta(engine):
     """When a pair auto-merges mid-run, the survivor's content rewrite
     allocates a fresh seq (see test_seq_bumped_on_rewrite), so it re-enters

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -348,6 +348,32 @@ def test_dedup_run_llm_disabled_does_not_advance_watermark(engine):
     assert get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY) == 0
 
 
+def test_dedup_run_vectorless_seed_blocks_watermark(engine):
+    """A vectorless seed must be a barrier: no later seed may drain past it,
+    or the watermark jumps a hole and the vectorless seed's pairs are never
+    re-checked once vectors are restored (#81 regression)."""
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark
+
+    id_a, seq_a = _make_fact(engine, "Vectorless note", "A note whose vector went missing.")
+    id_b, seq_b = _make_fact(engine, "Second note", "A second, unrelated note.")
+    assert seq_a < seq_b
+
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id = ?", (id_a,))  # only the LOWER-seq seed loses its vector
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_duplicate_response()):
+        run_duplicate_detection(engine)
+
+    # With the `break` fix the finder stops at the vectorless barrier
+    # (seq_a): the cursor may advance past legitimately-drained seeds before
+    # it (e.g. the engine's own user_node), but must never reach seq_a or
+    # jump the hole to seq_b.
+    assert get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY) < seq_a
+
+
 def test_auto_merge_survivor_requeues_into_delta(engine):
     """When a pair auto-merges mid-run, the survivor's content rewrite
     allocates a fresh seq (see test_seq_bumped_on_rewrite), so it re-enters

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -156,3 +156,75 @@ def test_merged_content_stored_in_proposal(engine):
     assert "Python Programming Language" in proposal["proposed_action"]
     assert "Python is a popular programming language used widely." in proposal["proposed_action"]
     assert "Both describe Python" in proposal["reason"]
+
+
+# --- #81 delta-selection ---
+
+def _make_fact(engine, title, content):
+    """Create a node without auto-linking; return (id, seq)."""
+    original = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        node_id, _ = engine.remember(
+            CreateNodeRequest(content=content, type=NodeType.fact, title=title, tags=["test"]),
+            agent_id="test",
+        )
+    finally:
+        engine.settings.auto_link_similarity_threshold = original
+    seq = engine.db.conn.execute("SELECT seq FROM nodes WHERE id = ?", (node_id,)).fetchone()["seq"]
+    return node_id, seq
+
+
+def test_dedup_finder_skips_seeds_at_or_below_watermark(engine):
+    from ormah.background.duplicate_merger import _find_merge_candidates
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, set_watermark
+
+    _make_fact(engine, "Python is dynamic", "Python is a dynamically typed language.")
+    _make_fact(engine, "Python typing", "Python is a dynamically typed programming language.")
+
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+    set_watermark(engine, DUPLICATE_WATERMARK_KEY, max_seq)
+    candidates, seeds = _find_merge_candidates(engine, limit=100, delta=True)
+    assert candidates == [] and seeds == []
+    # legacy mode (agent path) ignores the watermark entirely
+    legacy = _find_merge_candidates(engine, limit=100)
+    assert isinstance(legacy, list) and len(legacy) >= 1
+
+
+def test_dedup_new_seed_pairs_with_old_neighbor(engine):
+    from ormah.background.duplicate_merger import _find_merge_candidates
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, set_watermark
+
+    old_id, old_seq = _make_fact(engine, "Server port", "The ormah server listens on port 8787.")
+    set_watermark(engine, DUPLICATE_WATERMARK_KEY, old_seq)
+
+    new_id, _ = _make_fact(engine, "Ormah port", "The ormah server runs on port 8787.")
+
+    candidates, _ = _find_merge_candidates(engine, limit=100, delta=True)
+    pair_ids = {(c["node_a"]["id"], c["node_b"]["id"]) for c in candidates}
+    assert any(old_id in p and new_id in p for p in pair_ids)
+
+
+def test_empty_vector_index_does_not_drain_dedup_seeds(engine):
+    """Fail-closed (overview invariant): seed with text but no persisted
+    vector must not drain (empty/backfilling node_vectors window)."""
+    from ormah.background.duplicate_merger import _find_merge_candidates
+
+    node_id, seq = _make_fact(engine, "Vectorless note", "A note whose vector is missing.")
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors")
+
+    _, seeds = _find_merge_candidates(engine, limit=100, delta=True)
+    assert (node_id, seq) not in seeds
+
+
+def test_dedup_finder_delta_reports_drained_in_seq_order(engine):
+    from ormah.background.duplicate_merger import _find_merge_candidates
+
+    made = [_make_fact(engine, f"Note {i}", f"Unrelated singleton note number {i}.")
+            for i in range(3)]
+    _, seeds = _find_merge_candidates(engine, limit=100, delta=True)
+    seed_ids = [s[0] for s in seeds]
+    for node_id, _seq in made:
+        assert node_id in seed_ids  # zero-candidate seeds still drained
+    assert [s[1] for s in seeds] == sorted(s[1] for s in seeds)

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest.mock import patch, MagicMock
 
 from ormah.models.node import CreateNodeRequest, NodeType
@@ -228,6 +229,22 @@ def test_dedup_finder_delta_reports_drained_in_seq_order(engine):
     for node_id, _seq in made:
         assert node_id in seed_ids  # zero-candidate seeds still drained
     assert [s[1] for s in seeds] == sorted(s[1] for s in seeds)
+
+
+def test_dedup_barrier_logs_once_per_run(engine, caplog):
+    """The vectorless drain barrier warns once per run, not once per seed."""
+    from ormah.background.duplicate_merger import _find_merge_candidates
+
+    id_a, _ = _make_fact(engine, "Vectorless note A", "First note whose vector is missing.")
+    id_b, _ = _make_fact(engine, "Vectorless note B", "Second note whose vector is missing.")
+    with engine.db.transaction() as conn:
+        conn.execute("DELETE FROM node_vectors WHERE id IN (?, ?)", (id_a, id_b))
+
+    with caplog.at_level(logging.WARNING):
+        _find_merge_candidates(engine, limit=100, delta=True)
+
+    matches = [r for r in caplog.records if "no persisted vector" in r.message]
+    assert len(matches) == 1
 
 
 def _duplicate_response():

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -228,3 +228,146 @@ def test_dedup_finder_delta_reports_drained_in_seq_order(engine):
     for node_id, _seq in made:
         assert node_id in seed_ids  # zero-candidate seeds still drained
     assert [s[1] for s in seeds] == sorted(s[1] for s in seeds)
+
+
+def _duplicate_response():
+    return json.dumps({
+        "is_duplicate": True,
+        "merged_title": "Merged fact",
+        "merged_content": "The merged content.",
+        "reason": "Same statement.",
+    })
+
+
+def test_run_does_not_rejudge_pair_below_watermark(engine):
+    """Reproduces #81: with the cursor past both nodes, a run must not spend
+    LLM calls on them again."""
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark, set_watermark
+
+    _make_fact(engine, "Editor choice", "The user edits everything in neovim.")
+    _make_fact(engine, "Editor pick", "The user does all editing in neovim.")
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+    set_watermark(engine, DUPLICATE_WATERMARK_KEY, max_seq)
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    llm = MagicMock(return_value=_duplicate_response())
+    with patch(_LLM_PATCH, llm):
+        run_duplicate_detection(engine)
+
+    llm.assert_not_called()
+    assert get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY) == max_seq
+
+
+def test_run_creates_proposal_for_delta_pair_and_advances(engine):
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark
+
+    engine.settings.auto_merge_threshold = 999.0  # force proposal path, not auto-merge
+    _make_fact(engine, "Backup time", "Backups run every night at 2am.")
+    _make_fact(engine, "Backup schedule", "The backup runs nightly at 2am.")
+    max_seq = engine.db.conn.execute("SELECT MAX(seq) m FROM nodes").fetchone()["m"]
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_duplicate_response()):
+        run_duplicate_detection(engine)
+
+    proposals = engine.db.conn.execute(
+        "SELECT 1 FROM proposals WHERE type = 'merge' AND status = 'pending'"
+    ).fetchall()
+    assert len(proposals) >= 1
+    assert get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY) == max_seq
+
+
+def test_run_judges_full_content_not_400_char_preview(engine):
+    """The LLM must receive the node's untruncated row (merge safety, parity
+    with today's run), not the finder's 400-char preview. The marker sits
+    beyond 400 chars but under _llm_check_duplicate's own pre-existing
+    2000-char ceiling."""
+    from ormah.background.duplicate_merger import run_duplicate_detection
+
+    marker = "UNIQUE-TAIL-MARKER-9137"
+    long_content = "The deploy procedure is documented step by step. " * 12 + marker
+    _make_fact(engine, "Deploy procedure", long_content)
+    _make_fact(engine, "Deployment steps", long_content.replace("documented", "written"))
+    assert len(long_content) > 400
+
+    seen_prompts: list[str] = []
+
+    # NOTE: _llm_check_duplicate calls llm_generate(settings, prompt, json_mode=True),
+    # so the mock MUST take `settings` FIRST — otherwise settings lands in `prompt`
+    # and `marker in p` silently reads False (bug caught in Task 3's analogous mock).
+    def capture(settings, prompt, *args, **kwargs):
+        seen_prompts.append(prompt)
+        return json.dumps({"is_duplicate": False, "reason": "distinct"})
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, side_effect=capture):
+        run_duplicate_detection(engine)
+
+    assert seen_prompts, "expected at least one LLM call for the near-duplicate pair"
+    assert any(marker in p for p in seen_prompts)
+
+
+def test_run_llm_failure_parks_dedup_watermark_exactly(engine):
+    """A clean seed batch BEFORE the failing pair advances; the cursor stops
+    exactly at the last clean seed before the failure (no `or wm == 0`
+    escape hatch — the advance must be exact)."""
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark
+
+    # unrelated singleton first: a clean, candidate-less seed with low seq
+    _, clean_seq = _make_fact(engine, "Lone note", "A singleton note about nothing similar.")
+    # then the near-duplicate pair whose LLM check will fail
+    _, pair_seq_a = _make_fact(engine, "Coffee dose", "The user drinks two espressos daily.")
+    _make_fact(engine, "Espresso habit", "The user has two espressos every day.")
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=None):  # LLM unavailable for every pair
+        run_duplicate_detection(engine)
+
+    wm = get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY)
+    assert wm >= clean_seq      # clean prefix advanced
+    assert wm < pair_seq_a      # cursor parked before the failed seed
+
+
+def test_dedup_run_llm_disabled_does_not_advance_watermark(engine):
+    """Guard order: `if not settings.llm_enabled: return` fires BEFORE any
+    selection or advance."""
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark
+
+    _make_fact(engine, "Any note", "A note that would otherwise be a seed.")
+    engine.settings.llm_provider = "none"
+    _reset_adapter()
+    run_duplicate_detection(engine)
+    assert get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY) == 0
+
+
+def test_auto_merge_survivor_requeues_into_delta(engine):
+    """When a pair auto-merges mid-run, the survivor's content rewrite
+    allocates a fresh seq (see test_seq_bumped_on_rewrite), so it re-enters
+    the delta on the next run — skipping its stale pairs loses no work."""
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.watermark import DUPLICATE_WATERMARK_KEY, get_watermark
+
+    engine.settings.auto_merge_threshold = 0.0  # force the auto-merge path
+    id_a, _ = _make_fact(engine, "Deploy cmd", "Deploy with make release every Friday.")
+    id_b, _ = _make_fact(engine, "Release cmd", "Release with make release every Friday.")
+
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+    with patch(_LLM_PATCH, return_value=_duplicate_response()):
+        run_duplicate_detection(engine)
+
+    survivors = [r["id"] for r in engine.db.conn.execute(
+        "SELECT id FROM nodes WHERE id IN (?, ?)", (id_a, id_b)).fetchall()]
+    assert len(survivors) == 1  # one node merged away
+    surv_seq = engine.db.conn.execute(
+        "SELECT seq FROM nodes WHERE id = ?", (survivors[0],)).fetchone()["seq"]
+    wm = get_watermark(engine.db.conn, DUPLICATE_WATERMARK_KEY)
+    assert surv_seq > wm  # survivor sits ABOVE the cursor: re-selected next run

--- a/tests/test_background/test_watermark.py
+++ b/tests/test_background/test_watermark.py
@@ -1,0 +1,48 @@
+"""Tests for the shared seq-watermark helpers (#81)."""
+
+from __future__ import annotations
+
+from ormah.background.watermark import get_watermark, set_watermark
+
+
+def test_default_is_zero(engine):
+    assert get_watermark(engine.db.conn, "duplicate_check_watermark") == 0
+
+
+def test_roundtrip(engine):
+    set_watermark(engine, "duplicate_check_watermark", 42)
+    assert get_watermark(engine.db.conn, "duplicate_check_watermark") == 42
+
+
+def test_overwrite(engine):
+    set_watermark(engine, "conflict_check_watermark", 7)
+    set_watermark(engine, "conflict_check_watermark", 9)
+    assert get_watermark(engine.db.conn, "conflict_check_watermark") == 9
+
+
+def test_keys_are_independent(engine):
+    set_watermark(engine, "duplicate_check_watermark", 5)
+    assert get_watermark(engine.db.conn, "conflict_check_watermark") == 0
+    # and independent of the auto_linker's key
+    assert get_watermark(engine.db.conn, "auto_link_watermark") == 0
+
+
+def test_malformed_value_reads_as_zero(engine):
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+            ("duplicate_check_watermark", "not-a-number"),
+        )
+    assert get_watermark(engine.db.conn, "duplicate_check_watermark") == 0
+
+
+def test_full_rebuild_resets_all_incremental_watermarks(engine):
+    """Mass reindex re-allocates seq; every incremental cursor must be cleared
+    (upstream already does this for auto_link_watermark, builder.py:36)."""
+    set_watermark(engine, "duplicate_check_watermark", 42)
+    set_watermark(engine, "conflict_check_watermark", 43)
+
+    engine.builder.full_rebuild()
+
+    assert get_watermark(engine.db.conn, "duplicate_check_watermark") == 0
+    assert get_watermark(engine.db.conn, "conflict_check_watermark") == 0


### PR DESCRIPTION
## What & why

Part of #81. `duplicate_merger` and `conflict_detector` selected candidates with
`ORDER BY RANDOM()` over the whole store every run, so on a growing store a genuinely-new
duplicate/conflict waited until chance surfaced its node — coverage never converged
(measured: 9,453 / 10,287 nodes never appeared in any checked pair). This applies the same
incremental **seq-watermark** pattern #26 gave `auto_linker` to its two O(n²) siblings, so
each background run processes only nodes newer than the last (O(Δ) instead of O(n²)).

## Design

- **Shared `background/watermark.py`** — key-parametrized `get`/`set` on `meta`
  (`duplicate_check_watermark`, `conflict_check_watermark`). `auto_linker` is left on its own
  private copy to keep this diff small; migrating it is a follow-up.
- **Opt-in `delta` flag on both finders.** `delta=False` (default) is today's `ORDER BY
  RANDOM()` selection **byte-for-byte** and a plain-list return — the agent / two-call
  maintenance path (`memory_engine.py`) is unchanged and never advances a cursor. Only the
  background `run_*` jobs pass `delta=True`. This is load-bearing: with the default
  `llm_provider="none"`, the `run_*` jobs never fire, so an agent-only deployment must keep
  the random path to make progress.
- **Vector neighbours stay age-unfiltered** — a new seed pairs against neighbours of any age,
  so every new duplicate/conflict (which always involves ≥1 new node) is reachable.
- **Watermark advances only past the contiguous drained prefix.** A seed with no persisted
  vector is a fail-closed **barrier** (the vector index can be empty/backfilling right after
  `full_rebuild`): later seeds are still processed (liveness, mirroring `auto_linker`) but no
  seed drains past the barrier, so the cursor can't jump the hole. An LLM-unavailable pair
  likewise stops the advance at its seed.
- **`run_duplicate_detection` re-fetches full rows** before the LLM/merge — the finder's
  candidate previews truncate content to 400 chars, and merging from a preview would corrupt
  node content.
- **`full_rebuild` clears all three cursors** (+ the conflict scope stamp), since mass reindex
  re-allocates `seq`.
- Config: `duplicate_check_max_nodes_per_run` / `conflict_check_max_nodes_per_run` (default 500),
  mirroring `auto_link_max_nodes_per_run`.

## Peer review

This went through the repo's peer-review pipeline, which caught three real correctness bugs,
each fixed with a regression test first:

1. **Vectorless watermark hole** — the advance considered only drained seeds, so a drained
   higher-seq seed advanced the cursor *past* a vectorless-skipped lower-seq seed, permanently
   stranding its pairs. Fixed by making the vectorless seed a drain barrier.
2. **Ephemeral scope reset** — the `conflict_check_all_spaces` reset lived only as a local var
   in the finder while the run wrote the scope stamp unconditionally; an empty/barrier batch
   therefore lost the reset. Fixed by persisting the reset in the run before selection.
3. **Background dedup inheriting `auto_link_checked`** — routing the run through the finder
   made background dedup skip every pair `auto_linker` had already examined (that table is
   auto_linker's alone). Fixed by having the background run ignore `auto_link_checked`
   (`respect_checked=False`); the agent path keeps it.

A once-per-run warning now logs when a vectorless barrier parks a cursor.

## Known limitations (follow-ups, out of scope here)

- **Embedding-corpus reindex does not reset the cursors** — `_reindex_all_embeddings` (an
  embedding schema/model upgrade) replaces vectors without bumping `seq` or clearing a
  watermark, so already-drained nodes aren't re-examined with the new embeddings. This is a
  pre-existing property of the #26 pattern (it affects `auto_link_watermark` identically) and a
  correct fix must distinguish a schema change from a missing-vector backfill (to avoid
  amplifying #32) — better as its own cross-cutting issue. A content *edit* is unaffected
  (`update_node` re-embeds and bumps `seq`).
- **A permanently-unembeddable node parks its cursor** and replays its batch's LLM work each
  run — the same fail-closed cost `auto_linker` carries; bounded-retry / dead-letter is #122.
- **Pending-proposal suppression** — a duplicate pair suppressed because one node sits in an
  unrelated pending merge proposal isn't re-judged after the seed passes (the OR-match is
  intentional — it serializes overlapping merges). Recovery on proposal rejection is a
  follow-up.

## Tests

New coverage for the watermark helper, delta vs legacy selection, new×old pairing, the
vectorless barrier (finder + run level, incl. liveness), scope-toggle reset (finder + run),
LLM-failure parking, the full-content re-fetch guard, and the `auto_link_checked` regression.
Full `tests/test_background/` passes (excluding two pre-existing environment-leak failures
unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

