### PR TITLE
fix(backup): restore the source graph active Self

### DIFF
--- a/docs/15 - Cloud Backup, Verification, and Restore.md
+++ b/docs/15 - Cloud Backup, Verification, and Restore.md
@@ -1,6 +1,6 @@
 # Cloud Backup, Verification, and Restore
 
-Verified against the current Ormah client and the hardened C01 cloud protocol on 2026-07-27.
+Verified against the current Ormah client and the hardened C01 cloud protocol on 2026-07-29.
 
 This guide explains what happens when Ormah protects a memory graph in the cloud. It starts with a
 small worked example, then adds the security and failure-handling details one layer at a time.
@@ -73,7 +73,7 @@ blob bytes.
 | Term | Plain meaning |
 | --- | --- |
 | Memory store | One local Ormah graph, identified by a UUIDv4 `store_id` |
-| Local backup | A timestamped copy of `nodes/` and `deleted/` on the same machine |
+| Local backup | A timestamped copy of `nodes/` and `deleted/`, plus the active Self pointer |
 | Bundle | A gzip-compressed tar archive containing the backup and integrity manifest |
 | Ciphertext | The encrypted bytes produced by age; unreadable without an identity |
 | Snapshot | One committed encrypted cloud recovery point, identified by a server ULID |
@@ -140,7 +140,13 @@ Otherwise it creates a new backup such as:
 `-- backup.json
 ```
 
-`backup.json` records when and why the local backup was made. The snapshot deliberately excludes:
+`backup.json` records when and why the local backup was made and the exact `user_node_id` selected as
+the graph's active Self. That small pointer is portable source state even though the rest of SQLite is
+derived. It prevents a fresh installation's temporary Self node from remaining active after a full
+restore. Historical duplicate Self nodes are copied like every other node; backup and restore do not
+merge or repair them.
+
+The snapshot deliberately excludes:
 
 - `index.db`, its WAL, and other derived indexes;
 - account tokens, `.env`, and API keys;
@@ -382,12 +388,13 @@ For the latest committed snapshot, the current verification path:
 7. rejects absolute paths, `..`, backslashes, links, duplicates, Unicode/case collisions, excess
    members, and excess expanded bytes;
 8. recomputes every file size and SHA-256 and compares them with the encrypted manifest;
-9. parses every active and deleted Markdown node;
-10. creates a throwaway SQLite database and rebuilds its index from the extracted active nodes;
-11. requires the rebuilt active-node count to equal `manifest.node_count`;
-12. runs an FTS search and requires it to return a known restored node;
-13. records `last_verify_ok=true` and the exact snapshot ID;
-14. deletes the temporary directory in `finally`, whether verification succeeds or fails.
+9. validates that `backup.json`'s active Self pointer names the exact included `system:self` node;
+10. parses every active and deleted Markdown node;
+11. creates a throwaway SQLite database and rebuilds its index from the extracted active nodes;
+12. requires the rebuilt active-node count to equal `manifest.node_count`;
+13. runs an FTS search and requires it to return a known restored node;
+14. records `last_verify_ok=true` and the exact snapshot ID;
+15. deletes the temporary directory in `finally`, whether verification succeeds or fails.
 
 For our three-file example, the scratch index must rebuild exactly `2` active nodes. The deleted
 node is parsed and integrity-checked but correctly does not become an active search result.
@@ -459,10 +466,20 @@ The restore command:
 7. delegates to the existing `BackupService.restore()` path;
 8. creates a safety backup of any current Mac memory before replacement;
 9. replaces only the source-of-truth `nodes/` and `deleted/` directories;
-10. rebuilds the Mac's SQLite search index from Markdown.
+10. rebuilds the Mac's SQLite search index from Markdown;
+11. replaces the Mac-local active Self pointer with the source graph's recorded `user_node_id`.
 
 For the example, the result is two active nodes, one deleted node retained as a tombstone, and a
-fresh searchable index containing the two active nodes.
+fresh searchable index containing the two active nodes. If installing Ormah on the Mac created a
+temporary isolated Self node before restore, the pre-restore safety backup preserves it and the full
+restore then removes it with the rest of the target graph. The source graph's selected Self becomes
+active exactly as backed up.
+
+This is intentionally replacement, not merge. Restore does not inspect connections to decide which
+Self node looks most important, transfer target-only nodes, or rewrite historical source duplicates.
+Those are sync or explicit repair concerns. A new backup records the choice exactly. An older backup
+without the pointer is accepted only when it contains zero or one `system:self` node; an ambiguous
+legacy backup fails before touching the target and asks for a fresh backup from the source machine.
 
 Cloud restore remains available when subscription entitlement expires, while the service retains
 the snapshot. Cancellation pauses new uploads; it does not turn recovery into a ransom gate.
