### PR TITLE
feat(cloud): negotiate hardened upload protocol

### DIFF
--- a/src/ormah/cloud/client.py
+++ b/src/ormah/cloud/client.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import socket
+import time
 import uuid
+from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +15,15 @@ DATA_DIR = Path.home() / ".local" / "share" / "ormah"
 DEVICE_ID_PATH = DATA_DIR / "device_id"
 ACCOUNT_TOKEN_KEY = "ORMAH_ACCOUNT_TOKEN"
 ACCOUNT_EMAIL_KEY = "ORMAH_ACCOUNT_EMAIL"
+PROTOCOL_CACHE_SECONDS = 300
+DEFAULT_MAX_CIPHERTEXT_BYTES = 512 * 1024 * 1024
+
+
+def _client_version() -> str:
+    try:
+        return package_version("ormah")
+    except PackageNotFoundError:
+        return "0.0.0"
 
 
 class CloudError(RuntimeError):
@@ -96,6 +107,7 @@ class CloudClient:
         self.base_url = base_url.rstrip("/") + "/"
         self.token = token
         self.device_id = device_id
+        self._protocol_cache: tuple[float, dict[str, Any]] | None = None
         self._http = httpx.Client(
             base_url=self.base_url,
             timeout=httpx.Timeout(timeout),
@@ -111,10 +123,14 @@ class CloudClient:
     def __exit__(self, *args) -> None:
         self.close()
 
-    def _headers(self) -> dict[str, str]:
-        if not self.token:
-            return {}
-        return {"Authorization": f"Bearer {self.token}"}
+    def _headers(self, authenticated: bool) -> dict[str, str]:
+        headers = {
+            "X-Ormah-Client-Version": _client_version(),
+            "X-Request-ID": str(uuid.uuid4()),
+        }
+        if authenticated and self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
 
     def _request_json(
         self,
@@ -125,10 +141,14 @@ class CloudClient:
         **kwargs,
     ) -> dict[str, Any]:
         try:
+            headers = self._headers(authenticated)
+            supplied_headers = kwargs.pop("headers", None)
+            if supplied_headers:
+                headers.update(supplied_headers)
             response = self._http.request(
                 method,
                 path,
-                headers=self._headers() if authenticated else {},
+                headers=headers,
                 **kwargs,
             )
         except httpx.HTTPError as exc:
@@ -193,6 +213,39 @@ class CloudClient:
     def get_entitlements(self) -> dict[str, Any]:
         return self._request_json("GET", "me/entitlements")
 
+    def get_protocol(self, *, refresh: bool = False) -> dict[str, Any]:
+        now = time.monotonic()
+        if (
+            not refresh
+            and self._protocol_cache is not None
+            and now - self._protocol_cache[0] < PROTOCOL_CACHE_SECONDS
+        ):
+            return self._protocol_cache[1]
+        payload = self._request_json("GET", "protocol", authenticated=False)
+        self._protocol_cache = (now, payload)
+        return payload
+
+    def processing_limit(self, *, require_hardened_write: bool) -> int:
+        try:
+            protocol = self.get_protocol()
+        except CloudError:
+            if require_hardened_write:
+                raise
+            return DEFAULT_MAX_CIPHERTEXT_BYTES
+        capabilities = protocol.get("capabilities")
+        limit = protocol.get("max_ciphertext_bytes")
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit <= 0:
+            raise CloudError("Ormah Cloud advertised an invalid ciphertext processing limit.")
+        if require_hardened_write and (
+            protocol.get("protocol_version") != 2
+            or not isinstance(capabilities, list)
+            or "immutable-promotion" not in capabilities
+        ):
+            raise CloudError(
+                "Ormah Cloud does not advertise immutable upload promotion; upload stopped."
+            )
+        return min(limit, DEFAULT_MAX_CIPHERTEXT_BYTES)
+
     def revoke_token(self) -> dict[str, Any]:
         device_id = self.device_id or get_or_create_device_id()
         payload = self._request_json("GET", "me/tokens")
@@ -214,6 +267,11 @@ class CloudClient:
         return self._request_json("POST", "me/tokens/revoke", json={"token_id": token_id})
 
     def create_upload(self, store_id: str, size: int, sha256: str) -> dict[str, Any]:
+        limit = self.processing_limit(require_hardened_write=True)
+        if size > limit:
+            raise CloudError(
+                f"Encrypted bundle is larger than the supported {limit}-byte processing limit."
+            )
         return self._request_json(
             "POST",
             f"stores/{store_id}/uploads",

--- a/src/ormah/cloud/jobs.py
+++ b/src/ormah/cloud/jobs.py
@@ -11,7 +11,7 @@ import tempfile
 
 from ormah.backup import BackupInfo, service_from_settings
 from ormah.cloud.bundle import open_bundle, build_bundle
-from ormah.cloud.client import client_from_settings
+from ormah.cloud.client import CloudError, client_from_settings
 from ormah.cloud.entitlements import EntitlementStatus, check_entitlement
 from ormah.cloud.keys import (
     STORE_ID_NAME,
@@ -150,10 +150,22 @@ def run_cloud_backup(engine) -> str | None:
             upload_id = upload.get("upload_id")
             snapshot_id = upload.get("snapshot_id")
             put_url = upload.get("put_url")
+            expires_at = upload.get("expires_at")
+            required_headers = upload.get("required_headers", {})
             if not all(isinstance(value, str) and value for value in (upload_id, snapshot_id, put_url)):
                 raise RuntimeError("Cloud upload reservation response was malformed.")
+            if not isinstance(expires_at, str):
+                raise RuntimeError("Cloud upload reservation did not include an expiry.")
+            parsed_expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            if parsed_expiry.tzinfo is None or parsed_expiry <= _utc_now():
+                raise RuntimeError("Cloud upload reservation is already expired.")
+            if not isinstance(required_headers, dict) or not all(
+                isinstance(name, str) and isinstance(value, str)
+                for name, value in required_headers.items()
+            ):
+                raise RuntimeError("Cloud upload reservation headers were malformed.")
 
-            put_file(put_url, bundle)
+            put_file(put_url, bundle, required_headers)
             finalized = client.finalize_upload(store_id, upload_id)
             finalized_snapshot = finalized.get("snapshot_id")
             if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
@@ -246,6 +258,11 @@ def run_restore_verification(engine) -> bool:
         snapshot_id = latest.get("snapshot_id") if isinstance(latest, dict) else None
         if not isinstance(snapshot_id, str) or not snapshot_id:
             raise RuntimeError("Cloud snapshot listing was malformed.")
+        size_bytes = latest.get("size_bytes") if isinstance(latest, dict) else None
+        if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
+            raise RuntimeError("Cloud snapshot listing did not include a valid size.")
+        if size_bytes > client.processing_limit(require_hardened_write=False):
+            raise CloudError("Cloud snapshot exceeds this client's safe processing limit.")
 
         presigned = client.presign_download(store_id, snapshot_id)
         get_url = presigned.get("get_url")

--- a/src/ormah/cloud/restore.py
+++ b/src/ormah/cloud/restore.py
@@ -47,17 +47,17 @@ def _committed_blobs(client, store_id: str) -> list[dict[str, Any]]:
     return [blob for blob in blobs if isinstance(blob, dict)]
 
 
-def _select_snapshot(blobs: list[dict[str, Any]], requested: str | None) -> str:
+def _select_snapshot(blobs: list[dict[str, Any]], requested: str | None) -> dict[str, Any]:
     if not blobs:
         raise CloudRestoreError("No committed cloud snapshots are available for this store.")
     if requested:
         if any(blob.get("snapshot_id") == requested for blob in blobs):
-            return requested
+            return next(blob for blob in blobs if blob.get("snapshot_id") == requested)
         raise CloudRestoreError(f"Cloud snapshot not found: {requested}")
     snapshot_id = blobs[0].get("snapshot_id")
     if not isinstance(snapshot_id, str) or not snapshot_id:
         raise CloudRestoreError("Cloud snapshot listing was malformed.")
-    return snapshot_id
+    return blobs[0]
 
 
 def restore_cloud_snapshot(
@@ -81,7 +81,13 @@ def restore_cloud_snapshot(
     client = None
     try:
         client = client_from_settings(settings)
-        chosen = _select_snapshot(_committed_blobs(client, store_id), snapshot_id)
+        chosen_blob = _select_snapshot(_committed_blobs(client, store_id), snapshot_id)
+        chosen = chosen_blob.get("snapshot_id")
+        size_bytes = chosen_blob.get("size_bytes")
+        if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
+            raise CloudRestoreError("Cloud snapshot listing did not include a valid size.")
+        if size_bytes > client.processing_limit(require_hardened_write=False):
+            raise CloudRestoreError("Cloud snapshot exceeds this client's safe processing limit.")
         presigned = client.presign_download(store_id, chosen)
         get_url = presigned.get("get_url")
         if not isinstance(get_url, str) or not get_url:

--- a/src/ormah/cloud/transfer.py
+++ b/src/ormah/cloud/transfer.py
@@ -9,6 +9,11 @@ import httpx
 
 
 TRANSFER_TIMEOUT = httpx.Timeout(300.0, connect=10.0)
+ALLOWED_PUT_HEADERS = {
+    "content-length",
+    "content-type",
+    "x-amz-checksum-sha256",
+}
 
 
 def sha256_file(path: Path) -> str:
@@ -19,9 +24,23 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def put_file(url: str, path: Path) -> None:
-    """PUT an encrypted bundle to a presigned object URL."""
-    response = httpx.put(url, content=path.read_bytes(), timeout=TRANSFER_TIMEOUT)
+def _validated_put_headers(required_headers: dict[str, str] | None) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for name, value in (required_headers or {}).items():
+        normalized = name.lower()
+        if normalized not in ALLOWED_PUT_HEADERS:
+            raise ValueError(f"Cloud service requested unsupported PUT header: {name}")
+        if not isinstance(value, str) or "\r" in value or "\n" in value:
+            raise ValueError(f"Cloud service returned an invalid PUT header: {name}")
+        headers[normalized] = value
+    return headers
+
+
+def put_file(url: str, path: Path, required_headers: dict[str, str] | None = None) -> None:
+    """Stream an encrypted bundle to a presigned object URL."""
+    headers = _validated_put_headers(required_headers)
+    with path.open("rb") as source:
+        response = httpx.put(url, content=source, headers=headers, timeout=TRANSFER_TIMEOUT)
     response.raise_for_status()
 
 

--- a/tests/test_cli_cloud_backup.py
+++ b/tests/test_cli_cloud_backup.py
@@ -43,6 +43,9 @@ class RestoreClient:
     def presign_download(self, store_id, snapshot_id):
         return {"get_url": "https://objects.example/restore"}
 
+    def processing_limit(self, *, require_hardened_write):
+        return 512 * 1024 * 1024
+
     def close(self):
         self.closed = True
 
@@ -122,6 +125,32 @@ def test_cloud_restore_does_not_check_entitlement(tmp_path, monkeypatch):
     )
 
     with pytest.raises(restore.CloudRestoreError, match="No committed"):
+        restore_cloud_snapshot(settings)
+
+
+def test_cloud_restore_rejects_oversized_snapshot_before_download(tmp_path, monkeypatch):
+    from ormah.cloud import restore
+
+    store_id = str(uuid.uuid4())
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    settings = Settings(
+        memory_dir=memory_dir,
+        backup_dir=tmp_path / "backups",
+        account_token="test-token",
+    )
+    client = RestoreClient()
+    client.processing_limit = lambda **kwargs: 50
+    monkeypatch.setattr(restore, "key_file_exists", lambda: True)
+    monkeypatch.setattr(restore, "client_from_settings", lambda settings: client)
+    monkeypatch.setattr(
+        restore,
+        "download_file",
+        lambda *args: (_ for _ in ()).throw(AssertionError("download must not start")),
+    )
+
+    with pytest.raises(restore.CloudRestoreError, match="safe processing limit"):
         restore_cloud_snapshot(settings)
 
 

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -80,6 +80,16 @@ def test_revoke_resolves_server_token_id_from_device():
 @respx.mock
 def test_upload_blob_and_head_methods_match_service_shapes():
     store_id = str(uuid.uuid4())
+    protocol_route = respx.get(f"{BASE_URL}/protocol").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "protocol_version": 2,
+                "capabilities": ["immutable-promotion"],
+                "max_ciphertext_bytes": 1024,
+            },
+        )
+    )
     create_route = respx.post(f"{BASE_URL}/stores/{store_id}/uploads").mock(
         return_value=httpx.Response(
             201,
@@ -118,6 +128,9 @@ def test_upload_blob_and_head_methods_match_service_shapes():
     assert create_route.calls[0].request.content == (
         b'{"size_bytes":42,"sha256":"' + b"a" * 64 + b'"}'
     )
+    assert create_route.calls[0].request.headers["x-ormah-client-version"]
+    assert uuid.UUID(create_route.calls[0].request.headers["x-request-id"])
+    assert protocol_route.call_count == 1
     assert finalize_route.calls[0].request.content == b'{"advance_head":{"expected_seq":3}}'
     assert download_route.calls[0].request.content == b'{"snapshot_id":"snapshot"}'
 
@@ -174,6 +187,42 @@ def test_non_cas_conflict_still_raises():
 
 
 @respx.mock
+def test_upload_fails_closed_without_immutable_protocol():
+    respx.get(f"{BASE_URL}/protocol").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "protocol_version": 1,
+                "capabilities": [],
+                "max_ciphertext_bytes": 1024,
+            },
+        )
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="immutable"):
+            client.create_upload(str(uuid.uuid4()), 42, "a" * 64)
+
+
+@respx.mock
+def test_upload_rejects_bundle_above_negotiated_limit_before_reservation():
+    respx.get(f"{BASE_URL}/protocol").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "protocol_version": 2,
+                "capabilities": ["immutable-promotion"],
+                "max_ciphertext_bytes": 10,
+            },
+        )
+    )
+    create = respx.post(f"{BASE_URL}/stores/{uuid.uuid4()}/uploads")
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="processing limit"):
+            client.create_upload(str(uuid.uuid4()), 11, "a" * 64)
+    assert not create.called
+
+
+@respx.mock
 def test_network_errors_are_wrapped():
     respx.get(f"{BASE_URL}/me/entitlements").mock(
         side_effect=httpx.ConnectError("offline")
@@ -181,6 +230,15 @@ def test_network_errors_are_wrapped():
     with CloudClient(BASE_URL, TOKEN) as client:
         with pytest.raises(CloudError, match="Could not reach"):
             client.get_entitlements()
+
+
+@respx.mock
+def test_read_processing_limit_falls_back_offline_but_write_does_not():
+    respx.get(f"{BASE_URL}/protocol").mock(side_effect=httpx.ConnectError("offline"))
+    with CloudClient(BASE_URL, TOKEN) as client:
+        assert client.processing_limit(require_hardened_write=False) == 512 * 1024 * 1024
+        with pytest.raises(CloudError, match="Could not reach"):
+            client.processing_limit(require_hardened_write=True)
 
 
 def test_device_id_is_stable_uuid4_and_mode_0600(tmp_path):

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -34,6 +34,8 @@ class FakeCloudClient:
             "upload_id": "upload-1",
             "snapshot_id": "01SNAPSHOT",
             "put_url": "https://objects.example/put",
+            "expires_at": (NOW + timedelta(minutes=15)).isoformat(),
+            "required_headers": {"x-amz-checksum-sha256": "signed-checksum"},
         }
 
     def finalize_upload(self, *args):
