### PR TITLE
fix(desktop): reopen main window on Dock icon click

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -239,7 +239,14 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building the Ormah desktop app")
-        .run(|_app_handle, _event| {
+        .run(|app_handle, event| {
+            // macOS fires Reopen when the Dock icon is clicked while the app
+            // has no visible windows (e.g. after closing to tray) — without
+            // this, only the tray menu's "Open Ormah" item can bring the
+            // window back.
+            if let tauri::RunEvent::Reopen { .. } = event {
+                commands::open_graph(app_handle);
+            }
             // Server is a daemon — it outlives the app process intentionally.
         });
 }


### PR DESCRIPTION
## Summary
- The app hides its window on close instead of destroying it (tray/daemon keep running), but the final `.run()` callback discarded every `RunEvent`, including macOS's `Reopen` — fired when the Dock icon is clicked while the app has no visible windows.
- Result: only the tray menu's "Open Ormah" item could bring the window back; clicking the Dock icon did nothing, which is inconsistent with standard macOS tray-app behavior (Slack, Discord, etc.).
- Wires `RunEvent::Reopen` to the same `commands::open_graph()` call the tray already uses.

## Test plan
- [x] `cargo check` passes
- [ ] Build locally, close window to tray, click Dock icon — window should reopen and focus