@@ -479,6 +496,7 @@ the snapshot. Cancellation pauses new uploads; it does not turn recovery into a 
 | Process dies during promotion | Durable lease/state lets janitor reconcile safely rather than guessing |
 | Ciphertext is truncated or altered | Age decryption or archive/manifest verification fails |
 | A Markdown file is malformed | Parse stage fails; snapshot is not marked verified |
+| Active Self pointer is missing, invalid, or ambiguous | Verification/restore fails closed before replacing the live graph |
 | Scratch index/search fails | Snapshot remains committed but is not reported as verified restorable |
 | Verification fails | Live graph bytes and mtimes remain untouched; exact error is recorded locally |
 | Restore starts on a populated machine | A safety backup is created before source directories are replaced |

--- a/src/ormah/backup.py
+++ b/src/ormah/backup.py
@@ -9,10 +9,12 @@ import logging
 from pathlib import Path
 import re
 import shutil
+import sqlite3
 import threading
 
 from ormah.index.builder import IndexBuilder
 from ormah.index.db import Database
+from ormah.models.node import MemoryNode
 from ormah.store.markdown import parse_node
 from ormah.store.file_store import FileStore
 
@@ -24,6 +26,7 @@ BACKUP_NAME_RE = re.compile(
     r"^memory_(?P<timestamp>\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2})(?:_(?P<suffix>\d{2}))?$"
 )
 MANIFEST_NAME = "backup.json"
+BACKUP_FORMAT_VERSION = 2
 SOURCE_DIRS = ("nodes", "deleted")
 _BACKUP_CREATE_LOCK = threading.RLock()
 
@@ -123,6 +126,135 @@ def _parse_backup_created_at(path: Path) -> datetime:
         return datetime.min.replace(tzinfo=timezone.utc)
 
 
