### PR TITLE
perf(whisper): skip machine-generated turns at the /agent/whisper boundary (#134)

### DIFF
--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
 from ormah.background.maintenance_manager import MaintenanceManager
+from ormah.engine.prompt_classifier import is_synthetic_prompt
 from ormah.models.node import ConnectRequest, CreateNodeRequest, UpdateNodeRequest
 from ormah.models.proposals import ResolveProposalRequest
 from ormah.models.search import SearchQuery
@@ -136,6 +137,24 @@ async def whisper(request: Request):
     space = body.get("space")
     session_id = body.get("session_id", "")
     engine = request.app.state.engine
+
+    from ormah.config import settings as _settings
+
+    # Machine-generated turn (subagent notification, scheduled task, loop check):
+    # no human will read an injection, so skip BEFORE anything per-turn happens.
+    # This must stay above both the session buffer below (it feeds topic-shift and
+    # continuation for the NEXT human turn) and the engine (whose first statement
+    # consumes the one-time onboarding nudge) — both side effects are irreversible,
+    # so a guard further down cannot undo them (#134).
+    if _settings.whisper_synthetic_filter_enabled and is_synthetic_prompt(
+        prompt, _settings.whisper_synthetic_prompt_patterns
+    ):
+        await anyio.to_thread.run_sync(
+            lambda: engine.note_synthetic_whisper_skip(
+                prompt=prompt, space=space, session_id=session_id,
+            )
+        )
+        return TextResponse(text="")
 
     # Build recent_prompts from session buffer
     recent_prompts: list[str] | None = None

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -203,6 +203,15 @@ class Settings(BaseSettings):
     # Whisper intent classification
     whisper_intent_threshold: float = 0.65  # min cosine similarity for intent match
 
+    # Machine-generated turns (subagent task-notifications, scheduled tasks,
+    # autonomous-loop checks) reach the UserPromptSubmit hook like any prompt.
+    # Whispering into them burns encode+search+rerank where no human reads, and
+    # the injection can never be "referenced" — contaminating the usage judge.
+    # Defaults cover Claude Code's own markers; add install-specific regexes
+    # (headless scripts, other agents) here. Anchored at the prompt start.
+    whisper_synthetic_filter_enabled: bool = True
+    whisper_synthetic_prompt_patterns: list[str] = []
+
     # Whisper topic-shift detection (skip injection when topic unchanged)
     whisper_topic_shift_enabled: bool = True
     whisper_topic_shift_threshold: float = 0.75  # cosine sim above this = same topic

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 import numpy as np
 
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
+from ormah.engine.prompt_classifier import is_synthetic_prompt
 from ormah.index.graph import GraphIndex
 from ormah.text.tokens import distinctive_tokens
 
@@ -392,6 +393,26 @@ class ContextBuilder:
             logger.info(
                 "Whisper diagnostics: prompt=%r no_engine -> skip",
                 prompt_snippet,
+            )
+            if _return_debug:
+                return "", _injected_ids
+            return ""
+
+        # Machine-generated turn (subagent notification, scheduled task, loop
+        # check): no human will read the injection, and the usage judge would
+        # score it as an unreferenced miss. Skip before the classifier — the
+        # last point where no encode/search/rerank has been paid (#134).
+        _s = getattr(self.engine, "settings", None)
+        if getattr(_s, "whisper_synthetic_filter_enabled", True) and is_synthetic_prompt(
+            prompt, getattr(_s, "whisper_synthetic_prompt_patterns", ()) or ()
+        ):
+            logger.info(
+                "Whisper diagnostics: prompt=%r synthetic_prompt -> skip",
+                prompt_snippet,
+            )
+            self._log_decision(
+                session_id=session_id, space=space, prompt=prompt,
+                intent=None, outcome="silent_synthetic",
             )
             if _return_debug:
                 return "", _injected_ids

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 import numpy as np
 
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
-from ormah.engine.prompt_classifier import is_synthetic_prompt
 from ormah.index.graph import GraphIndex
 from ormah.text.tokens import distinctive_tokens
 
@@ -393,26 +392,6 @@ class ContextBuilder:
             logger.info(
                 "Whisper diagnostics: prompt=%r no_engine -> skip",
                 prompt_snippet,
-            )
-            if _return_debug:
-                return "", _injected_ids
-            return ""
-
-        # Machine-generated turn (subagent notification, scheduled task, loop
-        # check): no human will read the injection, and the usage judge would
-        # score it as an unreferenced miss. Skip before the classifier — the
-        # last point where no encode/search/rerank has been paid (#134).
-        _s = getattr(self.engine, "settings", None)
-        if getattr(_s, "whisper_synthetic_filter_enabled", True) and is_synthetic_prompt(
-            prompt, getattr(_s, "whisper_synthetic_prompt_patterns", ()) or ()
-        ):
-            logger.info(
-                "Whisper diagnostics: prompt=%r synthetic_prompt -> skip",
-                prompt_snippet,
-            )
-            self._log_decision(
-                session_id=session_id, space=space, prompt=prompt,
-                intent=None, outcome="silent_synthetic",
             )
             if _return_debug:
                 return "", _injected_ids

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1065,6 +1065,24 @@ class MemoryEngine:
 
         return f"Connected {req.source_id[:8]}... →[{req.edge.value}]→ {req.target_id[:8]}..."
 
+    def note_synthetic_whisper_skip(
+        self,
+        prompt: str,
+        space: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Record a whisper call skipped because the prompt was machine-generated.
+
+        Called from the ``/agent/whisper`` boundary instead of ``get_whisper_context``:
+        the skip has to happen before this engine runs at all (its first statement
+        consumes the one-time onboarding nudge), so the decision row is written here
+        to keep ``whisper_decisions`` one-row-per-call (#134).
+        """
+        self.context_builder._log_decision(
+            session_id=session_id, space=space, prompt=prompt,
+            intent=None, outcome="silent_synthetic",
+        )
+
     def get_whisper_context(
         self,
         prompt: str,

--- a/src/ormah/engine/prompt_classifier.py
+++ b/src/ormah/engine/prompt_classifier.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
@@ -12,6 +13,39 @@ import numpy as np
 from ormah.embeddings.base import EmbeddingAdapter
 
 logger = logging.getLogger(__name__)
+
+# Machine-generated turns that reach the UserPromptSubmit hook. Matched ANCHORED
+# at the start of the prompt: a human ASKING about one of these markers is a real
+# prompt and still gets a whisper. Fail-open — when in doubt, whisper.
+# Deliberately excluded: wrapper tags like <ide_opened_file> and <system-reminder>,
+# which PREFIX a real human prompt rather than replace it (issue #134).
+_SYNTHETIC_PATTERNS = (
+    re.compile(r"<task-notification>"),
+    re.compile(r"<scheduled-task\b"),
+    re.compile(r"#\s*Autonomous loop check\b"),
+)
+
+
+def is_synthetic_prompt(prompt: str, extra_patterns: Sequence[str] = ()) -> bool:
+    """True when the prompt was authored by a machine, not a human.
+
+    ``extra_patterns`` carries install-specific regexes from settings; the
+    defaults stay generic to Claude Code. An invalid pattern is logged and
+    ignored — a config typo must never take the whisper down.
+    """
+    text = prompt.lstrip()
+    if not text:
+        return False
+    if any(p.match(text) for p in _SYNTHETIC_PATTERNS):
+        return True
+    for raw in extra_patterns or ():
+        try:
+            if re.match(raw, text):
+                return True
+        except (re.error, TypeError) as e:
+            logger.warning("Ignoring invalid synthetic-prompt pattern %r: %s", raw, e)
+    return False
+
 
 # Archetype prompts per intent category.  More examples = better embedding
 # space coverage for paraphrases the user might actually type.

--- a/src/ormah/engine/prompt_classifier.py
+++ b/src/ormah/engine/prompt_classifier.py
@@ -20,9 +20,9 @@ logger = logging.getLogger(__name__)
 # Deliberately excluded: wrapper tags like <ide_opened_file> and <system-reminder>,
 # which PREFIX a real human prompt rather than replace it (issue #134).
 _SYNTHETIC_PATTERNS = (
-    re.compile(r"<task-notification>"),
-    re.compile(r"<scheduled-task\b"),
-    re.compile(r"#\s*Autonomous loop check\b"),
+    re.compile(r"<task-notification>", re.IGNORECASE),
+    re.compile(r"<scheduled-task\b", re.IGNORECASE),
+    re.compile(r"#\s*Autonomous loop check\b", re.IGNORECASE),
 )
 
 

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -203,6 +203,7 @@ CREATE TABLE IF NOT EXISTS whisper_decisions (
     outcome         TEXT NOT NULL,      -- 'injected' | 'silent_short' | 'silent_conversational'
                                         -- | 'silent_topic_shift' | 'silent_no_candidates'
                                         -- | 'silent_gate' | 'silent_blackout' | 'silent_error'
+                                        -- | 'silent_synthetic'
     candidate_count INTEGER DEFAULT 0,  -- results returned by search before filtering
     injected_count  INTEGER DEFAULT 0,  -- memories actually injected
     max_gate_score  REAL,               -- best absolute gate score among candidates

--- a/tests/test_engine/test_prompt_classifier.py
+++ b/tests/test_engine/test_prompt_classifier.py
@@ -11,6 +11,7 @@ from ormah.engine.prompt_classifier import (
     PromptClassifier,
     PromptIntent,
     extract_time_params,
+    is_synthetic_prompt,
     strip_temporal_phrases,
 )
 
@@ -512,3 +513,49 @@ class TestContinuationIntent:
         intent = classifier.classify("continue where we left off")
         assert "continuation" in intent.categories
         assert "created_after" in intent.search_params
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-prompt filter (issue #134)
+# ---------------------------------------------------------------------------
+
+
+class TestIsSyntheticPrompt:
+    def test_task_notification_is_synthetic(self):
+        assert is_synthetic_prompt("<task-notification>\n<task-id>abc</task-id>") is True
+
+    def test_scheduled_task_is_synthetic(self):
+        assert is_synthetic_prompt('<scheduled-task name="drive-watch" file="/x/S.md">') is True
+
+    def test_autonomous_loop_is_synthetic(self):
+        assert is_synthetic_prompt("# Autonomous loop check\n\nYou're being invoked") is True
+
+    def test_leading_whitespace_still_matches(self):
+        assert is_synthetic_prompt("\n  <task-notification>\n<task-id>a</task-id>") is True
+
+    def test_ide_wrapper_with_human_prompt_is_not_synthetic(self):
+        # REGRESSION GUARD (issue #134): the IDE prefixes this tag to a REAL human
+        # prompt — 46/46 such events on the live DB carried human text. Filtering it
+        # would silence the whisper for every prompt sent with a file open in the IDE.
+        prompt = (
+            "<ide_opened_file>The user opened the file /x/notes.md in the IDE."
+            "</ide_opened_file>\nnão, isso fica em estratégia — revisa o portfólio"
+        )
+        assert is_synthetic_prompt(prompt) is False
+
+    def test_human_asking_about_a_marker_is_not_synthetic(self):
+        # The anchor is deliberate and fail-open: when in doubt, whisper.
+        assert is_synthetic_prompt("what is a <task-notification> block?") is False
+
+    def test_extra_pattern_from_settings_matches(self):
+        assert is_synthetic_prompt(
+            "You are classifying the relationship between two memories",
+            extra_patterns=[r"You are classifying the relationship"],
+        ) is True
+
+    def test_invalid_extra_pattern_fails_open(self):
+        # A config typo must degrade to "filters less", never kill the whisper.
+        assert is_synthetic_prompt("hello there", extra_patterns=["[unclosed"]) is False
+
+    def test_empty_prompt_is_not_synthetic(self):
+        assert is_synthetic_prompt("") is False

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -2853,52 +2853,21 @@ class TestWhisperDecisions:
             "SELECT * FROM whisper_decisions ORDER BY id"
         ).fetchall()
 
-    def test_synthetic_prompt_logs_silent_synthetic(self, db_graph):
+    def test_note_synthetic_whisper_skip_writes_the_decision_row(self, db_graph):
+        # The skip itself happens at the /agent/whisper boundary (see
+        # TestSyntheticPromptEndpoint); the engine only records it, so
+        # whisper_decisions stays one-row-per-call.
         db, graph = db_graph
         builder = self._builder_with_db(db, graph)
-
-        out = builder.build_whisper_context(
-            prompt="<task-notification>\n<task-id>x</task-id>\n<status>done</status>",
-            session_id="s-synth",
+        builder._log_decision(
+            session_id="s-synth", space="proj", prompt="<task-notification>\n<task-id>x</task-id>",
+            intent=None, outcome="silent_synthetic",
         )
 
-        assert out == ""
         rows = self._decisions(db)
         assert len(rows) == 1
         assert rows[0]["outcome"] == "silent_synthetic"
         assert rows[0]["session_id"] == "s-synth"
-
-    def test_ide_wrapped_human_prompt_is_not_skipped(self, db_graph):
-        # REGRESSION GUARD (issue #134): must NOT log silent_synthetic — this is a
-        # real human prompt the IDE merely prefixed. 46/46 live events carried
-        # human text after the tag, so filtering it would silence the whisper
-        # whenever a file is open in the IDE.
-        db, graph = db_graph
-        builder = self._builder_with_db(db, graph, results=[])
-
-        builder.build_whisper_context(
-            prompt=("<ide_opened_file>The user opened /x/a.md in the IDE."
-                    "</ide_opened_file>\nrevisa o portfólio de segurança"),
-            session_id="s-ide",
-        )
-
-        rows = self._decisions(db)
-        assert len(rows) == 1
-        assert rows[0]["outcome"] != "silent_synthetic"
-
-    def test_filter_disabled_does_not_skip(self, db_graph):
-        db, graph = db_graph
-        builder = self._builder_with_db(db, graph, results=[])
-        builder.engine.settings = _make_settings_mock(
-            whisper_synthetic_filter_enabled=False,
-        )
-
-        builder.build_whisper_context(
-            prompt="<task-notification>\n<task-id>x</task-id>", session_id="s-off",
-        )
-
-        rows = self._decisions(db)
-        assert rows[0]["outcome"] != "silent_synthetic"
 
     def test_short_prompt_logs_silent_short(self, db_graph):
         db, graph = db_graph
@@ -3221,6 +3190,105 @@ class TestTopicShiftServedMemory:
             )
 
         assert "Sessionless topic memory" not in result
+
+
+class TestSyntheticPromptEndpoint:
+    """A machine-generated turn is skipped at the /agent/whisper boundary,
+    BEFORE any per-turn state mutation (#134).
+
+    The guard must sit above the session buffer and above the engine, because
+    both carry irreversible per-turn side effects: the ring buffer feeds
+    topic-shift/continuation for the NEXT human turn, and the engine's first
+    statement consumes the one-time onboarding nudge (meta.onboarding_prompted).
+    """
+
+    def _client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ormah.api.routes_agent import router
+
+        app = FastAPI()
+        app.include_router(router)
+        engine = MagicMock()
+        engine.get_whisper_context.return_value = ""
+        app.state.engine = engine
+        return TestClient(app), engine
+
+    def test_synthetic_prompt_never_reaches_the_engine(self):
+        # REGRESSION GUARD (#134, council/codex R1): the engine's first statement is
+        # _maybe_get_onboarding_nudge, which INSERTs meta.onboarding_prompted and
+        # returns the nudge exactly once. If a machine turn reaches the engine, it
+        # burns the onboarding and the first human never sees it.
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": "<task-notification>\n<task-id>x</task-id>",
+                  "session_id": "s-synth"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["text"] == ""
+        engine.get_whisper_context.assert_not_called()
+        _session_buffers.clear()
+
+    def test_synthetic_prompt_does_not_enter_the_session_buffer(self):
+        # A machine turn must not pollute recent_prompts: the buffer feeds the
+        # topic-shift centroid for the next HUMAN turn.
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, _ = self._client()
+
+        client.post(
+            "/agent/whisper",
+            json={"prompt": "<scheduled-task name=\"drive-watch\" file=\"/x/S.md\">",
+                  "session_id": "s-buf"},
+        )
+
+        assert "s-buf" not in _session_buffers
+        _session_buffers.clear()
+
+    def test_synthetic_prompt_records_telemetry(self):
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        client.post(
+            "/agent/whisper",
+            json={"prompt": "<task-notification>\n<task-id>x</task-id>",
+                  "session_id": "s-tel", "space": "proj"},
+        )
+
+        engine.note_synthetic_whisper_skip.assert_called_once()
+        kwargs = engine.note_synthetic_whisper_skip.call_args.kwargs
+        assert kwargs["session_id"] == "s-tel"
+        assert kwargs["space"] == "proj"
+        _session_buffers.clear()
+
+    def test_ide_wrapped_human_prompt_reaches_the_engine(self):
+        # REGRESSION GUARD (#134): <ide_opened_file> merely PREFIXES a real human
+        # prompt (46/46 on a live 30d corpus) — it must flow through untouched.
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": ("<ide_opened_file>The user opened /x/a.md in the IDE."
+                             "</ide_opened_file>\nrevisa o portfólio de segurança"),
+                  "session_id": "s-ide"},
+        )
+
+        assert resp.status_code == 200
+        engine.get_whisper_context.assert_called_once()
+        assert "s-ide" in _session_buffers
+        _session_buffers.clear()
 
 
 class TestSessionBufferEviction:

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -1778,9 +1778,13 @@ def _make_settings_mock(
     claude_maintenance_enabled=False,
     whisper_no_overlap_ce_floor=0.45,
     whisper_no_overlap_cosine_floor=0.70,
+    whisper_synthetic_filter_enabled=True,
+    whisper_synthetic_prompt_patterns=(),
 ):
     """Create a MagicMock settings object with affinity-related float attributes."""
     settings = MagicMock()
+    settings.whisper_synthetic_filter_enabled = whisper_synthetic_filter_enabled
+    settings.whisper_synthetic_prompt_patterns = whisper_synthetic_prompt_patterns
     settings.whisper_reranker_min_score = whisper_reranker_min_score
     settings.whisper_exploration_enabled = whisper_exploration_enabled
     settings.affinity_similarity_threshold = affinity_similarity_threshold
@@ -2848,6 +2852,53 @@ class TestWhisperDecisions:
         return db.conn.execute(
             "SELECT * FROM whisper_decisions ORDER BY id"
         ).fetchall()
+
+    def test_synthetic_prompt_logs_silent_synthetic(self, db_graph):
+        db, graph = db_graph
+        builder = self._builder_with_db(db, graph)
+
+        out = builder.build_whisper_context(
+            prompt="<task-notification>\n<task-id>x</task-id>\n<status>done</status>",
+            session_id="s-synth",
+        )
+
+        assert out == ""
+        rows = self._decisions(db)
+        assert len(rows) == 1
+        assert rows[0]["outcome"] == "silent_synthetic"
+        assert rows[0]["session_id"] == "s-synth"
+
+    def test_ide_wrapped_human_prompt_is_not_skipped(self, db_graph):
+        # REGRESSION GUARD (issue #134): must NOT log silent_synthetic — this is a
+        # real human prompt the IDE merely prefixed. 46/46 live events carried
+        # human text after the tag, so filtering it would silence the whisper
+        # whenever a file is open in the IDE.
+        db, graph = db_graph
+        builder = self._builder_with_db(db, graph, results=[])
+
+        builder.build_whisper_context(
+            prompt=("<ide_opened_file>The user opened /x/a.md in the IDE."
+                    "</ide_opened_file>\nrevisa o portfólio de segurança"),
+            session_id="s-ide",
+        )
+
+        rows = self._decisions(db)
+        assert len(rows) == 1
+        assert rows[0]["outcome"] != "silent_synthetic"
+
+    def test_filter_disabled_does_not_skip(self, db_graph):
+        db, graph = db_graph
+        builder = self._builder_with_db(db, graph, results=[])
+        builder.engine.settings = _make_settings_mock(
+            whisper_synthetic_filter_enabled=False,
+        )
+
+        builder.build_whisper_context(
+            prompt="<task-notification>\n<task-id>x</task-id>", session_id="s-off",
+        )
+
+        rows = self._decisions(db)
+        assert rows[0]["outcome"] != "silent_synthetic"
 
     def test_short_prompt_logs_silent_short(self, db_graph):
         db, graph = db_graph

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -2856,18 +2856,26 @@ class TestWhisperDecisions:
     def test_note_synthetic_whisper_skip_writes_the_decision_row(self, db_graph):
         # The skip itself happens at the /agent/whisper boundary (see
         # TestSyntheticPromptEndpoint); the engine only records it, so
-        # whisper_decisions stays one-row-per-call.
+        # whisper_decisions stays one-row-per-call. Goes through the real
+        # MemoryEngine method to cover the endpoint -> engine wiring.
+        from ormah.engine.memory_engine import MemoryEngine
+
         db, graph = db_graph
         builder = self._builder_with_db(db, graph)
-        builder._log_decision(
-            session_id="s-synth", space="proj", prompt="<task-notification>\n<task-id>x</task-id>",
-            intent=None, outcome="silent_synthetic",
+        engine = MagicMock(spec=MemoryEngine)
+        engine.context_builder = builder
+        MemoryEngine.note_synthetic_whisper_skip(
+            engine,
+            prompt="<task-notification>\n<task-id>x</task-id>",
+            space="proj",
+            session_id="s-synth",
         )
 
         rows = self._decisions(db)
         assert len(rows) == 1
         assert rows[0]["outcome"] == "silent_synthetic"
         assert rows[0]["session_id"] == "s-synth"
+        assert rows[0]["space"] == "proj"
 
     def test_short_prompt_logs_silent_short(self, db_graph):
         db, graph = db_graph
@@ -3288,6 +3296,45 @@ class TestSyntheticPromptEndpoint:
         assert resp.status_code == 200
         engine.get_whisper_context.assert_called_once()
         assert "s-ide" in _session_buffers
+        _session_buffers.clear()
+
+    def test_kill_switch_lets_synthetic_prompts_through(self, monkeypatch):
+        from ormah.api.routes_agent import _session_buffers
+        from ormah.config import settings as global_settings
+
+        monkeypatch.setattr(global_settings, "whisper_synthetic_filter_enabled", False)
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        client.post(
+            "/agent/whisper",
+            json={"prompt": "<task-notification>\n<task-id>x</task-id>",
+                  "session_id": "s-killswitch"},
+        )
+
+        engine.get_whisper_context.assert_called_once()
+        engine.note_synthetic_whisper_skip.assert_not_called()
+        _session_buffers.clear()
+
+    def test_extra_patterns_from_settings_apply_at_the_boundary(self, monkeypatch):
+        from ormah.api.routes_agent import _session_buffers
+        from ormah.config import settings as global_settings
+
+        monkeypatch.setattr(
+            global_settings, "whisper_synthetic_prompt_patterns",
+            [r"You are classifying the relationship"],
+        )
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": "You are classifying the relationship between two memories",
+                  "session_id": "s-extra"},
+        )
+
+        assert resp.json()["text"] == ""
+        engine.get_whisper_context.assert_not_called()
         _session_buffers.clear()
 
 


### PR DESCRIPTION
Fixes #134.

## Problem

The `UserPromptSubmit` hook fires on every turn, including machine-authored ones: subagent `<task-notification>` blocks, scheduled tasks, autonomous-loop checks. The whisper pipeline pays a full encode + hybrid search + cross-encoder rerank on prompts no human will read, and records the outcome as a real recall event.

Measured on a live 30-day corpus (`retrieval_events`, 1,716 prompts with text): **631 events (36.8%) are machine-authored end-to-end, and 421 of them received an injection.** These injections can never be "referenced", so the heuristic usage judge counts each one as an unreferenced miss — depressing the observed usage rate and inflating `silent_gate` with calls that should never have been made.

## What this does

A `is_synthetic_prompt()` predicate plus a guard at the `/agent/whisper` boundary, before any per-turn state changes.

**The guard's placement is load-bearing.** It cannot live inside `ContextBuilder`, because two irreversible side effects happen above it:

- `routes_agent` appends the prompt to the session ring buffer *before* calling the engine, polluting the topic-shift centroid for the next human turn.
- `get_whisper_context`'s first statement is `_maybe_get_onboarding_nudge`, which `INSERT`s `meta.onboarding_prompted` and returns the nudge exactly once. Since `get_whisper_context` returns `onboarding` when the builder yields `""`, a task-notification on a fresh install consumed the one-time onboarding — and the first human never saw it.

Telemetry is preserved via `MemoryEngine.note_synthetic_whisper_skip`, keeping `whisper_decisions` one-row-per-call with a new `silent_synthetic` outcome. No migration: `outcome` is free-text and `_whisper_decision_stats` aggregates with an open `GROUP BY`.

## Wrapper tags are deliberately NOT filtered

`<ide_opened_file>` (and `<system-reminder>`, `<command-name>`) **prefix a real human prompt** rather than replace it — **46 of 46** such events on the live corpus carried human text after the tag. Filtering on those prefixes would silence the whisper for every prompt sent with a file open in the IDE. Two regression tests lock this door.

The same reasoning drives anchoring at the prompt start: a human asking *"what is a `<task-notification>` block?"* still gets a whisper. When in doubt, whisper.

## Defaults vs configuration

Defaults cover only Claude Code's own markers (`<task-notification>`, `<scheduled-task`, `# Autonomous loop check`) — **295 events / 17.2%** on the measured corpus. Install-specific traffic (headless scripts, other agents) goes in `whisper_synthetic_prompt_patterns` rather than upstream defaults, which would be over-fitting to one install. An invalid regex there is logged and ignored: a config typo must degrade to "filters less", never take the whisper down.

`whisper_synthetic_filter_enabled` is the kill-switch.

## Verification

Beyond the tests, verified against the live corpus and a running server:

- Predicate over 1,716 real prompts: 295 matched by defaults (17.2%), **0 of the 46 wrapper-prefixed human prompts** wrongly filtered.
- Live probe on a running instance: synthetic turn → `{"text":""}` and `silent_synthetic` logged with **0 rows in `retrieval_events`**; IDE-wrapped human prompt → whispers injected normally.

## Notes

There is no structural signal to detect machine turns — the `UserPromptSubmit` payload is `session_id, transcript_path, cwd, prompt_id, permission_mode, hook_event_name, prompt` (captured from a real `claude -p` run). Prefix matching is the only route available, and pattern lists rot: if the `silent_synthetic` count falls toward zero while synthetic traffic continues, the markers went stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)