### PR TITLE
fix(ingest): gate leading_orphan recovery on forward progress (ADR guard, fixes #149)

### DIFF
--- a/src/ormah/adapters/cli_adapter.py
+++ b/src/ormah/adapters/cli_adapter.py
@@ -450,8 +450,14 @@ def cmd_whisper_store(args):
             # prompt. With forward progress the orphan is a false positive (ADR-0003,
             # #149): drop the fragment and advance, or every hook fire re-extracts the
             # whole transcript.
+            original_offset = start_offset
             start_offset = 0
             result = parse_transcript(path, start_offset=0)
+            if result.safe_end_offset <= original_offset:
+                # The rewind made no progress: the "orphan" tail is a still-open in-flight
+                # response, not a recoverable one. ADR-0003: a no-progress transcript
+                # parks, it does not re-extract the closed prefix on every hook fire.
+                sys.exit(0)
     except Exception:
         sys.exit(0)
 

--- a/src/ormah/adapters/cli_adapter.py
+++ b/src/ormah/adapters/cli_adapter.py
@@ -440,13 +440,16 @@ def cmd_whisper_store(args):
     if start_offset >= path.stat().st_size:
         sys.exit(0)
 
-    from ormah.transcript.parser import parse_transcript
+    from ormah.transcript.parser import parse_transcript, should_rewind
 
     try:
         result = parse_transcript(path, start_offset=start_offset)
-        if result.leading_orphan:
-            # Cursor left mid-response by an older version: re-parse from the start to
-            # recover the dropped tail with its prompt (one-time full re-extract).
+        if should_rewind(result, start_offset):
+            # Orphan with NO forward progress: a genuine cursor left mid-response by an
+            # older version — re-parse from the start to recover the dropped tail with its
+            # prompt. With forward progress the orphan is a false positive (ADR-0003,
+            # #149): drop the fragment and advance, or every hook fire re-extracts the
+            # whole transcript.
             start_offset = 0
             result = parse_transcript(path, start_offset=0)
     except Exception:

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -18,7 +18,7 @@ from watchdog.observers import Observer
 
 from ormah.engine.memory_engine import MemoryEngine
 from ormah.text.tokens import distinctive_tokens
-from ormah.transcript.parser import TranscriptResult, TranscriptTurn, parse_transcript
+from ormah.transcript.parser import TranscriptResult, TranscriptTurn, parse_transcript, should_rewind
 
 logger = logging.getLogger(__name__)
 
@@ -771,10 +771,12 @@ def _ingest_session(
 
     try:
         result = parse_transcript(path, start_offset=prev_offset)
-        if result.leading_orphan:
-            # A cursor left mid-response by an older version: re-parse the whole file so
-            # the dropped tail is recovered and re-paired with its prompt. A one-time
-            # re-ingest of this file; the background dedup jobs reconcile any overlap.
+        if should_rewind(result, prev_offset):
+            # Orphan with NO forward progress: a genuine cursor left mid-response by an
+            # older version. Re-parse the whole file so the dropped tail is re-paired with
+            # its prompt. With forward progress the orphan is a false positive (ADR-0003,
+            # #149): the fragment is dropped and the cursor advances — rewinding there
+            # would re-ingest the whole file on every tick forever.
             logger.info("Session watcher recovering legacy mid-response cursor for %s", rel)
             prev_offset = 0
             result = parse_transcript(path, start_offset=0)

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -18,7 +18,12 @@ from watchdog.observers import Observer
 
 from ormah.engine.memory_engine import MemoryEngine
 from ormah.text.tokens import distinctive_tokens
-from ormah.transcript.parser import TranscriptResult, TranscriptTurn, parse_transcript, should_rewind
+from ormah.transcript.parser import (
+    TranscriptResult,
+    TranscriptTurn,
+    parse_transcript,
+    should_rewind,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -777,9 +782,15 @@ def _ingest_session(
             # its prompt. With forward progress the orphan is a false positive (ADR-0003,
             # #149): the fragment is dropped and the cursor advances — rewinding there
             # would re-ingest the whole file on every tick forever.
+            original_offset = prev_offset
             logger.info("Session watcher recovering legacy mid-response cursor for %s", rel)
             prev_offset = 0
             result = parse_transcript(path, start_offset=0)
+            if result.safe_end_offset <= original_offset:
+                # The rewind itself made no progress: the "orphan" tail is a still-open
+                # in-flight response, not a recoverable one. ADR-0003: a no-progress
+                # transcript parks, it does not re-extract the closed prefix every tick.
+                return IngestResult.NO_PROGRESS
     except Exception as e:  # noqa: BLE001 - transcript parsers can raise provider-specific errors
         logger.warning("Session transcript parse error for %s: %s", path, e)
         return IngestResult.NO_PROGRESS

--- a/src/ormah/transcript/parser.py
+++ b/src/ormah/transcript/parser.py
@@ -322,3 +322,17 @@ def parse_transcript(path: Path, start_offset: int = 0) -> TranscriptResult:
         turns=turns,
         source=source,
     )
+
+
+def should_rewind(result: TranscriptResult, start_offset: int) -> bool:
+    """Gate the leading-orphan recovery on forward progress (ADR-0003, bug #149).
+
+    Rewind (re-parse from offset 0) only when the flagged parse made no forward
+    progress — the orphan consumed the whole slice, i.e. a genuine legacy
+    mid-response cursor. When the safe boundary still advanced past the cursor,
+    the orphan is a false positive (e.g. an "API Error" assistant record right
+    after a terminal stop_reason): the fragment is dropped and the cursor moves
+    on. Rewinding there re-ingests the whole file on every tick forever, because
+    the trigger is a permanent property of the file's bytes.
+    """
+    return result.leading_orphan and result.safe_end_offset <= start_offset

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -1623,6 +1623,47 @@ def test_legacy_orphan_with_later_turns_advances_and_drops(engine, tmp_path, cap
     assert "Prompt two" in prompt        # later turn ingested normally
 
 
+def test_inflight_orphan_rewind_parks_without_reingest(engine, tmp_path, caplog):
+    """ADR-0003 critical regression (Codex review, #149): an orphan with NO forward
+    progress whose rewind (full re-parse) ALSO makes no progress — because the tail is a
+    still-open (in-flight) response, not a genuinely recoverable one — must park
+    (NO_PROGRESS) rather than re-extract the closed prefix on every tick."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+
+    closed_turn = [
+        {"type": "user", "message": {"content": "Prompt about the release plan"}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Answer about the release plan"}]}},
+    ]
+    with open(jsonl, "w") as f:
+        for line in closed_turn:
+            f.write(json.dumps(line) + "\n")
+    boundary = parse_transcript(jsonl).safe_end_offset  # cursor parked here by tick N
+
+    # An in-flight response fragment: text-bearing, non-terminal stop_reason, no
+    # following user turn and no closure — the response is genuinely still being written.
+    with open(jsonl, "a") as f:
+        f.write(json.dumps({"type": "assistant", "message": {"stop_reason": "tool_use",
+            "content": [{"type": "text", "text": "In-flight fragment"}]}}) + "\n")
+    _mark_idle(jsonl)
+
+    rel = str(jsonl.relative_to(watch_dir))
+    state = {rel: {"end_offset": boundary, "hash": "stale", "user_turns": 1, "node_ids": []}}
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE) as mock_llm, \
+         caplog.at_level(logging.INFO, logger="ormah.background.session_watcher"):
+        r1 = _ingest_session(engine, jsonl, state, watch_dir, 1)
+        r2 = _ingest_session(engine, jsonl, state, watch_dir, 1)
+
+    assert r1 == IngestResult.NO_PROGRESS
+    assert r2 == IngestResult.NO_PROGRESS
+    assert mock_llm.call_count == 0                       # never re-ingested
+    assert state[rel]["end_offset"] == boundary            # cursor left untouched
+
+
 # --- Test 19: in-flight skip reschedules the dropped event (no lost tail) ---
 
 def test_inflight_skip_reschedules(engine, tmp_path):

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -1444,6 +1445,182 @@ def test_concurrent_ingest_skipped(engine, tmp_path):
         t1.join(timeout=5)
 
     assert calls == 1
+
+
+# --- ADR-0003 (#149): gate the rewind on forward progress ---
+
+
+def test_api_error_orphan_advances_without_reingest(engine, tmp_path, caplog):
+    """ADR-0003 regression (bug #149): an assistant 'API Error' record right after a
+    terminal end_turn flags leading_orphan on the next tick. The watcher must NOT rewind
+    to 0 (36x whole-file re-extractions); it drops the fragment, ingests the tail past
+    the boundary, and the following tick is a cheap NO_PROGRESS."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+
+    first_turn = [
+        {"type": "user", "message": {"content": "Prompt one"}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Answer one"}]}},
+    ]
+    tail = [
+        {"type": "assistant", "message": {"stop_reason": "stop_sequence",
+            "content": [{"type": "text",
+                "text": "API Error: Connection closed mid-response."}]}},
+        {"type": "user", "message": {"content": "continue with the previous response"}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text",
+                "text": "Answer two continues with additional detail"}]}},
+    ]
+    with open(jsonl, "w") as f:
+        for line in first_turn:
+            f.write(json.dumps(line) + "\n")
+    boundary = parse_transcript(jsonl).safe_end_offset  # where tick N parked the cursor
+    with open(jsonl, "a") as f:
+        for line in tail:
+            f.write(json.dumps(line) + "\n")
+    _mark_idle(jsonl)
+
+    rel = str(jsonl.relative_to(watch_dir))
+    state = {rel: {"end_offset": boundary, "hash": "stale", "user_turns": 1, "node_ids": []}}
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE) as mock_llm, \
+         caplog.at_level(logging.INFO, logger="ormah.background.session_watcher"):
+        r1 = _ingest_session(engine, jsonl, state, watch_dir, 1)
+        assert r1 == IngestResult.OK
+        assert "recovering legacy mid-response cursor" not in caplog.text  # no rewind
+        assert state[rel]["end_offset"] == jsonl.stat().st_size            # tail consumed
+        assert state[rel]["end_offset"] > boundary                          # monotonic
+        assert mock_llm.call_count == 1
+        prompt = str(mock_llm.call_args_list[0])
+        assert "Answer one" not in prompt   # slice before the cursor NOT re-ingested
+        assert "API Error" not in prompt    # orphan fragment dropped, not committed
+        assert "continue" in prompt         # previously-stranded tail IS ingested
+
+        r2 = _ingest_session(engine, jsonl, state, watch_dir, 1)
+        assert r2 == IngestResult.NO_PROGRESS   # second tick: nothing re-extracted
+        assert mock_llm.call_count == 1
+        assert state[rel]["end_offset"] == jsonl.stat().st_size
+
+
+def test_no_progress_orphan_still_rewinds(engine, tmp_path, caplog):
+    """A genuine legacy mid-response cursor (orphan AND no forward progress) still
+    triggers the one-time whole-file recovery, re-pairing the tail with its prompt."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    records = [
+        {"type": "user", "message": {"content": "Prompt about the architecture decision"}},
+        {"type": "assistant", "message": {"stop_reason": "tool_use",
+            "content": [{"type": "text", "text": "First part"}]}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Second part"}]}},
+    ]
+    with open(jsonl, "w") as f:
+        for line in records:
+            f.write(json.dumps(line) + "\n")
+    raw = jsonl.read_bytes().splitlines(keepends=True)
+    mid = len(raw[0]) + len(raw[1])  # cursor parked mid-response by an older version
+    _mark_idle(jsonl)
+
+    rel = str(jsonl.relative_to(watch_dir))
+    state = {rel: {"end_offset": mid, "hash": "stale", "user_turns": 1, "node_ids": []}}
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE) as mock_llm, \
+         caplog.at_level(logging.INFO, logger="ormah.background.session_watcher"):
+        r1 = _ingest_session(engine, jsonl, state, watch_dir, 1)
+    assert r1 == IngestResult.OK
+    assert "recovering legacy mid-response cursor" in caplog.text
+    prompt = str(mock_llm.call_args_list[0])
+    assert "Prompt about the architecture decision" in prompt  # re-paired from offset 0
+    assert state[rel]["end_offset"] == jsonl.stat().st_size
+
+
+def test_below_min_turns_orphan_reparse_is_cheap_noop(engine, tmp_path, caplog):
+    """ADR-0003 residual: with the guard, an advanced-but-below-min_turns payload on an
+    ACTIVE file defers (TRANSIENT) and re-parses on later ticks as a parse-only no-op —
+    no rewind, no LLM call, no duplication — until it idles or crosses min_turns."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+
+    first_turn = [
+        {"type": "user", "message": {"content": "Prompt one"}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Answer one"}]}},
+    ]
+    tail = [
+        {"type": "assistant", "message": {"stop_reason": "stop_sequence",
+            "content": [{"type": "text",
+                "text": "API Error: Connection closed mid-response."}]}},
+        {"type": "user", "message": {"content": "continue"}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Answer two"}]}},
+    ]
+    with open(jsonl, "w") as f:
+        for line in first_turn:
+            f.write(json.dumps(line) + "\n")
+    boundary = parse_transcript(jsonl).safe_end_offset
+    with open(jsonl, "a") as f:
+        for line in tail:
+            f.write(json.dumps(line) + "\n")
+    # NO _mark_idle: mtime is fresh, so the file is ACTIVE and 1 turn < min_turns=5 defers.
+
+    rel = str(jsonl.relative_to(watch_dir))
+    state = {rel: {"end_offset": boundary, "hash": "stale", "user_turns": 1, "node_ids": []}}
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE) as mock_llm, \
+         caplog.at_level(logging.INFO, logger="ormah.background.session_watcher"):
+        r1 = _ingest_session(engine, jsonl, state, watch_dir, 5)
+        r2 = _ingest_session(engine, jsonl, state, watch_dir, 5)
+    assert r1 == IngestResult.TRANSIENT and r2 == IngestResult.TRANSIENT  # defer, retry later
+    assert "recovering legacy mid-response cursor" not in caplog.text     # never rewinds
+    assert mock_llm.call_count == 0                                       # parse-only no-op
+    assert state[rel]["end_offset"] == boundary                           # cursor held, not lost
+
+
+def test_legacy_orphan_with_later_turns_advances_and_drops(engine, tmp_path, caplog):
+    """ADR-0003 accepted-loss pinning (watcher level): a genuine legacy mid-response cursor
+    in a file that ALSO has later closed turns → no rewind, the fragment tail is dropped
+    (bounded, one-time loss), the later turn is ingested, cursor reaches EOF."""
+    watch_dir = tmp_path / "projects"
+    project_dir = watch_dir / "-Users-alice-Code-myproject"
+    project_dir.mkdir(parents=True)
+    jsonl = project_dir / "abc123.jsonl"
+    records = [
+        {"type": "user", "message": {"content": "Prompt one"}},
+        {"type": "assistant", "message": {"stop_reason": "tool_use",
+            "content": [{"type": "text", "text": "First part"}]}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Second part"}]}},
+        {"type": "user", "message": {"content": "Prompt two continues the architecture discussion"}},
+        {"type": "assistant", "message": {"stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Answer two follows up with more detail"}]}},
+    ]
+    with open(jsonl, "w") as f:
+        for line in records:
+            f.write(json.dumps(line) + "\n")
+    raw = jsonl.read_bytes().splitlines(keepends=True)
+    mid = len(raw[0]) + len(raw[1])  # legacy cursor parked mid-response
+    _mark_idle(jsonl)
+
+    rel = str(jsonl.relative_to(watch_dir))
+    state = {rel: {"end_offset": mid, "hash": "stale", "user_turns": 1, "node_ids": []}}
+
+    with patch(_LLM_PATCH, return_value=_LLM_RESPONSE) as mock_llm, \
+         caplog.at_level(logging.INFO, logger="ormah.background.session_watcher"):
+        r1 = _ingest_session(engine, jsonl, state, watch_dir, 1)
+    assert r1 == IngestResult.OK
+    assert "recovering legacy mid-response cursor" not in caplog.text  # ADR: no rewind
+    assert state[rel]["end_offset"] == jsonl.stat().st_size
+    prompt = str(mock_llm.call_args_list[0])
+    assert "Second part" not in prompt   # the accepted, bounded loss
+    assert "Prompt one" not in prompt    # pre-cursor content not re-ingested
+    assert "Prompt two" in prompt        # later turn ingested normally
 
 
 # --- Test 19: in-flight skip reschedules the dropped event (no lost tail) ---

--- a/tests/test_transcript/test_parser.py
+++ b/tests/test_transcript/test_parser.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ormah.transcript.parser import extract_user_prompts, parse_transcript
+from ormah.transcript.parser import extract_user_prompts, parse_transcript, should_rewind
 
 
 def _write_jsonl(tmp_path: Path, lines: list[dict], name: str = "abc123.jsonl") -> Path:
@@ -594,3 +594,113 @@ class TestSafeBoundary:
         assert result.safe_conversation == ""
         # The raw payload still has the content; it just isn't safe to commit yet.
         assert "an answer" in result.conversation
+
+
+class TestShouldRewind:
+    """ADR-0003: rewind only on NO forward progress; an orphan-with-progress is dropped."""
+
+    def _api_error_lines(self):
+        return [
+            {"type": "user", "message": {"content": "Prompt one"}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Answer one"}]}},
+            {"type": "assistant", "message": {"stop_reason": "stop_sequence",
+                "content": [{"type": "text",
+                    "text": "API Error: Connection closed mid-response."}]}},
+            {"type": "user", "message": {"content": "continue"}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Answer two"}]}},
+        ]
+
+    def test_api_error_orphan_with_progress_does_not_rewind(self, tmp_path):
+        """The #149 byte pattern: end_turn boundary, then an assistant 'API Error' record
+        before the next user turn. The orphan flag fires (false positive) but the parse
+        still advances the safe boundary — so no rewind, and the tail is usable."""
+        lines = self._api_error_lines()
+        path = _write_jsonl(tmp_path, lines[:2])
+        boundary = parse_transcript(path).safe_end_offset
+        assert boundary == path.stat().st_size  # cursor parks exactly on the end_turn boundary
+        with open(path, "a") as f:
+            for line in lines[2:]:
+                f.write(json.dumps(line) + "\n")
+
+        result = parse_transcript(path, start_offset=boundary)
+        assert result.leading_orphan is True          # the false positive is still flagged
+        assert result.safe_end_offset > boundary      # but the parse made forward progress
+        assert should_rewind(result, boundary) is False
+        assert result.safe_user_turn_count == 1
+        assert "API Error" not in result.safe_conversation  # orphan fragment dropped
+
+    def test_no_progress_orphan_rewinds(self, tmp_path):
+        """A genuine legacy cursor parked mid-response: orphan AND no forward progress."""
+        lines = [
+            {"type": "user", "message": {"content": "Prompt one"}},
+            {"type": "assistant", "message": {"stop_reason": "tool_use",
+                "content": [{"type": "text", "text": "First part"}]}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Second part"}]}},
+        ]
+        path = _write_jsonl(tmp_path, lines)
+        raw = path.read_bytes().splitlines(keepends=True)
+        mid = len(raw[0]) + len(raw[1])  # cursor saved mid-response by an older version
+
+        result = parse_transcript(path, start_offset=mid)
+        assert result.leading_orphan is True
+        assert result.safe_end_offset == mid          # nothing closed: no progress
+        assert should_rewind(result, mid) is True
+
+    def test_no_orphan_never_rewinds_even_without_progress(self, tmp_path):
+        """No-progress alone (in-flight tail) must not rewind — only orphan+no-progress does."""
+        path = _write_jsonl(tmp_path, [{"type": "user", "message": {"content": "hi"}}])
+        result = parse_transcript(path, start_offset=0)
+        assert result.leading_orphan is False
+        assert result.safe_end_offset == 0
+        assert should_rewind(result, 0) is False
+
+    def test_large_orphan_with_progress_does_not_rewind(self, tmp_path):
+        """ADR-0003 large-orphan variant: a giant orphan fragment before the first user turn
+        still yields progress (boundary reaches the closed turn after it) — no rewind."""
+        big = "x" * 50_000
+        prefix = self._api_error_lines()[:2]
+        tail = [
+            {"type": "assistant", "message": {"stop_reason": "tool_use",
+                "content": [{"type": "text", "text": big}]}}
+            for _ in range(3)
+        ] + self._api_error_lines()[3:]  # user("continue") + assistant(end_turn)
+        path = _write_jsonl(tmp_path, prefix)
+        boundary = parse_transcript(path).safe_end_offset
+        with open(path, "a") as f:
+            for line in tail:
+                f.write(json.dumps(line) + "\n")
+
+        result = parse_transcript(path, start_offset=boundary)
+        assert result.leading_orphan is True
+        assert should_rewind(result, boundary) is False
+
+    def test_legacy_orphan_with_later_turns_drops_fragment(self, tmp_path):
+        """ADR-0003 accepted-loss pinning (council R1, Cursor+Codex): a GENUINE legacy
+        cursor mid-response whose file also contains later closed turns. The fragment tail
+        is dropped (its head was already ingested before the cursor; the loss is bounded
+        and one-time) and the cursor advances — deliberately NO rewind. If this assertion
+        ever needs to change, re-open ADR-0003 first."""
+        lines = [
+            {"type": "user", "message": {"content": "Prompt one"}},
+            {"type": "assistant", "message": {"stop_reason": "tool_use",
+                "content": [{"type": "text", "text": "First part"}]}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Second part"}]}},
+            {"type": "user", "message": {"content": "Prompt two"}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Answer two"}]}},
+        ]
+        path = _write_jsonl(tmp_path, lines)
+        raw = path.read_bytes().splitlines(keepends=True)
+        mid = len(raw[0]) + len(raw[1])  # legacy cursor parked mid-response
+
+        result = parse_transcript(path, start_offset=mid)
+        assert result.leading_orphan is True
+        assert result.safe_end_offset > mid                    # later turn closed → progress
+        assert should_rewind(result, mid) is False             # ADR-0003: drop, don't rewind
+        assert "Second part" not in result.safe_conversation   # the accepted, bounded loss
+        assert "Prompt two" in result.safe_conversation        # later turn fully usable
+        assert "Answer two" in result.safe_conversation

--- a/tests/test_whisper/test_whisper_out.py
+++ b/tests/test_whisper/test_whisper_out.py
@@ -424,6 +424,64 @@ class TestWhisperStoreCursor:
         assert "First part" in bodies[0]["content"]
         assert "Second part answer" in bodies[0]["content"]
 
+    def test_api_error_orphan_advances_cursor_without_full_reextract(
+        self, monkeypatch, tmp_path
+    ):
+        """ADR-0003 regression (bug #149, hook path): a false-positive leading_orphan —
+        an assistant 'API Error' record right after the end_turn boundary the cursor is
+        parked on — must not re-send the whole transcript. The orphan is dropped and only
+        the tail past the cursor is sent; the cursor advances to EOF."""
+        monkeypatch.setattr("ormah.adapters.cli_adapter.settings.whisper_out_min_turns", 1)
+        transcript = tmp_path / "session.jsonl"
+        first_turn = [
+            {"type": "user", "message": {"content": "Prompt one"}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Answer one"}]}},
+        ]
+        tail = [
+            {"type": "assistant", "message": {"stop_reason": "stop_sequence",
+                "content": [{"type": "text",
+                    "text": "API Error: Connection closed mid-response."}]}},
+            {"type": "user", "message": {"content": "continue"}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Answer two"}]}},
+        ]
+        transcript.write_text("\n".join(json.dumps(r) for r in first_turn) + "\n")
+        from ormah.transcript.parser import parse_transcript
+        boundary = parse_transcript(transcript).safe_end_offset
+        with transcript.open("a") as f:
+            for r in tail:
+                f.write(json.dumps(r) + "\n")
+
+        from ormah.adapters.cli_adapter import _WHISPER_CURSOR_DIR, _WHISPER_CURSOR_FILE
+        _WHISPER_CURSOR_DIR.mkdir(parents=True, exist_ok=True)
+        _WHISPER_CURSOR_FILE.write_text(json.dumps({"sess1": boundary}))
+
+        bodies = []
+
+        def handler(request):
+            bodies.append(json.loads(request.content))
+            return _mock_response({"status": "processed", "extracted": 1, "memories": []})
+
+        transport = httpx.MockTransport(handler)
+        monkeypatch.setattr(
+            "ormah.adapters.cli_adapter._whisper_store_client",
+            lambda: httpx.Client(transport=transport, base_url="http://test"),
+        )
+        hook_input = json.dumps({
+            "transcript_path": str(transcript), "cwd": "/tmp",
+            "session_id": "sess1", "trigger": "auto",
+        })
+
+        _run_cli(["whisper", "store"], monkeypatch, stdin_text=hook_input)
+
+        assert len(bodies) == 1
+        assert "Answer one" not in bodies[0]["content"]  # no whole-file re-extract
+        assert "API Error" not in bodies[0]["content"]   # orphan fragment dropped
+        assert "continue" in bodies[0]["content"]        # stranded tail recovered
+        cursors = json.loads(_WHISPER_CURSOR_FILE.read_text())
+        assert cursors["sess1"] == transcript.stat().st_size  # cursor monotonic, at EOF
+
     def test_cursor_skips_already_processed(self, monkeypatch, tmp_path):
         """Second run on unchanged file → no HTTP call."""
         transcript = tmp_path / "session.jsonl"

--- a/tests/test_whisper/test_whisper_out.py
+++ b/tests/test_whisper/test_whisper_out.py
@@ -482,6 +482,53 @@ class TestWhisperStoreCursor:
         cursors = json.loads(_WHISPER_CURSOR_FILE.read_text())
         assert cursors["sess1"] == transcript.stat().st_size  # cursor monotonic, at EOF
 
+    def test_inflight_orphan_rewind_parks_cursor_unchanged(self, monkeypatch, tmp_path):
+        """ADR-0003 critical regression (Codex review, #149): an orphan with NO forward
+        progress whose rewind ALSO makes no progress — a still-open in-flight response, not
+        a genuinely recoverable one — must park: no POST, cursor untouched."""
+        monkeypatch.setattr("ormah.adapters.cli_adapter.settings.whisper_out_min_turns", 1)
+        transcript = tmp_path / "session.jsonl"
+
+        closed_turn = [
+            {"type": "user", "message": {"content": "Prompt about the release plan"}},
+            {"type": "assistant", "message": {"stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Answer about the release plan"}]}},
+        ]
+        transcript.write_text("\n".join(json.dumps(r) for r in closed_turn) + "\n")
+        from ormah.transcript.parser import parse_transcript
+        boundary = parse_transcript(transcript).safe_end_offset
+
+        with transcript.open("a") as f:
+            f.write(json.dumps({"type": "assistant", "message": {"stop_reason": "tool_use",
+                "content": [{"type": "text", "text": "In-flight fragment"}]}}) + "\n")
+
+        from ormah.adapters.cli_adapter import _WHISPER_CURSOR_DIR, _WHISPER_CURSOR_FILE
+        _WHISPER_CURSOR_DIR.mkdir(parents=True, exist_ok=True)
+        _WHISPER_CURSOR_FILE.write_text(json.dumps({"sess1": boundary}))
+
+        bodies = []
+
+        def handler(request):
+            bodies.append(json.loads(request.content))
+            return _mock_response({"status": "processed", "extracted": 1, "memories": []})
+
+        transport = httpx.MockTransport(handler)
+        monkeypatch.setattr(
+            "ormah.adapters.cli_adapter._whisper_store_client",
+            lambda: httpx.Client(transport=transport, base_url="http://test"),
+        )
+        hook_input = json.dumps({
+            "transcript_path": str(transcript), "cwd": "/tmp",
+            "session_id": "sess1", "trigger": "auto",
+        })
+
+        _run_cli(["whisper", "store"], monkeypatch, stdin_text=hook_input)
+        _run_cli(["whisper", "store"], monkeypatch, stdin_text=hook_input)
+
+        assert bodies == []  # never re-ingested
+        cursors = json.loads(_WHISPER_CURSOR_FILE.read_text())
+        assert cursors["sess1"] == boundary  # cursor left untouched
+
     def test_cursor_skips_already_processed(self, monkeypatch, tmp_path):
         """Second run on unchanged file → no HTTP call."""
         transcript = tmp_path / "session.jsonl"


### PR DESCRIPTION
Fixes #149.

## What

A false-positive `leading_orphan` — an `assistant(stop_reason=end_turn)` safe boundary followed by an `assistant("API Error…")` record before the next user turn — made the recovery rewind re-ingest the same transcript **forever** (observed: the same 788K-char payload extracted 36× in 14h, ~773 near-duplicate memories) while the ~530KB tail past the boundary was never ingested.

This PR gates the rewind on **forward progress** with a single shared predicate, so the watcher and the hook path cannot diverge:

- `should_rewind(result, start_offset)` in `transcript/parser.py`: rewind only when `result.leading_orphan and result.safe_end_offset <= start_offset` (no forward progress). An orphan **with** progress is a false positive: the fragment is dropped and the cursor advances — which also un-strands the tail.
- `background/session_watcher.py` and `adapters/cli_adapter.py` (whisper store) both call it instead of checking `leading_orphan` directly.
- Post-rewind park guard (found in review): when the whole-file re-parse still lands `safe_end_offset <=` the original cursor (orphan still in-flight), both consumers now **park** (`NO_PROGRESS` / silent exit) instead of re-ingesting the closed prefix on every tick.

Genuine legacy mid-response cursors (orphan **and** no progress, with recoverable content) still rewind once, as before.

## Tests (TDD, red-first)

- Parser: 5 new tests — the #149 byte pattern (orphan flagged, progress, no rewind, `API Error` excluded from safe conversation), no-progress legacy cursor still rewinds, no-orphan-no-rewind, large-orphan variant, and a pinning test documenting the deliberate bounded drop of a legacy fragment tail when later closed turns exist.
- Watcher: 5 new tests — cursor monotonic across two ticks with a single extraction, cheap parse-only no-op below `min_turns` on an active file, accepted-drop pinning, legacy recovery preserved, and in-flight orphan parking with zero re-ingest and untouched state.
- Whisper hook: 2 new tests — cursor advances to EOF sending only the tail (no full re-extract, orphan excluded), and in-flight orphan parking with cursor untouched. The existing legacy-recovery test is untouched and still passes.

Full suite: 1449 passed; the 11 remaining failures are environment-dependent (global `~/.config/ormah/.env` leaking into bare `Settings()`) and fail identically on the merge base `f8ff9d7` — verified on a clean worktree. `ruff check src/ tests/`: clean.

## Known residual (deliberate, filed separately)

A session whose **final** record is a *terminal* API-error orphan still pays one whole-file re-ingest (the pre-existing legacy-recovery path; cursor then reaches EOF and parks — no loop). Fixing it requires classifying orphan provenance, which this design deliberately avoids; follow-up issue to be filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)