+def _read_index_user_node_id(memory_dir: Path) -> tuple[bool, str | None]:
+    """Read the active Self pointer without creating or modifying the index."""
+    db_path = Path(memory_dir) / "index.db"
+    if not db_path.is_file():
+        return False, None
+
+    connection = None
+    try:
+        connection = sqlite3.connect(f"{db_path.resolve().as_uri()}?mode=ro", uri=True)
+        row = connection.execute(
+            "SELECT value FROM meta WHERE key = 'user_node_id'"
+        ).fetchone()
+    except sqlite3.Error:
+        return False, None
+    finally:
+        if connection is not None:
+            connection.close()
+
+    if row is None:
+        return False, None
+    value = row[0]
+    if not isinstance(value, str) or not value.strip():
+        raise BackupError("The active Self pointer in index.db is invalid.")
+    return True, value
+
+
+def _parsed_nodes(nodes_dir: Path) -> tuple[list[MemoryNode], list[Path]]:
+    nodes: list[MemoryNode] = []
+    malformed: list[Path] = []
+    if not nodes_dir.is_dir():
+        return nodes, malformed
+    for path in sorted(nodes_dir.glob("*.md")):
+        if not path.is_file():
+            continue
+        try:
+            nodes.append(parse_node(path.read_text(encoding="utf-8")))
+        except Exception:
+            malformed.append(path)
+    return nodes, malformed
+
+
+def _validate_user_node_id(nodes_dir: Path, user_node_id: str, *, context: str) -> str:
+    nodes, _malformed = _parsed_nodes(nodes_dir)
+    matches = [node for node in nodes if node.id == user_node_id]
+    if len(matches) != 1 or matches[0].source != "system:self":
+        raise BackupError(
+            f"{context} records active Self node {user_node_id!r}, but that exact "
+            "system:self node is not present in nodes/."
+        )
+    return user_node_id
+
+
+def _infer_user_node_id(nodes_dir: Path, *, context: str) -> str | None:
+    nodes, malformed = _parsed_nodes(nodes_dir)
+    if malformed:
+        raise BackupError(
+            f"Cannot determine the active Self node for {context}: "
+            f"{len(malformed)} node file(s) could not be parsed."
+        )
+    self_ids = sorted({node.id for node in nodes if node.source == "system:self"})
+    if not self_ids:
+        return None
+    if len(self_ids) == 1:
+        return self_ids[0]
+    raise BackupError(
+        f"Cannot determine the active Self node for {context}: found {len(self_ids)} "
+        "system:self nodes and no portable active pointer. Create a fresh backup on the "
+        "source machine before restoring."
+    )
+
+
+def resolve_current_user_node_id(memory_dir: Path) -> str | None:
+    """Return the live graph's active Self node, validating it against Markdown."""
+    memory_dir = Path(memory_dir).expanduser()
+    has_pointer, user_node_id = _read_index_user_node_id(memory_dir)
+    if has_pointer:
+        assert user_node_id is not None
+        return _validate_user_node_id(
+            memory_dir / "nodes",
+            user_node_id,
+            context="the live memory graph",
+        )
+    return _infer_user_node_id(memory_dir / "nodes", context="the live memory graph")
+
+
+def resolve_backup_user_node_id(backup_path: Path) -> str | None:
+    """Return and validate the active Self pointer carried by a local backup.
+
+    Version-1 backups predate the portable pointer. They remain restorable only
+    when their Markdown contains zero or exactly one system:self node.
+    """
+    backup_path = Path(backup_path)
+    manifest_path = backup_path / MANIFEST_NAME
+    if not manifest_path.is_file():
+        return _infer_user_node_id(backup_path / "nodes", context="the legacy backup")
+
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise BackupError(f"Backup manifest is unreadable: {manifest_path}") from exc
+    if not isinstance(manifest, dict):
+        raise BackupError("Backup manifest must contain a JSON object.")
+
+    version = manifest.get("version", 1)
+    if not isinstance(version, int) or isinstance(version, bool) or version not in {1, 2}:
+        raise BackupError(f"Unsupported backup manifest version: {version!r}")
+    if version == 1:
+        return _infer_user_node_id(backup_path / "nodes", context="the legacy backup")
+    if "user_node_id" not in manifest:
+        raise BackupError("Backup manifest version 2 is missing user_node_id.")
+
+    user_node_id = manifest["user_node_id"]
+    if user_node_id is None:
+        inferred = _infer_user_node_id(backup_path / "nodes", context="the backup")
+        if inferred is not None:
+            raise BackupError(
+                "Backup manifest records no active Self node, but nodes/ contains a "
+                "system:self node."
+            )
+        return None
+    if not isinstance(user_node_id, str) or not user_node_id.strip():
+        raise BackupError("Backup manifest user_node_id must be a non-empty string or null.")
+    return _validate_user_node_id(
+        backup_path / "nodes",
+        user_node_id,
+        context="the backup",
+    )
+
+
 class BackupService:
     """Creates, lists, prunes, and restores local memory file backups."""
 
@@ -159,6 +291,8 @@ class BackupService:
         if not self.memory_dir.exists():
             raise BackupError(f"Memory directory not found: {self.memory_dir}")
 
+        user_node_id = resolve_current_user_node_id(self.memory_dir)
+
         created_at = now or _utc_now()
         name = self._unique_backup_name(created_at)
         destination = self.backup_dir / name
@@ -178,12 +312,20 @@ class BackupService:
                 else:
                     target.mkdir()
 
