### PR TITLE
fix(desktop): notarize and staple the dmg, not just the app inside it

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -130,6 +130,23 @@ jobs:
           APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
         run: cargo tauri build --target ${{ matrix.target }}
 
+      # tauri-bundler notarizes and staples the .app, then builds the .dmg
+      # around it and code-signs the dmg container — but never submits the
+      # dmg itself for notarization. Without this, Gatekeeper rejects the
+      # downloaded dmg on open (spctl: "Unnotarized Developer ID") even
+      # though the .app inside is validly notarized.
+      - name: Notarize and staple dmg (macOS)
+        if: runner.os == 'macOS'
+        working-directory: desktop
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+        run: |
+          DMG=$(find "src-tauri/target/${{ matrix.target }}/release/bundle/dmg" -name '*.dmg')
+          xcrun notarytool submit "$DMG" --key-id "$APPLE_API_KEY" --key "$APPLE_API_KEY_PATH" --issuer "$APPLE_API_ISSUER" --wait
+          xcrun stapler staple "$DMG"
+
       - name: Stop DNS resolver keepalive
         if: runner.os == 'macOS' && always()
         run: kill "$DNS_KEEPALIVE_PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `cargo tauri build` (via tauri-bundler) notarizes and staples the `.app`, then builds the `.dmg` around it and only code-signs the dmg container — it never submits the dmg itself to Apple's notary service.
- Verified against the published `desktop-v0.3.13` release: `xcrun stapler validate` and `spctl` pass fine on the `.app` inside the dmg, but `spctl -a -t open --context context:primary-signature` on the dmg itself returns `rejected, source=Unnotarized Developer ID`. A user double-clicking the downloaded dmg hits a Gatekeeper warning before ever reaching the app.
- Adds an explicit `notarytool submit --wait` + `stapler staple` step on the built dmg, placed before the DNS keepalive is stopped so it benefits from the existing mDNSResponder workaround.

## Test plan
- [ ] Next tagged desktop release: confirm `xcrun stapler validate` succeeds directly on the released `.dmg` (not just the `.app` inside it)
- [ ] `spctl -a -t open --context context:primary-signature -v <dmg>` reports `accepted, source=Notarized Developer ID`