### PR TITLE
fix(setup): skip the Claude Code hooks and MCP the ormah plugin already provides

### DIFF
--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2346,6 +2346,10 @@ def _claude_code_detected() -> bool:
 
 
 def _claude_code_is_wired() -> bool:
+    # The plugin ships the hooks and the MCP server — an install with a working
+    # plugin is wired even when settings.json holds nothing of ours.
+    if _claude_code_plugin_provides_hooks():
+        return True
     # Check for ormah whisper hooks in settings.json and ormah MCP in .claude.json
     settings_path = Path.home() / ".claude" / "settings.json"
     try:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -684,25 +684,29 @@ def _install_markdown_block(
     target.write_text(updated)
 
 
-def _plugin_enabled_in_settings(settings_path: Path, plugin_name: str) -> bool:
-    """Return True when the plugin is enabled in a Claude settings file."""
+def _enabled_plugin_keys(settings_path: Path, plugin_name: str) -> list[str]:
+    """Return the fully-qualified enabledPlugins keys for a plugin, in file order."""
     if not settings_path.exists():
-        return False
+        return []
     try:
         data = json.loads(settings_path.read_text())
     except (json.JSONDecodeError, ValueError):
-        return False
+        return []
 
     enabled_plugins = data.get("enabledPlugins", {})
     if not isinstance(enabled_plugins, dict):
-        return False
+        return []
 
-    for key, enabled in enabled_plugins.items():
-        if enabled is not True:
-            continue
-        if key == plugin_name or key.startswith(f"{plugin_name}@"):
-            return True
-    return False
+    return [
+        key
+        for key, enabled in enabled_plugins.items()
+        if enabled is True and (key == plugin_name or key.startswith(f"{plugin_name}@"))
+    ]
+
+
+def _plugin_enabled_in_settings(settings_path: Path, plugin_name: str) -> bool:
+    """Return True when the plugin is enabled in a Claude settings file."""
+    return bool(_enabled_plugin_keys(settings_path, plugin_name))
 
 
 def _candidate_project_roots(cwd: Path | None = None) -> list[Path]:
@@ -2299,6 +2303,12 @@ def _claude_code_plugin_provides_hooks() -> bool:
       - installed: ``plugins[]`` in ~/.claude/plugins/installed_plugins.json,
                    carrying the scope and the resolved installPath.
 
+    The two files must agree on the SAME fully-qualified key (e.g.
+    ``ormah@some-market``), not merely both mention an "ormah"-prefixed key:
+    a stale, still-installed marketplace entry must never stand in for the
+    marketplace that is actually enabled, or a broken active install could
+    hide behind a healthy but abandoned one.
+
     This predicate licenses deleting the user's own wiring, so it requires both,
     plus hooks/hooks.json AND .mcp.json under that installPath — the wire guard
     strips both the CLI hooks and the CLI's MCP entry, so proving only the
@@ -2317,7 +2327,8 @@ def _claude_code_plugin_provides_hooks() -> bool:
     Fails open: any unreadable or unparseable config returns False, so setup
     wires exactly as it does today.
     """
-    if not _plugin_enabled_in_settings(Path.home() / ".claude" / "settings.json", "ormah"):
+    enabled_keys = _enabled_plugin_keys(Path.home() / ".claude" / "settings.json", "ormah")
+    if not enabled_keys:
         return False
 
     registry_path = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
@@ -2330,9 +2341,8 @@ def _claude_code_plugin_provides_hooks() -> bool:
     if not isinstance(plugins, dict):
         return False
 
-    for key, entries in plugins.items():
-        if not isinstance(key, str) or key.split("@")[0] != "ormah":
-            continue
+    for key in enabled_keys:
+        entries = plugins.get(key)
         if not isinstance(entries, list):
             continue
         for entry in entries:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2290,6 +2290,57 @@ class AgentDescriptor:
     platform: list[str] | None = field(default=None)
 
 
+def _claude_code_plugin_provides_hooks() -> bool:
+    """True when a user-scoped ormah plugin is enabled AND actually installed.
+
+    Claude Code keeps the two states in two different files, and an enabled flag
+    is not proof that a working plugin exists:
+      - enabled:   ``enabledPlugins`` in ~/.claude/settings.json
+      - installed: ``plugins[]`` in ~/.claude/plugins/installed_plugins.json,
+                   carrying the scope and the resolved installPath.
+
+    This predicate licenses deleting the user's own wiring, so it requires both,
+    plus hooks/hooks.json under that installPath. A stale flag pointing at a
+    missing cache dir or a half-finished update would otherwise leave the user
+    with no whisper at all — silently.
+
+    Only a user-scoped plugin counts: configure_claude_hooks writes to the global
+    ~/.claude/settings.json, which serves every project, so those hooks are
+    redundant only when the plugin is global too. A project-scoped plugin keeps
+    its duplication rather than break the whisper everywhere else.
+
+    Fails open: any unreadable or unparseable config returns False, so setup
+    wires exactly as it does today.
+    """
+    if not _plugin_enabled_in_settings(Path.home() / ".claude" / "settings.json", "ormah"):
+        return False
+
+    registry_path = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+    try:
+        data = json.loads(registry_path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+
+    plugins = data.get("plugins") if isinstance(data, dict) else None
+    if not isinstance(plugins, dict):
+        return False
+
+    for key, entries in plugins.items():
+        if not isinstance(key, str) or key.split("@")[0] != "ormah":
+            continue
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict) or entry.get("scope") != "user":
+                continue
+            install_path = entry.get("installPath")
+            if not isinstance(install_path, str) or not install_path:
+                continue
+            if (Path(install_path) / "hooks" / "hooks.json").is_file():
+                return True
+    return False
+
+
 def _claude_code_detected() -> bool:
     return _find_binary("claude") is not None
 

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2446,9 +2446,25 @@ def _pi_is_wired() -> bool:
 
 
 def _claude_code_wire() -> None:
-    ormah_bin = get_ormah_bin_path()
-    configure_claude_hooks(ormah_bin)
-    configure_claude_code_mcp(ormah_bin)
+    # The plugin registers the same UserPromptSubmit/PreCompact/SessionEnd hooks
+    # and the same MCP server. Wiring them again in ~/.claude/settings.json runs
+    # both copies: the whisper fires twice per human turn, and no merge can dedupe
+    # across the two files. The agent and slash command are namespaced by the
+    # plugin (ormah:maintenance vs ormah-maintenance), so they are not duplicate
+    # registrations — they stay installed, as does CLAUDE.md, which no plugin can
+    # write.
+    if _claude_code_plugin_provides_hooks():
+        _remove_claude_hooks()
+        _remove_mcp_from_json(Path.home() / ".claude.json")
+        info(
+            "Claude Code plugin already provides the hooks and MCP server "
+            "— removed redundant CLI wiring"
+        )
+    else:
+        ormah_bin = get_ormah_bin_path()
+        configure_claude_hooks(ormah_bin)
+        configure_claude_code_mcp(ormah_bin)
+
     install_claude_md()
     install_claude_agents()
     install_claude_commands()

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2400,7 +2400,7 @@ def _hooks_manifest_wires_ormah(hooks_json_path: Path) -> bool:
 
 
 def _mcp_manifest_wires_ormah(mcp_json_path: Path) -> bool:
-    """True when a plugin's .mcp.json is a real manifest declaring an ormah server.
+    """True when a plugin's .mcp.json declares the ormah-mcp wrapper command.
 
     An interrupted plugin update can leave .mcp.json present but empty
     (``{"mcpServers": {}}``); that must not count as "the plugin provides
@@ -2413,7 +2413,21 @@ def _mcp_manifest_wires_ormah(mcp_json_path: Path) -> bool:
     if not isinstance(data, dict):
         return False
     servers = data.get("mcpServers")
-    return isinstance(servers, dict) and "ormah" in servers
+    if not isinstance(servers, dict):
+        return False
+
+    server = servers.get("ormah")
+    if not isinstance(server, dict):
+        return False
+
+    command = server.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return False
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return False
+    return bool(parts) and Path(parts[0]).name == "ormah-mcp"
 
 
 def _claude_code_detected() -> bool:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2301,11 +2301,16 @@ def _claude_code_is_wired() -> bool:
         data = json.loads(settings_path.read_text())
         hooks = data.get("hooks") or {}
         for matchers in hooks.values():
-            if isinstance(matchers, list):
-                for entry in matchers:
-                    cmd = entry.get("command", "") if isinstance(entry, dict) else str(entry)
-                    if "ormah whisper" in cmd:
-                        return True
+            if not isinstance(matchers, list):
+                continue
+            for matcher in matchers:
+                if not isinstance(matcher, dict):
+                    continue
+                inner = matcher.get("hooks")
+                if not isinstance(inner, list):
+                    continue
+                if any(_is_ormah_hook(entry) for entry in inner):
+                    return True
     except (OSError, json.JSONDecodeError, AttributeError):
         pass
     claude_json = Path.home() / ".claude.json"

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -1678,7 +1678,7 @@ def _remove_mcp_from_json(config_path: Path) -> None:
     else:
         data["mcpServers"] = mcp_servers
 
-    config_path.write_text(json.dumps(data, indent=2) + "\n")
+    _atomic_write(str(config_path), json.dumps(data, indent=2) + "\n")
     ok(f"Removed ormah from {config_path}")
 
 

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2300,9 +2300,14 @@ def _claude_code_plugin_provides_hooks() -> bool:
                    carrying the scope and the resolved installPath.
 
     This predicate licenses deleting the user's own wiring, so it requires both,
-    plus hooks/hooks.json under that installPath. A stale flag pointing at a
-    missing cache dir or a half-finished update would otherwise leave the user
-    with no whisper at all — silently.
+    plus hooks/hooks.json AND .mcp.json under that installPath — the wire guard
+    strips both the CLI hooks and the CLI's MCP entry, so proving only the
+    hooks manifest is not enough: a half-finished update could ship hooks.json
+    without yet shipping .mcp.json, and stripping the MCP entry with no
+    plugin-provided replacement would cost the user remember/recall with the
+    whisper still silently intact. A stale flag pointing at a missing cache
+    dir or a half-finished update would otherwise leave the user with no
+    whisper at all — silently.
 
     Only a user-scoped plugin counts: configure_claude_hooks writes to the global
     ~/.claude/settings.json, which serves every project, so those hooks are
@@ -2336,7 +2341,10 @@ def _claude_code_plugin_provides_hooks() -> bool:
             install_path = entry.get("installPath")
             if not isinstance(install_path, str) or not install_path:
                 continue
-            if (Path(install_path) / "hooks" / "hooks.json").is_file():
+            install_dir = Path(install_path)
+            if (install_dir / "hooks" / "hooks.json").is_file() and (
+                install_dir / ".mcp.json"
+            ).is_file():
                 return True
     return False
 

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2324,6 +2324,14 @@ def _claude_code_plugin_provides_hooks() -> bool:
     redundant only when the plugin is global too. A project-scoped plugin keeps
     its duplication rather than break the whisper everywhere else.
 
+    Both manifests must also actually declare content, not merely exist:
+    hooks.json must parse and contain at least one hook entry that
+    ``_is_ormah_hook`` recognizes as Ormah's, and .mcp.json must parse and
+    declare an ``ormah`` entry under ``mcpServers``. An interrupted update
+    can leave empty placeholder files (``{"hooks": {}}`` / ``{"mcpServers":
+    {}}``) that pass an ``is_file()`` check while providing nothing — that
+    must not license the strip either.
+
     Fails open: any unreadable or unparseable config returns False, so setup
     wires exactly as it does today.
     """
@@ -2352,11 +2360,60 @@ def _claude_code_plugin_provides_hooks() -> bool:
             if not isinstance(install_path, str) or not install_path:
                 continue
             install_dir = Path(install_path)
-            if (install_dir / "hooks" / "hooks.json").is_file() and (
-                install_dir / ".mcp.json"
-            ).is_file():
+            if _hooks_manifest_wires_ormah(
+                install_dir / "hooks" / "hooks.json"
+            ) and _mcp_manifest_wires_ormah(install_dir / ".mcp.json"):
                 return True
     return False
+
+
+def _hooks_manifest_wires_ormah(hooks_json_path: Path) -> bool:
+    """True when a plugin's hooks.json is a real manifest declaring an Ormah hook.
+
+    An interrupted plugin update can leave hooks.json present but empty
+    (``{"hooks": {}}``) or non-existent as JSON; either must not count as
+    "the plugin provides hooks". Reuses ``_is_ormah_hook`` so a renamed event
+    still counts — only the hook entry's command shape matters, not the
+    event name.
+    """
+    try:
+        data = json.loads(hooks_json_path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    for matchers in hooks.values():
+        if not isinstance(matchers, list):
+            continue
+        for matcher in matchers:
+            if not isinstance(matcher, dict):
+                continue
+            inner = matcher.get("hooks")
+            if not isinstance(inner, list):
+                continue
+            if any(_is_ormah_hook(entry) for entry in inner):
+                return True
+    return False
+
+
+def _mcp_manifest_wires_ormah(mcp_json_path: Path) -> bool:
+    """True when a plugin's .mcp.json is a real manifest declaring an ormah server.
+
+    An interrupted plugin update can leave .mcp.json present but empty
+    (``{"mcpServers": {}}``); that must not count as "the plugin provides
+    the MCP server".
+    """
+    try:
+        data = json.loads(mcp_json_path.read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    servers = data.get("mcpServers")
+    return isinstance(servers, dict) and "ormah" in servers
 
 
 def _claude_code_detected() -> bool:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -560,6 +560,23 @@ class TestClaudeCodePluginProvidesHooks:
         with patch("ormah.setup.Path.home", return_value=tmp_path):
             assert _claude_code_plugin_provides_hooks() is False
 
+    def test_false_when_mcp_manifest_has_empty_ormah_entry(self, tmp_path):
+        """An ormah key without a runnable command must not license stripping CLI MCP."""
+        self._enable(tmp_path)
+        self._install(tmp_path, mcp_content={"mcpServers": {"ormah": {}}})
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_mcp_manifest_uses_non_plugin_command(self, tmp_path):
+        """The replacement MCP must be the plugin wrapper command."""
+        self._enable(tmp_path)
+        self._install(
+            tmp_path,
+            mcp_content={"mcpServers": {"ormah": {"command": "/usr/bin/ormah"}}},
+        )
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
     def test_false_when_hooks_manifest_has_only_third_party_hook(self, tmp_path):
         """Proves the check inspects ormah's own hooks, not just any hook."""
         self._enable(tmp_path)

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -28,9 +28,10 @@ from ormah.setup import (
     CLAUDE_MD_SENTINEL_START,
     PI_AGENTS_MD_SENTINEL_END,
     PI_AGENTS_MD_SENTINEL_START,
-    _get_agent,
     _atomic_write,
+    _claude_code_is_wired,
     _discover_transcripts,
+    _get_agent,
     _is_ormah_hook,
     _merge_hooks,
     _merge_json_file,
@@ -1785,6 +1786,59 @@ class TestInstallPiMd:
 
         captured = capsys.readouterr()
         assert "Instructions added to ./AGENTS.md" in captured.out
+
+
+class TestClaudeCodeIsWired:
+    def _write_settings(self, tmp_path: Path, data: dict) -> Path:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(exist_ok=True)
+        settings_path = claude_dir / "settings.json"
+        settings_path.write_text(json.dumps(data, indent=2) + "\n")
+        return settings_path
+
+    def test_detects_cli_hooks_when_no_mcp_entry_exists(self, tmp_path):
+        """Regression: the hooks branch read entry.get("command") off the matcher
+        dict, so it never matched; only the .claude.json MCP fallback could
+        return True. No ~/.claude.json here, so the fallback cannot rescue it."""
+        self._write_settings(tmp_path, {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"hooks": [{"type": "command", "command": "/usr/bin/ormah whisper inject", "timeout": 10}]}
+                ]
+            }
+        })
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_is_wired() is True
+
+    def test_third_party_hook_is_not_mistaken_for_ormah(self, tmp_path):
+        self._write_settings(tmp_path, {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"hooks": [{"type": "command", "command": "/usr/bin/other-tool whisper inject"}]}
+                ]
+            }
+        })
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_is_wired() is False
+
+    def test_falls_back_to_mcp_entry_when_no_hooks(self, tmp_path):
+        self._write_settings(tmp_path, {"hooks": {}})
+        (tmp_path / ".claude.json").write_text(
+            json.dumps({"mcpServers": {"ormah": {"command": "/usr/bin/ormah", "args": ["mcp"]}}}) + "\n"
+        )
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_is_wired() is True
+
+    def test_malformed_matcher_does_not_raise(self, tmp_path):
+        self._write_settings(tmp_path, {
+            "hooks": {"UserPromptSubmit": ["not-a-dict", {"no_hooks_key": True}, {"hooks": "not-a-list"}]}
+        })
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_is_wired() is False
 
 
 class TestInstallPiAgents:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -501,6 +501,32 @@ class TestClaudeCodePluginProvidesHooks:
         with patch("ormah.setup.Path.home", return_value=tmp_path):
             assert _claude_code_plugin_provides_hooks() is False
 
