### PR TITLE
chore(release): prepare 0.14.2 and desktop 0.3.16

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "once_cell",
  "reqwest 0.12.28",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.15"
+version = "0.3.16"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.1"
+version = "0.14.2"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump Ormah Python and Claude plugin versions from 0.14.1 to 0.14.2
- bump desktop app versions from 0.3.15 to 0.3.16
- prepare the active-Self cloud restore fix from PR #163 for client and desktop distribution

## Verification

- `ORMAH_LLM_PROVIDER=none uv run pytest tests/ -q` -> 1475 passed, 1 deselected
- `uv run ruff check src/ tests/` -> clean
- `uv run python .github/release/verify_release_versions.py 0.14.2` -> passed
- `npm ci && npm run build` in `desktop/ui` -> passed
- `cargo check --locked` in `desktop/src-tauri` -> passed (one existing unused-function warning)

## Publishing order after merge

1. dispatch the Python Release workflow for 0.14.2 from main
2. wait for PyPI and GitHub release success
3. tag main as desktop-v0.3.16
4. wait for signed/notarized desktop artifacts and updater feed