### PR TITLE
fix(desktop): pin 0.14 and reopen from macOS Dock

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -35,6 +35,17 @@ jobs:
             exit 1
           fi
 
+      - name: Verify bundled Ormah release
+        shell: bash
+        run: |
+          PY_VERSION=$(sed -n 's/^version = "\([^"]*\)"$/\1/p' pyproject.toml | head -n 1)
+          PYPI_VERSION=$(curl -fsSL https://pypi.org/pypi/ormah/json | python3 -c 'import json, sys; print(json.load(sys.stdin)["info"]["version"])')
+          if [ "$PY_VERSION" != "$PYPI_VERSION" ]; then
+            echo "Desktop embeds ormah $PY_VERSION, but PyPI latest is $PYPI_VERSION" >&2
+            echo "Publish the Python release before tagging the desktop app." >&2
+            exit 1
+          fi
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,10 +2509,11 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "once_cell",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "tauri",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.13"
+version = "0.3.14"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"
@@ -24,6 +24,7 @@ serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tokio = { version = "1", features = ["time", "rt", "macros"] }
 once_cell = "1"
+semver = "1"
 
 # Single-instance guard: macOS uses this plugin (Unix socket). On Linux the
 # plugin relies on claiming a D-Bus name, which fails silently and lets

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -239,14 +239,16 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building the Ormah desktop app")
-        .run(|app_handle, event| {
+        .run(|_app_handle, _event| {
             // macOS fires Reopen when the Dock icon is clicked while the app
             // has no visible windows (e.g. after closing to tray) — without
             // this, only the tray menu's "Open Ormah" item can bring the
             // window back.
-            if let tauri::RunEvent::Reopen { .. } = event {
-                commands::open_graph(app_handle);
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                commands::open_graph(_app_handle);
             }
+
             // Server is a daemon — it outlives the app process intentionally.
         });
 }

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -131,7 +131,23 @@ fn needs_upgrade() -> bool {
     else {
         return false;
     };
-    !String::from_utf8_lossy(&out.stdout).contains(ORMAH_VERSION)
+    if !out.status.success() {
+        return true;
+    }
+    should_upgrade(&out.stdout, ORMAH_VERSION)
+}
+
+fn should_upgrade(output: &[u8], required: &str) -> bool {
+    let Ok(required) = semver::Version::parse(required) else {
+        return true;
+    };
+    let installed = String::from_utf8_lossy(output)
+        .split_whitespace()
+        .find_map(|word| semver::Version::parse(word).ok());
+    match installed {
+        Some(installed) => installed < required,
+        None => true,
+    }
 }
 
 /// Remove Python env vars that AppImage sets and that corrupt child Python runtimes.
@@ -161,5 +177,30 @@ async fn install_via_uv<R: Runtime>(app: &AppHandle<R>) -> bool {
             false
         }
         Err(e) => { eprintln!("uv sidecar error: {e}"); false }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_upgrade;
+
+    #[test]
+    fn upgrades_an_older_cli() {
+        assert!(should_upgrade(b"ormah 0.13.6\n", "0.14.0"));
+    }
+
+    #[test]
+    fn leaves_the_pinned_cli_unchanged() {
+        assert!(!should_upgrade(b"ormah 0.14.0\n", "0.14.0"));
+    }
+
+    #[test]
+    fn never_downgrades_a_newer_cli() {
+        assert!(!should_upgrade(b"ormah 0.15.0\n", "0.14.0"));
+    }
+
+    #[test]
+    fn repairs_unparseable_version_output() {
+        assert!(should_upgrade(b"unknown\n", "0.14.0"));
     }
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-httpx>=0.35.0",
     "respx>=0.22.0",
-    "ruff>=0.8.0",
+    "ruff>=0.8.0,<0.16",
 ]
 litellm = ["litellm>=1.0.0"]
 
@@ -55,7 +55,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-httpx>=0.35.0",
     "respx>=0.22.0",
-    "ruff>=0.8.0",
+    "ruff>=0.8.0,<0.16",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Problem

The notarized desktop-v0.3.13 build embeds Ormah 0.13.6, so launching it downgrades a manually installed 0.14.0 client. It also hides its window on close but ignores macOS Dock reopen events. Both surfaced during the real Linux-to-cloud-to-Mac 1,769-node restore acceptance.

## Solution

- bump the desktop app to 0.3.14, built from Ormah 0.14.0
- compare semantic CLI versions and upgrade only older clients, never downgrade newer ones
- handle macOS `RunEvent::Reopen` by showing and focusing the existing window
- fail desktop release CI unless the embedded Ormah version equals the latest published PyPI version

## Verification

- `cargo test`: 4 passed
- `npm run build` in `desktop/ui`: passed
- `uv run ruff check src/ tests/`: passed
- release guard: embedded 0.14.0 == PyPI 0.14.0
- app/Cargo versions: 0.3.14
- macOS compilation/notarization is performed by the release workflow on the Apple runner

## Acceptance after release

Install the notarized DMG on the acceptance Mac, verify the CLI remains 0.14.0, verify the hidden window reopens from the Dock, and verify the restored graph reports 1,769 nodes.