### PR TITLE
fix(server): keep the backend supervised and surface outages

### DIFF
--- a/docs/11 - Setup and Installation.md
+++ b/docs/11 - Setup and Installation.md
@@ -123,11 +123,14 @@ Older docs that point to `~/Library/Logs/ormah/` or only to `journalctl` are not
 Supported commands:
 
 ```bash
-ormah server start
-ormah server start -d
+ormah server start       # foreground; stops when this process exits
+ormah server start -d    # supervised background service (recommended)
 ormah server stop
 ormah server status
 ```
+
+`ormah server stop` also removes the supervised service. Ormah remains stopped
+until `ormah setup` or `ormah server start -d` explicitly enables it again.
 
 Health checks:
 

--- a/src/ormah/adapters/cli_adapter.py
+++ b/src/ormah/adapters/cli_adapter.py
@@ -26,7 +26,7 @@ def _api(fn):
     try:
         return fn()
     except httpx.ConnectError:
-        print("Ormah server not running. Start it with: ormah server start", file=sys.stderr)
+        print("Ormah server not running. Start it with: ormah server start -d", file=sys.stderr)
         sys.exit(1)
     except httpx.HTTPStatusError as e:
         print(f"Error: {e.response.status_code} {e.response.text}", file=sys.stderr)
@@ -284,9 +284,27 @@ def cmd_whisper_inject(args):
             r = c.post("/agent/whisper", json=body)
             r.raise_for_status()
             text = r.json().get("text", "")
+    except httpx.ConnectError:
+        warning_key = f"server-down-warning:{session_id or 'unknown'}"
+        cursors = _load_cursors()
+        if not cursors.get(warning_key):
+            cursors[warning_key] = True
+            _save_cursors(cursors)
+            print(json.dumps({
+                "systemMessage": (
+                    "Ormah's backend is unavailable. Automatic memory recall and capture "
+                    "are paused. Run `ormah server start -d` to restore it."
+                )
+            }))
+        sys.exit(0)
     except Exception:
         # Server down, timeout, or any error — exit silently
         sys.exit(0)
