### PR TITLE
chore(release): prepare 0.14.3

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.2"
+version = "0.14.3"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump Ormah Python and Claude plugin versions from 0.14.2 to 0.14.3
- ships the supervised-backend ownership fix from #165 (issue #157) to PyPI and the Claude plugin

Desktop versions are untouched: `main` is already at 0.3.16 from #164, and the `desktop-v0.3.16` tag was deliberately deferred so this change could ship in the same signed/notarized build.

## Verification

- `ORMAH_LLM_PROVIDER=none uv run pytest -q` -> 1484 passed, 1 deselected
- `uv run ruff check src/ tests/` -> clean
- `uv run python .github/release/verify_release_versions.py 0.14.3` -> passed

## Publishing order after merge

1. dispatch the Python Release workflow for 0.14.3 from `main`
2. wait for PyPI and GitHub release success
3. tag `main` as `desktop-v0.3.16`
4. wait for signed/notarized desktop artifacts and updater feed