+    def test_false_when_enabled_key_does_not_match_installed_key(self, tmp_path):
+        """The enabled key must be matched to the SAME registry key. A stale
+        but healthy ormah@old-market install must not license stripping when
+        the actually-enabled plugin (ormah@new-market) is broken."""
+        self._enable(tmp_path, key="ormah@new-market")
+        plugins_dir = tmp_path / ".claude" / "plugins"
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+        broken_path = tmp_path / "vanished"  # never created -> no manifests
+        good_path = plugins_dir / "cache" / "ormah" / "old-market" / "0.1.0"
+        (good_path / "hooks").mkdir(parents=True, exist_ok=True)
+        (good_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (good_path / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
+        (plugins_dir / "installed_plugins.json").write_text(json.dumps({
+            "version": 2,
+            "plugins": {
+                "ormah@new-market": [
+                    {"scope": "user", "installPath": str(broken_path), "version": "1.0.0"}
+                ],
+                "ormah@old-market": [
+                    {"scope": "user", "installPath": str(good_path), "version": "0.1.0"}
+                ],
+            },
+        }, indent=2) + "\n")
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
 
 class TestClaudeCodeWirePluginGuard:
     def _seed_working_plugin(self, tmp_path: Path, *, enabled: bool = True, scope: str = "user") -> Path:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -30,6 +30,7 @@ from ormah.setup import (
     PI_AGENTS_MD_SENTINEL_START,
     _atomic_write,
     _claude_code_is_wired,
+    _claude_code_plugin_provides_hooks,
     _discover_transcripts,
     _get_agent,
     _is_ormah_hook,
@@ -392,6 +393,95 @@ class TestConfigureClaudeCodeMcp:
             "/usr/local/bin/claude", "mcp", "add", "ormah", "--scope", "user",
             "--", "/usr/local/bin/ormah", "mcp",
         ]
+
+
+class TestClaudeCodePluginProvidesHooks:
+    def _enable(self, tmp_path: Path, value=True, key: str = "ormah@ormah") -> None:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(exist_ok=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"enabledPlugins": {key: value}}, indent=2) + "\n"
+        )
+
+    def _install(self, tmp_path: Path, *, scope: str = "user", with_hooks: bool = True,
+                 key: str = "ormah@ormah", install_path: Path | None = None) -> Path:
+        plugins_dir = tmp_path / ".claude" / "plugins"
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+        target = install_path if install_path is not None else plugins_dir / "cache" / "ormah" / "ormah" / "0.13.3"
+        if with_hooks:
+            (target / "hooks").mkdir(parents=True, exist_ok=True)
+            (target / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (plugins_dir / "installed_plugins.json").write_text(json.dumps({
+            "version": 2,
+            "plugins": {key: [{"scope": scope, "installPath": str(target), "version": "0.13.3"}]},
+        }, indent=2) + "\n")
+        return target
+
+    def test_true_when_enabled_and_installed_with_hooks(self, tmp_path):
+        self._enable(tmp_path)
+        self._install(tmp_path)
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is True
+
+    def test_true_for_any_marketplace_name(self, tmp_path):
+        self._enable(tmp_path, key="ormah@some-other-market")
+        self._install(tmp_path, key="ormah@some-other-market")
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is True
+
+    def test_false_when_enabled_but_not_installed(self, tmp_path):
+        """A stale enabled flag must never license deleting the working wiring."""
+        self._enable(tmp_path)
+        # no installed_plugins.json at all
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_registry_lists_plugin_but_install_path_is_gone(self, tmp_path):
+        self._enable(tmp_path)
+        self._install(tmp_path, install_path=tmp_path / "vanished", with_hooks=False)
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_install_exists_but_hooks_json_is_missing(self, tmp_path):
+        """An interrupted update can leave the dir without its hooks manifest."""
+        self._enable(tmp_path)
+        target = self._install(tmp_path, with_hooks=False)
+        target.mkdir(parents=True, exist_ok=True)
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_installed_but_disabled(self, tmp_path):
+        self._enable(tmp_path, value=False)
+        self._install(tmp_path)
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_plugin_is_project_scoped(self, tmp_path):
+        """Deliberate: the CLI hooks are global and serve every other project.
+        Stripping them for a one-project plugin would break the whisper there."""
+        self._enable(tmp_path)
+        self._install(tmp_path, scope="project")
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_for_another_plugin(self, tmp_path):
+        self._enable(tmp_path, key="superpowers@claude-plugins-official")
+        self._install(tmp_path, key="superpowers@claude-plugins-official")
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_fails_open_on_corrupt_registry(self, tmp_path):
+        self._enable(tmp_path)
+        plugins_dir = tmp_path / ".claude" / "plugins"
+        plugins_dir.mkdir(parents=True)
+        (plugins_dir / "installed_plugins.json").write_text("{not json")
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_fails_open_on_missing_settings(self, tmp_path):
+        self._install(tmp_path)
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
 
 
 class TestConfigureClaudeDesktop:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -405,13 +405,21 @@ class TestClaudeCodePluginProvidesHooks:
         )
 
     def _install(self, tmp_path: Path, *, scope: str = "user", with_hooks: bool = True,
-                 key: str = "ormah@ormah", install_path: Path | None = None) -> Path:
+                 with_mcp: bool | None = None, key: str = "ormah@ormah",
+                 install_path: Path | None = None) -> Path:
+        # with_mcp mirrors with_hooks by default, so every existing call site
+        # (none of which pass with_mcp) keeps its current install-dir behavior.
+        if with_mcp is None:
+            with_mcp = with_hooks
         plugins_dir = tmp_path / ".claude" / "plugins"
         plugins_dir.mkdir(parents=True, exist_ok=True)
         target = install_path if install_path is not None else plugins_dir / "cache" / "ormah" / "ormah" / "0.13.3"
         if with_hooks:
             (target / "hooks").mkdir(parents=True, exist_ok=True)
             (target / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        if with_mcp:
+            target.mkdir(parents=True, exist_ok=True)
+            (target / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
         (plugins_dir / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {key: [{"scope": scope, "installPath": str(target), "version": "0.13.3"}]},
@@ -448,6 +456,15 @@ class TestClaudeCodePluginProvidesHooks:
         self._enable(tmp_path)
         target = self._install(tmp_path, with_hooks=False)
         target.mkdir(parents=True, exist_ok=True)
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_mcp_manifest_is_missing(self, tmp_path):
+        """Hooks alone don't prove the plugin also ships the MCP server it
+        licenses stripping — an interrupted update can leave hooks.json
+        behind without .mcp.json."""
+        self._enable(tmp_path)
+        self._install(tmp_path, with_mcp=False)
         with patch("ormah.setup.Path.home", return_value=tmp_path):
             assert _claude_code_plugin_provides_hooks() is False
 
@@ -492,6 +509,7 @@ class TestClaudeCodeWirePluginGuard:
         install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
         (install_path / "hooks").mkdir(parents=True)
         (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (install_path / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
         (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {"ormah@ormah": [
@@ -643,6 +661,7 @@ class TestClaudeCodeWirePluginGuard:
         install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
         (install_path / "hooks").mkdir(parents=True)
         (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (install_path / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
         (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {"ormah@ormah": [
@@ -2127,6 +2146,7 @@ class TestClaudeCodeIsWired:
         install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
         (install_path / "hooks").mkdir(parents=True)
         (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (install_path / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
         (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {"ormah@ormah": [

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -2056,6 +2056,35 @@ class TestRemoveMcpFromJson:
         result = json.loads(config.read_text())
         assert result == original
 
+    def test_write_is_atomic(self, tmp_path):
+        """~/.claude.json holds the user's whole Claude Code config, and a later
+        change makes this path run on every setup --update for plugin users. A
+        bare write_text truncates it on a crash mid-write."""
+        config = tmp_path / "claude.json"
+        config.write_text(json.dumps({
+            "mcpServers": {
+                "ormah": {"command": "/bin/ormah", "args": ["mcp"]},
+                "other": {"command": "/bin/other"},
+            }
+        }, indent=2) + "\n")
+
+        with patch("ormah.setup._atomic_write") as atomic_write:
+            _remove_mcp_from_json(config)
+
+        atomic_write.assert_called_once()
+        written_path = atomic_write.call_args[0][0]
+        assert str(written_path) == str(config)
+        payload = json.loads(atomic_write.call_args[0][1])
+        assert payload["mcpServers"] == {"other": {"command": "/bin/other"}}
+
+    def test_corrupt_file_is_left_untouched(self, tmp_path):
+        config = tmp_path / "claude.json"
+        config.write_text("{not json")
+
+        _remove_mcp_from_json(config)
+
+        assert config.read_text() == "{not json"
+
 
 class TestRemoveCodexMcpConfig:
     def test_removes_ormah_block(self, tmp_path):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -31,6 +31,7 @@ from ormah.setup import (
     _atomic_write,
     _claude_code_is_wired,
     _claude_code_plugin_provides_hooks,
+    _claude_code_wire,
     _discover_transcripts,
     _get_agent,
     _is_ormah_hook,
@@ -482,6 +483,190 @@ class TestClaudeCodePluginProvidesHooks:
         self._install(tmp_path)
         with patch("ormah.setup.Path.home", return_value=tmp_path):
             assert _claude_code_plugin_provides_hooks() is False
+
+
+class TestClaudeCodeWirePluginGuard:
+    def _seed_working_plugin(self, tmp_path: Path, *, enabled: bool = True, scope: str = "user") -> Path:
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(exist_ok=True)
+        install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
+        (install_path / "hooks").mkdir(parents=True)
+        (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
+            "version": 2,
+            "plugins": {"ormah@ormah": [
+                {"scope": scope, "installPath": str(install_path), "version": "0.13.3"}
+            ]},
+        }, indent=2) + "\n")
+        (claude_dir / "settings.json").write_text(json.dumps({
+            "enabledPlugins": {"ormah@ormah": enabled},
+            "theme": "dark",
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"hooks": [{"type": "command", "command": "/usr/bin/ormah whisper inject", "timeout": 10}]}
+                ],
+                "SessionEnd": [
+                    {"hooks": [{"type": "command", "command": "/usr/bin/ormah whisper store", "timeout": 300}]}
+                ],
+            },
+        }, indent=2) + "\n")
+        (tmp_path / ".claude.json").write_text(json.dumps({
+            "mcpServers": {"ormah": {"type": "stdio", "command": "/usr/bin/ormah", "args": ["mcp"]}}
+        }, indent=2) + "\n")
+        return claude_dir
+
+    def test_working_plugin_strips_hooks_and_mcp_and_writes_no_wiring(self, tmp_path):
+        claude_dir = self._seed_working_plugin(tmp_path)
+
+        with (
+            patch("ormah.setup.Path.home", return_value=tmp_path),
+            patch("ormah.setup.configure_claude_hooks") as configure_hooks,
+            patch("ormah.setup.configure_claude_code_mcp") as configure_mcp,
+            patch("ormah.setup.install_claude_agents") as install_agents,
+            patch("ormah.setup.install_claude_commands") as install_commands,
+            patch("ormah.setup.install_claude_md") as install_md,
+        ):
+            _claude_code_wire()
+
+        settings = json.loads((claude_dir / "settings.json").read_text())
+        assert "hooks" not in settings                              # both ormah hooks stripped
+        assert settings["enabledPlugins"] == {"ormah@ormah": True}  # untouched
+        assert settings["theme"] == "dark"                          # co-tenant keys survive
+        assert "mcpServers" not in json.loads((tmp_path / ".claude.json").read_text())
+
+        configure_hooks.assert_not_called()
+        configure_mcp.assert_not_called()
+        # not duplicate registrations — the plugin namespaces these
+        install_md.assert_called_once()
+        install_agents.assert_called_once()
+        install_commands.assert_called_once()
+
+    def test_strip_preserves_third_party_hooks(self, tmp_path):
+        claude_dir = self._seed_working_plugin(tmp_path)
+        settings = json.loads((claude_dir / "settings.json").read_text())
+        settings["hooks"]["UserPromptSubmit"][0]["hooks"].append(
+            {"type": "command", "command": "/usr/bin/other-tool run"}
+        )
+        (claude_dir / "settings.json").write_text(json.dumps(settings, indent=2) + "\n")
+
+        with (
+            patch("ormah.setup.Path.home", return_value=tmp_path),
+            patch("ormah.setup.install_claude_md"),
+            patch("ormah.setup.install_claude_agents"),
+            patch("ormah.setup.install_claude_commands"),
+        ):
+            _claude_code_wire()
+
+        hooks = json.loads((claude_dir / "settings.json").read_text())["hooks"]
+        surviving = hooks["UserPromptSubmit"][0]["hooks"]
+        assert len(surviving) == 1
+        assert surviving[0]["command"] == "/usr/bin/other-tool run"
+
+    def test_enabled_but_uninstalled_plugin_wires_normally(self, tmp_path):
+        """A stale enabled flag must not cost the user the whisper."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"enabledPlugins": {"ormah@ormah": True}}, indent=2) + "\n"
+        )  # no installed_plugins.json
+
+        with (
+            patch("ormah.setup.Path.home", return_value=tmp_path),
+            patch("ormah.setup.get_ormah_bin_path", return_value="/usr/bin/ormah"),
+            patch("ormah.setup.configure_claude_hooks") as configure_hooks,
+            patch("ormah.setup.configure_claude_code_mcp") as configure_mcp,
+            patch("ormah.setup.install_claude_agents"),
+            patch("ormah.setup.install_claude_commands"),
+            patch("ormah.setup.install_claude_md"),
+        ):
+            _claude_code_wire()
+
+        configure_hooks.assert_called_once_with("/usr/bin/ormah")
+        configure_mcp.assert_called_once_with("/usr/bin/ormah")
+
+    def test_project_scoped_plugin_wires_normally(self, tmp_path):
+        """Deliberate: the CLI hooks are global and serve every other project."""
+        self._seed_working_plugin(tmp_path, scope="project")
+
+        with (
+            patch("ormah.setup.Path.home", return_value=tmp_path),
+            patch("ormah.setup.get_ormah_bin_path", return_value="/usr/bin/ormah"),
+            patch("ormah.setup.configure_claude_hooks") as configure_hooks,
+            patch("ormah.setup.configure_claude_code_mcp"),
+            patch("ormah.setup.install_claude_agents"),
+            patch("ormah.setup.install_claude_commands"),
+            patch("ormah.setup.install_claude_md"),
+        ):
+            _claude_code_wire()
+
+        configure_hooks.assert_called_once_with("/usr/bin/ormah")
+
+    def test_plugin_disabled_wires_normally(self, tmp_path):
+        self._seed_working_plugin(tmp_path, enabled=False)
+
+        with (
+            patch("ormah.setup.Path.home", return_value=tmp_path),
+            patch("ormah.setup.get_ormah_bin_path", return_value="/usr/bin/ormah"),
+            patch("ormah.setup.configure_claude_hooks") as configure_hooks,
+            patch("ormah.setup.configure_claude_code_mcp"),
+            patch("ormah.setup.install_claude_agents"),
+            patch("ormah.setup.install_claude_commands"),
+            patch("ormah.setup.install_claude_md"),
+        ):
+            _claude_code_wire()
+
+        configure_hooks.assert_called_once_with("/usr/bin/ormah")
+
+    def test_unreadable_settings_wires_normally(self, tmp_path):
+        """Fail-open: an unparseable config must not silently disable the whisper."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text("{not json")
+
+        with (
+            patch("ormah.setup.Path.home", return_value=tmp_path),
+            patch("ormah.setup.get_ormah_bin_path", return_value="/usr/bin/ormah"),
+            patch("ormah.setup.configure_claude_hooks") as configure_hooks,
+            patch("ormah.setup.configure_claude_code_mcp"),
+            patch("ormah.setup.install_claude_agents"),
+            patch("ormah.setup.install_claude_commands"),
+            patch("ormah.setup.install_claude_md"),
+        ):
+            _claude_code_wire()
+
+        configure_hooks.assert_called_once_with("/usr/bin/ormah")
+
+    def test_fresh_plugin_install_removes_nothing(self, tmp_path):
+        """Working plugin, no CLI wiring ever done — the guard is idempotent."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
+        (install_path / "hooks").mkdir(parents=True)
+        (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
+            "version": 2,
+            "plugins": {"ormah@ormah": [
+                {"scope": "user", "installPath": str(install_path), "version": "0.13.3"}
+            ]},
+        }, indent=2) + "\n")
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"enabledPlugins": {"ormah@ormah": True}}, indent=2) + "\n"
+        )
+
+        with (
+            patch("ormah.setup.Path.home", return_value=tmp_path),
+            patch("ormah.setup.configure_claude_hooks") as configure_hooks,
+            patch("ormah.setup.install_claude_md") as install_md,
+            patch("ormah.setup.install_claude_agents"),
+            patch("ormah.setup.install_claude_commands"),
+        ):
+            _claude_code_wire()
+
+        assert json.loads((claude_dir / "settings.json").read_text()) == {
+            "enabledPlugins": {"ormah@ormah": True}
+        }
+        configure_hooks.assert_not_called()
+        install_md.assert_called_once()
 
 
 class TestConfigureClaudeDesktop:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -396,6 +396,22 @@ class TestConfigureClaudeCodeMcp:
         ]
 
 
+REALISTIC_HOOKS_JSON = {
+    "hooks": {
+        "UserPromptSubmit": [
+            {"hooks": [{
+                "type": "command",
+                "command": "${CLAUDE_PLUGIN_ROOT}/bin/ormah-whisper-inject",
+                "timeout": 10,
+            }]}
+        ]
+    }
+}
+REALISTIC_MCP_JSON = {
+    "mcpServers": {"ormah": {"type": "stdio", "command": "${CLAUDE_PLUGIN_ROOT}/bin/ormah-mcp"}}
+}
+
+
 class TestClaudeCodePluginProvidesHooks:
     def _enable(self, tmp_path: Path, value=True, key: str = "ormah@ormah") -> None:
         claude_dir = tmp_path / ".claude"
@@ -406,7 +422,8 @@ class TestClaudeCodePluginProvidesHooks:
 
     def _install(self, tmp_path: Path, *, scope: str = "user", with_hooks: bool = True,
                  with_mcp: bool | None = None, key: str = "ormah@ormah",
-                 install_path: Path | None = None) -> Path:
+                 install_path: Path | None = None, hooks_content: dict | None = None,
+                 mcp_content: dict | None = None) -> Path:
         # with_mcp mirrors with_hooks by default, so every existing call site
         # (none of which pass with_mcp) keeps its current install-dir behavior.
         if with_mcp is None:
@@ -416,10 +433,12 @@ class TestClaudeCodePluginProvidesHooks:
         target = install_path if install_path is not None else plugins_dir / "cache" / "ormah" / "ormah" / "0.13.3"
         if with_hooks:
             (target / "hooks").mkdir(parents=True, exist_ok=True)
-            (target / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+            content = hooks_content if hooks_content is not None else REALISTIC_HOOKS_JSON
+            (target / "hooks" / "hooks.json").write_text(json.dumps(content) + "\n")
         if with_mcp:
             target.mkdir(parents=True, exist_ok=True)
-            (target / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
+            content = mcp_content if mcp_content is not None else REALISTIC_MCP_JSON
+            (target / ".mcp.json").write_text(json.dumps(content) + "\n")
         (plugins_dir / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {key: [{"scope": scope, "installPath": str(target), "version": "0.13.3"}]},
@@ -527,6 +546,33 @@ class TestClaudeCodePluginProvidesHooks:
         with patch("ormah.setup.Path.home", return_value=tmp_path):
             assert _claude_code_plugin_provides_hooks() is False
 
+    def test_false_when_hooks_manifest_is_empty_object(self, tmp_path):
+        """An interrupted update can leave hooks.json parseable but empty."""
+        self._enable(tmp_path)
+        self._install(tmp_path, hooks_content={"hooks": {}})
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_mcp_manifest_has_no_ormah_server(self, tmp_path):
+        """An interrupted update can leave .mcp.json parseable but empty."""
+        self._enable(tmp_path)
+        self._install(tmp_path, mcp_content={"mcpServers": {}})
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
+    def test_false_when_hooks_manifest_has_only_third_party_hook(self, tmp_path):
+        """Proves the check inspects ormah's own hooks, not just any hook."""
+        self._enable(tmp_path)
+        self._install(tmp_path, hooks_content={
+            "hooks": {
+                "UserPromptSubmit": [
+                    {"hooks": [{"type": "command", "command": "/usr/bin/other-tool run"}]}
+                ]
+            }
+        })
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_plugin_provides_hooks() is False
+
 
 class TestClaudeCodeWirePluginGuard:
     def _seed_working_plugin(self, tmp_path: Path, *, enabled: bool = True, scope: str = "user") -> Path:
@@ -534,8 +580,8 @@ class TestClaudeCodeWirePluginGuard:
         claude_dir.mkdir(exist_ok=True)
         install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
         (install_path / "hooks").mkdir(parents=True)
-        (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
-        (install_path / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
+        (install_path / "hooks" / "hooks.json").write_text(json.dumps(REALISTIC_HOOKS_JSON) + "\n")
+        (install_path / ".mcp.json").write_text(json.dumps(REALISTIC_MCP_JSON) + "\n")
         (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {"ormah@ormah": [
@@ -686,8 +732,8 @@ class TestClaudeCodeWirePluginGuard:
         claude_dir.mkdir()
         install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
         (install_path / "hooks").mkdir(parents=True)
-        (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
-        (install_path / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
+        (install_path / "hooks" / "hooks.json").write_text(json.dumps(REALISTIC_HOOKS_JSON) + "\n")
+        (install_path / ".mcp.json").write_text(json.dumps(REALISTIC_MCP_JSON) + "\n")
         (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {"ormah@ormah": [
@@ -2171,8 +2217,8 @@ class TestClaudeCodeIsWired:
         )
         install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
         (install_path / "hooks").mkdir(parents=True)
-        (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
-        (install_path / ".mcp.json").write_text(json.dumps({"mcpServers": {}}) + "\n")
+        (install_path / "hooks" / "hooks.json").write_text(json.dumps(REALISTIC_HOOKS_JSON) + "\n")
+        (install_path / ".mcp.json").write_text(json.dumps(REALISTIC_MCP_JSON) + "\n")
         (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
             "version": 2,
             "plugins": {"ormah@ormah": [

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1930,6 +1930,36 @@ class TestClaudeCodeIsWired:
         with patch("ormah.setup.Path.home", return_value=tmp_path):
             assert _claude_code_is_wired() is False
 
+    def test_plugin_providing_hooks_counts_as_wired(self, tmp_path):
+        """The plugin provides the hooks and MCP server; without this the UI
+        would report a working install as not wired once Task 4 strips the CLI
+        wiring."""
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir(exist_ok=True)
+        (claude_dir / "settings.json").write_text(
+            json.dumps({"enabledPlugins": {"ormah@ormah": True}}, indent=2) + "\n"
+        )
+        install_path = claude_dir / "plugins" / "cache" / "ormah" / "ormah" / "0.13.3"
+        (install_path / "hooks").mkdir(parents=True)
+        (install_path / "hooks" / "hooks.json").write_text(json.dumps({"hooks": {}}) + "\n")
+        (claude_dir / "plugins" / "installed_plugins.json").write_text(json.dumps({
+            "version": 2,
+            "plugins": {"ormah@ormah": [
+                {"scope": "user", "installPath": str(install_path), "version": "0.13.3"}
+            ]},
+        }, indent=2) + "\n")
+        # no ormah hooks in settings.json, no ~/.claude.json — the plugin is the only wiring
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_is_wired() is True
+
+    def test_enabled_but_uninstalled_plugin_alone_is_not_wired(self, tmp_path):
+        """Nothing would actually fire — reporting 'wired' would be a lie."""
+        self._write_settings(tmp_path, {"enabledPlugins": {"ormah@ormah": True}})
+
+        with patch("ormah.setup.Path.home", return_value=tmp_path):
+            assert _claude_code_is_wired() is False
+
 
 class TestInstallPiAgents:
     def test_creates_agent_file(self, tmp_path, capsys):

--- a/tests/test_setup_json.py
+++ b/tests/test_setup_json.py
@@ -4,7 +4,29 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
+
 import ormah.setup as setup
+
+
+@pytest.fixture(autouse=True)
+def _isolate_claude_home(tmp_path, monkeypatch):
+    """Structurally block every test in this file from touching the real
+    ~/.claude — regardless of what the test under it does or forgets to do.
+
+    _claude_code_wire()'s plugin-guard branch calls Path.home() directly, but
+    its plain-wiring branch (configure_claude_hooks / configure_claude_code_mcp)
+    calls os.path.expanduser("~/...") instead — patching Path.home alone leaves
+    that path unguarded. Both resolve "~" via the HOME env var (pathlib.Path.home
+    delegates to os.path.expanduser internally), so pinning HOME structurally
+    blocks every call site in one move, regardless of which one a test reaches.
+    A test that reaches either without this fixture would rewrite the
+    developer's real ~/.claude/settings.json and ~/.claude.json. conftest.py's
+    guard does not cover this (it only intercepts unlink/rmtree, and
+    _REAL_ORMAH_PATHS does not list these files), so this file provides its
+    own blanket isolation.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
 
 
 def set_detected(monkeypatch, *agent_ids: str) -> None:
@@ -61,8 +83,7 @@ def test_run_setup_json_wires_detected(monkeypatch, tmp_path):
     ):
         monkeypatch.setattr(setup, name, lambda *a, _n=name: calls.append(_n))
 
-    with patch("ormah.setup.Path.home", return_value=tmp_path):
-        result = setup.run_setup_json()
+    result = setup.run_setup_json()
 
     assert result["detected"] == ["claude_code"]
     assert result["wired"] == ["claude_code"]
@@ -86,8 +107,7 @@ def test_run_setup_json_captures_errors(monkeypatch, tmp_path):
     ):
         monkeypatch.setattr(setup, name, lambda *a: None)
 
-    with patch("ormah.setup.Path.home", return_value=tmp_path):
-        result = setup.run_setup_json()
+    result = setup.run_setup_json()
 
     assert result["wired"] == []
     assert "claude_code" in result["errors"]

--- a/tests/test_setup_json.py
+++ b/tests/test_setup_json.py
@@ -50,7 +50,7 @@ def test_detect_clients_codex_via_dir(tmp_path):
     assert d["codex"] is True
 
 
-def test_run_setup_json_wires_detected(monkeypatch):
+def test_run_setup_json_wires_detected(monkeypatch, tmp_path):
     calls: list[str] = []
     monkeypatch.setattr(setup, "get_ormah_bin_path", lambda: "/bin/ormah")
     monkeypatch.setattr(setup, "_preload_local_models", lambda: None)
@@ -61,7 +61,8 @@ def test_run_setup_json_wires_detected(monkeypatch):
     ):
         monkeypatch.setattr(setup, name, lambda *a, _n=name: calls.append(_n))
 
-    result = setup.run_setup_json()
+    with patch("ormah.setup.Path.home", return_value=tmp_path):
+        result = setup.run_setup_json()
 
     assert result["detected"] == ["claude_code"]
     assert result["wired"] == ["claude_code"]
@@ -70,7 +71,7 @@ def test_run_setup_json_wires_detected(monkeypatch):
     assert "configure_claude_hooks" in calls
 
 
-def test_run_setup_json_captures_errors(monkeypatch):
+def test_run_setup_json_captures_errors(monkeypatch, tmp_path):
     monkeypatch.setattr(setup, "get_ormah_bin_path", lambda: "/bin/ormah")
     monkeypatch.setattr(setup, "_preload_local_models", lambda: None)
     set_detected(monkeypatch, "claude_code")
@@ -85,7 +86,8 @@ def test_run_setup_json_captures_errors(monkeypatch):
     ):
         monkeypatch.setattr(setup, name, lambda *a: None)
 
-    result = setup.run_setup_json()
+    with patch("ormah.setup.Path.home", return_value=tmp_path):
+        result = setup.run_setup_json()
 
     assert result["wired"] == []
     assert "claude_code" in result["errors"]


### PR DESCRIPTION
Closes #145.

With the Claude Code plugin installed, `ormah setup` wires the same three hooks a **second** time into `~/.claude/settings.json`. Both wirings fire, so every human turn runs the whisper twice — two encodes, two hybrid searches, two cross-encoder reranks. The MCP server is registered twice for the same reason.

## Evidence

Live `retrieval_events` on my install (plugin 0.13.3 + settings.json wiring), last 7 days, grouped by `(session_id, prompt_hash)`:

| rows per prompt | prompts |
| --- | --- |
| 1 | 198 |
| **2** | **319** |
| 3–5 | 7 |

Both wirings resolve to the same binary — the plugin shim is `exec ormah whisper inject` and `which ormah` is the path `configure_claude_hooks` hardcodes. Pure duplicate work. Beyond cost, every per-event metric in `whisper_health` is double-counted.

`_install_hooks` merges carefully *within* `settings.json`, but the plugin's hooks live in a **different file**, so no merge can ever dedupe across the two.

## Why the existing guard didn't hold — and a finding that widens the issue

`--skip-client-setup` exists and `integrations/claude-plugin/SETUP.md:38` is explicit about it, but it is **opt-in** and the paths a plugin user actually hits don't pass it: `install.sh` (plain and `--update`) and the desktop button via `run_setup_json`.

**New finding, not in the issue:** `configure_claude_hooks` and `configure_claude_code_mcp` use `os.path.expanduser("~/...")`, which reads `$HOME` — not `Path.home()`. Two tests in `tests/test_setup_json.py` reach `_claude_code_wire()` without isolating HOME, so **running the test suite re-wires the developer's real config**. That is very likely the real reason manual cleanup never sticks — more frequent than `ormah setup` itself. Fixed here (`a478221`), structurally, by pinning `HOME`.

## The fix

A guard at the top of `_claude_code_wire()` — the single funnel all three entry points pass through. When a user-scoped plugin is **verified working**, setup strips the redundant CLI hooks + MCP and skips re-writing them, so existing installs self-heal.

`_claude_code_plugin_provides_hooks()` licenses deleting the user's working config, so it is deliberately strict. It requires **all** of:

1. the plugin **enabled** in `~/.claude/settings.json`;
2. a **user-scoped** entry in `~/.claude/plugins/installed_plugins.json` under the **same fully-qualified key** that is enabled;
3. that entry's `installPath/hooks/hooks.json` **parsed**, declaring at least one hook `_is_ormah_hook()` accepts;
4. `installPath/.mcp.json` **parsed**, declaring `mcpServers.ormah`.

Any failure → `False` → setup wires exactly as today. A wrong `False` costs a duplicate (loud, measurable); a wrong `True` costs the user the whisper (silent). The default takes the loud side.

Each of those four is a separate peer-review correction — every earlier revision mistook one signal for another: enabled ≠ installed, registry entry ≠ manifests on disk, manifest exists ≠ manifest valid, some `ormah@*` key ≠ *the* enabled key.

**Scope of the strip:** hooks + MCP only. The agent and slash command are namespaced by the plugin (`/ormah:maintenance` vs `/ormah-maintenance`) — different names, not duplicate registrations, and they never auto-execute, so they contribute nothing to the double-whisper. They keep being installed, as does `CLAUDE.md`, which no plugin can write.

## Also fixed here (both needed by the above)

- `_claude_code_is_wired` never detected hooks: it read `entry.get("command")` off the **matcher** dict, whose only key is `"hooks"`, so the branch always saw `""` and the function could only return True via the `.claude.json` MCP fallback. It now inspects `matcher["hooks"][*]` via `_is_ormah_hook`, and treats a working plugin as wired — without that, stripping the MCP entry would make the desktop agent panel report a working install as "not wired".
- `_remove_mcp_from_json` wrote `~/.claude.json` with a bare `write_text` while its sibling used `_atomic_write`. This change makes that path run on every `setup --update` for plugin users, against the file holding the whole Claude Code config — a crash mid-write would truncate it.

## Known limitation (deliberate, tested)

A **project**- or **local**-scoped plugin does not trigger the guard, so the duplication persists there. `configure_claude_hooks` writes the **global** settings, which serve every project; removing them because one project enabled the plugin would break the whisper everywhere else. Global-active ↔ global-wired is the only safe symmetry. A test pins this so the behaviour is deliberate rather than accidental.

## Follow-up (not in this PR)

`_codex_is_wired` has the identical dead-branch bug this PR fixes for Claude Code. Left alone — Codex's hooks schema wasn't verified to match.

## Verification

- `pytest tests/` (HOME isolated): **1429 passed**. Same failures as the base commit — `TestConfigureCodexMcp` (the real `codex` binary breaks its mock) — plus two caused by the isolation harness itself. **Zero regressions**; +30 tests.
- `ruff check src/ tests/`: clean.
- Reviewed by a two-peer council (Cursor + Codex) at the plan stage and again on this diff; both rounds rejected an earlier revision, and every accepted finding is folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