+
+    warning_key = f"server-down-warning:{session_id or 'unknown'}"
+    cursors = _load_cursors()
+    if cursors.pop(warning_key, None) is not None:
+        _save_cursors(cursors)
 
     if not text.strip():
         text = ""

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -91,7 +91,7 @@ def create_mcp_server(
             return [
                 TextContent(
                     type="text",
-                    text="Ormah server not running. Start it with: ormah server start",
+                    text="Ormah server not running. Start it with: ormah server start -d",
                 )
             ]
         except httpx.ReadTimeout:

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -116,33 +116,40 @@ def _cmd_eval_recall_import(args):
 def _cmd_server_start(args):
     if args.daemon:
         from ormah.console import info, warn
-        from ormah.server_manager import get_ormah_bin_path, install_autostart, wait_for_server
+        from ormah.server_manager import get_ormah_bin_path, restart_with_autostart
         from ormah.setup import WRAPPER_PATH, generate_server_wrapper
 
         ormah_bin = get_ormah_bin_path()
         if not WRAPPER_PATH.exists():
             generate_server_wrapper(ormah_bin)
-        install_autostart(ormah_bin, wrapper_path=str(WRAPPER_PATH))
-        if not wait_for_server(show_progress=True):
+        if not restart_with_autostart(
+            ormah_bin,
+            wrapper_path=str(WRAPPER_PATH),
+            show_progress=True,
+        ):
             warn("Server did not start in time")
             info("Check ~/.local/share/ormah/logs/ormah.log")
             sys.exit(1)
     else:
         import uvicorn
         from ormah.config import settings
-        from ormah.console import info
-        from ormah.server_manager import is_port_in_use
+        from ormah.console import info, warn
+        from ormah.server_manager import is_port_in_use, is_server_running
 
-        # Pre-flight: if the port is already taken (typically by an existing
-        # ormah server), exit cleanly instead of letting uvicorn crash on bind.
-        # Under launchd/systemd KeepAlive this prevents a respawn loop that would
-        # re-run expensive startup work on every restart.
+        # A duplicate Ormah start is a clean no-op. A foreign listener must fail
+        # so launchd/systemd keeps retrying instead of treating the job as done.
         if is_port_in_use(settings.host, settings.port):
-            info(
-                f"A process is already listening on {settings.host}:{settings.port}; "
-                "assuming an ormah server is already running. Exiting."
+            if is_server_running():
+                info(
+                    f"Ormah is already running on {settings.host}:{settings.port}. "
+                    "Exiting."
+                )
+                return
+            warn(
+                f"Port {settings.port} is in use by another process; "
+                "Ormah could not start."
             )
-            return
+            sys.exit(1)
 
         uvicorn.run(
             "ormah.main:app",

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -117,7 +117,7 @@ async def lifespan(app: FastAPI):
     if hasattr(app.state, "hippocampus_observers"):
         stop_hippocampus(app.state.hippocampus_observers)
 
-    # Shutdown — wait for running jobs to finish (up to 10s)
+    # Shutdown — wait for running jobs to finish
     if hasattr(app.state, "scheduler"):
         app.state.scheduler.shutdown(wait=True)
     engine.shutdown()

--- a/src/ormah/server_manager.py
+++ b/src/ormah/server_manager.py
@@ -26,6 +26,9 @@ PLIST_DIR = Path.home() / "Library" / "LaunchAgents"
 PLIST_PATH = PLIST_DIR / f"{LAUNCHD_LABEL}.plist"
 LOG_DIR = Path.home() / ".local" / "share" / "ormah" / "logs"
 
+_GRACEFUL_STOP_TIMEOUT_SECONDS = 15.0
+_FORCED_STOP_TIMEOUT_SECONDS = 5.0
+
 SYSTEMD_DIR = Path.home() / ".config" / "systemd" / "user"
 SYSTEMD_UNIT = SYSTEMD_DIR / "ormah.service"
 
@@ -261,6 +264,29 @@ def _wait_for_pid_exit(pid: int, timeout: float = 5.0) -> bool:
     return False
 
 
+def _terminate_pid(pid: int) -> bool:
+    """Stop a process, escalating only after its graceful shutdown window."""
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+
+    if _wait_for_pid_exit(pid, timeout=_GRACEFUL_STOP_TIMEOUT_SECONDS):
+        return True
+
+    print(f"Warning: process {pid} did not exit after SIGTERM; sending SIGKILL.")
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return True
+    except PermissionError:
+        return False
+
+    return _wait_for_pid_exit(pid, timeout=_FORCED_STOP_TIMEOUT_SECONDS)
+
+
 @dataclass
 class _StopServerResult:
     found: bool = False
@@ -355,15 +381,10 @@ def _stop_running_server() -> _StopServerResult:
     killed = 0
     for pid in _find_manual_server_pids():
         res.found = True
-        try:
-            os.kill(pid, signal.SIGTERM)
-        except (ProcessLookupError, PermissionError):
-            res.failed = True
-            continue
-        if _wait_for_pid_exit(pid):
+        if _terminate_pid(pid):
             killed += 1
         else:
-            print(f"Warning: process {pid} did not exit after SIGTERM.")
+            print(f"Failed to stop process {pid}.")
             res.failed = True
 
     if killed:

--- a/src/ormah/server_manager.py
+++ b/src/ormah/server_manager.py
@@ -96,9 +96,8 @@ def is_server_running() -> bool:
 def is_port_in_use(host: str, port: int) -> bool:
     """Return True if something is already accepting connections on host:port.
 
-    Used as a pre-flight before binding: if another process (typically an
-    already-running ormah server) owns the port, the launcher exits cleanly
-    instead of letting uvicorn crash on bind and KeepAlive respawn it in a loop.
+    Used as a pre-flight before binding so the launcher can distinguish an
+    existing Ormah server from a foreign listener before starting uvicorn.
     """
     try:
         with socket.create_connection((host, port), timeout=0.5):
@@ -376,6 +375,38 @@ def _stop_running_server() -> _StopServerResult:
         print("No running Ormah server found.")
 
     return res
+
+
+def restart_with_autostart(
+    ormah_bin: str,
+    wrapper_path: str | None = None,
+    *,
+    show_progress: bool = False,
+) -> bool:
+    """Replace any running server with one owned by launchd/systemd.
+
+    A reachable port does not prove that the process is supervised. Stop the
+    existing process first and fail closed if ownership cannot be established.
+    """
+    stop_result = _stop_running_server()
+    if stop_result.failed:
+        print("Could not stop the existing Ormah server; auto-start was not installed.")
+        return False
+
+    if is_port_in_use(settings.host, settings.port):
+        print(
+            f"Port {settings.port} is still in use after stopping Ormah; "
+            "auto-start was not installed."
+        )
+        return False
+
+    try:
+        install_autostart(ormah_bin, wrapper_path=wrapper_path)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"Could not install Ormah auto-start: {exc}")
+        return False
+
+    return wait_for_server(show_progress=show_progress)
 
 
 def stop_running_server() -> bool:

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -25,11 +25,9 @@ from ormah.config import settings
 from ormah.console import info, ok, play_finale, step, warn
 from ormah.embeddings.cache import get_fastembed_cache_dir, get_model_cache_dirname
 from ormah.server_manager import (
-    _stop_running_server,
     get_ormah_bin_path,
-    install_autostart,
     is_server_running,
-    wait_for_server,
+    restart_with_autostart,
 )
 
 ENV_DIR = Path.home() / ".config" / "ormah"
@@ -2651,34 +2649,20 @@ def run_setup(
     # 4.5 Preload local models into Ormah's shared model cache
     _preload_local_models()
 
-    # 5. Start server + install auto-start. During updates, restart an existing
-    # daemon so newly installed backend routes match the refreshed UI assets.
-    if update and is_server_running():
-        step("Restarting server")
-        stop_result = _stop_running_server()
-        if stop_result.failed:
-            warn("Existing server did not stop cleanly; attempting restart anyway")
-        install_autostart(ormah_bin, wrapper_path=str(wrapper_path))
-        ok("Updated auto-start (launches on login)")
-
-        if wait_for_server(show_progress=True):
-            server_ok = True
-        else:
-            _diagnose_server_failure()
-            server_ok = False
-    elif is_server_running():
-        ok("Server already running")
-        server_ok = True
+    # 5. A healthy port is not enough: setup guarantees the running backend is
+    # owned by launchd/systemd, replacing a manual process when necessary.
+    server_was_running = is_server_running()
+    step("Restarting server" if server_was_running else "Starting server")
+    server_ok = restart_with_autostart(
+        ormah_bin,
+        wrapper_path=str(wrapper_path),
+        show_progress=True,
+    )
+    if server_ok:
+        action = "Updated" if update else "Installed"
+        ok(f"{action} auto-start (launches on login)")
     else:
-        step("Starting server")
-        install_autostart(ormah_bin, wrapper_path=str(wrapper_path))
-        ok("Installed auto-start (launches on login)")
-
-        if wait_for_server(show_progress=True):
-            server_ok = True
-        else:
-            _diagnose_server_failure()
-            server_ok = False
+        _diagnose_server_failure()
 
     if not skip_client_setup:
         for agent in detected_agents:

--- a/tests/test_adapters/test_cli_adapter.py
+++ b/tests/test_adapters/test_cli_adapter.py
@@ -420,6 +420,7 @@ def test_server_not_running(monkeypatch):
     code, out, err = _run_cli(["status"], monkeypatch)
     assert code == 1
     assert "not running" in err
+    assert "ormah server start -d" in err
 
 
 def test_http_error(monkeypatch):
@@ -480,9 +481,19 @@ def test_whisper_inject_malformed_json(monkeypatch):
     assert out.strip() == ""
 
 
-def test_whisper_inject_server_down(monkeypatch):
+def test_whisper_inject_server_down_warns_once_and_rearms(monkeypatch, tmp_path):
+    cursor_file = tmp_path / "whisper-cursors.json"
+    monkeypatch.setattr("ormah.adapters.cli_adapter._WHISPER_CURSOR_FILE", cursor_file)
+    monkeypatch.setattr("ormah.adapters.cli_adapter._WHISPER_CURSOR_DIR", tmp_path)
+    monkeypatch.setattr("ormah.config.settings.whisper_nudge_interval", 0)
+    monkeypatch.setattr("ormah.config.settings.whisper_out_enabled", False)
+
+    server_up = False
+
     def handler(request):
-        raise httpx.ConnectError("Connection refused")
+        if not server_up:
+            raise httpx.ConnectError("Connection refused")
+        return _mock_response({"text": ""})
 
     transport = httpx.MockTransport(handler)
     monkeypatch.setattr(
@@ -494,9 +505,29 @@ def test_whisper_inject_server_down(monkeypatch):
         lambda path: "proj",
     )
     hook_input = json.dumps({"prompt": "hello", "cwd": "/path/to/proj", "session_id": "test"})
+
+    # The first failure is visible to the user.
+    code, out, err = _run_cli(["whisper", "inject"], monkeypatch, stdin_text=hook_input)
+    assert code == 0
+    parsed = json.loads(out)
+    assert "backend is unavailable" in parsed["systemMessage"]
+    assert "ormah server start -d" in parsed["systemMessage"]
+
+    # Repeated prompts during the same outage do not spam the session.
     code, out, err = _run_cli(["whisper", "inject"], monkeypatch, stdin_text=hook_input)
     assert code == 0
     assert out.strip() == ""
+
+    # A successful request clears the throttle so a later outage warns again.
+    server_up = True
+    code, out, err = _run_cli(["whisper", "inject"], monkeypatch, stdin_text=hook_input)
+    assert code == 0
+    assert out.strip() == ""
+
+    server_up = False
+    code, out, err = _run_cli(["whisper", "inject"], monkeypatch, stdin_text=hook_input)
+    assert code == 0
+    assert "systemMessage" in json.loads(out)
 
 
 def test_whisper_inject_empty_context(monkeypatch):

--- a/tests/test_adapters/test_mcp_adapter.py
+++ b/tests/test_adapters/test_mcp_adapter.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
+from mcp.types import CallToolRequest, CallToolRequestParams
 
 from ormah.adapters import mcp_adapter
 
@@ -77,6 +79,22 @@ async def test_dispatch_uses_extended_timeout_for_maintenance(monkeypatch):
 
     assert captured["base_url"] == "http://localhost:8787"
     assert captured["timeout"] == mcp_adapter._MAINTENANCE_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_call_tool_connect_error_recommends_supervised_start(monkeypatch):
+    dispatch = AsyncMock(side_effect=httpx.ConnectError("Connection refused"))
+    monkeypatch.setattr(mcp_adapter, "_dispatch", dispatch)
+    server = mcp_adapter.create_mcp_server("http://localhost:8787")
+    handler = server.request_handlers[CallToolRequest]
+
+    result = await handler(
+        CallToolRequest(params=CallToolRequestParams(name="recall", arguments={}))
+    )
+
+    message = result.root.content[0].text
+    assert "Ormah server not running" in message
+    assert "ormah server start -d" in message
 
 
 def test_format_timeout_error_for_maintenance_is_explicit():

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -71,14 +71,29 @@ def test_plist_has_throttle_interval():
 
 
 def test_server_start_exits_clean_when_port_in_use():
-    """`ormah server start` must NOT launch uvicorn when the port is already
-    owned by another server — it returns cleanly so KeepAlive does not respawn."""
+    """A healthy Ormah listener makes a duplicate foreground start a no-op."""
     from ormah import cli
 
     args = mock.Mock(daemon=False, reload=False)
     with mock.patch("ormah.server_manager.is_port_in_use", return_value=True), \
+         mock.patch("ormah.server_manager.is_server_running", return_value=True), \
          mock.patch("uvicorn.run") as run:
         cli._cmd_server_start(args)
+    run.assert_not_called()
+
+
+def test_server_start_fails_when_foreign_process_owns_port():
+    """A foreign listener must make the supervisor retry instead of going dormant."""
+    from ormah import cli
+
+    args = mock.Mock(daemon=False, reload=False)
+    with mock.patch("ormah.server_manager.is_port_in_use", return_value=True), \
+         mock.patch("ormah.server_manager.is_server_running", return_value=False), \
+         mock.patch("uvicorn.run") as run, \
+         pytest.raises(SystemExit) as exc_info:
+        cli._cmd_server_start(args)
+
+    assert exc_info.value.code == 1
     run.assert_not_called()
 
 
@@ -91,3 +106,59 @@ def test_server_start_runs_uvicorn_when_port_free():
          mock.patch("uvicorn.run") as run:
         cli._cmd_server_start(args)
     run.assert_called_once()
+
+
+def test_restart_with_autostart_transfers_ownership_and_waits_for_health():
+    stop_result = server_manager._StopServerResult(found=True, stopped=True)
+    with mock.patch("ormah.server_manager._stop_running_server", return_value=stop_result) as stop, \
+         mock.patch("ormah.server_manager.is_port_in_use", return_value=False) as port_in_use, \
+         mock.patch("ormah.server_manager.install_autostart") as install, \
+         mock.patch("ormah.server_manager.wait_for_server", return_value=True) as wait:
+        result = server_manager.restart_with_autostart(
+            "/abs/path/ormah",
+            wrapper_path="/abs/path/ormah-server",
+            show_progress=True,
+        )
+
+    assert result is True
+    stop.assert_called_once()
+    port_in_use.assert_called_once_with(server_manager.settings.host, server_manager.settings.port)
+    install.assert_called_once_with("/abs/path/ormah", wrapper_path="/abs/path/ormah-server")
+    wait.assert_called_once_with(show_progress=True)
+
+
+def test_restart_with_autostart_fails_closed_when_stop_fails():
+    stop_result = server_manager._StopServerResult(found=True, failed=True)
+    with mock.patch("ormah.server_manager._stop_running_server", return_value=stop_result), \
+         mock.patch("ormah.server_manager.install_autostart") as install, \
+         mock.patch("ormah.server_manager.wait_for_server") as wait:
+        result = server_manager.restart_with_autostart("/abs/path/ormah")
+
+    assert result is False
+    install.assert_not_called()
+    wait.assert_not_called()
+
+
+def test_restart_with_autostart_fails_closed_when_port_remains_occupied():
+    stop_result = server_manager._StopServerResult(found=True, stopped=True)
+    with mock.patch("ormah.server_manager._stop_running_server", return_value=stop_result), \
+         mock.patch("ormah.server_manager.is_port_in_use", return_value=True), \
+         mock.patch("ormah.server_manager.install_autostart") as install, \
+         mock.patch("ormah.server_manager.wait_for_server") as wait:
+        result = server_manager.restart_with_autostart("/abs/path/ormah")
+
+    assert result is False
+    install.assert_not_called()
+    wait.assert_not_called()
+
+
+def test_restart_with_autostart_fails_closed_when_install_fails():
+    stop_result = server_manager._StopServerResult()
+    with mock.patch("ormah.server_manager._stop_running_server", return_value=stop_result), \
+         mock.patch("ormah.server_manager.is_port_in_use", return_value=False), \
+         mock.patch("ormah.server_manager.install_autostart", side_effect=OSError("denied")), \
+         mock.patch("ormah.server_manager.wait_for_server") as wait:
+        result = server_manager.restart_with_autostart("/abs/path/ormah")
+
+    assert result is False
+    wait.assert_not_called()

--- a/tests/test_server_manager.py
+++ b/tests/test_server_manager.py
@@ -46,6 +46,50 @@ def test_is_port_in_use_true_when_ipv6_socket_listening():
         assert server_manager.is_port_in_use("::1", port) is True
 
 
+def test_terminate_pid_allows_graceful_shutdown_window():
+    pid = 1234
+    with mock.patch("ormah.server_manager.os.kill") as kill, \
+         mock.patch("ormah.server_manager._wait_for_pid_exit", return_value=True) as wait:
+        result = server_manager._terminate_pid(pid)
+
+    assert result is True
+    kill.assert_called_once_with(pid, server_manager.signal.SIGTERM)
+    wait.assert_called_once_with(
+        pid,
+        timeout=server_manager._GRACEFUL_STOP_TIMEOUT_SECONDS,
+    )
+
+
+def test_terminate_pid_escalates_after_graceful_timeout():
+    pid = 1234
+    with mock.patch("ormah.server_manager.os.kill") as kill, \
+         mock.patch(
+             "ormah.server_manager._wait_for_pid_exit",
+             side_effect=[False, True],
+         ) as wait:
+        result = server_manager._terminate_pid(pid)
+
+    assert result is True
+    assert kill.call_args_list == [
+        mock.call(pid, server_manager.signal.SIGTERM),
+        mock.call(pid, server_manager.signal.SIGKILL),
+    ]
+    assert wait.call_args_list == [
+        mock.call(pid, timeout=server_manager._GRACEFUL_STOP_TIMEOUT_SECONDS),
+        mock.call(pid, timeout=server_manager._FORCED_STOP_TIMEOUT_SECONDS),
+    ]
+
+
+def test_terminate_pid_fails_when_process_survives_sigkill():
+    pid = 1234
+    with mock.patch("ormah.server_manager.os.kill") as kill, \
+         mock.patch("ormah.server_manager._wait_for_pid_exit", return_value=False):
+        result = server_manager._terminate_pid(pid)
+
+    assert result is False
+    assert kill.call_args_list[-1] == mock.call(pid, server_manager.signal.SIGKILL)
+
+
 def test_plist_keepalive_only_on_unsuccessful_exit():
     """KeepAlive must not be unconditional: a clean exit (port already taken)
     must not trigger a launchd respawn storm."""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -650,8 +650,9 @@ class TestRunSetup:
             stack.enter_context(patch("ormah.setup.configure_llm"))
             stack.enter_context(patch("ormah.setup._preload_local_models"))
             stack.enter_context(patch("ormah.setup.is_server_running", return_value=False))
-            mock_install = stack.enter_context(patch("ormah.setup.install_autostart"))
-            stack.enter_context(patch("ormah.setup.wait_for_server", return_value=False))
+            mock_restart = stack.enter_context(
+                patch("ormah.setup.restart_with_autostart", return_value=False)
+            )
             mock_diagnose = stack.enter_context(patch("ormah.setup._diagnose_server_failure"))
             mock_backfill = stack.enter_context(patch("ormah.setup.backfill_transcripts"))
             mock_finale = stack.enter_context(patch("ormah.setup.play_finale"))
@@ -662,7 +663,11 @@ class TestRunSetup:
                 run_setup(skip_client_setup=True)
 
         assert exc_info.value.code == 1
-        mock_install.assert_called_once_with("/abs/path/ormah", wrapper_path=str(tmp_path / "ormah-server"))
+        mock_restart.assert_called_once_with(
+            "/abs/path/ormah",
+            wrapper_path=str(tmp_path / "ormah-server"),
+            show_progress=True,
+        )
         mock_diagnose.assert_called_once()
         mock_backfill.assert_not_called()
         mock_finale.assert_not_called()
@@ -690,6 +695,9 @@ class TestRunSetup:
             )
             stack.enter_context(patch("ormah.setup._preload_local_models"))
             stack.enter_context(patch("ormah.setup.is_server_running", return_value=True))
+            mock_restart = stack.enter_context(
+                patch("ormah.setup.restart_with_autostart", return_value=True)
+            )
             mock_maintenance_prompt = stack.enter_context(patch("ormah.setup.configure_agent_maintenance"))
             mock_configure_llm = stack.enter_context(patch("ormah.setup.configure_llm"))
             mock_claude_hooks = stack.enter_context(patch("ormah.setup.configure_claude_hooks"))
@@ -726,10 +734,13 @@ class TestRunSetup:
         mock_pi_extension.assert_not_called()
         mock_pi_md.assert_not_called()
         mock_pi_agents.assert_not_called()
+        mock_restart.assert_called_once_with(
+            "/abs/path/ormah",
+            wrapper_path=str(tmp_path / "ormah-server"),
+            show_progress=True,
+        )
 
     def test_update_restarts_existing_server(self, tmp_path, capsys):
-        from ormah.server_manager import _StopServerResult
-
         wrapper = tmp_path / "ormah-server"
         with ExitStack() as stack:
             stack.enter_context(patch("ormah.setup.get_ormah_bin_path", return_value="/abs/path/ormah"))
@@ -738,14 +749,9 @@ class TestRunSetup:
             stack.enter_context(patch("ormah.setup.generate_server_wrapper", return_value=wrapper))
             stack.enter_context(patch("ormah.setup._preload_local_models"))
             stack.enter_context(patch("ormah.setup.is_server_running", return_value=True))
-            mock_stop = stack.enter_context(
-                patch(
-                    "ormah.setup._stop_running_server",
-                    return_value=_StopServerResult(found=True, stopped=True),
-                )
+            mock_restart = stack.enter_context(
+                patch("ormah.setup.restart_with_autostart", return_value=True)
             )
-            mock_install = stack.enter_context(patch("ormah.setup.install_autostart"))
-            mock_wait = stack.enter_context(patch("ormah.setup.wait_for_server", return_value=True))
             stack.enter_context(patch("ormah.setup.backfill_transcripts"))
             stack.enter_context(patch("ormah.setup.play_finale"))
             stack.enter_context(patch("ormah.setup._print_setup_summary"))
@@ -753,9 +759,11 @@ class TestRunSetup:
 
             run_setup(update=True, skip_client_setup=True)
 
-        mock_stop.assert_called_once()
-        mock_install.assert_called_once_with("/abs/path/ormah", wrapper_path=str(wrapper))
-        mock_wait.assert_called_once_with(show_progress=True)
+        mock_restart.assert_called_once_with(
+            "/abs/path/ormah",
+            wrapper_path=str(wrapper),
+            show_progress=True,
+        )
 
         out = capsys.readouterr().out
         assert "Restarting server" in out
@@ -925,13 +933,17 @@ class TestCliEntryPoint:
             patch("ormah.setup.WRAPPER_PATH", wrapper),
             patch("ormah.setup.generate_server_wrapper", return_value=wrapper),
             patch("ormah.server_manager.get_ormah_bin_path", return_value="/abs/path/ormah"),
-            patch("ormah.server_manager.install_autostart"),
-            patch("ormah.server_manager.wait_for_server", return_value=False),
+            patch("ormah.server_manager.restart_with_autostart", return_value=False) as restart,
             pytest.raises(SystemExit) as exc_info,
         ):
             main()
 
         assert exc_info.value.code == 1
+        restart.assert_called_once_with(
+            "/abs/path/ormah",
+            wrapper_path=str(wrapper),
+            show_progress=True,
+        )
 
     def test_claude_md_install_defaults_to_auto_scope(self):
         from ormah.cli import main


### PR DESCRIPTION
## Problem

A reachable backend was treated as equivalent to a supervised backend. Setup could therefore leave a manually started process owning port 8787 while launchd/systemd considered its Ormah job successfully finished. If that process later died, the supervisor was dormant and Claude Code hooks hid the outage.

A foreign listener on port 8787 could produce the same dormant state because the supervised child exited successfully on any port conflict.

## Solution

- add a fail-closed `restart_with_autostart()` ownership transfer: stop the existing Ormah process, verify the port is free, install/load supervision, then wait for health
- allow graceful shutdown for 15 seconds, then use SIGKILL and verify exit so a slow shutdown cannot leave the supervisor unloaded
- route normal setup, update setup, and `ormah server start -d` through that path; the desktop sidecar inherits this through its existing daemon command
- exit successfully on a port conflict only when the listener is a healthy Ormah server; foreign listeners now fail so launchd/systemd retries
- recommend `ormah server start -d` from MCP and CLI connection errors
- show a throttled Claude Code `systemMessage` when whisper inject cannot reach the backend, and re-arm it after recovery
- document foreground, supervised, and explicit stop semantics

This does not auto-start Ormah from MCP or hooks. `ormah server stop` still removes supervision and Ormah remains stopped until the user explicitly runs setup or `ormah server start -d`.

## Verification

- `UV_CACHE_DIR=/tmp/uv-cache ORMAH_LLM_PROVIDER=none uv run pytest -q` (1484 passed, 1 deselected)
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ tests/`
- `git diff --check`

No configuration or environment changes.

Fixes #157