### PR TITLE
feat(cloud): add C02 protection state foundation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "python-slugify>=8.0.0",
     "pyyaml>=6.0.0",
     "pyrage>=1.3.0",
+    "filelock>=3.16.0",
 ]
 
 [project.optional-dependencies]

--- a/src/ormah/cloud/jobs.py
+++ b/src/ormah/cloud/jobs.py
@@ -49,18 +49,18 @@ def _existing_store_id(memory_dir: Path) -> str | None:
     return get_or_create_store_id(memory_dir)
 
 
-def _safe_update(store_id: str | None, **changes) -> None:
+def _safe_update(store_id: str | None, *, memory_dir: Path, **changes) -> None:
     if store_id is None:
         return
     try:
-        update_state(store_id, **changes)
+        update_state(store_id, memory_dir=memory_dir, **changes)
     except Exception as exc:
         logger.warning("Could not persist Ormah Cloud state: %s", exc)
 
 
-def _record_upload_error(store_id: str | None, message: str) -> None:
+def _record_upload_error(store_id: str | None, message: str, *, memory_dir: Path) -> None:
     logger.warning("Ormah Cloud backup skipped or failed: %s", message)
-    _safe_update(store_id, last_upload_error=message)
+    _safe_update(store_id, memory_dir=memory_dir, last_upload_error=message)
 
 
 def _snapshot_files(root: Path) -> dict[str, Path]:
@@ -119,12 +119,20 @@ def run_cloud_backup(engine) -> str | None:
 
         if not key_file_exists():
             store_id = _existing_store_id(settings.memory_dir)
-            _record_upload_error(store_id, "Cloud encryption key is missing; run `ormah cloud init`.")
+            _record_upload_error(
+                store_id,
+                "Cloud encryption key is missing; run `ormah cloud init`.",
+                memory_dir=settings.memory_dir,
+            )
             return None
 
         store_id = _existing_store_id(settings.memory_dir)
         if store_id is None:
-            _record_upload_error(None, "Cloud store id is missing; run `ormah cloud init`.")
+            _record_upload_error(
+                None,
+                "Cloud store id is missing; run `ormah cloud init`.",
+                memory_dir=settings.memory_dir,
+            )
             return None
 
         entitlement = check_entitlement(settings)
@@ -132,6 +140,7 @@ def run_cloud_backup(engine) -> str | None:
             _record_upload_error(
                 store_id,
                 f"Cloud backup paused because entitlement is {entitlement.value}.",
+                memory_dir=settings.memory_dir,
             )
             return None
 
@@ -183,16 +192,20 @@ def run_cloud_backup(engine) -> str | None:
             if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
                 raise RuntimeError("Cloud upload finalize response was malformed.")
 
+        uploaded_at = _utc_now()
         _safe_update(
             store_id,
-            last_upload_at=_utc_now(),
+            memory_dir=settings.memory_dir,
+            last_upload_at=uploaded_at,
             last_upload_snapshot_id=snapshot_id,
             last_upload_error=None,
+            last_successful_upload_at=uploaded_at,
+            last_successful_backup_snapshot_id=snapshot_id,
         )
         logger.info("Uploaded encrypted Ormah Cloud snapshot %s", snapshot_id)
         return snapshot_id
     except Exception as exc:
-        _record_upload_error(store_id, str(exc))
+        _record_upload_error(store_id, str(exc), memory_dir=settings.memory_dir)
         return None
     finally:
         close = getattr(client, "close", None) if client is not None else None
@@ -293,10 +306,13 @@ def run_restore_verification(engine) -> bool:
         verified_at = _utc_now()
         _safe_update(
             store_id,
+            memory_dir=settings.memory_dir,
             last_verify_at=verified_at,
             last_verify_ok=True,
             last_verify_snapshot_id=snapshot_id,
             last_verify_error=None,
+            last_successful_verify_at=verified_at,
+            last_verified_snapshot_id=snapshot_id,
         )
         logger.info("Verified Ormah Cloud snapshot %s is restorable", snapshot_id)
         return True
