### PR TITLE
fix(desktop): provision whisper reranker on upgrade

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -89,12 +89,16 @@ Also set `plugins.updater.pubkey` in `tauri.conf.json` and
 
 ## Known follow-ups
 
-- **Model downloads on first run** — embedding weights (~100 MB) are downloaded
-  by fastembed at runtime to `~/.cache/fastembed`. The onboarding flow waits for
-  the server, which covers this window.
-- **App updates** — after updating the app, users re-click "Connect" to upgrade
-  ormah via `uv tool install ormah==<new-version>`. Automatic upgrade on launch
-  is a TODO.
+- **Model downloads on first run** — embedding and whisper-reranker weights are
+  downloaded by FastEmbed during server startup into Ormah's shared model cache at
+  `~/.local/share/ormah/models`. Server readiness waits for each download attempt, so
+  provisioning does not depend on whether desktop onboarding runs. If the reranker
+  download fails, Ormah remains available with conservative embedding-only whisper and
+  retries provisioning on the next server start.
+- **Python runtime updates** — each desktop build pins an Ormah package version. On
+  launch the app installs a missing/older version with `uv tool install`, then restarts
+  the daemon so the new Python code and migrations are active. It never downgrades a
+  newer installed runtime.
 - **Updater appcast** — the CI `publish` job attaches artifacts but the
   `latest.json` regeneration/upload is a TODO.
 

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -33,23 +33,55 @@ pub fn start<R: Runtime>(app: AppHandle<R>) {
 }
 
 async fn ensure_running<R: Runtime>(app: AppHandle<R>) {
-    if find_ormah().is_none() {
-        let _ = app.emit("ormah://status", Phase::Installing { version: ORMAH_VERSION });
-        if !install_via_uv(&app).await {
+    let installed = find_ormah().is_some();
+    let runtime_action = choose_runtime_action(installed, installed && needs_upgrade());
+    let runtime_changed = match runtime_action {
+        RuntimeAction::Install | RuntimeAction::Upgrade => {
             let _ = app.emit(
                 "ormah://status",
-                Phase::Failed {
-                    reason: "Could not install ormah. Check your internet connection.".into(),
+                Phase::Installing {
+                    version: ORMAH_VERSION,
                 },
             );
-            return;
+            if !install_via_uv(&app).await {
+                let _ = app.emit(
+                    "ormah://status",
+                    Phase::Failed {
+                        reason: "Could not install ormah. Check your internet connection.".into(),
+                    },
+                );
+                return;
+            }
+            true
         }
-    } else if needs_upgrade() {
-        let _ = app.emit("ormah://status", Phase::Installing { version: ORMAH_VERSION });
-        let _ = install_via_uv(&app).await;
+        RuntimeAction::Reuse => false,
+    };
+
+    // A uv reinstall replaces files on disk but cannot replace modules in the already-running
+    // daemon. Restart after successful install/upgrade so migrations and model provisioning run
+    // under the newly pinned Python package.
+    if runtime_changed {
+        stop_daemon();
     }
     let _ = app.emit("ormah://status", Phase::Starting);
     start_daemon();
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuntimeAction {
+    Install,
+    Upgrade,
+    Reuse,
+}
+
+fn choose_runtime_action(installed: bool, upgrade_needed: bool) -> RuntimeAction {
+    if !installed {
+        RuntimeAction::Install
+    } else if upgrade_needed {
+        RuntimeAction::Upgrade
+    } else {
+        RuntimeAction::Reuse
+    }
 }
 
 /// Find the ormah binary. Checks uv tool install locations first (GUI apps
@@ -182,7 +214,22 @@ async fn install_via_uv<R: Runtime>(app: &AppHandle<R>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::should_upgrade;
+    use super::{choose_runtime_action, should_upgrade, RuntimeAction};
+
+    #[test]
+    fn installs_when_runtime_is_missing() {
+        assert_eq!(choose_runtime_action(false, false), RuntimeAction::Install);
+    }
+
+    #[test]
+    fn upgrades_when_installed_runtime_is_old() {
+        assert_eq!(choose_runtime_action(true, true), RuntimeAction::Upgrade);
+    }
+
+    #[test]
+    fn reuses_matching_or_newer_runtime() {
+        assert_eq!(choose_runtime_action(true, false), RuntimeAction::Reuse);
+    }
 
     #[test]
     fn upgrades_an_older_cli() {

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -395,7 +395,13 @@ class MemoryEngine:
             logger.warning("Embedding model warmup failed: %s", e)
 
     def _warmup_reranker(self) -> None:
-        """Mark whisper reranker availability up front instead of failing per prompt."""
+        """Download/load the whisper reranker before the server becomes ready.
+
+        Model provisioning must not depend on first-run agent onboarding: desktop upgrades can
+        legitimately reuse an existing onboarding marker on a machine whose model cache is empty.
+        A download failure still degrades to conservative embedding-only whisper so local memory
+        remains usable offline.
+        """
         if not self.settings.whisper_reranker_enabled:
             logger.info("Whisper reranker disabled in settings.")
             self._whisper_reranker_available = False
@@ -413,14 +419,11 @@ class MemoryEngine:
                 cache_dir,
             )
             if not model_is_cached(model_name):
-                logger.warning(
-                    "Whisper reranker is enabled but model %s is not cached in %s. "
-                    "Whisper will run without reranking until the model is preloaded.",
+                logger.info(
+                    "Whisper reranker model %s is not cached in %s; downloading...",
                     model_name,
                     cache_dir,
                 )
-                self._whisper_reranker_available = False
-                return
 
             logger.info("Loading whisper reranker...")
             preload_model(model_name)

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -232,7 +232,7 @@ def test_stats(engine):
     assert stats["store"]["total_nodes"] == 2
 
 
-def test_warmup_reranker_marks_unavailable_when_cache_missing(settings):
+def test_warmup_reranker_provisions_model_when_cache_missing(settings):
     with (
         patch("ormah.engine.memory_engine.MemoryEngine._warmup_embedder"),
         patch("ormah.embeddings.reranker.model_is_cached", return_value=False),
@@ -243,8 +243,26 @@ def test_warmup_reranker_marks_unavailable_when_cache_missing(settings):
         engine = MemoryEngine(settings)
         engine.startup()
 
+    assert engine._whisper_reranker_available is True
+    preload_model.assert_called_once_with(settings.whisper_reranker_model)
+    engine.shutdown()
+
+
+def test_warmup_reranker_degrades_when_provisioning_fails(settings):
+    with (
+        patch("ormah.engine.memory_engine.MemoryEngine._warmup_embedder"),
+        patch("ormah.embeddings.reranker.model_is_cached", return_value=False),
+        patch(
+            "ormah.embeddings.reranker.preload_model",
+            side_effect=RuntimeError("network unavailable"),
+        ),
+    ):
+        from ormah.engine.memory_engine import MemoryEngine
+
+        engine = MemoryEngine(settings)
+        engine.startup()
+
     assert engine._whisper_reranker_available is False
-    preload_model.assert_not_called()
     engine.shutdown()
 
 


### PR DESCRIPTION
## Problem

An already-onboarded desktop installation could upgrade the Ormah Python package without ever downloading the whisper cross-encoder. Whisper then ran behind the conservative embedding-only gate and could appear silent. The desktop also did not restart an old daemon after replacing the uv tool environment.

## Solution

- provision/load the configured reranker during server startup, independently of onboarding
- preserve embedding-only fallback when a real download/load attempt fails
- classify desktop runtime install, upgrade, and reuse explicitly
- stop the old daemon after a successful install/upgrade before starting the pinned runtime
- fail visibly when the runtime install fails
- update desktop runtime/model documentation

## Verification

- 40 memory-engine tests passed
- 33 reranker tests passed
- 104 whisper tests passed; the one deselected TestClient case is an existing AnyIO sandbox hang and does not cover this path
- the remaining encode-once whisper test passed separately
- 11 setup/model tests passed
- Ruff passed across src/ and tests/
- 7 Rust sidecar tests passed
- real empty-cache smoke downloaded about 88 MB, changed cache detection false to true, and loaded TextCrossEncoder

No version files are changed in this PR. After review, this needs a Python patch release and a desktop release pinned to that version.