### PR TITLE
feat(maintenance): detect synthetic-prompt patterns that stopped matching and propose corrections (#143)

### DIFF
--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -28,6 +28,9 @@ _TASK_RUNNERS = {
     "memory_backup": ("ormah.backup", "run_auto_backup"),
     "cloud_backup": ("ormah.cloud.jobs", "run_cloud_backup"),
     "restore_verification": ("ormah.cloud.jobs", "run_restore_verification"),
+    "synthetic_pattern_monitor": (
+        "ormah.background.synthetic_pattern_monitor", "run_synthetic_pattern_monitor",
+    ),
 }
 
 _TASK_DESCRIPTIONS = {
@@ -43,6 +46,7 @@ _TASK_DESCRIPTIONS = {
     "memory_backup": "Creates a local backup of memory source files when one is due.",
     "cloud_backup": "Encrypts and uploads a due cloud backup without changing the sync head.",
     "restore_verification": "Downloads, decrypts, rebuilds, and searches the latest cloud backup.",
+    "synthetic_pattern_monitor": "Detects synthetic-prompt patterns that stopped matching and proposes removing or repairing them. Proposes only — never edits your config (#143).",
 }
 
 # Order for sleep cycle (full maintenance pass)

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
 from ormah.background.maintenance_manager import MaintenanceManager
+from ormah.engine.prompt_classifier import is_synthetic_prompt
 from ormah.models.node import ConnectRequest, CreateNodeRequest, UpdateNodeRequest
 from ormah.models.proposals import ResolveProposalRequest
 from ormah.models.search import SearchQuery
@@ -136,6 +137,24 @@ async def whisper(request: Request):
     space = body.get("space")
     session_id = body.get("session_id", "")
     engine = request.app.state.engine
+
+    from ormah.config import settings as _settings
+
+    # Machine-generated turn (subagent notification, scheduled task, loop check):
+    # no human will read an injection, so skip BEFORE anything per-turn happens.
+    # This must stay above both the session buffer below (it feeds topic-shift and
+    # continuation for the NEXT human turn) and the engine (whose first statement
+    # consumes the one-time onboarding nudge) — both side effects are irreversible,
+    # so a guard further down cannot undo them (#134).
+    if _settings.whisper_synthetic_filter_enabled and is_synthetic_prompt(
+        prompt, _settings.whisper_synthetic_prompt_patterns
+    ):
+        await anyio.to_thread.run_sync(
+            lambda: engine.note_synthetic_whisper_skip(
+                prompt=prompt, space=space, session_id=session_id,
+            )
+        )
+        return TextResponse(text="")
 
     # Build recent_prompts from session buffer
     recent_prompts: list[str] | None = None

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -154,6 +154,7 @@ async def whisper(request: Request):
             await anyio.to_thread.run_sync(
                 lambda: engine.note_synthetic_whisper_skip(
                     prompt=prompt, space=space, session_id=session_id,
+                    matched_pattern=matched,
                 )
             )
             return TextResponse(text="")

--- a/src/ormah/api/routes_agent.py
+++ b/src/ormah/api/routes_agent.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
 from ormah.background.maintenance_manager import MaintenanceManager
-from ormah.engine.prompt_classifier import is_synthetic_prompt
+from ormah.engine.prompt_classifier import match_synthetic_pattern
 from ormah.models.node import ConnectRequest, CreateNodeRequest, UpdateNodeRequest
 from ormah.models.proposals import ResolveProposalRequest
 from ormah.models.search import SearchQuery
@@ -146,15 +146,17 @@ async def whisper(request: Request):
     # continuation for the NEXT human turn) and the engine (whose first statement
     # consumes the one-time onboarding nudge) — both side effects are irreversible,
     # so a guard further down cannot undo them (#134).
-    if _settings.whisper_synthetic_filter_enabled and is_synthetic_prompt(
-        prompt, _settings.whisper_synthetic_prompt_patterns
-    ):
-        await anyio.to_thread.run_sync(
-            lambda: engine.note_synthetic_whisper_skip(
-                prompt=prompt, space=space, session_id=session_id,
-            )
+    if _settings.whisper_synthetic_filter_enabled:
+        matched = match_synthetic_pattern(
+            prompt, _settings.whisper_synthetic_prompt_patterns
         )
-        return TextResponse(text="")
+        if matched is not None:
+            await anyio.to_thread.run_sync(
+                lambda: engine.note_synthetic_whisper_skip(
+                    prompt=prompt, space=space, session_id=session_id,
+                )
+            )
+            return TextResponse(text="")
 
     # Build recent_prompts from session buffer
     recent_prompts: list[str] | None = None

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -124,6 +124,17 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
+    from ormah.background.synthetic_pattern_monitor import run_synthetic_pattern_monitor
+
+    scheduler.add_job(
+        tracked(tracker, "synthetic_pattern_monitor", run_synthetic_pattern_monitor, engine),
+        "interval",
+        minutes=s.whisper_pattern_monitor_interval_minutes,
+        id="synthetic_pattern_monitor",
+        name="Synthetic pattern monitor",
+        misfire_grace_time=_MISFIRE_GRACE,
+    )
+
     from ormah.backup import run_auto_backup
 
     scheduler.add_job(

--- a/src/ormah/background/synthetic_pattern_monitor.py
+++ b/src/ormah/background/synthetic_pattern_monitor.py
@@ -159,27 +159,35 @@ def run_synthetic_pattern_monitor(
     created = 0
     for entry in rotted:
         action = _proposed_action(entry)
-        # Any status, not just pending: a rejected proposal must stay dead, and a
-        # rotted pattern the user already saw must not be re-filed every night.
-        #
-        # `created > last_seen` is what keeps that from being permanent (council
-        # I2): a proposal filed BEFORE the pattern's last match is about an
-        # episode that has since ended, so it no longer blocks. A pattern that
-        # rots, gets repaired, resumes matching and rots again therefore gets a
-        # fresh proposal, while the ordinary "still dead" case stays deduped.
-        existing = engine.db.conn.execute(
-            "SELECT 1 FROM proposals WHERE type = ? AND proposed_action = ? "
-            "AND created > ? LIMIT 1",
-            (ProposalType.pattern.value, action, entry.last_seen),
-        ).fetchone()
-        if existing is not None:
-            continue
         reason = (
             f"Last matched {entry.last_seen}, more than "
             f"{settings.whisper_pattern_rot_days} days ago, while whisper traffic "
             f"continued. Origin: {entry.origin}."
         )
+        # Dedup has two rules, both needed:
+        #
+        # - A `pending` proposal always blocks. If the user never resolves it and
+        #   the pattern later rots again, `created > last_seen` alone would stop
+        #   blocking once last_seen moves past the old `created`, filing a SECOND
+        #   pending proposal for the same action with a contradictory reason
+        #   (council-pr A1). There is never a reason to queue two identical
+        #   pending proposals at once.
+        # - A resolved proposal (approved/rejected) only blocks if it postdates
+        #   the pattern's last match (council I2): filed BEFORE that match, it is
+        #   about an episode that has since ended and must not block a fresh
+        #   rot episode after a repair.
+        #
+        # The SELECT and INSERT run inside one transaction so the scheduler and
+        # a manual `/admin` trigger can't both observe "not found" and insert two
+        # rows for the same identity (council-pr A2, TOCTOU).
         with engine.db.transaction() as conn:
+            existing = conn.execute(
+                "SELECT 1 FROM proposals WHERE type = ? AND proposed_action = ? "
+                "AND (status = 'pending' OR created > ?) LIMIT 1",
+                (ProposalType.pattern.value, action, entry.last_seen),
+            ).fetchone()
+            if existing is not None:
+                continue
             conn.execute(
                 "INSERT INTO proposals (id, type, status, source_nodes, "
                 "proposed_action, reason, created) "

--- a/src/ormah/background/synthetic_pattern_monitor.py
+++ b/src/ormah/background/synthetic_pattern_monitor.py
@@ -1,0 +1,95 @@
+"""Detect synthetic-prompt patterns that stopped matching (#143).
+
+The #134 filter's pattern list rots two ways: Claude Code renames a marker, or
+the operator's tooling changes. Neither leaves a trace — the filter keeps
+running and simply matches nothing. This module turns that silence into a
+signal by asking, per pattern, when it last fired.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import sqlite3
+
+from ormah.engine.prompt_classifier import _SYNTHETIC_PATTERNS
+
+BUILTIN = "builtin"
+OPERATOR = "operator"
+
+
+@dataclass(frozen=True)
+class RottedPattern:
+    """A live pattern that matched before and has now gone quiet."""
+
+    pattern: str
+    origin: str  # BUILTIN | OPERATOR — decides the proposal text, not the mechanics
+    last_seen: str  # ISO-8601, from whisper_decisions.logged_at
+
+
+def live_patterns(settings) -> list[tuple[str, str]]:
+    """(pattern_source, origin) for every pattern the filter would apply today.
+
+    Sourced from the live config, never from history: a pattern the user already
+    removed from .env is not actionable and must not be proposed.
+
+    Deduplicated by pattern string, OPERATOR winning: an operator who copies a
+    builtin regex into .env would otherwise yield two entries for one regex, two
+    different proposal texts, and therefore two proposals the dedup cannot
+    collapse (council I1). OPERATOR wins because that is the copy the user can
+    actually act on.
+    """
+    merged: dict[str, str] = {compiled.pattern: BUILTIN for compiled in _SYNTHETIC_PATTERNS}
+    for raw in settings.whisper_synthetic_prompt_patterns or ():
+        merged[raw] = OPERATOR
+    return list(merged.items())
+
+
+def find_rotted_patterns(
+    conn: sqlite3.Connection,
+    settings,
+    now: datetime,
+) -> list[RottedPattern]:
+    """Live patterns whose last match predates the rot window. Pure read.
+
+    Rot is "matched before and stopped" — not "matches zero". A pattern that
+    never matched is irrelevant to this install (no scheduled tasks, say), and
+    proposing its removal would be noise the user learns to ignore.
+    """
+    # With the filter off, NOTHING writes silent_synthetic, so every last_seen
+    # freezes while ordinary human traffic keeps the vacation guard satisfied —
+    # every pattern would age into a false proposal claiming an upstream rename
+    # that never happened, and the user might delete a still-valid filter
+    # (council C1). No filter, no signal, no opinion.
+    if not settings.whisper_synthetic_filter_enabled:
+        return []
+
+    cutoff = (now - timedelta(days=settings.whisper_pattern_rot_days)).isoformat()
+
+    # Vacation guard: with no traffic at all, every pattern looks rotted.
+    if conn.execute(
+        "SELECT 1 FROM whisper_decisions WHERE logged_at > ? LIMIT 1", (cutoff,)
+    ).fetchone() is None:
+        return []
+
+    history = {
+        row[0]: (row[1], row[2])
+        for row in conn.execute(
+            "SELECT matched_pattern, MAX(logged_at), COUNT(*) FROM whisper_decisions "
+            "WHERE outcome = 'silent_synthetic' AND matched_pattern IS NOT NULL "
+            "GROUP BY matched_pattern"
+        ).fetchall()
+    }
+
+    rotted = []
+    for pattern, origin in live_patterns(settings):
+        entry = history.get(pattern)
+        if entry is None:
+            continue  # never matched — irrelevant to this install, not rot
+        seen, hits = entry
+        if seen > cutoff:
+            continue  # still firing
+        if hits < settings.whisper_pattern_rot_min_matches:
+            continue  # fired once in passing; not evidence of a live workflow
+        rotted.append(RottedPattern(pattern=pattern, origin=origin, last_seen=seen))
+    return rotted

--- a/src/ormah/background/synthetic_pattern_monitor.py
+++ b/src/ormah/background/synthetic_pattern_monitor.py
@@ -9,10 +9,15 @@ signal by asking, per pattern, when it last fired.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
+import logging
 import sqlite3
+import uuid
 
 from ormah.engine.prompt_classifier import _SYNTHETIC_PATTERNS
+from ormah.models.proposals import ProposalType
+
+logger = logging.getLogger(__name__)
 
 BUILTIN = "builtin"
 OPERATOR = "operator"
@@ -93,3 +98,84 @@ def find_rotted_patterns(
             continue  # fired once in passing; not evidence of a live workflow
         rotted.append(RottedPattern(pattern=pattern, origin=origin, last_seen=seen))
     return rotted
+
+
+_MANUAL = "MANUAL ACTION REQUIRED — "
+
+
+def _proposed_action(rotted: RottedPattern) -> str:
+    """Stable text derived ONLY from the pattern — this string is the dedup key.
+
+    Never interpolate a count or a date here. It would change every run, the
+    dedup in run_synthetic_pattern_monitor would never hit, and the job would
+    file one proposal per day forever. Variable evidence belongs in `reason`.
+
+    The MANUAL ACTION REQUIRED prefix is load-bearing: approving a proposal of
+    this type executes nothing (auto-applying config is deliberately out of
+    scope), yet the shared proposals surface still reports success and drops the
+    item from the queue. Without this prefix a user can approve and reasonably
+    believe the repair happened (council I3).
+    """
+    if rotted.origin == OPERATOR:
+        return (
+            f"{_MANUAL}remove this entry from ORMAH_WHISPER_SYNTHETIC_PROMPT_PATTERNS "
+            f"in your .env: {rotted.pattern}"
+        )
+    return (
+        f"{_MANUAL}Claude Code marker {rotted.pattern} stopped appearing; it was "
+        "likely renamed upstream. Report it — this is a built-in default and is "
+        "not in your .env, so there is nothing for you to edit."
+    )
+
+
+def run_synthetic_pattern_monitor(
+    engine,
+    *,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Propose corrections for synthetic patterns that went quiet (#143).
+
+    Proposes, never applies: a wrongly-silenced prompt fails invisibly, so the
+    human stays in the loop. Approving does nothing by design — the user copies
+    the rendered line into their own .env.
+    """
+    now = now or datetime.now(timezone.utc)
+    settings = engine.settings
+    rotted = find_rotted_patterns(engine.db.conn, settings, now)
+
+    created = 0
+    for entry in rotted:
+        action = _proposed_action(entry)
+        # Any status, not just pending: a rejected proposal must stay dead, and a
+        # rotted pattern the user already saw must not be re-filed every night.
+        #
+        # `created > last_seen` is what keeps that from being permanent (council
+        # I2): a proposal filed BEFORE the pattern's last match is about an
+        # episode that has since ended, so it no longer blocks. A pattern that
+        # rots, gets repaired, resumes matching and rots again therefore gets a
+        # fresh proposal, while the ordinary "still dead" case stays deduped.
+        existing = engine.db.conn.execute(
+            "SELECT 1 FROM proposals WHERE type = ? AND proposed_action = ? "
+            "AND created > ? LIMIT 1",
+            (ProposalType.pattern.value, action, entry.last_seen),
+        ).fetchone()
+        if existing is not None:
+            continue
+        reason = (
+            f"Last matched {entry.last_seen}, more than "
+            f"{settings.whisper_pattern_rot_days} days ago, while whisper traffic "
+            f"continued. Origin: {entry.origin}."
+        )
+        with engine.db.transaction() as conn:
+            conn.execute(
+                "INSERT INTO proposals (id, type, status, source_nodes, "
+                "proposed_action, reason, created) "
+                "VALUES (?, ?, 'pending', '[]', ?, ?, ?)",
+                (str(uuid.uuid4()), ProposalType.pattern.value, action, reason,
+                 now.isoformat()),
+            )
+        created += 1
+
+    if created:
+        logger.info("synthetic_pattern_monitor: filed %d pattern proposal(s)", created)
+    return {"rotted": len(rotted), "proposals_created": created}

--- a/src/ormah/background/synthetic_pattern_monitor.py
+++ b/src/ormah/background/synthetic_pattern_monitor.py
@@ -157,6 +157,7 @@ def run_synthetic_pattern_monitor(
     rotted = find_rotted_patterns(engine.db.conn, settings, now)
 
     created = 0
+    refreshed = 0
     for entry in rotted:
         action = _proposed_action(entry)
         reason = (
@@ -166,27 +167,42 @@ def run_synthetic_pattern_monitor(
         )
         # Dedup has two rules, both needed:
         #
-        # - A `pending` proposal always blocks. If the user never resolves it and
-        #   the pattern later rots again, `created > last_seen` alone would stop
-        #   blocking once last_seen moves past the old `created`, filing a SECOND
-        #   pending proposal for the same action with a contradictory reason
-        #   (council-pr A1). There is never a reason to queue two identical
-        #   pending proposals at once.
+        # - A `pending` proposal always blocks a second INSERT. If the user never
+        #   resolves it and the pattern later rots again, `created > last_seen`
+        #   alone would stop blocking once last_seen moves past the old `created`,
+        #   filing a SECOND pending proposal for the same action with a
+        #   contradictory reason (council-pr A1). There is never a reason to queue
+        #   two identical pending proposals at once.
         # - A resolved proposal (approved/rejected) only blocks if it postdates
         #   the pattern's last match (council I2): filed BEFORE that match, it is
         #   about an episode that has since ended and must not block a fresh
         #   rot episode after a repair.
         #
-        # The SELECT and INSERT run inside one transaction so the scheduler and
-        # a manual `/admin` trigger can't both observe "not found" and insert two
-        # rows for the same identity (council-pr A2, TOCTOU).
+        # Blocking is not the same as staying silent. A pending proposal filed
+        # BEFORE the pattern's last match describes an episode that has since
+        # ended — the marker came back and rotted a second time. Skipping it
+        # would leave the queue quoting the FIRST episode's evidence while a new
+        # regression went unreported (council-pr B1). Refresh it in place: one
+        # row per action, and the evidence stops lying.
+        #
+        # The SELECT and the write run inside one transaction so the scheduler
+        # and a manual `/admin` trigger can't both observe "not found" and insert
+        # two rows for the same identity (council-pr A2, TOCTOU).
         with engine.db.transaction() as conn:
             existing = conn.execute(
-                "SELECT 1 FROM proposals WHERE type = ? AND proposed_action = ? "
-                "AND (status = 'pending' OR created > ?) LIMIT 1",
+                "SELECT id, status, created FROM proposals "
+                "WHERE type = ? AND proposed_action = ? "
+                "AND (status = 'pending' OR created > ?) "
+                "ORDER BY created DESC LIMIT 1",
                 (ProposalType.pattern.value, action, entry.last_seen),
             ).fetchone()
             if existing is not None:
+                if existing["status"] == "pending" and existing["created"] <= entry.last_seen:
+                    conn.execute(
+                        "UPDATE proposals SET reason = ?, created = ? WHERE id = ?",
+                        (reason, now.isoformat(), existing["id"]),
+                    )
+                    refreshed += 1
                 continue
             conn.execute(
                 "INSERT INTO proposals (id, type, status, source_nodes, "
@@ -197,6 +213,10 @@ def run_synthetic_pattern_monitor(
             )
         created += 1
 
-    if created:
-        logger.info("synthetic_pattern_monitor: filed %d pattern proposal(s)", created)
-    return {"rotted": len(rotted), "proposals_created": created}
+    if created or refreshed:
+        logger.info(
+            "synthetic_pattern_monitor: filed %d, refreshed %d pattern proposal(s)",
+            created, refreshed,
+        )
+    return {"rotted": len(rotted), "proposals_created": created,
+            "proposals_refreshed": refreshed}

--- a/src/ormah/background/synthetic_pattern_monitor.py
+++ b/src/ormah/background/synthetic_pattern_monitor.py
@@ -60,9 +60,15 @@ def find_rotted_patterns(
     Rot is "matched before and stopped" — not "matches zero". A pattern that
     never matched is irrelevant to this install (no scheduled tasks, say), and
     proposing its removal would be noise the user learns to ignore.
+
+    Each live pattern also passes a per-pattern opportunity guard: the question
+    is not "was there any traffic at all" (one prompt after a month away used to
+    satisfy that and rot the entire list), but "how much traffic happened since
+    THIS pattern last fired". Little traffic means the user was away, not that
+    the marker died.
     """
     # With the filter off, NOTHING writes silent_synthetic, so every last_seen
-    # freezes while ordinary human traffic keeps the vacation guard satisfied —
+    # freezes while ordinary human traffic keeps the opportunity guard satisfied —
     # every pattern would age into a false proposal claiming an upstream rename
     # that never happened, and the user might delete a still-valid filter
     # (council C1). No filter, no signal, no opinion.
@@ -70,12 +76,6 @@ def find_rotted_patterns(
         return []
 
     cutoff = (now - timedelta(days=settings.whisper_pattern_rot_days)).isoformat()
-
-    # Vacation guard: with no traffic at all, every pattern looks rotted.
-    if conn.execute(
-        "SELECT 1 FROM whisper_decisions WHERE logged_at > ? LIMIT 1", (cutoff,)
-    ).fetchone() is None:
-        return []
 
     history = {
         row[0]: (row[1], row[2])
@@ -96,6 +96,19 @@ def find_rotted_patterns(
             continue  # still firing
         if hits < settings.whisper_pattern_rot_min_matches:
             continue  # fired once in passing; not evidence of a live workflow
+        # Opportunity guard, per pattern (replaces the old global vacation guard).
+        # The right question is not "was there any traffic at all" — one prompt
+        # after a month away satisfied that and proposed the whole list as rotted.
+        # It is "how much traffic happened SINCE this pattern last fired?". Little
+        # traffic means the user was away, not that the marker died.
+        # ponytail: a flat count, not the pattern's historical rate. A rare pattern
+        # needs more silence than a common one to prove rot; upgrade to
+        # rate-based expectation (hits/traffic * opportunity) if this proves noisy.
+        opportunity = conn.execute(
+            "SELECT COUNT(*) FROM whisper_decisions WHERE logged_at > ?", (seen,)
+        ).fetchone()[0]
+        if opportunity < settings.whisper_pattern_rot_min_opportunity:
+            continue
         rotted.append(RottedPattern(pattern=pattern, origin=origin, last_seen=seen))
     return rotted
 

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -214,9 +214,7 @@ class Settings(BaseSettings):
 
     # Rot detection for the list above (#143). A pattern that matched before and
     # stopped is stale; a pattern that never matched is merely irrelevant to this
-    # install and stays silent. rot_days is also the traffic-guard window: no
-    # whisper traffic at all in it means the user was away, not that the patterns
-    # died — so nothing is proposed.
+    # install and stays silent.
     whisper_pattern_rot_days: int = 30
     whisper_pattern_monitor_interval_minutes: int = 1440
     # A pattern that fired once, months ago, is not evidence of a live workflow.
@@ -224,6 +222,10 @@ class Settings(BaseSettings):
     # alert — which defeats the feature. Require a real history before calling
     # anything rotted (council I4).
     whisper_pattern_rot_min_matches: int = 2
+    # How much whisper traffic must have happened since a pattern last fired before
+    # "it stopped" beats "it just did not come up". Guards against a user returning
+    # from vacation and having every pattern proposed as rotted.
+    whisper_pattern_rot_min_opportunity: int = 50
 
     # Whisper topic-shift detection (skip injection when topic unchanged)
     whisper_topic_shift_enabled: bool = True
@@ -446,6 +448,18 @@ class Settings(BaseSettings):
     def _whisper_log_cleanup_positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError(f"whisper log cleanup settings must be >= 1, got {v}")
+        return v
+
+    @field_validator(
+        "whisper_pattern_rot_days",
+        "whisper_pattern_monitor_interval_minutes",
+        "whisper_pattern_rot_min_matches",
+        "whisper_pattern_rot_min_opportunity",
+    )
+    @classmethod
+    def _whisper_pattern_monitor_positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError(f"whisper pattern monitor settings must be >= 1, got {v}")
         return v
 
     @field_validator("core_memory_cap")

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -212,6 +212,19 @@ class Settings(BaseSettings):
     whisper_synthetic_filter_enabled: bool = True
     whisper_synthetic_prompt_patterns: list[str] = []
 
+    # Rot detection for the list above (#143). A pattern that matched before and
+    # stopped is stale; a pattern that never matched is merely irrelevant to this
+    # install and stays silent. rot_days is also the traffic-guard window: no
+    # whisper traffic at all in it means the user was away, not that the patterns
+    # died — so nothing is proposed.
+    whisper_pattern_rot_days: int = 30
+    whisper_pattern_monitor_interval_minutes: int = 1440
+    # A pattern that fired once, months ago, is not evidence of a live workflow.
+    # Proposing its removal is noise, and noise teaches the user to ignore the
+    # alert — which defeats the feature. Require a real history before calling
+    # anything rotted (council I4).
+    whisper_pattern_rot_min_matches: int = 2
+
     # Whisper topic-shift detection (skip injection when topic unchanged)
     whisper_topic_shift_enabled: bool = True
     whisper_topic_shift_threshold: float = 0.75  # cosine sim above this = same topic

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -203,6 +203,15 @@ class Settings(BaseSettings):
     # Whisper intent classification
     whisper_intent_threshold: float = 0.65  # min cosine similarity for intent match
 
+    # Machine-generated turns (subagent task-notifications, scheduled tasks,
+    # autonomous-loop checks) reach the UserPromptSubmit hook like any prompt.
+    # Whispering into them burns encode+search+rerank where no human reads, and
+    # the injection can never be "referenced" — contaminating the usage judge.
+    # Defaults cover Claude Code's own markers; add install-specific regexes
+    # (headless scripts, other agents) here. Anchored at the prompt start.
+    whisper_synthetic_filter_enabled: bool = True
+    whisper_synthetic_prompt_patterns: list[str] = []
+
     # Whisper topic-shift detection (skip injection when topic unchanged)
     whisper_topic_shift_enabled: bool = True
     whisper_topic_shift_threshold: float = 0.75  # cosine sim above this = same topic

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -301,6 +301,7 @@ class ContextBuilder:
         candidate_count: int = 0,
         injected_count: int = 0,
         max_gate_score: float | None = None,
+        matched_pattern: str | None = None,
     ) -> None:
         """Write one whisper_decisions row per whisper call — including silence.
 
@@ -317,11 +318,12 @@ class ContextBuilder:
                 conn.execute(
                     "INSERT INTO whisper_decisions "
                     "(session_id, space, prompt_hash, intent, outcome, "
-                    "candidate_count, injected_count, max_gate_score, logged_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "candidate_count, injected_count, max_gate_score, logged_at, "
+                    "matched_pattern) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     (session_id, space, prompt_hash, intent_str, outcome,
                      candidate_count, injected_count, max_gate_score,
-                     datetime.now(timezone.utc).isoformat()),
+                     datetime.now(timezone.utc).isoformat(), matched_pattern),
                 )
         except Exception as e:
             logger.warning("whisper_decisions write failed: %s", e)

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 import numpy as np
 
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
+from ormah.engine.prompt_classifier import is_synthetic_prompt
 from ormah.index.graph import GraphIndex
 from ormah.text.tokens import distinctive_tokens
 
@@ -392,6 +393,26 @@ class ContextBuilder:
             logger.info(
                 "Whisper diagnostics: prompt=%r no_engine -> skip",
                 prompt_snippet,
+            )
+            if _return_debug:
+                return "", _injected_ids
+            return ""
+
+        # Machine-generated turn (subagent notification, scheduled task, loop
+        # check): no human will read the injection, and the usage judge would
+        # score it as an unreferenced miss. Skip before the classifier — the
+        # last point where no encode/search/rerank has been paid (#134).
+        _s = getattr(self.engine, "settings", None)
+        if getattr(_s, "whisper_synthetic_filter_enabled", True) and is_synthetic_prompt(
+            prompt, getattr(_s, "whisper_synthetic_prompt_patterns", ()) or ()
+        ):
+            logger.info(
+                "Whisper diagnostics: prompt=%r synthetic_prompt -> skip",
+                prompt_snippet,
+            )
+            self._log_decision(
+                session_id=session_id, space=space, prompt=prompt,
+                intent=None, outcome="silent_synthetic",
             )
             if _return_debug:
                 return "", _injected_ids

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 import numpy as np
 
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
-from ormah.engine.prompt_classifier import is_synthetic_prompt
 from ormah.index.graph import GraphIndex
 from ormah.text.tokens import distinctive_tokens
 
@@ -393,26 +392,6 @@ class ContextBuilder:
             logger.info(
                 "Whisper diagnostics: prompt=%r no_engine -> skip",
                 prompt_snippet,
-            )
-            if _return_debug:
-                return "", _injected_ids
-            return ""
-
-        # Machine-generated turn (subagent notification, scheduled task, loop
-        # check): no human will read the injection, and the usage judge would
-        # score it as an unreferenced miss. Skip before the classifier — the
-        # last point where no encode/search/rerank has been paid (#134).
-        _s = getattr(self.engine, "settings", None)
-        if getattr(_s, "whisper_synthetic_filter_enabled", True) and is_synthetic_prompt(
-            prompt, getattr(_s, "whisper_synthetic_prompt_patterns", ()) or ()
-        ):
-            logger.info(
-                "Whisper diagnostics: prompt=%r synthetic_prompt -> skip",
-                prompt_snippet,
-            )
-            self._log_decision(
-                session_id=session_id, space=space, prompt=prompt,
-                intent=None, outcome="silent_synthetic",
             )
             if _return_debug:
                 return "", _injected_ids

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1065,6 +1065,24 @@ class MemoryEngine:
 
         return f"Connected {req.source_id[:8]}... →[{req.edge.value}]→ {req.target_id[:8]}..."
 
+    def note_synthetic_whisper_skip(
+        self,
+        prompt: str,
+        space: str | None = None,
+        session_id: str | None = None,
+    ) -> None:
+        """Record a whisper call skipped because the prompt was machine-generated.
+
+        Called from the ``/agent/whisper`` boundary instead of ``get_whisper_context``:
+        the skip has to happen before this engine runs at all (its first statement
+        consumes the one-time onboarding nudge), so the decision row is written here
+        to keep ``whisper_decisions`` one-row-per-call (#134).
+        """
+        self.context_builder._log_decision(
+            session_id=session_id, space=space, prompt=prompt,
+            intent=None, outcome="silent_synthetic",
+        )
+
     def get_whisper_context(
         self,
         prompt: str,

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1070,6 +1070,7 @@ class MemoryEngine:
         prompt: str,
         space: str | None = None,
         session_id: str | None = None,
+        matched_pattern: str | None = None,
     ) -> None:
         """Record a whisper call skipped because the prompt was machine-generated.
 
@@ -1081,6 +1082,7 @@ class MemoryEngine:
         self.context_builder._log_decision(
             session_id=session_id, space=space, prompt=prompt,
             intent=None, outcome="silent_synthetic",
+            matched_pattern=matched_pattern,
         )
 
     def get_whisper_context(

--- a/src/ormah/engine/prompt_classifier.py
+++ b/src/ormah/engine/prompt_classifier.py
@@ -26,25 +26,32 @@ _SYNTHETIC_PATTERNS = (
 )
 
 
-def is_synthetic_prompt(prompt: str, extra_patterns: Sequence[str] = ()) -> bool:
-    """True when the prompt was authored by a machine, not a human.
+def match_synthetic_pattern(prompt: str, extra_patterns: Sequence[str] = ()) -> str | None:
+    """The source of the pattern that matched, or None when the prompt is human.
+
+    Returns the regex source rather than a bool so callers can record WHICH
+    pattern fired — a pattern that stops firing is a rotted pattern (#143).
 
     ``extra_patterns`` carries install-specific regexes from settings; the
     defaults stay generic to Claude Code. An invalid pattern is logged and
     ignored — a config typo must never take the whisper down.
+
+    An operator can configure the empty pattern "", which matches everything and
+    returns "" — falsy but a real match. Callers MUST test ``is not None``.
     """
     text = prompt.lstrip()
     if not text:
-        return False
-    if any(p.match(text) for p in _SYNTHETIC_PATTERNS):
-        return True
+        return None
+    for compiled in _SYNTHETIC_PATTERNS:
+        if compiled.match(text):
+            return compiled.pattern
     for raw in extra_patterns or ():
         try:
             if re.match(raw, text):
-                return True
+                return raw
         except (re.error, TypeError) as e:
             logger.warning("Ignoring invalid synthetic-prompt pattern %r: %s", raw, e)
-    return False
+    return None
 
 
 # Archetype prompts per intent category.  More examples = better embedding

--- a/src/ormah/engine/prompt_classifier.py
+++ b/src/ormah/engine/prompt_classifier.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
@@ -12,6 +13,39 @@ import numpy as np
 from ormah.embeddings.base import EmbeddingAdapter
 
 logger = logging.getLogger(__name__)
+
+# Machine-generated turns that reach the UserPromptSubmit hook. Matched ANCHORED
+# at the start of the prompt: a human ASKING about one of these markers is a real
+# prompt and still gets a whisper. Fail-open — when in doubt, whisper.
+# Deliberately excluded: wrapper tags like <ide_opened_file> and <system-reminder>,
+# which PREFIX a real human prompt rather than replace it (issue #134).
+_SYNTHETIC_PATTERNS = (
+    re.compile(r"<task-notification>"),
+    re.compile(r"<scheduled-task\b"),
+    re.compile(r"#\s*Autonomous loop check\b"),
+)
+
+
+def is_synthetic_prompt(prompt: str, extra_patterns: Sequence[str] = ()) -> bool:
+    """True when the prompt was authored by a machine, not a human.
+
+    ``extra_patterns`` carries install-specific regexes from settings; the
+    defaults stay generic to Claude Code. An invalid pattern is logged and
+    ignored — a config typo must never take the whisper down.
+    """
+    text = prompt.lstrip()
+    if not text:
+        return False
+    if any(p.match(text) for p in _SYNTHETIC_PATTERNS):
+        return True
+    for raw in extra_patterns or ():
+        try:
+            if re.match(raw, text):
+                return True
+        except (re.error, TypeError) as e:
+            logger.warning("Ignoring invalid synthetic-prompt pattern %r: %s", raw, e)
+    return False
+
 
 # Archetype prompts per intent category.  More examples = better embedding
 # space coverage for paraphrases the user might actually type.

--- a/src/ormah/engine/prompt_classifier.py
+++ b/src/ormah/engine/prompt_classifier.py
@@ -20,9 +20,9 @@ logger = logging.getLogger(__name__)
 # Deliberately excluded: wrapper tags like <ide_opened_file> and <system-reminder>,
 # which PREFIX a real human prompt rather than replace it (issue #134).
 _SYNTHETIC_PATTERNS = (
-    re.compile(r"<task-notification>"),
-    re.compile(r"<scheduled-task\b"),
-    re.compile(r"#\s*Autonomous loop check\b"),
+    re.compile(r"<task-notification>", re.IGNORECASE),
+    re.compile(r"<scheduled-task\b", re.IGNORECASE),
+    re.compile(r"#\s*Autonomous loop check\b", re.IGNORECASE),
 )
 
 

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -215,6 +215,7 @@ class Database:
 
             self._migrate_whisper_log_schema(conn)
             self._migrate_retrieval_event_schema(conn)
+            self._migrate_whisper_decisions_schema(conn)
 
             self._migrate_affinity_schema(conn, existing_tables)
             self._ensure_signals_schema(conn)
@@ -255,6 +256,15 @@ class Database:
         for name, column_type in additions.items():
             if name not in cols:
                 conn.execute(f"ALTER TABLE whisper_log ADD COLUMN {name} {column_type}")
+
+    def _migrate_whisper_decisions_schema(self, conn: sqlite3.Connection) -> None:
+        """Record which synthetic pattern fired, so rot detection has a signal (#143)."""
+        cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(whisper_decisions)").fetchall()
+        }
+        if "matched_pattern" not in cols:
+            conn.execute("ALTER TABLE whisper_decisions ADD COLUMN matched_pattern TEXT")
 
     def _migrate_retrieval_event_schema(self, conn: sqlite3.Connection) -> None:
         """Normalize prompt payloads without rebuilding exact feedback rows."""

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -207,7 +207,9 @@ CREATE TABLE IF NOT EXISTS whisper_decisions (
     candidate_count INTEGER DEFAULT 0,  -- results returned by search before filtering
     injected_count  INTEGER DEFAULT 0,  -- memories actually injected
     max_gate_score  REAL,               -- best absolute gate score among candidates
-    logged_at       TEXT NOT NULL
+    logged_at       TEXT NOT NULL,
+    matched_pattern TEXT                -- synthetic pattern source that fired;
+                                        -- NULL unless outcome='silent_synthetic' (#143)
 );
 CREATE INDEX IF NOT EXISTS idx_whisper_decisions_session ON whisper_decisions(session_id);
 CREATE INDEX IF NOT EXISTS idx_whisper_decisions_logged  ON whisper_decisions(logged_at);

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -203,6 +203,7 @@ CREATE TABLE IF NOT EXISTS whisper_decisions (
     outcome         TEXT NOT NULL,      -- 'injected' | 'silent_short' | 'silent_conversational'
                                         -- | 'silent_topic_shift' | 'silent_no_candidates'
                                         -- | 'silent_gate' | 'silent_blackout' | 'silent_error'
+                                        -- | 'silent_synthetic'
     candidate_count INTEGER DEFAULT 0,  -- results returned by search before filtering
     injected_count  INTEGER DEFAULT 0,  -- memories actually injected
     max_gate_score  REAL,               -- best absolute gate score among candidates

--- a/src/ormah/models/proposals.py
+++ b/src/ormah/models/proposals.py
@@ -13,6 +13,7 @@ class ProposalType(str, Enum):
     merge = "merge"
     conflict = "conflict"
     decay = "decay"
+    pattern = "pattern"  # synthetic-prompt pattern correction (#143)
 
 
 class ProposalStatus(str, Enum):

--- a/tests/test_background/test_scheduler.py
+++ b/tests/test_background/test_scheduler.py
@@ -1,0 +1,14 @@
+"""Background job registration (#143)."""
+
+from __future__ import annotations
+
+from ormah.background.scheduler import start_scheduler
+
+
+def test_synthetic_pattern_monitor_is_registered(engine):
+    scheduler, _tracker = start_scheduler(engine)
+    try:
+        job_ids = {job.id for job in scheduler.get_jobs()}
+        assert "synthetic_pattern_monitor" in job_ids
+    finally:
+        scheduler.shutdown(wait=False)

--- a/tests/test_background/test_synthetic_pattern_monitor.py
+++ b/tests/test_background/test_synthetic_pattern_monitor.py
@@ -203,7 +203,7 @@ def test_rotted_pattern_creates_one_pending_proposal(engine):
 
     result = run_synthetic_pattern_monitor(engine, now=NOW)
 
-    assert result == {"rotted": 1, "proposals_created": 1}
+    assert result == {"rotted": 1, "proposals_created": 1, "proposals_refreshed": 0}
     row = engine.db.conn.execute(
         "SELECT type, status, source_nodes, proposed_action, reason FROM proposals"
     ).fetchone()
@@ -332,6 +332,10 @@ def test_abandoned_pending_proposal_is_not_duplicated(engine):
         _decision(engine, outcome="injected", matched_pattern=None,
                   logged_at=much_later - timedelta(minutes=i + 1))
 
+    before = engine.db.conn.execute(
+        "SELECT reason FROM proposals WHERE type = 'pattern'"
+    ).fetchone()["reason"]
+
     second = run_synthetic_pattern_monitor(engine, now=much_later)
 
     assert second["proposals_created"] == 0
@@ -339,6 +343,16 @@ def test_abandoned_pending_proposal_is_not_duplicated(engine):
         "SELECT COUNT(*) FROM proposals WHERE type = 'pattern' AND status = 'pending'"
     ).fetchone()[0]
     assert total == 1
+
+    # Not duplicating is only half of it: the surviving row must describe the
+    # SECOND episode, not keep quoting the first (council-pr B1).
+    assert second["proposals_refreshed"] == 1
+    row = engine.db.conn.execute(
+        "SELECT reason, created FROM proposals WHERE type = 'pattern'"
+    ).fetchone()
+    assert row["reason"] != before
+    assert (later + timedelta(days=1)).isoformat() in row["reason"]
+    assert row["created"] == much_later.isoformat()
 
 
 def test_proposed_action_says_the_action_is_manual(engine):
@@ -359,7 +373,7 @@ def test_no_rot_creates_nothing(engine):
               matched_pattern=TASK_NOTIFICATION, logged_at=NOW - timedelta(days=1))
 
     assert run_synthetic_pattern_monitor(engine, now=NOW) == {
-        "rotted": 0, "proposals_created": 0,
+        "rotted": 0, "proposals_created": 0, "proposals_refreshed": 0,
     }
 
 

--- a/tests/test_background/test_synthetic_pattern_monitor.py
+++ b/tests/test_background/test_synthetic_pattern_monitor.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+from pydantic import ValidationError
+
 from ormah.background.synthetic_pattern_monitor import (
     BUILTIN,
     OPERATOR,
@@ -11,6 +14,7 @@ from ormah.background.synthetic_pattern_monitor import (
     live_patterns,
     run_synthetic_pattern_monitor,
 )
+from ormah.config import Settings
 
 NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
 TASK_NOTIFICATION = r"<task-notification>"
@@ -61,16 +65,25 @@ def test_pattern_still_firing_is_not_rot(engine):
     assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
 
 
-def _rotted_history(engine, pattern, *, hits=2, age_days=60):
-    """`hits` past matches for `pattern`, plus recent human traffic.
+def _rotted_history(engine, pattern, *, hits=2, age_days=60, opportunity=None):
+    """`hits` past matches for `pattern`, then enough later traffic to prove the
+    pattern had a real chance to fire again (the opportunity guard).
 
     hits defaults to 2 because whisper_pattern_rot_min_matches defaults to 2 — a
     single historical match is deliberately not rot (council I4).
+
+    opportunity defaults to the configured minimum: a rotted pattern needs ample
+    traffic since it last fired, or "it stopped" cannot be told from "the user was
+    away".
     """
     for i in range(hits):
         _decision(engine, outcome="silent_synthetic", matched_pattern=pattern,
                   logged_at=NOW - timedelta(days=age_days + i))
-    _decision(engine, outcome="injected", matched_pattern=None, logged_at=NOW)
+    n = (engine.settings.whisper_pattern_rot_min_opportunity
+         if opportunity is None else opportunity)
+    for i in range(n):
+        _decision(engine, outcome="injected", matched_pattern=None,
+                  logged_at=NOW - timedelta(minutes=n - i))
 
 
 def test_pattern_that_matched_before_and_stopped_is_rot(engine):
@@ -115,14 +128,39 @@ def test_single_historical_match_is_not_rot(engine):
     assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
 
 
-def test_no_traffic_at_all_proposes_nothing(engine):
-    """The vacation guard. Two weeks away must not rot every pattern at once."""
+def test_no_traffic_since_last_match_proposes_nothing(engine):
+    """Rewritten from the old global vacation guard, which the opportunity guard
+    replaces (final review, Important): zero traffic since the pattern last fired
+    is zero opportunity to prove it stopped, whatever the calendar says."""
     engine.settings.whisper_pattern_rot_days = 30
     _decision(engine, outcome="silent_synthetic",
               matched_pattern=TASK_NOTIFICATION, logged_at=NOW - timedelta(days=60))
-    # No row inside the window at all.
+    # No row after the match at all — zero opportunity.
 
     assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
+
+
+def test_returning_from_vacation_does_not_rot_everything(engine):
+    """The old global guard was satisfied by ONE prompt after a month away and
+    proposed the entire pattern list as rotted (final review, Important)."""
+    engine.settings.whisper_pattern_rot_days = 30
+    # Fired right up until the user left, 36 days ago...
+    _rotted_history(engine, TASK_NOTIFICATION, age_days=36, opportunity=0)
+    # ...then a single prompt on returning.
+    _decision(engine, outcome="injected", matched_pattern=None, logged_at=NOW)
+
+    assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
+
+
+def test_ample_traffic_since_last_match_is_rot(engine):
+    """The mirror case: the marker really did stop, and there was plenty of
+    traffic in which it could have appeared."""
+    engine.settings.whisper_pattern_rot_days = 30
+    _rotted_history(engine, TASK_NOTIFICATION)
+
+    rotted = find_rotted_patterns(engine.db.conn, engine.settings, NOW)
+
+    assert [r.pattern for r in rotted] == [TASK_NOTIFICATION]
 
 
 def test_pattern_removed_from_config_is_ignored(engine):
@@ -260,7 +298,10 @@ def test_a_second_rot_episode_gets_a_fresh_proposal(engine):
     _decision(engine, outcome="silent_synthetic",
               matched_pattern=TASK_NOTIFICATION, logged_at=later + timedelta(days=1))
     much_later = later + timedelta(days=60)
-    _decision(engine, outcome="injected", matched_pattern=None, logged_at=much_later)
+    n = engine.settings.whisper_pattern_rot_min_opportunity
+    for i in range(n):
+        _decision(engine, outcome="injected", matched_pattern=None,
+                  logged_at=much_later - timedelta(minutes=n - i))
 
     result = run_synthetic_pattern_monitor(engine, now=much_later)
 
@@ -305,3 +346,33 @@ def test_decay_manager_does_not_eat_pattern_proposals(engine):
         "SELECT COUNT(*) FROM proposals WHERE type = 'pattern'"
     ).fetchone()[0]
     assert count == 1
+
+
+def _settings(**overrides):
+    """Settings isolated from the user's global .env (which carries an
+    llm_provider this branch rejects — an unrelated ValidationError would make
+    these tests pass for the wrong reason)."""
+    base = dict(_env_file=None, llm_provider="none", ingest_llm_provider="none")
+    base.update(overrides)
+    return Settings(**base)
+
+
+def test_zero_monitor_interval_is_rejected():
+    """0 makes APScheduler fire every second, forever, and tracked() logs each
+    run as a success — an invisible hot loop (final review, Important)."""
+    with pytest.raises(ValidationError, match="whisper pattern monitor settings must be >= 1"):
+        _settings(whisper_pattern_monitor_interval_minutes=0)
+
+
+def test_zero_rot_days_is_rejected():
+    """0 used to silently disable the job (rot_days doubled as the guard window)."""
+    with pytest.raises(ValidationError, match="whisper pattern monitor settings must be >= 1"):
+        _settings(whisper_pattern_rot_days=0)
+
+
+def test_defaults_are_valid():
+    s = _settings()
+    assert s.whisper_pattern_rot_days == 30
+    assert s.whisper_pattern_monitor_interval_minutes == 1440
+    assert s.whisper_pattern_rot_min_matches == 2
+    assert s.whisper_pattern_rot_min_opportunity == 50

--- a/tests/test_background/test_synthetic_pattern_monitor.py
+++ b/tests/test_background/test_synthetic_pattern_monitor.py
@@ -310,6 +310,37 @@ def test_a_second_rot_episode_gets_a_fresh_proposal(engine):
     assert count == 2
 
 
+def test_abandoned_pending_proposal_is_not_duplicated(engine):
+    """An unresolved pending proposal must not be filed twice.
+
+    The pattern rots, a proposal is filed and left pending, the marker comes back,
+    then rots again. `created > last_seen` alone stops blocking at that point, so
+    without the pending rule the queue would show two identical proposals with
+    contradictory reasons (council-pr A1).
+    """
+    _rot_one_builtin(engine)
+    first = run_synthetic_pattern_monitor(engine, now=NOW)
+    assert first["proposals_created"] == 1  # left pending on purpose
+
+    # The marker comes back, fires twice, then goes quiet again.
+    later = NOW + timedelta(days=100)
+    for i in range(2):
+        _decision(engine, outcome="silent_synthetic",
+                  matched_pattern=TASK_NOTIFICATION, logged_at=later + timedelta(days=i))
+    much_later = later + timedelta(days=60)
+    for i in range(engine.settings.whisper_pattern_rot_min_opportunity):
+        _decision(engine, outcome="injected", matched_pattern=None,
+                  logged_at=much_later - timedelta(minutes=i + 1))
+
+    second = run_synthetic_pattern_monitor(engine, now=much_later)
+
+    assert second["proposals_created"] == 0
+    total = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM proposals WHERE type = 'pattern' AND status = 'pending'"
+    ).fetchone()[0]
+    assert total == 1
+
+
 def test_proposed_action_says_the_action_is_manual(engine):
     """council I3. Approving executes nothing, yet the shared proposals surface
     reports success and drops the item — the text must not let the user believe

--- a/tests/test_background/test_synthetic_pattern_monitor.py
+++ b/tests/test_background/test_synthetic_pattern_monitor.py
@@ -9,6 +9,7 @@ from ormah.background.synthetic_pattern_monitor import (
     OPERATOR,
     find_rotted_patterns,
     live_patterns,
+    run_synthetic_pattern_monitor,
 )
 
 NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
@@ -148,3 +149,159 @@ def test_find_rotted_patterns_writes_nothing(engine):
 
     count = engine.db.conn.execute("SELECT COUNT(*) FROM proposals").fetchone()[0]
     assert count == 0
+
+
+def _rot_one_builtin(engine):
+    """A rotted <task-notification> plus live traffic — the standard setup.
+
+    Reuses _rotted_history from task 3, so the 2-match minimum stays in one place.
+    """
+    engine.settings.whisper_pattern_rot_days = 30
+    _rotted_history(engine, TASK_NOTIFICATION)
+
+
+def test_rotted_pattern_creates_one_pending_proposal(engine):
+    _rot_one_builtin(engine)
+
+    result = run_synthetic_pattern_monitor(engine, now=NOW)
+
+    assert result == {"rotted": 1, "proposals_created": 1}
+    row = engine.db.conn.execute(
+        "SELECT type, status, source_nodes, proposed_action, reason FROM proposals"
+    ).fetchone()
+    assert row["type"] == "pattern"
+    assert row["status"] == "pending"
+    assert row["source_nodes"] == "[]"
+    assert TASK_NOTIFICATION in row["proposed_action"]
+
+
+def test_running_twice_does_not_duplicate(engine):
+    """The job runs daily and the pattern stays rotted daily."""
+    _rot_one_builtin(engine)
+
+    run_synthetic_pattern_monitor(engine, now=NOW)
+    second = run_synthetic_pattern_monitor(engine, now=NOW + timedelta(days=1))
+
+    assert second["proposals_created"] == 0
+    count = engine.db.conn.execute("SELECT COUNT(*) FROM proposals").fetchone()[0]
+    assert count == 1
+
+
+def test_proposed_action_is_stable_across_days(engine):
+    """proposed_action IS the dedup key: a date or count in it would change every
+    run, the dedup would never hit, and this would file one proposal per day."""
+    _rot_one_builtin(engine)
+
+    run_synthetic_pattern_monitor(engine, now=NOW)
+    first = engine.db.conn.execute("SELECT proposed_action FROM proposals").fetchone()[0]
+    engine.db.conn.execute("DELETE FROM proposals")
+    run_synthetic_pattern_monitor(engine, now=NOW + timedelta(days=9))
+    later = engine.db.conn.execute("SELECT proposed_action FROM proposals").fetchone()[0]
+
+    assert first == later
+
+
+def test_rejected_proposal_is_not_re_proposed(engine):
+    """Rejecting means "I know, leave it" — it must not come back tomorrow."""
+    _rot_one_builtin(engine)
+    run_synthetic_pattern_monitor(engine, now=NOW)
+    engine.db.conn.execute("UPDATE proposals SET status = 'rejected'")
+    engine.db.conn.commit()
+
+    result = run_synthetic_pattern_monitor(engine, now=NOW + timedelta(days=1))
+
+    assert result["proposals_created"] == 0
+
+
+def test_builtin_and_operator_get_different_actions(engine):
+    """Telling the user to remove from .env a pattern that is not in their .env
+    is an instruction impossible to follow."""
+    engine.settings.whisper_pattern_rot_days = 30
+    engine.settings.whisper_synthetic_prompt_patterns = [r"BATCH JOB"]
+    _rotted_history(engine, TASK_NOTIFICATION)
+    _rotted_history(engine, r"BATCH JOB")
+
+    run_synthetic_pattern_monitor(engine, now=NOW)
+
+    actions = {
+        r["proposed_action"]
+        for r in engine.db.conn.execute("SELECT proposed_action FROM proposals").fetchall()
+    }
+    operator_action = next(a for a in actions if r"BATCH JOB" in a)
+    builtin_action = next(a for a in actions if TASK_NOTIFICATION in a)
+    assert "ORMAH_WHISPER_SYNTHETIC_PROMPT_PATTERNS" in operator_action
+    assert "ORMAH_WHISPER_SYNTHETIC_PROMPT_PATTERNS" not in builtin_action
+
+
+def test_reason_carries_the_variable_evidence(engine):
+    _rot_one_builtin(engine)
+
+    run_synthetic_pattern_monitor(engine, now=NOW)
+
+    reason = engine.db.conn.execute("SELECT reason FROM proposals").fetchone()[0]
+    assert (NOW - timedelta(days=60)).isoformat() in reason
+
+
+def test_a_second_rot_episode_gets_a_fresh_proposal(engine):
+    """council I2. Pattern rots, is repaired, resumes matching, rots AGAIN.
+
+    Without `created > last_seen` in the dedup, the historical row would block
+    the new episode forever and the second regression would go unreported.
+    """
+    _rot_one_builtin(engine)
+    run_synthetic_pattern_monitor(engine, now=NOW)
+    engine.db.conn.execute("UPDATE proposals SET status = 'approved'")
+    engine.db.conn.commit()
+
+    # The marker comes back (repaired), fires twice, then goes quiet again.
+    later = NOW + timedelta(days=100)
+    _decision(engine, outcome="silent_synthetic",
+              matched_pattern=TASK_NOTIFICATION, logged_at=later)
+    _decision(engine, outcome="silent_synthetic",
+              matched_pattern=TASK_NOTIFICATION, logged_at=later + timedelta(days=1))
+    much_later = later + timedelta(days=60)
+    _decision(engine, outcome="injected", matched_pattern=None, logged_at=much_later)
+
+    result = run_synthetic_pattern_monitor(engine, now=much_later)
+
+    assert result["proposals_created"] == 1
+    count = engine.db.conn.execute("SELECT COUNT(*) FROM proposals").fetchone()[0]
+    assert count == 2
+
+
+def test_proposed_action_says_the_action_is_manual(engine):
+    """council I3. Approving executes nothing, yet the shared proposals surface
+    reports success and drops the item — the text must not let the user believe
+    the repair happened."""
+    _rot_one_builtin(engine)
+
+    run_synthetic_pattern_monitor(engine, now=NOW)
+
+    action = engine.db.conn.execute("SELECT proposed_action FROM proposals").fetchone()[0]
+    assert action.startswith("MANUAL ACTION REQUIRED")
+
+
+def test_no_rot_creates_nothing(engine):
+    engine.settings.whisper_pattern_rot_days = 30
+    _decision(engine, outcome="silent_synthetic",
+              matched_pattern=TASK_NOTIFICATION, logged_at=NOW - timedelta(days=1))
+
+    assert run_synthetic_pattern_monitor(engine, now=NOW) == {
+        "rotted": 0, "proposals_created": 0,
+    }
+
+
+def test_decay_manager_does_not_eat_pattern_proposals(engine):
+    """decay_manager.py:20-24 deletes type='decay' proposals on EVERY run,
+    unguarded. This pins that 'pattern' is not caught by that DELETE."""
+    from ormah.background.decay_manager import run_decay
+
+    _rot_one_builtin(engine)
+    run_synthetic_pattern_monitor(engine, now=NOW)
+
+    run_decay(engine)
+
+    count = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM proposals WHERE type = 'pattern'"
+    ).fetchone()[0]
+    assert count == 1

--- a/tests/test_background/test_synthetic_pattern_monitor.py
+++ b/tests/test_background/test_synthetic_pattern_monitor.py
@@ -1,0 +1,150 @@
+"""Rot detection for the synthetic-prompt pattern list (#143)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from ormah.background.synthetic_pattern_monitor import (
+    BUILTIN,
+    OPERATOR,
+    find_rotted_patterns,
+    live_patterns,
+)
+
+NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=timezone.utc)
+TASK_NOTIFICATION = r"<task-notification>"
+
+
+def _decision(engine, *, outcome, matched_pattern, logged_at):
+    """Insert one whisper_decisions row directly — this is the job's only input."""
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO whisper_decisions (session_id, space, prompt_hash, intent, "
+            "outcome, logged_at, matched_pattern) VALUES (?, NULL, 'h', NULL, ?, ?, ?)",
+            ("s", outcome, logged_at.isoformat(), matched_pattern),
+        )
+
+
+def test_live_patterns_includes_builtins_and_operator_entries(engine):
+    engine.settings.whisper_synthetic_prompt_patterns = [r"BATCH JOB"]
+    live = live_patterns(engine.settings)
+
+    assert (TASK_NOTIFICATION, BUILTIN) in live
+    assert (r"BATCH JOB", OPERATOR) in live
+
+
+def test_live_patterns_dedups_an_operator_copy_of_a_builtin(engine):
+    """One regex must yield one entry, or it yields two proposals (council I1)."""
+    engine.settings.whisper_synthetic_prompt_patterns = [TASK_NOTIFICATION]
+
+    live = live_patterns(engine.settings)
+
+    assert [p for p, _ in live].count(TASK_NOTIFICATION) == 1
+    assert (TASK_NOTIFICATION, OPERATOR) in live  # operator wins: it is what the user can remove
+
+
+def test_pattern_that_never_matched_is_not_rot(engine):
+    """Irrelevance, not rot: <scheduled-task> matching zero means this install
+    never runs scheduled tasks. Proposing removal would be noise."""
+    engine.settings.whisper_pattern_rot_days = 30
+    _decision(engine, outcome="injected", matched_pattern=None, logged_at=NOW)
+
+    assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
+
+
+def test_pattern_still_firing_is_not_rot(engine):
+    engine.settings.whisper_pattern_rot_days = 30
+    _decision(engine, outcome="silent_synthetic",
+              matched_pattern=TASK_NOTIFICATION, logged_at=NOW - timedelta(days=2))
+
+    assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
+
+
+def _rotted_history(engine, pattern, *, hits=2, age_days=60):
+    """`hits` past matches for `pattern`, plus recent human traffic.
+
+    hits defaults to 2 because whisper_pattern_rot_min_matches defaults to 2 — a
+    single historical match is deliberately not rot (council I4).
+    """
+    for i in range(hits):
+        _decision(engine, outcome="silent_synthetic", matched_pattern=pattern,
+                  logged_at=NOW - timedelta(days=age_days + i))
+    _decision(engine, outcome="injected", matched_pattern=None, logged_at=NOW)
+
+
+def test_pattern_that_matched_before_and_stopped_is_rot(engine):
+    engine.settings.whisper_pattern_rot_days = 30
+    _rotted_history(engine, TASK_NOTIFICATION)
+
+    rotted = find_rotted_patterns(engine.db.conn, engine.settings, NOW)
+
+    assert len(rotted) == 1
+    assert rotted[0].pattern == TASK_NOTIFICATION
+    assert rotted[0].origin == BUILTIN
+
+
+def test_operator_pattern_rot_carries_the_operator_origin(engine):
+    engine.settings.whisper_pattern_rot_days = 30
+    engine.settings.whisper_synthetic_prompt_patterns = [r"BATCH JOB"]
+    _rotted_history(engine, r"BATCH JOB")
+
+    rotted = find_rotted_patterns(engine.db.conn, engine.settings, NOW)
+
+    assert [(r.pattern, r.origin) for r in rotted] == [(r"BATCH JOB", OPERATOR)]
+
+
+def test_filter_disabled_proposes_nothing(engine):
+    """council C1. With the filter off nothing writes silent_synthetic, so every
+    last_seen freezes while human traffic keeps the vacation guard happy — the
+    whole pattern list would age into false proposals claiming an upstream rename
+    that never happened, and the user might delete a still-valid filter."""
+    engine.settings.whisper_pattern_rot_days = 30
+    engine.settings.whisper_synthetic_filter_enabled = False
+    _rotted_history(engine, TASK_NOTIFICATION)
+
+    assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
+
+
+def test_single_historical_match_is_not_rot(engine):
+    """council I4. One match months ago is not evidence of a live workflow."""
+    engine.settings.whisper_pattern_rot_days = 30
+    engine.settings.whisper_pattern_rot_min_matches = 2
+    _rotted_history(engine, TASK_NOTIFICATION, hits=1)
+
+    assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
+
+
+def test_no_traffic_at_all_proposes_nothing(engine):
+    """The vacation guard. Two weeks away must not rot every pattern at once."""
+    engine.settings.whisper_pattern_rot_days = 30
+    _decision(engine, outcome="silent_synthetic",
+              matched_pattern=TASK_NOTIFICATION, logged_at=NOW - timedelta(days=60))
+    # No row inside the window at all.
+
+    assert find_rotted_patterns(engine.db.conn, engine.settings, NOW) == []
+
+
+def test_pattern_removed_from_config_is_ignored(engine):
+    """History for a pattern the user already deleted is not actionable."""
+    engine.settings.whisper_pattern_rot_days = 30
+    engine.settings.whisper_synthetic_prompt_patterns = []
+    _decision(engine, outcome="silent_synthetic",
+              matched_pattern=r"GONE FROM ENV", logged_at=NOW - timedelta(days=60))
+    _decision(engine, outcome="injected", matched_pattern=None, logged_at=NOW)
+
+    rotted = find_rotted_patterns(engine.db.conn, engine.settings, NOW)
+
+    assert all(r.pattern != r"GONE FROM ENV" for r in rotted)
+
+
+def test_find_rotted_patterns_writes_nothing(engine):
+    """Detection is a pure read; only task 4's job writes."""
+    engine.settings.whisper_pattern_rot_days = 30
+    _decision(engine, outcome="silent_synthetic",
+              matched_pattern=TASK_NOTIFICATION, logged_at=NOW - timedelta(days=60))
+    _decision(engine, outcome="injected", matched_pattern=None, logged_at=NOW)
+
+    find_rotted_patterns(engine.db.conn, engine.settings, NOW)
+
+    count = engine.db.conn.execute("SELECT COUNT(*) FROM proposals").fetchone()[0]
+    assert count == 0

--- a/tests/test_engine/test_prompt_classifier.py
+++ b/tests/test_engine/test_prompt_classifier.py
@@ -11,6 +11,7 @@ from ormah.engine.prompt_classifier import (
     PromptClassifier,
     PromptIntent,
     extract_time_params,
+    is_synthetic_prompt,
     strip_temporal_phrases,
 )
 
@@ -512,3 +513,49 @@ class TestContinuationIntent:
         intent = classifier.classify("continue where we left off")
         assert "continuation" in intent.categories
         assert "created_after" in intent.search_params
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-prompt filter (issue #134)
+# ---------------------------------------------------------------------------
+
+
+class TestIsSyntheticPrompt:
+    def test_task_notification_is_synthetic(self):
+        assert is_synthetic_prompt("<task-notification>\n<task-id>abc</task-id>") is True
+
+    def test_scheduled_task_is_synthetic(self):
+        assert is_synthetic_prompt('<scheduled-task name="drive-watch" file="/x/S.md">') is True
+
+    def test_autonomous_loop_is_synthetic(self):
+        assert is_synthetic_prompt("# Autonomous loop check\n\nYou're being invoked") is True
+
+    def test_leading_whitespace_still_matches(self):
+        assert is_synthetic_prompt("\n  <task-notification>\n<task-id>a</task-id>") is True
+
+    def test_ide_wrapper_with_human_prompt_is_not_synthetic(self):
+        # REGRESSION GUARD (issue #134): the IDE prefixes this tag to a REAL human
+        # prompt — 46/46 such events on the live DB carried human text. Filtering it
+        # would silence the whisper for every prompt sent with a file open in the IDE.
+        prompt = (
+            "<ide_opened_file>The user opened the file /x/notes.md in the IDE."
+            "</ide_opened_file>\nnão, isso fica em estratégia — revisa o portfólio"
+        )
+        assert is_synthetic_prompt(prompt) is False
+
+    def test_human_asking_about_a_marker_is_not_synthetic(self):
+        # The anchor is deliberate and fail-open: when in doubt, whisper.
+        assert is_synthetic_prompt("what is a <task-notification> block?") is False
+
+    def test_extra_pattern_from_settings_matches(self):
+        assert is_synthetic_prompt(
+            "You are classifying the relationship between two memories",
+            extra_patterns=[r"You are classifying the relationship"],
+        ) is True
+
+    def test_invalid_extra_pattern_fails_open(self):
+        # A config typo must degrade to "filters less", never kill the whisper.
+        assert is_synthetic_prompt("hello there", extra_patterns=["[unclosed"]) is False
+
+    def test_empty_prompt_is_not_synthetic(self):
+        assert is_synthetic_prompt("") is False

--- a/tests/test_engine/test_prompt_classifier.py
+++ b/tests/test_engine/test_prompt_classifier.py
@@ -11,7 +11,7 @@ from ormah.engine.prompt_classifier import (
     PromptClassifier,
     PromptIntent,
     extract_time_params,
-    is_synthetic_prompt,
+    match_synthetic_pattern,
     strip_temporal_phrases,
 )
 
@@ -520,42 +520,53 @@ class TestContinuationIntent:
 # ---------------------------------------------------------------------------
 
 
-class TestIsSyntheticPrompt:
-    def test_task_notification_is_synthetic(self):
-        assert is_synthetic_prompt("<task-notification>\n<task-id>abc</task-id>") is True
+class TestMatchSyntheticPattern:
+    """Which pattern fired — the signal rot detection needs (#143)."""
 
-    def test_scheduled_task_is_synthetic(self):
-        assert is_synthetic_prompt('<scheduled-task name="drive-watch" file="/x/S.md">') is True
+    def test_task_notification_returns_its_pattern_source(self):
+        assert match_synthetic_pattern("<task-notification>done</task-notification>") == (
+            r"<task-notification>"
+        )
 
-    def test_autonomous_loop_is_synthetic(self):
-        assert is_synthetic_prompt("# Autonomous loop check\n\nYou're being invoked") is True
+    def test_scheduled_task_returns_its_pattern_source(self):
+        assert match_synthetic_pattern("<scheduled-task id=3>") == r"<scheduled-task\b"
+
+    def test_autonomous_loop_returns_its_pattern_source(self):
+        assert match_synthetic_pattern("# Autonomous loop check") == (
+            r"#\s*Autonomous loop check\b"
+        )
 
     def test_leading_whitespace_still_matches(self):
-        assert is_synthetic_prompt("\n  <task-notification>\n<task-id>a</task-id>") is True
+        assert match_synthetic_pattern("\n  <task-notification>x") == r"<task-notification>"
 
-    def test_ide_wrapper_with_human_prompt_is_not_synthetic(self):
-        # REGRESSION GUARD (issue #134): the IDE prefixes this tag to a REAL human
-        # prompt — 46/46 such events on the live DB carried human text. Filtering it
-        # would silence the whisper for every prompt sent with a file open in the IDE.
-        prompt = (
-            "<ide_opened_file>The user opened the file /x/notes.md in the IDE."
-            "</ide_opened_file>\nnão, isso fica em estratégia — revisa o portfólio"
-        )
-        assert is_synthetic_prompt(prompt) is False
+    def test_operator_pattern_returns_the_raw_string(self):
+        assert match_synthetic_pattern("BATCH JOB 12 done", [r"BATCH JOB"]) == r"BATCH JOB"
 
-    def test_human_asking_about_a_marker_is_not_synthetic(self):
-        # The anchor is deliberate and fail-open: when in doubt, whisper.
-        assert is_synthetic_prompt("what is a <task-notification> block?") is False
+    def test_ide_wrapped_human_prompt_returns_none(self):
+        # <ide_opened_file> PREFIXES a real human prompt (#134 regression guard).
+        assert match_synthetic_pattern("<ide_opened_file>/a/b.py</ide_opened_file>fix this") is None
 
-    def test_extra_pattern_from_settings_matches(self):
-        assert is_synthetic_prompt(
-            "You are classifying the relationship between two memories",
-            extra_patterns=[r"You are classifying the relationship"],
-        ) is True
+    def test_human_asking_about_a_marker_returns_none(self):
+        # Anchored .match(), not .search() — a human discussing a marker is human.
+        assert match_synthetic_pattern("what is a <task-notification> block?") is None
 
-    def test_invalid_extra_pattern_fails_open(self):
-        # A config typo must degrade to "filters less", never kill the whisper.
-        assert is_synthetic_prompt("hello there", extra_patterns=["[unclosed"]) is False
+    def test_plain_human_prompt_returns_none(self):
+        assert match_synthetic_pattern("fix the parser") is None
 
-    def test_empty_prompt_is_not_synthetic(self):
-        assert is_synthetic_prompt("") is False
+    def test_empty_prompt_returns_none(self):
+        assert match_synthetic_pattern("") is None
+
+    def test_invalid_operator_regex_is_skipped_not_fatal(self):
+        # A config typo must never take the whisper down (fail-open).
+        assert match_synthetic_pattern("hello", ["[unclosed"]) is None
+
+    def test_invalid_regex_does_not_hide_a_later_valid_one(self):
+        assert match_synthetic_pattern("BATCH x", ["[unclosed", r"BATCH"]) == r"BATCH"
+
+    def test_empty_operator_pattern_returns_empty_string_not_none(self):
+        """The empty regex matches everything and returns "" — falsy but REAL.
+
+        Callers MUST test `is not None`. If this ever returns None, an operator
+        who configured "" silently loses all filtering.
+        """
+        assert match_synthetic_pattern("anything at all", [""]) == ""

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -3337,6 +3337,35 @@ class TestSyntheticPromptEndpoint:
         engine.get_whisper_context.assert_not_called()
         _session_buffers.clear()
 
+    def test_empty_operator_pattern_still_skips_the_whisper(self, monkeypatch):
+        """"" matches everything and is falsy — the guard must test `is not None`.
+
+        Truthiness here would silently disable filtering for this operator.
+        """
+        from ormah.config import settings
+
+        monkeypatch.setattr(settings, "whisper_synthetic_prompt_patterns", [""])
+        client, engine = self._client()  # reuse this class's existing helper
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": "an ordinary human prompt", "session_id": "s-empty"},
+        )
+        assert resp.status_code == 200
+        engine.get_whisper_context.assert_not_called()
+
+    def test_filter_disabled_lets_a_synthetic_prompt_through(self, monkeypatch):
+        """Kill-switch coverage: it was dropped in 566fe3a when the guard moved."""
+        from ormah.config import settings
+
+        monkeypatch.setattr(settings, "whisper_synthetic_filter_enabled", False)
+        client, engine = self._client()
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": "<task-notification>done", "session_id": "s-off"},
+        )
+        assert resp.status_code == 200
+        engine.get_whisper_context.assert_called_once()
+
 
 class TestSessionBufferEviction:
     """Dead sessions are evicted from _session_buffers on access (I12)."""

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -2853,52 +2853,21 @@ class TestWhisperDecisions:
             "SELECT * FROM whisper_decisions ORDER BY id"
         ).fetchall()
 
-    def test_synthetic_prompt_logs_silent_synthetic(self, db_graph):
+    def test_note_synthetic_whisper_skip_writes_the_decision_row(self, db_graph):
+        # The skip itself happens at the /agent/whisper boundary (see
+        # TestSyntheticPromptEndpoint); the engine only records it, so
+        # whisper_decisions stays one-row-per-call.
         db, graph = db_graph
         builder = self._builder_with_db(db, graph)
-
-        out = builder.build_whisper_context(
-            prompt="<task-notification>\n<task-id>x</task-id>\n<status>done</status>",
-            session_id="s-synth",
+        builder._log_decision(
+            session_id="s-synth", space="proj", prompt="<task-notification>\n<task-id>x</task-id>",
+            intent=None, outcome="silent_synthetic",
         )
 
-        assert out == ""
         rows = self._decisions(db)
         assert len(rows) == 1
         assert rows[0]["outcome"] == "silent_synthetic"
         assert rows[0]["session_id"] == "s-synth"
-
-    def test_ide_wrapped_human_prompt_is_not_skipped(self, db_graph):
-        # REGRESSION GUARD (issue #134): must NOT log silent_synthetic — this is a
-        # real human prompt the IDE merely prefixed. 46/46 live events carried
-        # human text after the tag, so filtering it would silence the whisper
-        # whenever a file is open in the IDE.
-        db, graph = db_graph
-        builder = self._builder_with_db(db, graph, results=[])
-
-        builder.build_whisper_context(
-            prompt=("<ide_opened_file>The user opened /x/a.md in the IDE."
-                    "</ide_opened_file>\nrevisa o portfólio de segurança"),
-            session_id="s-ide",
-        )
-
-        rows = self._decisions(db)
-        assert len(rows) == 1
-        assert rows[0]["outcome"] != "silent_synthetic"
-
-    def test_filter_disabled_does_not_skip(self, db_graph):
-        db, graph = db_graph
-        builder = self._builder_with_db(db, graph, results=[])
-        builder.engine.settings = _make_settings_mock(
-            whisper_synthetic_filter_enabled=False,
-        )
-
-        builder.build_whisper_context(
-            prompt="<task-notification>\n<task-id>x</task-id>", session_id="s-off",
-        )
-
-        rows = self._decisions(db)
-        assert rows[0]["outcome"] != "silent_synthetic"
 
     def test_short_prompt_logs_silent_short(self, db_graph):
         db, graph = db_graph
@@ -3221,6 +3190,105 @@ class TestTopicShiftServedMemory:
             )
 
         assert "Sessionless topic memory" not in result
+
+
+class TestSyntheticPromptEndpoint:
+    """A machine-generated turn is skipped at the /agent/whisper boundary,
+    BEFORE any per-turn state mutation (#134).
+
+    The guard must sit above the session buffer and above the engine, because
+    both carry irreversible per-turn side effects: the ring buffer feeds
+    topic-shift/continuation for the NEXT human turn, and the engine's first
+    statement consumes the one-time onboarding nudge (meta.onboarding_prompted).
+    """
+
+    def _client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ormah.api.routes_agent import router
+
+        app = FastAPI()
+        app.include_router(router)
+        engine = MagicMock()
+        engine.get_whisper_context.return_value = ""
+        app.state.engine = engine
+        return TestClient(app), engine
+
+    def test_synthetic_prompt_never_reaches_the_engine(self):
+        # REGRESSION GUARD (#134, council/codex R1): the engine's first statement is
+        # _maybe_get_onboarding_nudge, which INSERTs meta.onboarding_prompted and
+        # returns the nudge exactly once. If a machine turn reaches the engine, it
+        # burns the onboarding and the first human never sees it.
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": "<task-notification>\n<task-id>x</task-id>",
+                  "session_id": "s-synth"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["text"] == ""
+        engine.get_whisper_context.assert_not_called()
+        _session_buffers.clear()
+
+    def test_synthetic_prompt_does_not_enter_the_session_buffer(self):
+        # A machine turn must not pollute recent_prompts: the buffer feeds the
+        # topic-shift centroid for the next HUMAN turn.
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, _ = self._client()
+
+        client.post(
+            "/agent/whisper",
+            json={"prompt": "<scheduled-task name=\"drive-watch\" file=\"/x/S.md\">",
+                  "session_id": "s-buf"},
+        )
+
+        assert "s-buf" not in _session_buffers
+        _session_buffers.clear()
+
+    def test_synthetic_prompt_records_telemetry(self):
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        client.post(
+            "/agent/whisper",
+            json={"prompt": "<task-notification>\n<task-id>x</task-id>",
+                  "session_id": "s-tel", "space": "proj"},
+        )
+
+        engine.note_synthetic_whisper_skip.assert_called_once()
+        kwargs = engine.note_synthetic_whisper_skip.call_args.kwargs
+        assert kwargs["session_id"] == "s-tel"
+        assert kwargs["space"] == "proj"
+        _session_buffers.clear()
+
+    def test_ide_wrapped_human_prompt_reaches_the_engine(self):
+        # REGRESSION GUARD (#134): <ide_opened_file> merely PREFIXES a real human
+        # prompt (46/46 on a live 30d corpus) — it must flow through untouched.
+        from ormah.api.routes_agent import _session_buffers
+
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": ("<ide_opened_file>The user opened /x/a.md in the IDE."
+                             "</ide_opened_file>\nrevisa o portfólio de segurança"),
+                  "session_id": "s-ide"},
+        )
+
+        assert resp.status_code == 200
+        engine.get_whisper_context.assert_called_once()
+        assert "s-ide" in _session_buffers
+        _session_buffers.clear()
 
 
 class TestSessionBufferEviction:

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -1778,9 +1778,13 @@ def _make_settings_mock(
     claude_maintenance_enabled=False,
     whisper_no_overlap_ce_floor=0.45,
     whisper_no_overlap_cosine_floor=0.70,
+    whisper_synthetic_filter_enabled=True,
+    whisper_synthetic_prompt_patterns=(),
 ):
     """Create a MagicMock settings object with affinity-related float attributes."""
     settings = MagicMock()
+    settings.whisper_synthetic_filter_enabled = whisper_synthetic_filter_enabled
+    settings.whisper_synthetic_prompt_patterns = whisper_synthetic_prompt_patterns
     settings.whisper_reranker_min_score = whisper_reranker_min_score
     settings.whisper_exploration_enabled = whisper_exploration_enabled
     settings.affinity_similarity_threshold = affinity_similarity_threshold
@@ -2848,6 +2852,53 @@ class TestWhisperDecisions:
         return db.conn.execute(
             "SELECT * FROM whisper_decisions ORDER BY id"
         ).fetchall()
+
+    def test_synthetic_prompt_logs_silent_synthetic(self, db_graph):
+        db, graph = db_graph
+        builder = self._builder_with_db(db, graph)
+
+        out = builder.build_whisper_context(
+            prompt="<task-notification>\n<task-id>x</task-id>\n<status>done</status>",
+            session_id="s-synth",
+        )
+
+        assert out == ""
+        rows = self._decisions(db)
+        assert len(rows) == 1
+        assert rows[0]["outcome"] == "silent_synthetic"
+        assert rows[0]["session_id"] == "s-synth"
+
+    def test_ide_wrapped_human_prompt_is_not_skipped(self, db_graph):
+        # REGRESSION GUARD (issue #134): must NOT log silent_synthetic — this is a
+        # real human prompt the IDE merely prefixed. 46/46 live events carried
+        # human text after the tag, so filtering it would silence the whisper
+        # whenever a file is open in the IDE.
+        db, graph = db_graph
+        builder = self._builder_with_db(db, graph, results=[])
+
+        builder.build_whisper_context(
+            prompt=("<ide_opened_file>The user opened /x/a.md in the IDE."
+                    "</ide_opened_file>\nrevisa o portfólio de segurança"),
+            session_id="s-ide",
+        )
+
+        rows = self._decisions(db)
+        assert len(rows) == 1
+        assert rows[0]["outcome"] != "silent_synthetic"
+
+    def test_filter_disabled_does_not_skip(self, db_graph):
+        db, graph = db_graph
+        builder = self._builder_with_db(db, graph, results=[])
+        builder.engine.settings = _make_settings_mock(
+            whisper_synthetic_filter_enabled=False,
+        )
+
+        builder.build_whisper_context(
+            prompt="<task-notification>\n<task-id>x</task-id>", session_id="s-off",
+        )
+
+        rows = self._decisions(db)
+        assert rows[0]["outcome"] != "silent_synthetic"
 
     def test_short_prompt_logs_silent_short(self, db_graph):
         db, graph = db_graph

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -2856,18 +2856,26 @@ class TestWhisperDecisions:
     def test_note_synthetic_whisper_skip_writes_the_decision_row(self, db_graph):
         # The skip itself happens at the /agent/whisper boundary (see
         # TestSyntheticPromptEndpoint); the engine only records it, so
-        # whisper_decisions stays one-row-per-call.
+        # whisper_decisions stays one-row-per-call. Goes through the real
+        # MemoryEngine method to cover the endpoint -> engine wiring.
+        from ormah.engine.memory_engine import MemoryEngine
+
         db, graph = db_graph
         builder = self._builder_with_db(db, graph)
-        builder._log_decision(
-            session_id="s-synth", space="proj", prompt="<task-notification>\n<task-id>x</task-id>",
-            intent=None, outcome="silent_synthetic",
+        engine = MagicMock(spec=MemoryEngine)
+        engine.context_builder = builder
+        MemoryEngine.note_synthetic_whisper_skip(
+            engine,
+            prompt="<task-notification>\n<task-id>x</task-id>",
+            space="proj",
+            session_id="s-synth",
         )
 
         rows = self._decisions(db)
         assert len(rows) == 1
         assert rows[0]["outcome"] == "silent_synthetic"
         assert rows[0]["session_id"] == "s-synth"
+        assert rows[0]["space"] == "proj"
 
     def test_short_prompt_logs_silent_short(self, db_graph):
         db, graph = db_graph
@@ -3288,6 +3296,45 @@ class TestSyntheticPromptEndpoint:
         assert resp.status_code == 200
         engine.get_whisper_context.assert_called_once()
         assert "s-ide" in _session_buffers
+        _session_buffers.clear()
+
+    def test_kill_switch_lets_synthetic_prompts_through(self, monkeypatch):
+        from ormah.api.routes_agent import _session_buffers
+        from ormah.config import settings as global_settings
+
+        monkeypatch.setattr(global_settings, "whisper_synthetic_filter_enabled", False)
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        client.post(
+            "/agent/whisper",
+            json={"prompt": "<task-notification>\n<task-id>x</task-id>",
+                  "session_id": "s-killswitch"},
+        )
+
+        engine.get_whisper_context.assert_called_once()
+        engine.note_synthetic_whisper_skip.assert_not_called()
+        _session_buffers.clear()
+
+    def test_extra_patterns_from_settings_apply_at_the_boundary(self, monkeypatch):
+        from ormah.api.routes_agent import _session_buffers
+        from ormah.config import settings as global_settings
+
+        monkeypatch.setattr(
+            global_settings, "whisper_synthetic_prompt_patterns",
+            [r"You are classifying the relationship"],
+        )
+        _session_buffers.clear()
+        client, engine = self._client()
+
+        resp = client.post(
+            "/agent/whisper",
+            json={"prompt": "You are classifying the relationship between two memories",
+                  "session_id": "s-extra"},
+        )
+
+        assert resp.json()["text"] == ""
+        engine.get_whisper_context.assert_not_called()
         _session_buffers.clear()
 
 

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -3366,6 +3366,39 @@ class TestSyntheticPromptEndpoint:
         assert resp.status_code == 200
         engine.get_whisper_context.assert_called_once()
 
+    def test_boundary_records_which_builtin_pattern_fired(self, engine):
+        """Rot detection is impossible without knowing WHICH pattern matched (#143)."""
+        engine.note_synthetic_whisper_skip(
+            prompt="<task-notification>done",
+            session_id="s-1",
+            matched_pattern=r"<task-notification>",
+        )
+        row = engine.db.conn.execute(
+            "SELECT outcome, matched_pattern FROM whisper_decisions WHERE session_id = 's-1'"
+        ).fetchone()
+        assert row["outcome"] == "silent_synthetic"
+        assert row["matched_pattern"] == r"<task-notification>"
+
+    def test_boundary_records_an_operator_pattern_verbatim(self, engine):
+        engine.note_synthetic_whisper_skip(
+            prompt="BATCH JOB 7", session_id="s-2", matched_pattern=r"BATCH JOB",
+        )
+        row = engine.db.conn.execute(
+            "SELECT matched_pattern FROM whisper_decisions WHERE session_id = 's-2'"
+        ).fetchone()
+        assert row["matched_pattern"] == r"BATCH JOB"
+
+    def test_non_synthetic_decisions_leave_matched_pattern_null(self, engine):
+        """Only silent_synthetic rows carry a pattern; everything else stays NULL."""
+        engine.context_builder._log_decision(
+            session_id="s-3", space=None, prompt="a human prompt",
+            intent=None, outcome="silent_short",
+        )
+        row = engine.db.conn.execute(
+            "SELECT matched_pattern FROM whisper_decisions WHERE session_id = 's-3'"
+        ).fetchone()
+        assert row["matched_pattern"] is None
+
 
 class TestSessionBufferEviction:
     """Dead sessions are evicted from _session_buffers on access (I12)."""

--- a/tests/test_index/test_whisper_decisions_migration.py
+++ b/tests/test_index/test_whisper_decisions_migration.py
@@ -1,0 +1,32 @@
+"""The matched_pattern column must appear on pre-#143 databases too."""
+
+from __future__ import annotations
+
+from ormah.index.db import Database
+
+
+def test_migration_adds_matched_pattern_to_an_existing_db(tmp_path):
+    db_path = tmp_path / "old.db"  # Database.__init__ takes a Path, not a str (db.py:21)
+
+    # A pre-#143 whisper_decisions: same shape, no matched_pattern.
+    legacy = Database(db_path)
+    with legacy.transaction() as conn:
+        conn.execute("DROP TABLE IF EXISTS whisper_decisions")
+        conn.execute(
+            "CREATE TABLE whisper_decisions ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT, space TEXT,"
+            "  prompt_hash TEXT NOT NULL, intent TEXT, outcome TEXT NOT NULL,"
+            "  candidate_count INTEGER DEFAULT 0, injected_count INTEGER DEFAULT 0,"
+            "  max_gate_score REAL, logged_at TEXT NOT NULL)"
+        )
+    legacy.close()
+
+    migrated = Database(db_path)  # Path, never str — db.py:23 calls db_path.parent.mkdir()
+    migrated.init_schema()
+    cols = {
+        row[1]
+        for row in migrated.conn.execute("PRAGMA table_info(whisper_decisions)").fetchall()
+    }
+    migrated.close()
+
+    assert "matched_pattern" in cols

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -59,7 +59,7 @@ export interface NodeDetail {
   tags: string[];
 }
 
-export type ProposalType = "merge" | "conflict" | "decay";
+export type ProposalType = "merge" | "conflict" | "decay" | "pattern";
 export type ProposalStatus = "pending" | "approved" | "rejected";
 
 export interface ProposalNode {


### PR DESCRIPTION
Closes #143 (slice 1 of 2).

> **Stacked on #141.** This branch is cut from `fix/whisper-synthetic-prompt-filter`, so until #141
> merges the diff here also shows its commits. Review only the six commits from `b4b28d6` onward.
> The APIs consumed below (`is_synthetic_prompt`, `silent_synthetic`) do not exist on `main` yet.

## The problem

#134 added a regex list that skips machine-generated turns before retrieval. That list is a guess about
someone else's product: when Claude Code renames a marker, the pattern silently stops matching and the
filter quietly degrades. Nothing reports it — the list rots invisibly.

## The approach

Record *which* pattern fired, then notice when one stops firing.

- `is_synthetic_prompt -> bool` becomes `match_synthetic_pattern -> str | None`, returning the regex source.
- That value lands in a new `whisper_decisions.matched_pattern` column (migrated in place, no rebuild).
- A daily LLM-free job compares each live pattern's last match against a rot threshold and files a
  `pattern` proposal into the existing `proposals` table.

**Nothing is auto-applied.** A wrongly-silenced prompt fails invisibly, so the human stays in the loop:
the proposal renders the line, the user edits their own `.env`. Every `proposed_action` is prefixed
`MANUAL ACTION REQUIRED — ` because the shared proposals surface reports success on approve and executes
nothing for this type (see Known limitations).

## Guards against false positives

Each of these exists because a review caught the failure it prevents:

- **No signal without the filter.** With `whisper_synthetic_filter_enabled=false` nothing writes
  `silent_synthetic`, so every pattern would age into a proposal claiming a rename that never happened.
  Detection returns `[]`.
- **Rot needs opportunity, per pattern.** A pattern is only rotted if enough whisper traffic happened
  *since it last fired*. A global "was there any traffic" guard was satisfied by a single prompt after a
  month away and rotted the whole list.
- **Zero-valued knobs are rejected.** At `0`, `interval_minutes` was an invisible 1-second hot loop and
  `rot_days` silently disabled the job — opposite disasters, both silent.
- **`ProposalType.pattern`, never `decay`.** `decay_manager` runs an unguarded
  `DELETE FROM proposals WHERE type='decay' AND status='pending'` every night.
- **`proposed_action` derives from the regex alone** — it is the dedup key. Variable evidence (counts,
  dates) lives in `reason`, or the dedup never hits and the job files one proposal per day forever.

## Known limitations (deliberate, not oversights)

- **Opportunity is generic traffic, not per-pattern.** 50 human prompts with no subagent activity will
  classify `<task-notification>` as rotted, though it had zero real opportunities. Named in a `ponytail:`
  comment with its upgrade path; the real fix needs workload evidence, which is slice 2.
- **Approving executes nothing.** `resolve_proposal` only acts on `merge`/`conflict`. For an operator
  pattern this self-resolves (acting removes the `.env` entry, so the pattern leaves the live list). For
  a builtin it means an acknowledged rot stops being re-proposed — deliberate: re-proposing daily
  something the user already acknowledged is spam, since approving cannot move `last_seen`. Making the
  affordance honest belongs to #82.
- **Re-enabling the filter after a kill-switch period** can file one batch of rejectable proposals:
  `last_seen` freezes while traffic keeps counting. A real fix needs a toggle watermark — new structure
  for an emergency-only event.

## Tests

30 new cases: the empty pattern `""` (matches everything, returns `""` — falsy but a real match, so
callers must test `is not None`), the kill-switch, per-pattern opportunity, dedup, an abandoned pending
proposal, a second rot episode after a repair, the `decay_manager` trap, and the scheduler wiring.
Migration tested against a real pre-change database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)