@@ -310,6 +326,7 @@ def run_restore_verification(engine) -> bool:
                 store_id = None
         _safe_update(
             store_id,
+            memory_dir=settings.memory_dir,
             last_verify_at=_utc_now(),
             last_verify_ok=False,
             last_verify_snapshot_id=snapshot_id,

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -2,17 +2,103 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timedelta, timezone
+from enum import StrEnum
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 import threading
 import uuid
 
 
 CLOUD_STATE_DIR = Path.home() / ".local" / "share" / "ormah" / "cloud"
+CURRENT_CLOUD_STATE_SCHEMA_VERSION = 2
 _STATE_LOCK = threading.RLock()
+
+
+class ProtectionState(StrEnum):
+    """User-facing states for the paid backup protection journey."""
+
+    LOCAL_ONLY = "local_only"
+    SIGN_IN_REQUIRED = "sign_in_required"
+    SUBSCRIPTION_REQUIRED = "subscription_required"
+    INITIALIZING = "initializing"
+    UPLOADING_FIRST_BACKUP = "uploading_first_backup"
+    VERIFYING_FIRST_BACKUP = "verifying_first_backup"
+    PROTECTED = "protected"
+    CHANGES_PENDING = "changes_pending"
+    OFFLINE = "offline"
+    PAUSED = "paused"
+    STOPPED = "stopped"
+    ATTENTION_REQUIRED = "attention_required"
+
+
+class ProtectionIntentStatus(StrEnum):
+    """Durable phases for an explicit Protect action."""
+
+    PENDING = "pending"
+    ACCOUNT_BOUND = "account_bound"
+    CHECKOUT_PENDING = "checkout_pending"
+    READY = "ready"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    CANCELED = "canceled"
+    EXPIRED = "expired"
+
+
+class ProtectionOperationKind(StrEnum):
+    ENABLE = "enable"
+    DISABLE = "disable"
+    BACKUP = "backup"
+    VERIFY = "verify"
+    RESTORE = "restore"
+
+
+class ProtectionOperationPhase(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    UPLOADING = "uploading"
+    FINALIZING = "finalizing"
+    VERIFYING = "verifying"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+
+class ProtectionReasonCode(StrEnum):
+    """Stable machine-readable causes shared by CLI, REST, and desktop clients."""
+
+    NOT_ENABLED = "not_enabled"
+    SIGN_IN_REQUIRED = "sign_in_required"
+    SUBSCRIPTION_REQUIRED = "subscription_required"
+    OFFLINE = "offline"
+    ENTITLEMENT_EXPIRED = "entitlement_expired"
+    QUOTA_EXCEEDED = "quota_exceeded"
+    KEY_MISSING = "key_missing"
+    KEY_INVALID = "key_invalid"
+    UPLOAD_FAILED = "upload_failed"
+    VERIFICATION_FAILED = "verification_failed"
+    BUNDLE_CORRUPT = "bundle_corrupt"
+    INDEX_ENVIRONMENT_UNAVAILABLE = "index_environment_unavailable"
+    DISK_SPACE_INSUFFICIENT = "disk_space_insufficient"
+    OPERATION_INTERRUPTED = "operation_interrupted"
+    STORE_BUSY = "store_busy"
+    PROTECTION_STOPPED = "protection_stopped"
+
+
+@dataclass(frozen=True)
+class ProtectionOperation:
+    """Token-free operation result returned by shared protection adapters."""
+
+    operation_id: str
+    kind: ProtectionOperationKind
+    phase: ProtectionOperationPhase
+    state: ProtectionState
+    reason_code: ProtectionReasonCode | None = None
+    message: str | None = None
+    snapshot_id: str | None = None
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -29,6 +115,40 @@ def _parse_time(value: Any) -> datetime | None:
     return _as_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
 
 
+def _serialize_time(value: datetime | None) -> str | None:
+    return _as_utc(value).isoformat() if value is not None else None
+
+
+def _parse_enum(value: Any, enum_type: type[StrEnum], field_name: str) -> StrEnum | str | None:
+    if value is None:
+        return None
+    if isinstance(value, enum_type):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string or null")
+    try:
+        return enum_type(value)
+    except ValueError:
+        # A newer client may add a state before an older reader is upgraded. Preserve it exactly.
+        return value
+
+
+def _serialize_enum(value: StrEnum | str | None) -> str | None:
+    return value.value if isinstance(value, StrEnum) else value
+
+
+def _legacy_protection_state(values: dict[str, Any]) -> ProtectionState:
+    uploaded = values.get("last_upload_snapshot_id")
+    verified = values.get("last_verify_snapshot_id")
+    if uploaded is None:
+        return ProtectionState.LOCAL_ONLY
+    if values.get("last_verify_ok") is True and uploaded == verified:
+        return ProtectionState.PROTECTED
+    if values.get("last_verify_ok") is True:
+        return ProtectionState.CHANGES_PENDING
+    return ProtectionState.ATTENTION_REQUIRED
+
+
 def _validate_store_id(store_id: str) -> str:
     try:
         parsed = uuid.UUID(store_id)
@@ -43,6 +163,7 @@ def _validate_store_id(store_id: str) -> str:
 class CloudState:
     """Durable client state for one memory store."""
 
+    schema_version: int = CURRENT_CLOUD_STATE_SCHEMA_VERSION
     last_upload_at: datetime | None = None
     last_upload_snapshot_id: str | None = None
     last_upload_error: str | None = None
@@ -50,27 +171,74 @@ class CloudState:
     last_verify_ok: bool | None = None
     last_verify_snapshot_id: str | None = None
     last_verify_error: str | None = None
+    protection_enabled_at: datetime | None = None
+    protection_state: ProtectionState | str = ProtectionState.LOCAL_ONLY
+    pending_protection_intent_id: str | None = None
+    pending_protection_account_id: str | None = None
+    pending_protection_store_id: str | None = None
+    pending_protection_created_at: datetime | None = None
+    pending_protection_expires_at: datetime | None = None
+    pending_protection_status: ProtectionIntentStatus | str | None = None
+    protection_disabled_at: datetime | None = None
+    last_operation_id: str | None = None
+    last_operation_kind: ProtectionOperationKind | str | None = None
+    last_operation_phase: ProtectionOperationPhase | str | None = None
+    last_successful_upload_at: datetime | None = None
+    last_successful_backup_snapshot_id: str | None = None
+    last_successful_verify_at: datetime | None = None
+    last_verified_snapshot_id: str | None = None
+    last_error_code: ProtectionReasonCode | str | None = None
+    last_error_message: str | None = None
+    last_error_at: datetime | None = None
+    local_graph_fingerprint_at_upload: str | None = None
+    recovery_kit_verified_at: datetime | None = None
+    next_scheduled_upload_at: datetime | None = None
+    next_scheduled_verify_at: datetime | None = None
     extra: dict[str, Any] = field(default_factory=dict, repr=False)
 
     def to_dict(self) -> dict[str, Any]:
         payload = dict(self.extra)
         payload.update(
             {
-                "last_upload_at": (
-                    _as_utc(self.last_upload_at).isoformat()
-                    if self.last_upload_at is not None
-                    else None
-                ),
+                "schema_version": self.schema_version,
+                "last_upload_at": _serialize_time(self.last_upload_at),
                 "last_upload_snapshot_id": self.last_upload_snapshot_id,
                 "last_upload_error": self.last_upload_error,
-                "last_verify_at": (
-                    _as_utc(self.last_verify_at).isoformat()
-                    if self.last_verify_at is not None
-                    else None
-                ),
+                "last_verify_at": _serialize_time(self.last_verify_at),
                 "last_verify_ok": self.last_verify_ok,
                 "last_verify_snapshot_id": self.last_verify_snapshot_id,
                 "last_verify_error": self.last_verify_error,
+                "protection_enabled_at": _serialize_time(self.protection_enabled_at),
+                "protection_state": _serialize_enum(self.protection_state),
+                "pending_protection_intent_id": self.pending_protection_intent_id,
+                "pending_protection_account_id": self.pending_protection_account_id,
+                "pending_protection_store_id": self.pending_protection_store_id,
+                "pending_protection_created_at": _serialize_time(
+                    self.pending_protection_created_at
+                ),
+                "pending_protection_expires_at": _serialize_time(
+                    self.pending_protection_expires_at
+                ),
+                "pending_protection_status": _serialize_enum(
+                    self.pending_protection_status
+                ),
+                "protection_disabled_at": _serialize_time(self.protection_disabled_at),
+                "last_operation_id": self.last_operation_id,
+                "last_operation_kind": _serialize_enum(self.last_operation_kind),
+                "last_operation_phase": _serialize_enum(self.last_operation_phase),
+                "last_successful_upload_at": _serialize_time(self.last_successful_upload_at),
+                "last_successful_backup_snapshot_id": (
+                    self.last_successful_backup_snapshot_id
+                ),
+                "last_successful_verify_at": _serialize_time(self.last_successful_verify_at),
+                "last_verified_snapshot_id": self.last_verified_snapshot_id,
+                "last_error_code": _serialize_enum(self.last_error_code),
+                "last_error_message": self.last_error_message,
+                "last_error_at": _serialize_time(self.last_error_at),
+                "local_graph_fingerprint_at_upload": self.local_graph_fingerprint_at_upload,
+                "recovery_kit_verified_at": _serialize_time(self.recovery_kit_verified_at),
+                "next_scheduled_upload_at": _serialize_time(self.next_scheduled_upload_at),
+                "next_scheduled_verify_at": _serialize_time(self.next_scheduled_verify_at),
             }
         )
         return payload
@@ -81,20 +249,83 @@ class CloudState:
             raise ValueError("cloud state must be a JSON object")
         allowed = {item.name for item in fields(cls)} - {"extra"}
         values = {key: value for key, value in payload.items() if key in allowed}
-        values["last_upload_at"] = _parse_time(values.get("last_upload_at"))
-        values["last_verify_at"] = _parse_time(values.get("last_verify_at"))
-        for key in (
+
+        schema_version = values.get("schema_version", 1)
+        if (
+            not isinstance(schema_version, int)
+            or isinstance(schema_version, bool)
+            or schema_version < 1
+        ):
+            raise ValueError("schema_version must be a positive integer")
+        values["schema_version"] = max(
+            schema_version,
+            CURRENT_CLOUD_STATE_SCHEMA_VERSION,
+        )
+
+        time_fields = (
+            "last_upload_at",
+            "last_verify_at",
+            "protection_enabled_at",
+            "pending_protection_created_at",
+            "pending_protection_expires_at",
+            "protection_disabled_at",
+            "last_successful_upload_at",
+            "last_successful_verify_at",
+            "last_error_at",
+            "recovery_kit_verified_at",
+            "next_scheduled_upload_at",
+            "next_scheduled_verify_at",
+        )
+        for key in time_fields:
+            values[key] = _parse_time(values.get(key))
+
+        string_fields = (
             "last_upload_snapshot_id",
             "last_upload_error",
             "last_verify_snapshot_id",
             "last_verify_error",
-        ):
+            "pending_protection_intent_id",
+            "pending_protection_account_id",
+            "pending_protection_store_id",
+            "last_operation_id",
+            "last_successful_backup_snapshot_id",
+            "last_verified_snapshot_id",
+            "last_error_message",
+            "local_graph_fingerprint_at_upload",
+        )
+        for key in string_fields:
             value = values.get(key)
             if value is not None and not isinstance(value, str):
                 raise ValueError(f"{key} must be a string or null")
+
         verify_ok = values.get("last_verify_ok")
         if verify_ok is not None and not isinstance(verify_ok, bool):
             raise ValueError("last_verify_ok must be a boolean or null")
+
+        enum_fields = {
+            "protection_state": ProtectionState,
+            "pending_protection_status": ProtectionIntentStatus,
+            "last_operation_kind": ProtectionOperationKind,
+            "last_operation_phase": ProtectionOperationPhase,
+            "last_error_code": ProtectionReasonCode,
+        }
+        for key, enum_type in enum_fields.items():
+            if key in values:
+                values[key] = _parse_enum(values[key], enum_type, key)
+
+        if "last_successful_upload_at" not in payload:
+            values["last_successful_upload_at"] = values["last_upload_at"]
+        if "last_successful_backup_snapshot_id" not in payload:
+            values["last_successful_backup_snapshot_id"] = values.get(
+                "last_upload_snapshot_id"
+            )
+        if "last_successful_verify_at" not in payload and verify_ok is True:
+            values["last_successful_verify_at"] = values["last_verify_at"]
+        if "last_verified_snapshot_id" not in payload and verify_ok is True:
+            values["last_verified_snapshot_id"] = values.get("last_verify_snapshot_id")
+        if "protection_state" not in payload:
+            values["protection_state"] = _legacy_protection_state(values)
+
         extra = {key: value for key, value in payload.items() if key not in allowed}
         return cls(**values, extra=extra)
 
@@ -118,9 +349,25 @@ def save_state(
     state: CloudState,
     *,
     state_dir: Path | None = None,
+    memory_dir: Path | None = None,
+    lock_timeout: float = 30.0,
 ) -> CloudState:
     """Atomically persist one store's state with owner-only permissions."""
     path = state_path(store_id, state_dir=state_dir)
+
+    from ormah.cloud.store_lock import StoreLock
+
+    lock = (
+        StoreLock(memory_dir, timeout=lock_timeout)
+        if memory_dir is not None
+        else nullcontext()
+    )
+    with lock:
+        return _write_state(path, state)
+
+
+def _write_state(path: Path, state: CloudState) -> CloudState:
+    """Write state after the caller has acquired any required store lock."""
 
     from ormah.setup import _atomic_write
 
@@ -134,16 +381,48 @@ def save_state(
     return state
 
 
+def mutate_state(
+    store_id: str,
+    transform: Callable[[CloudState], CloudState],
+    *,
+    state_dir: Path | None = None,
+    memory_dir: Path | None = None,
+    lock_timeout: float = 30.0,
+) -> CloudState:
+    """Apply one read-modify-write transformation without losing concurrent updates."""
+    path = state_path(store_id, state_dir=state_dir)
+
+    from ormah.cloud.store_lock import StoreLock
+
+    lock = (
+        StoreLock(memory_dir, timeout=lock_timeout)
+        if memory_dir is not None
+        else nullcontext()
+    )
+    with lock, _STATE_LOCK:
+        current = load_state(store_id, state_dir=state_dir)
+        updated = transform(current)
+        if not isinstance(updated, CloudState):
+            raise TypeError("cloud state transform must return CloudState")
+        return _write_state(path, updated)
+
+
 def update_state(
     store_id: str,
     *,
     state_dir: Path | None = None,
+    memory_dir: Path | None = None,
+    lock_timeout: float = 30.0,
     **changes: Any,
 ) -> CloudState:
     """Update selected fields while preserving the rest of one store's state."""
-    with _STATE_LOCK:
-        state = replace(load_state(store_id, state_dir=state_dir), **changes)
-        return save_state(store_id, state, state_dir=state_dir)
+    return mutate_state(
+        store_id,
+        lambda state: replace(state, **changes),
+        state_dir=state_dir,
+        memory_dir=memory_dir,
+        lock_timeout=lock_timeout,
+    )
 
 
 def _existing_store_id(memory_dir: Path) -> str | None:
@@ -198,8 +477,10 @@ def cloud_status_payload(
         warnings.append(f"Cloud restore verification failed{detail}")
 
     return {
+        "schema_version": state.schema_version,
         "enabled": settings.cloud_backup_enabled,
         "store_id": store_id,
+        "protection_state": _serialize_enum(state.protection_state),
         "interval_hours": settings.cloud_backup_interval_hours,
         "entitlement": entitlement,
         "last_upload_at": (
@@ -216,5 +497,11 @@ def cloud_status_payload(
         "last_verify_ok": state.last_verify_ok,
         "last_verify_snapshot_id": state.last_verify_snapshot_id,
         "last_verify_error": state.last_verify_error,
+        "last_successful_upload_at": _serialize_time(state.last_successful_upload_at),
+        "last_successful_backup_snapshot_id": state.last_successful_backup_snapshot_id,
+        "last_successful_verify_at": _serialize_time(state.last_successful_verify_at),
+        "last_verified_snapshot_id": state.last_verified_snapshot_id,
+        "last_error_code": _serialize_enum(state.last_error_code),
+        "last_error_message": state.last_error_message,
         "warnings": warnings,
     }

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
 from dataclasses import dataclass, field, fields, replace
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
@@ -16,6 +15,18 @@ import uuid
 CLOUD_STATE_DIR = Path.home() / ".local" / "share" / "ormah" / "cloud"
 CURRENT_CLOUD_STATE_SCHEMA_VERSION = 2
 _STATE_LOCK = threading.RLock()
+
+
+class CloudStateError(RuntimeError):
+    """Base error for durable cloud-state failures."""
+
+
+class CloudStateLoadError(CloudStateError):
+    """Raised when an existing cloud-state file cannot be read or parsed safely."""
+
+
+class CloudStateVersionError(CloudStateError):
+    """Raised when an older client would overwrite state from a newer schema."""
 
 
 class ProtectionState(StrEnum):
@@ -336,20 +347,26 @@ def state_path(store_id: str, *, state_dir: Path | None = None) -> Path:
 
 
 def load_state(store_id: str, *, state_dir: Path | None = None) -> CloudState:
-    """Load one store's state; missing or corrupt files start empty."""
+    """Load one store's state, distinguishing absence from unsafe existing data."""
     path = state_path(store_id, state_dir=state_dir)
     try:
-        return CloudState.from_dict(json.loads(path.read_text(encoding="utf-8")))
-    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
         return CloudState()
+    except OSError as exc:
+        raise CloudStateLoadError(f"Could not read cloud state {path}: {exc}") from exc
+    try:
+        return CloudState.from_dict(json.loads(raw))
+    except (ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise CloudStateLoadError(f"Cloud state {path} is invalid: {exc}") from exc
 
 
 def save_state(
     store_id: str,
     state: CloudState,
     *,
+    memory_dir: Path,
     state_dir: Path | None = None,
-    memory_dir: Path | None = None,
     lock_timeout: float = 30.0,
 ) -> CloudState:
     """Atomically persist one store's state with owner-only permissions."""
@@ -357,17 +374,25 @@ def save_state(
 
     from ormah.cloud.store_lock import StoreLock
 
-    lock = (
-        StoreLock(memory_dir, timeout=lock_timeout)
-        if memory_dir is not None
-        else nullcontext()
-    )
-    with lock:
+    with StoreLock(memory_dir, timeout=lock_timeout):
+        if path.exists():
+            existing = load_state(store_id, state_dir=state_dir)
+            _ensure_writable_schema(existing)
         return _write_state(path, state)
+
+
+def _ensure_writable_schema(state: CloudState) -> None:
+    if state.schema_version > CURRENT_CLOUD_STATE_SCHEMA_VERSION:
+        raise CloudStateVersionError(
+            f"Cloud state schema {state.schema_version} is newer than this client's "
+            f"schema {CURRENT_CLOUD_STATE_SCHEMA_VERSION}; update Ormah before writing it."
+        )
 
 
 def _write_state(path: Path, state: CloudState) -> CloudState:
     """Write state after the caller has acquired any required store lock."""
+
+    _ensure_writable_schema(state)
 
     from ormah.setup import _atomic_write
 
@@ -385,8 +410,8 @@ def mutate_state(
     store_id: str,
     transform: Callable[[CloudState], CloudState],
     *,
+    memory_dir: Path,
     state_dir: Path | None = None,
-    memory_dir: Path | None = None,
     lock_timeout: float = 30.0,
 ) -> CloudState:
     """Apply one read-modify-write transformation without losing concurrent updates."""
@@ -394,12 +419,7 @@ def mutate_state(
 
     from ormah.cloud.store_lock import StoreLock
 
-    lock = (
-        StoreLock(memory_dir, timeout=lock_timeout)
-        if memory_dir is not None
-        else nullcontext()
-    )
-    with lock, _STATE_LOCK:
+    with StoreLock(memory_dir, timeout=lock_timeout), _STATE_LOCK:
         current = load_state(store_id, state_dir=state_dir)
         updated = transform(current)
         if not isinstance(updated, CloudState):
@@ -410,8 +430,8 @@ def mutate_state(
 def update_state(
     store_id: str,
     *,
+    memory_dir: Path,
     state_dir: Path | None = None,
-    memory_dir: Path | None = None,
     lock_timeout: float = 30.0,
     **changes: Any,
 ) -> CloudState:
@@ -448,7 +468,12 @@ def cloud_status_payload(
     except Exception as exc:
         store_id = None
         store_error = str(exc)
-    state = load_state(store_id, state_dir=state_dir) if store_id else CloudState()
+    state_error = None
+    try:
+        state = load_state(store_id, state_dir=state_dir) if store_id else CloudState()
+    except CloudStateError as exc:
+        state = CloudState()
+        state_error = str(exc)
 
     if entitlement is None:
         from ormah.cloud.entitlements import check_entitlement
@@ -462,6 +487,11 @@ def cloud_status_payload(
     warnings: list[str] = []
     if store_error is not None:
         warnings.append(f"Cloud store identity is invalid: {store_error}")
+    if state_error is not None:
+        warnings.append(
+            "Cloud protection state could not be read and was not overwritten: "
+            f"{state_error}"
+        )
     if settings.cloud_backup_enabled:
         if store_id is None and store_error is None:
             warnings.append("Cloud backup is enabled but this memory store is not initialized.")
@@ -480,7 +510,7 @@ def cloud_status_payload(
         "schema_version": state.schema_version,
         "enabled": settings.cloud_backup_enabled,
         "store_id": store_id,
-        "protection_state": _serialize_enum(state.protection_state),
+        "state_error": state_error,
         "interval_hours": settings.cloud_backup_interval_hours,
         "entitlement": entitlement,
         "last_upload_at": (

--- a/src/ormah/cloud/store_lock.py
+++ b/src/ormah/cloud/store_lock.py
@@ -1,0 +1,103 @@
+"""Cross-process lock for operations that act on one local memory store."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import threading
+
+from filelock import FileLock, Timeout as FileLockTimeout
+
+
+DEFAULT_STORE_LOCK_TIMEOUT = 30.0
+
+
+class StoreLockTimeout(TimeoutError):
+    """Raised when another process keeps a memory store busy past the timeout."""
+
+
+@dataclass
+class _LockEntry:
+    thread_lock: threading.RLock
+    process_lock: FileLock
+
+
+_REGISTRY_GUARD = threading.Lock()
+_LOCK_REGISTRY: dict[Path, _LockEntry] = {}
+
+
+def canonical_memory_dir(memory_dir: Path) -> Path:
+    """Return the stable local identity used for locking one memory directory."""
+    return Path(memory_dir).expanduser().resolve(strict=False)
+
+
+def store_lock_path(memory_dir: Path) -> Path:
+    """Return the lock path without consulting cloud enrollment or ``store_id``."""
+    return canonical_memory_dir(memory_dir) / ".ormah" / "store.lock"
+
+
+def _entry_for(path: Path) -> _LockEntry:
+    with _REGISTRY_GUARD:
+        entry = _LOCK_REGISTRY.get(path)
+        if entry is None:
+            entry = _LockEntry(threading.RLock(), FileLock(str(path)))
+            _LOCK_REGISTRY[path] = entry
+        return entry
+
+
+class StoreLock:
+    """A re-entrant, cross-process exclusive lock for a canonical memory path.
+
+    All callers derive the lock from the resolved memory directory. Cloud store IDs are
+    deliberately irrelevant so local-only, enrolled, and future sync operations cannot split
+    into different lock domains.
+    """
+
+    def __init__(
+        self,
+        memory_dir: Path,
+        *,
+        timeout: float = DEFAULT_STORE_LOCK_TIMEOUT,
+    ) -> None:
+        self.memory_dir = canonical_memory_dir(memory_dir)
+        self.path = store_lock_path(self.memory_dir)
+        self.timeout = timeout
+        self._entry = _entry_for(self.path)
+        self._depth = 0
+
+    def acquire(self) -> StoreLock:
+        self._entry.thread_lock.acquire()
+        process_acquired = False
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                self._entry.process_lock.acquire(timeout=self.timeout)
+                process_acquired = True
+            except FileLockTimeout as exc:
+                raise StoreLockTimeout(
+                    f"Memory store is busy; timed out waiting for {self.path}."
+                ) from exc
+            os.chmod(self.path, 0o600)
+        except BaseException:
+            if process_acquired:
+                self._entry.process_lock.release()
+            self._entry.thread_lock.release()
+            raise
+        self._depth += 1
+        return self
+
+    def release(self) -> None:
+        if self._depth == 0:
+            raise RuntimeError("StoreLock is not held")
+        self._depth -= 1
+        try:
+            self._entry.process_lock.release()
+        finally:
+            self._entry.thread_lock.release()
+
+    def __enter__(self) -> StoreLock:
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.release()

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -199,7 +199,11 @@ def test_cloud_backup_fresh_upload_short_circuits_bundle(
     from ormah.cloud import jobs
 
     settings, store_id = _settings(tmp_path)
-    save_state(store_id, CloudState(last_upload_at=NOW - timedelta(hours=23)))
+    save_state(
+        store_id,
+        CloudState(last_upload_at=NOW - timedelta(hours=23)),
+        memory_dir=settings.memory_dir,
+    )
     client = FakeCloudClient()
     _patch_upload_prerequisites(monkeypatch, client)
     monkeypatch.setattr(

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -7,9 +7,13 @@ import stat
 from types import SimpleNamespace
 import uuid
 
+import pytest
+
 from ormah.cloud.state import (
     CURRENT_CLOUD_STATE_SCHEMA_VERSION,
     CloudState,
+    CloudStateLoadError,
+    CloudStateVersionError,
     ProtectionIntentStatus,
     ProtectionOperationKind,
     ProtectionOperationPhase,
@@ -44,7 +48,7 @@ def test_state_round_trip_is_atomic_and_owner_only(tmp_path):
         last_error_code=ProtectionReasonCode.VERIFICATION_FAILED,
     )
 
-    save_state(store_id, state, state_dir=tmp_path)
+    save_state(store_id, state, memory_dir=tmp_path / "memory", state_dir=tmp_path)
 
     path = state_path(store_id, state_dir=tmp_path)
     assert load_state(store_id, state_dir=tmp_path) == state
@@ -57,11 +61,13 @@ def test_update_preserves_unmodified_fields(tmp_path):
     save_state(
         store_id,
         CloudState(last_upload_snapshot_id="old", last_verify_ok=True),
+        memory_dir=tmp_path / "memory",
         state_dir=tmp_path,
     )
 
     updated = update_state(
         store_id,
+        memory_dir=tmp_path / "memory",
         state_dir=tmp_path,
         last_upload_error="offline",
     )
@@ -79,7 +85,12 @@ def test_update_preserves_future_state_fields(tmp_path):
         encoding="utf-8",
     )
 
-    update_state(store_id, state_dir=tmp_path, last_upload_error="retrying")
+    update_state(
+        store_id,
+        memory_dir=tmp_path / "memory",
+        state_dir=tmp_path,
+        last_upload_error="retrying",
+    )
 
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["last_synced_snapshot_id"] == "future-e06"
@@ -113,7 +124,7 @@ def test_legacy_state_migrates_success_fields_and_protection_state(tmp_path):
     assert state.last_verified_snapshot_id == "01VERIFIED"
 
 
-def test_unknown_future_state_values_survive_an_older_writer(tmp_path):
+def test_newer_schema_is_readable_but_an_older_writer_refuses_to_overwrite_it(tmp_path):
     store_id = str(uuid.uuid4())
     path = state_path(store_id, state_dir=tmp_path)
     path.write_text(
@@ -128,32 +139,103 @@ def test_unknown_future_state_values_survive_an_older_writer(tmp_path):
         encoding="utf-8",
     )
 
-    update_state(store_id, state_dir=tmp_path, last_upload_error="offline")
+    before = path.read_bytes()
+    state = load_state(store_id, state_dir=tmp_path)
 
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    assert payload["schema_version"] == 99
-    assert payload["protection_state"] == "future_safe_state"
-    assert payload["last_operation_kind"] == "future_operation"
-    assert payload["future_c03_field"] == {"head": "01HEAD"}
+    assert state.schema_version == 99
+    assert state.protection_state == "future_safe_state"
+    assert state.last_operation_kind == "future_operation"
+    assert state.extra["future_c03_field"] == {"head": "01HEAD"}
+    with pytest.raises(CloudStateVersionError, match="newer than this client's schema"):
+        update_state(
+            store_id,
+            memory_dir=tmp_path / "memory",
+            state_dir=tmp_path,
+            last_upload_error="offline",
+        )
+    with pytest.raises(CloudStateVersionError, match="newer than this client's schema"):
+        save_state(
+            store_id,
+            CloudState(last_upload_error="offline"),
+            memory_dir=tmp_path / "memory",
+            state_dir=tmp_path,
+        )
+
+    assert path.read_bytes() == before
 
 
 def test_two_stores_never_share_state(tmp_path):
     first = str(uuid.uuid4())
     second = str(uuid.uuid4())
 
-    update_state(first, state_dir=tmp_path, last_upload_snapshot_id="first")
-    update_state(second, state_dir=tmp_path, last_upload_snapshot_id="second")
+    update_state(
+        first,
+        memory_dir=tmp_path / "first-memory",
+        state_dir=tmp_path,
+        last_upload_snapshot_id="first",
+    )
+    update_state(
+        second,
+        memory_dir=tmp_path / "second-memory",
+        state_dir=tmp_path,
+        last_upload_snapshot_id="second",
+    )
 
     assert load_state(first, state_dir=tmp_path).last_upload_snapshot_id == "first"
     assert load_state(second, state_dir=tmp_path).last_upload_snapshot_id == "second"
     assert state_path(first, state_dir=tmp_path) != state_path(second, state_dir=tmp_path)
 
 
-def test_missing_or_malformed_state_loads_empty(tmp_path):
+def test_missing_state_loads_empty_but_malformed_state_fails_closed(tmp_path):
     store_id = str(uuid.uuid4())
     assert load_state(store_id, state_dir=tmp_path) == CloudState()
-    state_path(store_id, state_dir=tmp_path).write_text("{not-json", encoding="utf-8")
-    assert load_state(store_id, state_dir=tmp_path) == CloudState()
+    path = state_path(store_id, state_dir=tmp_path)
+    path.write_text("{not-json", encoding="utf-8")
+    before = path.read_bytes()
+
+    with pytest.raises(CloudStateLoadError, match="is invalid"):
+        load_state(store_id, state_dir=tmp_path)
+    with pytest.raises(CloudStateLoadError, match="is invalid"):
+        update_state(
+            store_id,
+            memory_dir=tmp_path / "memory",
+            state_dir=tmp_path,
+            last_upload_error="must not replace corrupt state",
+        )
+    with pytest.raises(CloudStateLoadError, match="is invalid"):
+        save_state(
+            store_id,
+            CloudState(last_upload_error="must not replace corrupt state"),
+            memory_dir=tmp_path / "memory",
+            state_dir=tmp_path,
+        )
+
+    assert path.read_bytes() == before
+
+
+def test_one_invalid_field_cannot_erase_durable_protection_state(tmp_path):
+    store_id = str(uuid.uuid4())
+    path = state_path(store_id, state_dir=tmp_path)
+    payload = {
+        "schema_version": 2,
+        "last_upload_at": 1_753_000_000,
+        "protection_enabled_at": "2026-07-13T12:00:00+00:00",
+        "protection_state": "protected",
+        "pending_protection_intent_id": str(uuid.uuid4()),
+        "future_c03_field": {"head": "01HEAD"},
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    before = path.read_bytes()
+
+    with pytest.raises(CloudStateLoadError, match="timestamps must be ISO-8601"):
+        update_state(
+            store_id,
+            memory_dir=tmp_path / "memory",
+            state_dir=tmp_path,
+            last_verify_error="routine writer",
+        )
+
+    assert path.read_bytes() == before
 
 
 def test_state_path_rejects_path_traversal(tmp_path):
@@ -180,6 +262,7 @@ def test_cloud_status_derives_stale_and_verification_warnings(tmp_path):
             last_verify_ok=False,
             last_verify_error="bundle truncated",
         ),
+        memory_dir=memory_dir,
         state_dir=tmp_path / "state",
     )
     settings = Settings(
@@ -198,13 +281,42 @@ def test_cloud_status_derives_stale_and_verification_warnings(tmp_path):
     assert payload["store_id"] == store_id
     assert payload["last_upload_age_seconds"] == 49 * 3600
     assert payload["entitlement"] == "expired"
+    assert "protection_state" not in payload
+    assert payload["state_error"] is None
     assert any("stale" in warning for warning in payload["warnings"])
     assert any("bundle truncated" in warning for warning in payload["warnings"])
 
 
+def test_cloud_status_reports_corrupt_state_without_claiming_protection(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    path = state_path(store_id, state_dir=tmp_path / "state")
+    path.parent.mkdir(parents=True)
+    path.write_text('{"protection_state":"protected","last_verify_ok":"yes"}', encoding="utf-8")
+    settings = Settings(memory_dir=memory_dir, cloud_backup_enabled=True)
+
+    payload = cloud_status_payload(
+        settings,
+        entitlement="active",
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["state_error"] is not None
+    assert "protection_state" not in payload
+    assert any("was not overwritten" in warning for warning in payload["warnings"])
+    assert json.loads(path.read_text(encoding="utf-8"))["protection_state"] == "protected"
+
+
 def test_cloud_state_json_contains_only_plain_metadata(tmp_path):
     store_id = str(uuid.uuid4())
-    save_state(store_id, CloudState(last_upload_snapshot_id="01SAFE"), state_dir=tmp_path)
+    save_state(
+        store_id,
+        CloudState(last_upload_snapshot_id="01SAFE"),
+        memory_dir=tmp_path / "memory",
+        state_dir=tmp_path,
+    )
 
     payload = json.loads(state_path(store_id, state_dir=tmp_path).read_text(encoding="utf-8"))
 

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -8,7 +8,13 @@ from types import SimpleNamespace
 import uuid
 
 from ormah.cloud.state import (
+    CURRENT_CLOUD_STATE_SCHEMA_VERSION,
     CloudState,
+    ProtectionIntentStatus,
+    ProtectionOperationKind,
+    ProtectionOperationPhase,
+    ProtectionReasonCode,
+    ProtectionState,
     cloud_status_payload,
     load_state,
     save_state,
@@ -28,6 +34,14 @@ def test_state_round_trip_is_atomic_and_owner_only(tmp_path):
         last_verify_ok=False,
         last_verify_snapshot_id="01VERIFY",
         last_verify_error="hash mismatch",
+        protection_enabled_at=now,
+        protection_state=ProtectionState.ATTENTION_REQUIRED,
+        pending_protection_intent_id="intent-1",
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+        last_operation_id="operation-1",
+        last_operation_kind=ProtectionOperationKind.VERIFY,
+        last_operation_phase=ProtectionOperationPhase.FAILED,
+        last_error_code=ProtectionReasonCode.VERIFICATION_FAILED,
     )
 
     save_state(store_id, state, state_dir=tmp_path)
@@ -70,6 +84,57 @@ def test_update_preserves_future_state_fields(tmp_path):
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["last_synced_snapshot_id"] == "future-e06"
     assert payload["last_upload_error"] == "retrying"
+
+
+def test_legacy_state_migrates_success_fields_and_protection_state(tmp_path):
+    store_id = str(uuid.uuid4())
+    now = "2026-07-13T12:00:00+00:00"
+    path = state_path(store_id, state_dir=tmp_path)
+    path.write_text(
+        json.dumps(
+            {
+                "last_upload_at": now,
+                "last_upload_snapshot_id": "01VERIFIED",
+                "last_verify_at": now,
+                "last_verify_ok": True,
+                "last_verify_snapshot_id": "01VERIFIED",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = load_state(store_id, state_dir=tmp_path)
+
+    assert state.schema_version == CURRENT_CLOUD_STATE_SCHEMA_VERSION
+    assert state.protection_state is ProtectionState.PROTECTED
+    assert state.last_successful_upload_at == state.last_upload_at
+    assert state.last_successful_backup_snapshot_id == "01VERIFIED"
+    assert state.last_successful_verify_at == state.last_verify_at
+    assert state.last_verified_snapshot_id == "01VERIFIED"
+
+
+def test_unknown_future_state_values_survive_an_older_writer(tmp_path):
+    store_id = str(uuid.uuid4())
+    path = state_path(store_id, state_dir=tmp_path)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 99,
+                "protection_state": "future_safe_state",
+                "last_operation_kind": "future_operation",
+                "future_c03_field": {"head": "01HEAD"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    update_state(store_id, state_dir=tmp_path, last_upload_error="offline")
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 99
+    assert payload["protection_state"] == "future_safe_state"
+    assert payload["last_operation_kind"] == "future_operation"
+    assert payload["future_c03_field"] == {"head": "01HEAD"}
 
 
 def test_two_stores_never_share_state(tmp_path):
@@ -144,15 +209,10 @@ def test_cloud_state_json_contains_only_plain_metadata(tmp_path):
     payload = json.loads(state_path(store_id, state_dir=tmp_path).read_text(encoding="utf-8"))
 
     assert payload["last_upload_snapshot_id"] == "01SAFE"
-    assert set(payload) == {
-        "last_upload_at",
-        "last_upload_snapshot_id",
-        "last_upload_error",
-        "last_verify_at",
-        "last_verify_ok",
-        "last_verify_snapshot_id",
-        "last_verify_error",
-    }
+    assert set(payload) == set(CloudState().to_dict())
+    serialized = json.dumps(payload).lower()
+    for forbidden in ("account_token", "presigned", "age-secret-key", "recovery_phrase"):
+        assert forbidden not in serialized
 
 
 def test_admin_cloud_status_is_thin_wrapper(monkeypatch):

--- a/tests/test_cloud_store_lock.py
+++ b/tests/test_cloud_store_lock.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from multiprocessing import get_context
+import os
+from pathlib import Path
+import stat
+import time
+import uuid
+
+import pytest
+
+from ormah.cloud import store_lock
+from ormah.cloud.state import CloudState, load_state, mutate_state, update_state
+from ormah.cloud.store_lock import StoreLock, StoreLockTimeout, store_lock_path
+
+
+def _hold_store_lock(memory_dir: str, acquired, release) -> None:
+    with StoreLock(Path(memory_dir), timeout=5):
+        acquired.set()
+        if not release.wait(5):
+            raise RuntimeError("test did not release store lock")
+
+
+def _slow_upload_update(
+    store_id: str,
+    state_dir: str,
+    memory_dir: str,
+    entered,
+    release,
+) -> None:
+    def transform(state: CloudState) -> CloudState:
+        entered.set()
+        if not release.wait(5):
+            raise RuntimeError("test did not release state transform")
+        return replace(state, last_upload_snapshot_id="01UPLOAD")
+
+    mutate_state(
+        store_id,
+        transform,
+        state_dir=Path(state_dir),
+        memory_dir=Path(memory_dir),
+        lock_timeout=5,
+    )
+
+
+def _verify_update(store_id: str, state_dir: str, memory_dir: str) -> None:
+    update_state(
+        store_id,
+        state_dir=Path(state_dir),
+        memory_dir=Path(memory_dir),
+        lock_timeout=5,
+        last_verify_error="verification pending",
+    )
+
+
+def test_lock_identity_uses_canonical_memory_path_and_not_store_id(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    alias = tmp_path / "memory-alias"
+    alias.symlink_to(memory_dir, target_is_directory=True)
+
+    before_enrollment = store_lock_path(memory_dir)
+    (memory_dir / ".store_id").write_text(str(uuid.uuid4()) + "\n", encoding="utf-8")
+
+    assert store_lock_path(memory_dir) == before_enrollment
+    assert store_lock_path(alias) == before_enrollment
+    assert before_enrollment == memory_dir.resolve() / ".ormah" / "store.lock"
+
+
+def test_store_lock_is_owner_only_and_blocks_another_process(tmp_path):
+    memory_dir = tmp_path / "memory"
+    context = get_context("spawn")
+    acquired = context.Event()
+    release = context.Event()
+    holder = context.Process(
+        target=_hold_store_lock,
+        args=(str(memory_dir), acquired, release),
+    )
+    holder.start()
+    try:
+        assert acquired.wait(5)
+        assert stat.S_IMODE(store_lock_path(memory_dir).stat().st_mode) == 0o600
+        with pytest.raises(StoreLockTimeout, match="Memory store is busy"):
+            with StoreLock(memory_dir, timeout=0.1):
+                pass
+    finally:
+        release.set()
+        holder.join(5)
+
+    assert holder.exitcode == 0
+
+
+def test_two_process_state_updates_preserve_both_writers(tmp_path):
+    memory_dir = tmp_path / "memory"
+    state_dir = tmp_path / "state"
+    store_id = str(uuid.uuid4())
+    context = get_context("spawn")
+    entered = context.Event()
+    release = context.Event()
+    first = context.Process(
+        target=_slow_upload_update,
+        args=(store_id, str(state_dir), str(memory_dir), entered, release),
+    )
+    second = context.Process(
+        target=_verify_update,
+        args=(store_id, str(state_dir), str(memory_dir)),
+    )
+
+    first.start()
+    try:
+        assert entered.wait(5)
+        second.start()
+        time.sleep(0.2)
+        assert second.is_alive(), "second writer did not wait for the store lock"
+    finally:
+        release.set()
+        first.join(5)
+        if second.pid is not None:
+            second.join(5)
+
+    assert first.exitcode == 0
+    assert second.exitcode == 0
+    state = load_state(store_id, state_dir=state_dir)
+    assert state.last_upload_snapshot_id == "01UPLOAD"
+    assert state.last_verify_error == "verification pending"
+
+
+def test_store_lock_is_reentrant_in_one_thread(tmp_path):
+    memory_dir = tmp_path / "memory"
+    first = StoreLock(memory_dir)
+    second = StoreLock(memory_dir)
+
+    with first, second:
+        assert os.path.samefile(first.path, second.path)
+
+
+def test_permission_failure_does_not_leave_store_locked(tmp_path, monkeypatch):
+    memory_dir = tmp_path / "memory"
+    real_chmod = store_lock.os.chmod
+
+    def fail_chmod(path, mode):
+        raise PermissionError("read-only lock directory")
+
+    monkeypatch.setattr(store_lock.os, "chmod", fail_chmod)
+    with pytest.raises(PermissionError, match="read-only"):
+        with StoreLock(memory_dir, timeout=0.1):
+            pass
+
+    monkeypatch.setattr(store_lock.os, "chmod", real_chmod)
+    with StoreLock(memory_dir, timeout=0.1):
+        pass


### PR DESCRIPTION
## Problem

C02 needs one durable protection state contract shared by the scheduler, CLI, local API, and desktop app. The E05 state file preserves unknown JSON fields, but its read-modify-write lock is process-local, so concurrent desktop and CLI writers can silently lose each other's updates.

## Solution

- add schema-v2 cloud protection state, typed user states, operation phases, intent phases, and stable reason codes
- migrate legacy E05 upload/verification success into the new fields without dropping old or unknown fields
- add a canonical cross-process `StoreLock` rooted at `<resolved-memory-dir>/.ormah/store.lock`
- keep lock identity independent of `.store_id`, so local-only, cloud-enrolled, and future sync operations share one lock domain
- add an atomic `mutate_state()` primitive and move existing cloud-job state writes onto it
- retain successful upload/verification history alongside the existing E05 compatibility fields

`filelock` is used instead of maintaining separate Unix and Windows lock implementations.

## Verification

- `1523 passed` across the full suite, with the five TestClient files run separately outside the restricted AnyIO sandbox
- `ruff check src/ tests/` clean
- deterministic spawned-process tests cover exclusion and lost-update preservation
- migration tests cover legacy state, future schema versions, and unknown enum/field preservation

## Scope

This is the first C02 foundation slice. It does not enable protection, move backup orchestration, create Stripe Checkout sessions, or add desktop UI. Those follow as separate reviewed slices.
