### PR TITLE
chore(release): bump version to 0.14.0

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.13.6",
+  "version": "0.14.0",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.13.6"
+version = "0.14.0"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump Python package version to 0.14.0
- Keep the Claude plugin manifest version in sync with pyproject.toml

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv run python .github/release/verify_release_versions.py 0.14.0
- UV_CACHE_DIR=/tmp/uv-cache ORMAH_LLM_PROVIDER=none uv run pytest -q
- git diff --check