### PR TITLE
chore(release): Ormah 0.14.1 and desktop 0.3.15

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "once_cell",
  "reqwest 0.12.28",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.14"
+version = "0.3.15"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.0"
+version = "0.14.1"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump the Python package and Claude plugin to 0.14.1
- bump the desktop app to 0.3.15
- pin the desktop runtime to Ormah 0.14.1 through the existing build-time version source

## Why
Ships the PR #161 fix that provisions the Xenova reranker for existing desktop installs and restarts an older daemon after a runtime upgrade.

## Verification
- PR #161 CI: test and lint passed
- `python .github/release/verify_release_versions.py 0.14.1`
- `cargo metadata --manifest-path desktop/src-tauri/Cargo.toml --no-deps --format-version 1`
- `git diff --check`

The Python release workflow will run the full test suite before publishing. The desktop tag workflow will verify PyPI 0.14.1, build signed packages, notarize the macOS DMG, and publish updater metadata.