@@ -49,6 +51,9 @@ class FakeCloudClient:
 
     def presign_download(self, store_id, snapshot_id):
         return {"get_url": "https://objects.example/get"}
+
+    def processing_limit(self, *, require_hardened_write):
+        return 512 * 1024 * 1024
 
     def close(self):
         self.closed = True
@@ -106,7 +111,7 @@ def _patch_upload_prerequisites(monkeypatch, client: FakeCloudClient):
         return out_path
 
     monkeypatch.setattr(jobs, "build_bundle", fake_bundle)
-    monkeypatch.setattr(jobs, "put_file", lambda url, path: None)
+    monkeypatch.setattr(jobs, "put_file", lambda url, path, headers: None)
 
 
 def test_cloud_backup_disabled_is_first_guard(tmp_path, monkeypatch):
@@ -213,7 +218,11 @@ def test_failed_put_records_error_and_never_finalizes(
     settings, store_id = _settings(tmp_path)
     client = FakeCloudClient()
     _patch_upload_prerequisites(monkeypatch, client)
-    monkeypatch.setattr(jobs, "put_file", lambda url, path: (_ for _ in ()).throw(OSError("PUT failed")))
+    monkeypatch.setattr(
+        jobs,
+        "put_file",
+        lambda url, path, headers: (_ for _ in ()).throw(OSError("PUT failed")),
+    )
 
     assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
     assert client.finalized == []

--- a/tests/test_cloud_transfer.py
+++ b/tests/test_cloud_transfer.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from ormah.cloud.transfer import put_file
+
+
+@respx.mock
+def test_put_file_streams_and_applies_only_signed_headers(tmp_path, monkeypatch):
+    path = tmp_path / "bundle.age"
+    path.write_bytes(b"ciphertext" * 1024)
+    monkeypatch.setattr(
+        Path,
+        "read_bytes",
+        lambda self: (_ for _ in ()).throw(AssertionError("PUT must stream")),
+    )
+    route = respx.put("https://objects.example/pending").mock(
+        return_value=httpx.Response(200)
+    )
+
+    put_file(
+        "https://objects.example/pending",
+        path,
+        {"x-amz-checksum-sha256": "signed-value"},
+    )
+
+    request = route.calls[0].request
+    assert request.content == b"ciphertext" * 1024
+    assert request.headers["x-amz-checksum-sha256"] == "signed-value"
+
+
+def test_put_file_rejects_unexpected_or_malformed_headers(tmp_path):
+    path = tmp_path / "bundle.age"
+    path.write_bytes(b"ciphertext")
+    with pytest.raises(ValueError, match="unsupported"):
+        put_file("https://objects.example/pending", path, {"authorization": "secret"})
+    with pytest.raises(ValueError, match="invalid"):
+        put_file(
+            "https://objects.example/pending",
+            path,
+            {"content-type": "application/octet-stream\r\nX-Evil: yes"},
+        )


### PR DESCRIPTION
## Problem

The C01 service protocol moves uploads to checksum-bound pending keys and advertises a conservative ciphertext processing envelope. The E05 client currently buffers the entire encrypted bundle with `read_bytes()`, ignores service-required signed headers, and has no capability or size preflight.

## Solution

- add cached `GET /protocol` discovery and fail closed for cloud writes unless protocol v2 advertises immutable promotion;
- send the installed Ormah version and a per-request UUID in request headers;
- enforce the smaller of the service-advertised and local 512 MiB ciphertext processing limits before upload reservation or restore download/decryption;
- stream presigned PUTs from disk and apply only the allowlisted checksum/content headers returned by the service;
- validate upload reservation expiry and response shapes before transferring bytes;
- keep restore available when protocol discovery is offline by falling back to the conservative local read limit.

## Verification

- C01-focused client/backup/restore/transfer suite: `41 passed`.
- Ruff clean; `git diff --check` clean.
- Complete Ormah suite: `1447 passed`, with only the documented machine-environment failure `tests/test_config.py::test_llm_provider_defaults_to_none` because the real user config selects `litellm`; one test remains intentionally deselected.
- Tests prove PUT streaming without `Path.read_bytes`, signed-header allowlisting, fail-closed write negotiation, offline restore fallback, and oversized restore rejection before download.
- The companion service branch passed the real development-R2 immutable-promotion probe.

## Compatibility

This PR does not change local backup behavior, entitlement policy, encryption, restore replacement semantics, or sync behavior. Cloud writes require the hardened service contract after this client is released; downloads retain a bounded compatibility fallback.

Depends on r-spade/ormah-cloud#3. Do not enable the service minimum-client enforcement flag until this client release is available.