+            if user_node_id is not None:
+                _validate_user_node_id(
+                    tmp_destination / "nodes",
+                    user_node_id,
+                    context="the new backup",
+                )
+
             manifest = {
-                "version": 1,
+                "version": BACKUP_FORMAT_VERSION,
                 "created_at": created_at.isoformat(),
                 "reason": reason,
                 "source": "ormah backup",
                 "source_memory_dir": str(self.memory_dir),
+                "user_node_id": user_node_id,
                 "included": list(SOURCE_DIRS),
                 "excluded": [
                     "index.db",
@@ -266,6 +408,7 @@ class BackupService:
         """
         backup_path = self._resolve_backup_ref(backup_ref)
         restored_info = self._info_for(backup_path)
+        user_node_id = resolve_backup_user_node_id(backup_path)
         safety_backup = self.create(reason=f"pre-restore:{restored_info.name}", prune=False)
 
         self.memory_dir.mkdir(parents=True, exist_ok=True)
@@ -292,6 +435,7 @@ class BackupService:
             shutil.rmtree(restore_tmp, ignore_errors=True)
 
         rebuilt_nodes = self.rebuild_index() if rebuild_index else None
+        self._write_user_node_id(user_node_id)
         self.prune()
         logger.info("Restored Ormah memory backup: %s", restored_info.path)
         return RestoreResult(
@@ -307,6 +451,22 @@ class BackupService:
             database.init_schema()
             builder = IndexBuilder(database, FileStore(self.memory_dir / "nodes"))
             return builder.full_rebuild()
+        finally:
+            database.close()
+
+    def _write_user_node_id(self, user_node_id: str | None) -> None:
+        """Replace target-local identity state with the restored graph's pointer."""
+        database = Database(self.memory_dir / "index.db")
+        try:
+            database.init_schema()
+            with database.transaction() as connection:
+                if user_node_id is None:
+                    connection.execute("DELETE FROM meta WHERE key = 'user_node_id'")
+                else:
+                    connection.execute(
+                        "INSERT OR REPLACE INTO meta (key, value) VALUES ('user_node_id', ?)",
+                        (user_node_id,),
+                    )
         finally:
             database.close()
 

--- a/src/ormah/cloud/jobs.py
+++ b/src/ormah/cloud/jobs.py
@@ -9,7 +9,13 @@ import re
 import shutil
 import tempfile
 
-from ormah.backup import BackupInfo, service_from_settings
+from ormah.backup import (
+    BackupError,
+    BackupInfo,
+    resolve_backup_user_node_id,
+    resolve_current_user_node_id,
+    service_from_settings,
+)
 from ormah.cloud.bundle import open_bundle, build_bundle
 from ormah.cloud.client import CloudError, client_from_settings
 from ormah.cloud.entitlements import EntitlementStatus, check_entitlement
@@ -70,6 +76,12 @@ def _snapshot_files(root: Path) -> dict[str, Path]:
 
 
 def _backup_matches_memory(backup: BackupInfo, memory_dir: Path) -> bool:
+    try:
+        if resolve_backup_user_node_id(backup.path) != resolve_current_user_node_id(memory_dir):
+            return False
+    except BackupError:
+        return False
+
     source_files = _snapshot_files(memory_dir)
     backup_files = _snapshot_files(backup.path)
     if source_files.keys() != backup_files.keys():
@@ -208,6 +220,8 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
         raise RuntimeError(
             f"Bundle store id {info.store_id!r} does not match local store {expected_store_id!r}."
         )
+
+    resolve_backup_user_node_id(extracted)
 
     active_nodes = []
     for dirname in ("nodes", "deleted"):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+import json
 from pathlib import Path
 from types import SimpleNamespace
 import sqlite3
 from unittest.mock import patch
 
-from ormah.backup import BackupService, run_auto_backup
+import pytest
+
+from ormah.backup import BackupError, BackupService, resolve_backup_user_node_id, run_auto_backup
 from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+from ormah.index.db import Database
 from ormah.models.node import MemoryNode, NodeType, Tier
 from ormah.store.file_store import FileStore
 
@@ -26,6 +31,42 @@ def _save_node(memory_dir: Path, title: str, content: str) -> MemoryNode:
     node = MemoryNode(type=NodeType.fact, title=title, content=content)
     store.save(node)
     return node
+
+
+def _save_self_node(memory_dir: Path, title: str) -> MemoryNode:
+    node = MemoryNode(
+        type=NodeType.person,
+        tier=Tier.core,
+        source="system:self",
+        title=title,
+        content=f"Identity node {title}",
+    )
+    FileStore(memory_dir / "nodes").save(node)
+    return node
+
+
+def _set_active_self(memory_dir: Path, node_id: str) -> None:
+    database = Database(memory_dir / "index.db")
+    try:
+        database.init_schema()
+        with database.transaction() as connection:
+            connection.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES ('user_node_id', ?)",
+                (node_id,),
+            )
+    finally:
+        database.close()
+
+
+def _active_self(memory_dir: Path) -> str | None:
+    connection = sqlite3.connect(memory_dir / "index.db")
+    try:
+        row = connection.execute(
+            "SELECT value FROM meta WHERE key = 'user_node_id'"
+        ).fetchone()
+    finally:
+        connection.close()
+    return row[0] if row else None
 
 
 def test_create_backup_copies_nodes_and_deleted_only(tmp_path):
@@ -50,6 +91,22 @@ def test_create_backup_copies_nodes_and_deleted_only(tmp_path):
     assert list((backup.path / "deleted").glob(f"*_{deleted.short_id}.md"))
     assert not (backup.path / "index.db").exists()
     assert not (backup.path / ".env").exists()
+
+
+def test_create_backup_records_exact_active_self_with_historical_duplicate(tmp_path):
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    historical = _save_self_node(memory_dir, "Historical Self")
+    active = _save_self_node(memory_dir, "Active Self")
+    _set_active_self(memory_dir, active.id)
+
+    backup = _service(memory_dir, backup_dir).create()
+
+    manifest = json.loads((backup.path / "backup.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == 2
+    assert manifest["user_node_id"] == active.id
+    assert manifest["user_node_id"] != historical.id
+    assert resolve_backup_user_node_id(backup.path) == active.id
 
 
 def test_retention_keeps_latest_ten_backups(tmp_path):
@@ -116,6 +173,109 @@ def test_restore_replaces_memory_files_and_rebuilds_index(tmp_path):
     finally:
         conn.close()
     assert row == (original.id, "Original")
+
+
+def test_restore_replaces_target_self_pointer_without_reconciling_source_duplicates(tmp_path):
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    active = _save_self_node(memory_dir, "Source Active Self")
+    historical = _save_self_node(memory_dir, "Source Historical Self")
+    _save_node(memory_dir, "Source Memory", "Restored content")
+    _set_active_self(memory_dir, active.id)
+    service = _service(memory_dir, backup_dir)
+    backup = service.create()
+
+    store = FileStore(memory_dir / "nodes")
+    for path in store.list_paths():
+        path.unlink()
+    target_self = _save_self_node(memory_dir, "Target Generated Self")
+    _set_active_self(memory_dir, target_self.id)
+
+    result = service.restore(backup.name)
+
+    restored_ids = {node.id for node in FileStore(memory_dir / "nodes").list_all()}
+    assert active.id in restored_ids
+    assert historical.id in restored_ids
+    assert target_self.id not in restored_ids
+    assert _active_self(memory_dir) == active.id
+    assert result.safety_backup is not None
+    assert resolve_backup_user_node_id(result.safety_backup.path) == target_self.id
+
+    database = Database(memory_dir / "index.db")
+    try:
+        restarted = SimpleNamespace(
+            db=database,
+            file_store=FileStore(memory_dir / "nodes"),
+            user_node_id=None,
+        )
+        node_count = len(restarted.file_store.list_paths())
+        MemoryEngine._ensure_self_node(restarted)
+        assert restarted.user_node_id == active.id
+        assert len(restarted.file_store.list_paths()) == node_count
+    finally:
+        database.close()
+
+
+def test_restore_rejects_invalid_manifest_pointer_before_touching_target(tmp_path):
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    target = _save_node(memory_dir, "Target", "Must remain")
+    service = _service(memory_dir, backup_dir)
+    backup = service.create()
+    manifest_path = backup.path / "backup.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["user_node_id"] = "missing-self-node"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(BackupError, match="exact system:self node is not present"):
+        service.restore(backup.name)
+
+    assert FileStore(memory_dir / "nodes").load(target.id) is not None
+    assert len(service.list()) == 1
+
+
+def test_restore_adopts_unique_self_from_legacy_backup(tmp_path):
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    source_self = _save_self_node(memory_dir, "Legacy Source Self")
+    service = _service(memory_dir, backup_dir)
+    backup = service.create()
+    manifest_path = backup.path / "backup.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["version"] = 1
+    manifest.pop("user_node_id")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    for path in (memory_dir / "nodes").glob("*.md"):
+        path.unlink()
+    target_self = _save_self_node(memory_dir, "Target Self")
+    _set_active_self(memory_dir, target_self.id)
+
+    service.restore(backup.name)
+
+    assert _active_self(memory_dir) == source_self.id
+    assert FileStore(memory_dir / "nodes").load(target_self.id) is None
+
+
+def test_restore_rejects_ambiguous_legacy_self_before_touching_target(tmp_path):
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    first = _save_self_node(memory_dir, "First Self")
+    _save_self_node(memory_dir, "Second Self")
+    _set_active_self(memory_dir, first.id)
+    service = _service(memory_dir, backup_dir)
+    backup = service.create()
+    manifest_path = backup.path / "backup.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["version"] = 1
+    manifest.pop("user_node_id")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(BackupError, match="no portable active pointer"):
+        service.restore(backup.name)
+
+    assert _active_self(memory_dir) == first.id
+    assert len(service.list()) == 1
 
 
 def test_auto_backup_creates_only_when_due(tmp_path):

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import json
 from pathlib import Path
 import shutil
 from types import SimpleNamespace
@@ -14,6 +15,7 @@ from ormah.cloud.crypto import generate_identity
 from ormah.cloud.entitlements import EntitlementStatus
 from ormah.cloud.state import load_state, save_state, CloudState
 from ormah.config import Settings
+from ormah.index.db import Database
 from ormah.models.node import MemoryNode, NodeType
 from ormah.store.file_store import FileStore
 
@@ -265,6 +267,44 @@ def test_cloud_backup_never_reuses_newer_safety_backup_with_different_contents(t
     assert len(list((selected.path / "nodes").glob("*.md"))) == 1
 
 
+def test_cloud_backup_does_not_reuse_snapshot_with_different_active_self(tmp_path):
+    from ormah.cloud import jobs
+
+    settings, _ = _settings(tmp_path, with_node=False)
+    first = MemoryNode(type=NodeType.person, source="system:self", title="First Self")
+    second = MemoryNode(type=NodeType.person, source="system:self", title="Second Self")
+    store = FileStore(settings.memory_dir / "nodes")
+    store.save(first)
+    store.save(second)
+    database = Database(settings.memory_dir / "index.db")
+    try:
+        database.init_schema()
+        database.conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('user_node_id', ?)",
+            (first.id,),
+        )
+    finally:
+        database.close()
+    service = service_from_settings(settings)
+    first_backup = service.create()
+
+    database = Database(settings.memory_dir / "index.db")
+    try:
+        database.init_schema()
+        database.conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('user_node_id', ?)",
+            (second.id,),
+        )
+    finally:
+        database.close()
+
+    selected = jobs._backup_for_upload(service)
+
+    assert selected.name != first_backup.name
+    manifest = json.loads((selected.path / "backup.json").read_text(encoding="utf-8"))
+    assert manifest["user_node_id"] == second.id
+
+
 def test_two_stores_upload_under_their_own_ids(tmp_path, monkeypatch, cloud_state_dir):
     from ormah.cloud import jobs
 
@@ -382,6 +422,34 @@ def test_restore_verification_records_bundle_failures(
     assert state.last_verify_snapshot_id == "01SNAPSHOT"
     expected = "Hash mismatch" if failure == "hash-mismatch" else "decrypt"
     assert expected.lower() in state.last_verify_error.lower()
+
+
+def test_restore_verification_rejects_invalid_active_self_pointer(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path)
+    service = service_from_settings(settings)
+    backup = service.create(reason="invalid-identity-fixture")
+    manifest_path = backup.path / "backup.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["user_node_id"] = "missing-self-node"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    identity = generate_identity()
+    bundle = tmp_path / "invalid-identity.age"
+    build_bundle(
+        backup.path,
+        bundle,
+        [identity.to_public()],
+        store_id=store_id,
+        reason="cloud-backup",
+    )
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+
+    assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is False
+    assert "exact system:self node is not present" in load_state(store_id).last_verify_error
 
 
 def test_restore_verification_cleans_temporary_tree_on_failure(


### PR DESCRIPTION
## Problem

Full backup restore replaces Markdown but rebuilds the derived SQLite index while preserving the target machine user_node_id. On a fresh machine, that leaves its generated Self active and isolated instead of selecting the Self from the restored graph.

## Solution

- add backup manifest v2 with the exact active user_node_id
- validate that pointer against the included system:self Markdown node before destructive restore
- restore the pointer after rebuilding the derived index
- preserve target state in the existing pre-restore safety backup
- retain zero/one-Self compatibility for legacy v1 backups, but fail closed when a legacy backup is ambiguous
- include identity state in cloud-backup reuse and weekly restore verification
- document full-replacement semantics; no duplicate merging or identity repair is introduced

## Verification

- `uv run pytest tests/test_backup.py tests/test_cloud_bundle.py tests/test_cloud_jobs.py tests/test_cli_cloud_backup.py -q` -> 73 passed
- `uv run pytest tests/ -v` -> 1474 passed, one known environment-dependent failure in `tests/test_config.py::test_llm_provider_defaults_to_none` because this machine configures `llm_provider=litellm`
- `uv run ruff check src/ tests/` -> clean
- read-only validation against the real 1,769-node store resolved the established active Self `2b036a58-943f-468d-9869-69d70af815ec` despite a historical duplicate

## Scope

This remains full replacement with a safety backup. It does not merge target/source graphs, delete historical duplicate Self nodes, or implement sync reconciliation.