### PR TITLE
refactor(cloud): centralize protection operations

### DIFF
--- a/docs/15 - Cloud Backup, Verification, and Restore.md
+++ b/docs/15 - Cloud Backup, Verification, and Restore.md
@@ -521,9 +521,9 @@ cross-machine truth. `CloudProtectionService.backup_now()` calls `finalize_uploa
 `advance_head`, and the scheduler's `run_cloud_backup()` is now only a guarded adapter over that
 shared service.
 
-`CloudProtectionService` is also the reusable Python owner of backup status, immediate backup, and
-restore verification. CLI, local REST, scheduler, and the desktop app can therefore use the same
-state transitions and failure recording instead of duplicating the cloud workflow. Direct
+`CloudProtectionService` is the reusable Python owner of immediate backup and restore verification;
+`cloud_status_payload()` is the single status derivation used by CLI, local REST, and UI consumers.
+These entry points keep state transitions and failure recording out of presentation adapters. Direct
 `backup_now()` means run now; only the scheduler passes `only_if_due=true`. Manual verification is
 still permitted after protection is stopped because retained downloads are never entitlement- or
 scheduler-gated. A successful verification marks the store protected only when it verifies the

--- a/docs/15 - Cloud Backup, Verification, and Restore.md
+++ b/docs/15 - Cloud Backup, Verification, and Restore.md
@@ -517,8 +517,17 @@ pairing improves the new-machine experience without giving the service the plain
 | Sync | Converge changes between machines | Eventually, after merge/publication | Yes, using CAS |
 
 This separation is intentional. A scheduled backup must never silently publish itself as the latest
-cross-machine truth. In code, `run_cloud_backup()` calls `finalize_upload()` without
-`advance_head`.
+cross-machine truth. `CloudProtectionService.backup_now()` calls `finalize_upload()` without
+`advance_head`, and the scheduler's `run_cloud_backup()` is now only a guarded adapter over that
+shared service.
+
+`CloudProtectionService` is also the reusable Python owner of backup status, immediate backup, and
+restore verification. CLI, local REST, scheduler, and the desktop app can therefore use the same
+state transitions and failure recording instead of duplicating the cloud workflow. Direct
+`backup_now()` means run now; only the scheduler passes `only_if_due=true`. Manual verification is
+still permitted after protection is stopped because retained downloads are never entitlement- or
+scheduler-gated. A successful verification marks the store protected only when it verifies the
+latest successful backup, never merely because an older recovery point was restorable.
 
 ## Current experience versus the planned product experience
 

--- a/src/ormah/cloud/jobs.py
+++ b/src/ormah/cloud/jobs.py
@@ -16,7 +16,7 @@ def run_cloud_backup(engine) -> str | None:
 
     try:
         result = CloudProtectionService.from_engine(engine).backup_now(
-            reason="cloud", only_if_due=True
+            reason="scheduled", only_if_due=True
         )
         if result.phase is ProtectionOperationPhase.COMPLETED:
             return result.snapshot_id

--- a/src/ormah/cloud/jobs.py
+++ b/src/ormah/cloud/jobs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from ormah.cloud.protection import CloudProtectionService
+from ormah.cloud.protection import CloudProtectionService, safe_error_message
 from ormah.cloud.state import ProtectionOperationPhase
 
 
@@ -21,7 +21,12 @@ def run_cloud_backup(engine) -> str | None:
         if result.phase is ProtectionOperationPhase.COMPLETED:
             return result.snapshot_id
     except Exception as exc:
-        logger.warning("Scheduled Ormah Cloud backup failed with %s", type(exc).__name__)
+        message = safe_error_message(exc, getattr(engine.settings, "account_token", None))
+        logger.warning(
+            "Scheduled Ormah Cloud backup failed with %s: %s",
+            type(exc).__name__,
+            message,
+        )
     return None
 
 
@@ -35,7 +40,10 @@ def run_restore_verification(engine) -> bool:
         result = CloudProtectionService.from_engine(engine).verify_now()
         return result.phase is ProtectionOperationPhase.COMPLETED
     except Exception as exc:
+        message = safe_error_message(exc, getattr(engine.settings, "account_token", None))
         logger.warning(
-            "Scheduled Ormah Cloud restore verification failed with %s", type(exc).__name__
+            "Scheduled Ormah Cloud restore verification failed with %s: %s",
+            type(exc).__name__,
+            message,
         )
         return False

--- a/src/ormah/cloud/jobs.py
+++ b/src/ormah/cloud/jobs.py
@@ -1,344 +1,41 @@
-"""Scheduled encrypted cloud backup and restore-verification jobs."""
+"""Guarded scheduler adapters for shared cloud protection operations."""
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import logging
-from pathlib import Path
-import re
-import shutil
-import tempfile
 
-from ormah.backup import (
-    BackupError,
-    BackupInfo,
-    resolve_backup_user_node_id,
-    resolve_current_user_node_id,
-    service_from_settings,
-)
-from ormah.cloud.bundle import open_bundle, build_bundle
-from ormah.cloud.client import CloudError, client_from_settings
-from ormah.cloud.entitlements import EntitlementStatus, check_entitlement
-from ormah.cloud.keys import (
-    STORE_ID_NAME,
-    current_recipient,
-    get_or_create_store_id,
-    key_file_exists,
-    load_identities,
-)
-from ormah.cloud.state import load_state, update_state
-from ormah.cloud.transfer import download_file, put_file, sha256_file
-from ormah.index.builder import IndexBuilder
-from ormah.index.db import Database
-from ormah.index.graph import GraphIndex
-from ormah.store.file_store import FileStore
-from ormah.store.markdown import parse_node
+from ormah.cloud.protection import CloudProtectionService
+from ormah.cloud.state import ProtectionOperationPhase
 
 
 logger = logging.getLogger(__name__)
 
 
-def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _existing_store_id(memory_dir: Path) -> str | None:
-    memory_dir = Path(memory_dir).expanduser()
-    if not (memory_dir / STORE_ID_NAME).is_file():
-        return None
-    return get_or_create_store_id(memory_dir)
-
-
-def _safe_update(store_id: str | None, *, memory_dir: Path, **changes) -> None:
-    if store_id is None:
-        return
-    try:
-        update_state(store_id, memory_dir=memory_dir, **changes)
-    except Exception as exc:
-        logger.warning("Could not persist Ormah Cloud state: %s", exc)
-
-
-def _record_upload_error(store_id: str | None, message: str, *, memory_dir: Path) -> None:
-    logger.warning("Ormah Cloud backup skipped or failed: %s", message)
-    _safe_update(store_id, memory_dir=memory_dir, last_upload_error=message)
-
-
-def _snapshot_files(root: Path) -> dict[str, Path]:
-    files: dict[str, Path] = {}
-    for dirname in ("nodes", "deleted"):
-        source = Path(root) / dirname
-        if not source.is_dir():
-            continue
-        for path in source.glob("*.md"):
-            if path.is_file():
-                files[f"{dirname}/{path.name}"] = path
-    return files
-
-
-def _backup_matches_memory(backup: BackupInfo, memory_dir: Path) -> bool:
-    try:
-        if resolve_backup_user_node_id(backup.path) != resolve_current_user_node_id(memory_dir):
-            return False
-    except BackupError:
-        return False
-
-    source_files = _snapshot_files(memory_dir)
-    backup_files = _snapshot_files(backup.path)
-    if source_files.keys() != backup_files.keys():
-        return False
-    return all(
-        source_files[name].stat().st_size == backup_files[name].stat().st_size
-        and sha256_file(source_files[name]) == sha256_file(backup_files[name])
-        for name in source_files
-    )
-
-
-def _backup_for_upload(service) -> BackupInfo:
-    latest = service.latest()
-    if latest is not None and _backup_matches_memory(latest, service.memory_dir):
-        return latest
-    return service.create(reason="cloud")
-
-
-def _upload_due(store_id: str, interval_hours: int, now: datetime) -> bool:
-    last_upload = load_state(store_id).last_upload_at
-    if last_upload is None:
-        return True
-    return now - last_upload >= timedelta(hours=interval_hours)
-
-
 def run_cloud_backup(engine) -> str | None:
-    """Upload one due encrypted backup; log and persist failures without raising."""
-    settings = engine.settings
-    store_id: str | None = None
-    client = None
+    """Run one scheduled backup, swallowing every exception at the scheduler boundary."""
+
     try:
-        if not settings.cloud_backup_enabled:
-            logger.debug("Ormah Cloud backup is disabled")
-            return None
-
-        if not key_file_exists():
-            store_id = _existing_store_id(settings.memory_dir)
-            _record_upload_error(
-                store_id,
-                "Cloud encryption key is missing; run `ormah cloud init`.",
-                memory_dir=settings.memory_dir,
-            )
-            return None
-
-        store_id = _existing_store_id(settings.memory_dir)
-        if store_id is None:
-            _record_upload_error(
-                None,
-                "Cloud store id is missing; run `ormah cloud init`.",
-                memory_dir=settings.memory_dir,
-            )
-            return None
-
-        entitlement = check_entitlement(settings)
-        if entitlement not in {EntitlementStatus.ACTIVE, EntitlementStatus.GRACE}:
-            _record_upload_error(
-                store_id,
-                f"Cloud backup paused because entitlement is {entitlement.value}.",
-                memory_dir=settings.memory_dir,
-            )
-            return None
-
-        service = service_from_settings(settings)
-        if not service.has_backupable_memory():
-            logger.debug("Skipping Ormah Cloud backup; no memory nodes exist yet")
-            return None
-
-        now = _utc_now()
-        if not _upload_due(store_id, settings.cloud_backup_interval_hours, now):
-            logger.debug("Skipping Ormah Cloud backup; latest upload is still fresh")
-            return None
-
-        backup = _backup_for_upload(service)
-        with tempfile.TemporaryDirectory(prefix="ormah-cloud-upload-") as tmp:
-            bundle = Path(tmp) / f"{backup.name}.age"
-            build_bundle(
-                backup.path,
-                bundle,
-                [current_recipient()],
-                store_id=store_id,
-                reason="cloud-backup",
-            )
-            size = bundle.stat().st_size
-            digest = sha256_file(bundle)
-            client = client_from_settings(settings)
-            upload = client.create_upload(store_id, size, digest)
-            upload_id = upload.get("upload_id")
-            snapshot_id = upload.get("snapshot_id")
-            put_url = upload.get("put_url")
-            expires_at = upload.get("expires_at")
-            required_headers = upload.get("required_headers", {})
-            if not all(isinstance(value, str) and value for value in (upload_id, snapshot_id, put_url)):
-                raise RuntimeError("Cloud upload reservation response was malformed.")
-            if not isinstance(expires_at, str):
-                raise RuntimeError("Cloud upload reservation did not include an expiry.")
-            parsed_expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
-            if parsed_expiry.tzinfo is None or parsed_expiry <= _utc_now():
-                raise RuntimeError("Cloud upload reservation is already expired.")
-            if not isinstance(required_headers, dict) or not all(
-                isinstance(name, str) and isinstance(value, str)
-                for name, value in required_headers.items()
-            ):
-                raise RuntimeError("Cloud upload reservation headers were malformed.")
-
-            put_file(put_url, bundle, required_headers)
-            finalized = client.finalize_upload(store_id, upload_id)
-            finalized_snapshot = finalized.get("snapshot_id")
-            if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
-                raise RuntimeError("Cloud upload finalize response was malformed.")
-
-        uploaded_at = _utc_now()
-        _safe_update(
-            store_id,
-            memory_dir=settings.memory_dir,
-            last_upload_at=uploaded_at,
-            last_upload_snapshot_id=snapshot_id,
-            last_upload_error=None,
-            last_successful_upload_at=uploaded_at,
-            last_successful_backup_snapshot_id=snapshot_id,
+        result = CloudProtectionService.from_engine(engine).backup_now(
+            reason="cloud", only_if_due=True
         )
-        logger.info("Uploaded encrypted Ormah Cloud snapshot %s", snapshot_id)
-        return snapshot_id
+        if result.phase is ProtectionOperationPhase.COMPLETED:
+            return result.snapshot_id
     except Exception as exc:
-        _record_upload_error(store_id, str(exc), memory_dir=settings.memory_dir)
-        return None
-    finally:
-        close = getattr(client, "close", None) if client is not None else None
-        if close is not None:
-            try:
-                close()
-            except Exception:
-                pass
-
-
-def _probe_search(database: Database, nodes: list) -> None:
-    if not nodes:
-        raise RuntimeError("Restored snapshot has no active node available for a search probe.")
-    graph = GraphIndex(database)
-    for node in nodes:
-        words = re.findall(r"\w{2,}", f"{node.title or ''} {node.content}")
-        for word in sorted(words, key=len, reverse=True):
-            if any(result["id"] == node.id for result in graph.fts_search(word, limit=10)):
-                return
-    raise RuntimeError("Scratch search probe did not return a known restored node.")
-
-
-def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> int:
-    if info.store_id != expected_store_id:
-        raise RuntimeError(
-            f"Bundle store id {info.store_id!r} does not match local store {expected_store_id!r}."
-        )
-
-    resolve_backup_user_node_id(extracted)
-
-    active_nodes = []
-    for dirname in ("nodes", "deleted"):
-        for path in sorted((extracted / dirname).glob("*.md")):
-            node = parse_node(path.read_text(encoding="utf-8"))
-            if dirname == "nodes":
-                active_nodes.append(node)
-
-    database = Database(extracted / "scratch-index" / "index.db")
-    try:
-        database.init_schema()
-        rebuilt = IndexBuilder(database, FileStore(extracted / "nodes")).full_rebuild()
-        if rebuilt != info.node_count:
-            raise RuntimeError(
-                f"Scratch index rebuilt {rebuilt} nodes; bundle manifest declares {info.node_count}."
-            )
-        _probe_search(database, active_nodes)
-        return rebuilt
-    finally:
-        database.close()
+        logger.warning("Scheduled Ormah Cloud backup failed with %s", type(exc).__name__)
+    return None
 
 
 def run_restore_verification(engine) -> bool:
-    """Prove the latest committed snapshot decrypts, rebuilds, and searches."""
-    settings = engine.settings
-    store_id: str | None = None
-    snapshot_id: str | None = None
-    client = None
-    tmp_root: Path | None = None
+    """Run weekly verification, swallowing every exception at the scheduler boundary."""
+
     try:
-        if not settings.cloud_backup_enabled:
+        if not engine.settings.cloud_backup_enabled:
             logger.debug("Ormah Cloud restore verification is disabled")
             return False
-        if not key_file_exists():
-            raise RuntimeError("Cloud encryption key is missing; cannot verify restore.")
-        store_id = _existing_store_id(settings.memory_dir)
-        if store_id is None:
-            raise RuntimeError("Cloud store id is missing; cannot verify restore.")
-        if not settings.account_token:
-            raise RuntimeError("Ormah Cloud login is required to verify restore.")
-
-        client = client_from_settings(settings)
-        listing = client.list_blobs(store_id)
-        blobs = listing.get("blobs")
-        if not isinstance(blobs, list) or not blobs:
-            raise RuntimeError("No committed cloud snapshot is available to verify.")
-        latest = blobs[0]
-        snapshot_id = latest.get("snapshot_id") if isinstance(latest, dict) else None
-        if not isinstance(snapshot_id, str) or not snapshot_id:
-            raise RuntimeError("Cloud snapshot listing was malformed.")
-        size_bytes = latest.get("size_bytes") if isinstance(latest, dict) else None
-        if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
-            raise RuntimeError("Cloud snapshot listing did not include a valid size.")
-        if size_bytes > client.processing_limit(require_hardened_write=False):
-            raise CloudError("Cloud snapshot exceeds this client's safe processing limit.")
-
-        presigned = client.presign_download(store_id, snapshot_id)
-        get_url = presigned.get("get_url")
-        if not isinstance(get_url, str) or not get_url:
-            raise RuntimeError("Cloud download response was malformed.")
-
-        tmp_root = Path(tempfile.mkdtemp(prefix="ormah-restore-verify-"))
-        bundle = tmp_root / f"{snapshot_id}.age"
-        extracted = tmp_root / "snapshot"
-        download_file(get_url, bundle)
-        info = open_bundle(bundle, extracted, load_identities())
-        _verify_extracted_bundle(extracted, store_id, info)
-
-        verified_at = _utc_now()
-        _safe_update(
-            store_id,
-            memory_dir=settings.memory_dir,
-            last_verify_at=verified_at,
-            last_verify_ok=True,
-            last_verify_snapshot_id=snapshot_id,
-            last_verify_error=None,
-            last_successful_verify_at=verified_at,
-            last_verified_snapshot_id=snapshot_id,
-        )
-        logger.info("Verified Ormah Cloud snapshot %s is restorable", snapshot_id)
-        return True
+        result = CloudProtectionService.from_engine(engine).verify_now()
+        return result.phase is ProtectionOperationPhase.COMPLETED
     except Exception as exc:
-        message = str(exc)
-        logger.warning("Ormah Cloud restore verification failed: %s", message)
-        if store_id is None:
-            try:
-                store_id = _existing_store_id(settings.memory_dir)
-            except Exception:
-                store_id = None
-        _safe_update(
-            store_id,
-            memory_dir=settings.memory_dir,
-            last_verify_at=_utc_now(),
-            last_verify_ok=False,
-            last_verify_snapshot_id=snapshot_id,
-            last_verify_error=message,
+        logger.warning(
+            "Scheduled Ormah Cloud restore verification failed with %s", type(exc).__name__
         )
         return False
-    finally:
-        close = getattr(client, "close", None) if client is not None else None
-        if close is not None:
-            try:
-                close()
-            except Exception:
-                pass
-        if tmp_root is not None:
-            shutil.rmtree(tmp_root, ignore_errors=True)

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -1,0 +1,701 @@
+"""Shared encrypted cloud-backup and restore-verification orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import logging
+from pathlib import Path
+import re
+import shutil
+import tempfile
+from typing import Any
+import uuid
+
+from ormah.backup import (
+    BackupError,
+    BackupInfo,
+    resolve_backup_user_node_id,
+    resolve_current_user_node_id,
+    service_from_settings,
+)
+from ormah.cloud.bundle import BundleError, build_bundle, open_bundle
+from ormah.cloud.client import CloudError, client_from_settings
+from ormah.cloud.entitlements import EntitlementStatus, check_entitlement
+from ormah.cloud.keys import (
+    STORE_ID_NAME,
+    current_recipient,
+    get_or_create_store_id,
+    key_file_exists,
+    load_identities,
+)
+from ormah.cloud.state import (
+    CURRENT_CLOUD_STATE_SCHEMA_VERSION,
+    CloudState,
+    CloudStateVersionError,
+    ProtectionOperation,
+    ProtectionOperationKind,
+    ProtectionOperationPhase,
+    ProtectionReasonCode,
+    ProtectionState,
+    load_state,
+    update_state,
+)
+from ormah.cloud.store_lock import StoreLock
+from ormah.cloud.transfer import download_file, put_file, sha256_file
+from ormah.index.builder import IndexBuilder
+from ormah.index.db import Database
+from ormah.index.graph import GraphIndex
+from ormah.store.file_store import FileStore
+from ormah.store.markdown import parse_node
+
+
+logger = logging.getLogger(__name__)
+
+_URL_RE = re.compile(r"https?://[^\s]+", re.IGNORECASE)
+_BEARER_RE = re.compile(r"\bBearer\s+[^\s]+", re.IGNORECASE)
+_AGE_SECRET_RE = re.compile(r"AGE-SECRET-KEY-[A-Z0-9]+", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class CloudProtectionStatus:
+    """Typed, credential-free cloud protection health for one memory store."""
+
+    enabled: bool
+    store_id: str | None
+    protection_state: ProtectionState
+    entitlement: EntitlementStatus
+    state_error: str | None = None
+    last_upload_at: datetime | None = None
+    last_upload_snapshot_id: str | None = None
+    last_upload_error: str | None = None
+    last_verify_at: datetime | None = None
+    last_verify_ok: bool | None = None
+    last_verify_snapshot_id: str | None = None
+    last_verify_error: str | None = None
+    warnings: tuple[str, ...] = ()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _safe_message(value: object, *sensitive_values: str | None) -> str:
+    """Return a useful error without returning or logging credential-bearing material."""
+
+    message = str(value)
+    message = _URL_RE.sub("<redacted-url>", message)
+    message = _BEARER_RE.sub("Bearer <redacted>", message)
+    message = _AGE_SECRET_RE.sub("<redacted-age-key>", message)
+    for sensitive in sensitive_values:
+        if sensitive:
+            message = message.replace(sensitive, "<redacted>")
+    return message[:1000]
+
+
+def _existing_store_id(memory_dir: Path) -> str | None:
+    memory_dir = Path(memory_dir).expanduser()
+    if not (memory_dir / STORE_ID_NAME).is_file():
+        return None
+    return get_or_create_store_id(memory_dir)
+
+
+def _load_writable_state(store_id: str) -> CloudState:
+    state = load_state(store_id)
+    if state.schema_version > CURRENT_CLOUD_STATE_SCHEMA_VERSION:
+        raise CloudStateVersionError(
+            f"Cloud state schema {state.schema_version} is newer than this client's schema "
+            f"{CURRENT_CLOUD_STATE_SCHEMA_VERSION}; update Ormah before writing it."
+        )
+    return state
+
+
+def _snapshot_files(root: Path) -> dict[str, Path]:
+    files: dict[str, Path] = {}
+    for dirname in ("nodes", "deleted"):
+        source = Path(root) / dirname
+        if not source.is_dir():
+            continue
+        for path in source.glob("*.md"):
+            if path.is_file():
+                files[f"{dirname}/{path.name}"] = path
+    return files
+
+
+def _backup_matches_memory(backup: BackupInfo, memory_dir: Path) -> bool:
+    try:
+        if resolve_backup_user_node_id(backup.path) != resolve_current_user_node_id(memory_dir):
+            return False
+    except BackupError:
+        return False
+
+    source_files = _snapshot_files(memory_dir)
+    backup_files = _snapshot_files(backup.path)
+    if source_files.keys() != backup_files.keys():
+        return False
+    return all(
+        source_files[name].stat().st_size == backup_files[name].stat().st_size
+        and sha256_file(source_files[name]) == sha256_file(backup_files[name])
+        for name in source_files
+    )
+
+
+def _backup_for_upload(service, *, reason: str = "manual") -> BackupInfo:
+    latest = service.latest()
+    if latest is not None and _backup_matches_memory(latest, service.memory_dir):
+        return latest
+    return service.create(reason=reason)
+
+
+def _upload_due(state: CloudState, interval_hours: int, now: datetime) -> bool:
+    if state.last_upload_at is None:
+        return True
+    return now - state.last_upload_at >= timedelta(hours=interval_hours)
+
+
+def _known_state(state: CloudState) -> ProtectionState:
+    value = state.protection_state
+    return value if isinstance(value, ProtectionState) else ProtectionState.ATTENTION_REQUIRED
+
+
+def _state_after_backup(state: CloudState) -> ProtectionState:
+    current = _known_state(state)
+    if current in {ProtectionState.LOCAL_ONLY, ProtectionState.STOPPED}:
+        return current
+    if current is ProtectionState.UPLOADING_FIRST_BACKUP:
+        return ProtectionState.VERIFYING_FIRST_BACKUP
+    return ProtectionState.CHANGES_PENDING
+
+
+def _state_after_verification(state: CloudState, snapshot_id: str) -> ProtectionState:
+    current = _known_state(state)
+    if snapshot_id != state.last_successful_backup_snapshot_id:
+        return current
+    if current in {
+        ProtectionState.VERIFYING_FIRST_BACKUP,
+        ProtectionState.CHANGES_PENDING,
+        ProtectionState.ATTENTION_REQUIRED,
+        ProtectionState.OFFLINE,
+        ProtectionState.PROTECTED,
+    }:
+        return ProtectionState.PROTECTED
+    return current
+
+
+def _state_after_failure(
+    state: CloudState,
+    requested: ProtectionState,
+) -> ProtectionState:
+    current = _known_state(state)
+    if current in {ProtectionState.LOCAL_ONLY, ProtectionState.STOPPED}:
+        return current
+    return requested
+
+
+def _probe_search(database: Database, nodes: list[Any]) -> None:
+    if not nodes:
+        raise RuntimeError("Restored snapshot has no active node available for a search probe.")
+    graph = GraphIndex(database)
+    for node in nodes:
+        words = re.findall(r"\w{2,}", f"{node.title or ''} {node.content}")
+        for word in sorted(words, key=len, reverse=True):
+            if any(result["id"] == node.id for result in graph.fts_search(word, limit=10)):
+                return
+    raise RuntimeError("Scratch search probe did not return a known restored node.")
+
+
+def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> int:
+    if info.store_id != expected_store_id:
+        raise RuntimeError(
+            f"Bundle store id {info.store_id!r} does not match local store {expected_store_id!r}."
+        )
+
+    resolve_backup_user_node_id(extracted)
+
+    active_nodes = []
+    for dirname in ("nodes", "deleted"):
+        for path in sorted((extracted / dirname).glob("*.md")):
+            node = parse_node(path.read_text(encoding="utf-8"))
+            if dirname == "nodes":
+                active_nodes.append(node)
+
+    database = Database(extracted / "scratch-index" / "index.db")
+    try:
+        database.init_schema()
+        rebuilt = IndexBuilder(database, FileStore(extracted / "nodes")).full_rebuild()
+        if rebuilt != info.node_count:
+            raise RuntimeError(
+                f"Scratch index rebuilt {rebuilt} nodes; bundle manifest declares {info.node_count}."
+            )
+        _probe_search(database, active_nodes)
+        return rebuilt
+    finally:
+        database.close()
+
+
+class CloudProtectionService:
+    """Reusable cloud protection operations constructed from application settings."""
+
+    def __init__(self, settings) -> None:
+        self.settings = settings
+
+    @classmethod
+    def from_engine(cls, engine) -> CloudProtectionService:
+        return cls(engine.settings)
+
+    def _message(self, value: object) -> str:
+        return _safe_message(value, getattr(self.settings, "account_token", None))
+
+    def status(self) -> CloudProtectionStatus:
+        """Return typed health without exposing account or recovery credentials."""
+
+        settings = self.settings
+        store_id: str | None = None
+        state = CloudState()
+        state_error: str | None = None
+        warnings: list[str] = []
+        try:
+            store_id = _existing_store_id(settings.memory_dir)
+            if store_id is not None:
+                state = load_state(store_id)
+        except Exception as exc:
+            state_error = self._message(exc)
+            warnings.append(
+                f"Cloud protection state could not be read and was not overwritten: {state_error}"
+            )
+
+        entitlement = check_entitlement(settings)
+        if settings.cloud_backup_enabled and store_id is None and state_error is None:
+            warnings.append("Cloud backup is enabled but this memory store is not initialized.")
+        if state.last_upload_at is not None:
+            age = max(_utc_now() - state.last_upload_at, timedelta(0))
+            if age > timedelta(hours=settings.cloud_backup_interval_hours * 2):
+                warnings.append("Cloud backup is stale.")
+        if state.last_verify_ok is False:
+            warnings.append("Cloud restore verification failed.")
+
+        protection_state = (
+            ProtectionState.ATTENTION_REQUIRED
+            if state_error is not None or not isinstance(state.protection_state, ProtectionState)
+            else state.protection_state
+        )
+        return CloudProtectionStatus(
+            enabled=settings.cloud_backup_enabled,
+            store_id=store_id,
+            protection_state=protection_state,
+            entitlement=entitlement,
+            state_error=state_error,
+            last_upload_at=state.last_upload_at,
+            last_upload_snapshot_id=state.last_upload_snapshot_id,
+            last_upload_error=(
+                self._message(state.last_upload_error) if state.last_upload_error else None
+            ),
+            last_verify_at=state.last_verify_at,
+            last_verify_ok=state.last_verify_ok,
+            last_verify_snapshot_id=state.last_verify_snapshot_id,
+            last_verify_error=(
+                self._message(state.last_verify_error) if state.last_verify_error else None
+            ),
+            warnings=tuple(warnings),
+        )
+
+    def backup_now(
+        self,
+        reason: str = "manual",
+        *,
+        only_if_due: bool = False,
+    ) -> ProtectionOperation:
+        """Create, encrypt, upload, and finalize one backup."""
+
+        operation_id = str(uuid.uuid4())
+        try:
+            with StoreLock(self.settings.memory_dir):
+                return self._backup_now(
+                    operation_id,
+                    reason=reason,
+                    only_if_due=only_if_due,
+                )
+        except Exception as exc:
+            return self._backup_failure(operation_id, exc)
+
+    def _backup_now(
+        self,
+        operation_id: str,
+        *,
+        reason: str,
+        only_if_due: bool,
+    ) -> ProtectionOperation:
+        settings = self.settings
+        store_id: str | None = None
+        client = None
+        try:
+            if not settings.cloud_backup_enabled:
+                logger.debug("Ormah Cloud backup is disabled")
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                    ProtectionOperationPhase.CANCELED,
+                    ProtectionState.LOCAL_ONLY,
+                    ProtectionReasonCode.NOT_ENABLED,
+                    "Cloud backup is disabled.",
+                )
+
+            if not key_file_exists():
+                store_id = _existing_store_id(settings.memory_dir)
+                return self._backup_failure(
+                    operation_id,
+                    "Cloud encryption key is missing; run `ormah cloud init`.",
+                    store_id=store_id,
+                    reason_code=ProtectionReasonCode.KEY_MISSING,
+                )
+
+            store_id = _existing_store_id(settings.memory_dir)
+            if store_id is None:
+                return self._backup_failure(
+                    operation_id,
+                    "Cloud store id is missing; run `ormah cloud init`.",
+                    reason_code=ProtectionReasonCode.NOT_ENABLED,
+                )
+
+            state = _load_writable_state(store_id)
+            entitlement = check_entitlement(settings)
+            if entitlement not in {EntitlementStatus.ACTIVE, EntitlementStatus.GRACE}:
+                return self._backup_failure(
+                    operation_id,
+                    f"Cloud backup paused because entitlement is {entitlement.value}.",
+                    store_id=store_id,
+                    reason_code=ProtectionReasonCode.ENTITLEMENT_EXPIRED,
+                    phase=ProtectionOperationPhase.CANCELED,
+                    protection_state=ProtectionState.PAUSED,
+                )
+
+            backup_service = service_from_settings(settings)
+            if not backup_service.has_backupable_memory():
+                logger.debug("Skipping Ormah Cloud backup; no memory nodes exist yet")
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                    ProtectionOperationPhase.CANCELED,
+                    state.protection_state
+                    if isinstance(state.protection_state, ProtectionState)
+                    else ProtectionState.ATTENTION_REQUIRED,
+                    message="No memory nodes are available to back up.",
+                )
+
+            now = _utc_now()
+            if only_if_due and not _upload_due(state, settings.cloud_backup_interval_hours, now):
+                logger.debug("Skipping Ormah Cloud backup; latest upload is still fresh")
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                    ProtectionOperationPhase.CANCELED,
+                    state.protection_state
+                    if isinstance(state.protection_state, ProtectionState)
+                    else ProtectionState.ATTENTION_REQUIRED,
+                    message="The latest cloud backup is still fresh.",
+                    snapshot_id=state.last_upload_snapshot_id,
+                )
+
+            backup = _backup_for_upload(backup_service, reason=reason)
+            with tempfile.TemporaryDirectory(prefix="ormah-cloud-upload-") as tmp:
+                bundle = Path(tmp) / f"{backup.name}.age"
+                build_bundle(
+                    backup.path,
+                    bundle,
+                    [current_recipient()],
+                    store_id=store_id,
+                    reason="cloud-backup",
+                )
+                size = bundle.stat().st_size
+                digest = sha256_file(bundle)
+                client = client_from_settings(settings)
+                upload = client.create_upload(store_id, size, digest)
+                upload_id = upload.get("upload_id")
+                snapshot_id = upload.get("snapshot_id")
+                put_url = upload.get("put_url")
+                expires_at = upload.get("expires_at")
+                required_headers = upload.get("required_headers", {})
+                if not all(
+                    isinstance(value, str) and value for value in (upload_id, snapshot_id, put_url)
+                ):
+                    raise RuntimeError("Cloud upload reservation response was malformed.")
+                if not isinstance(expires_at, str):
+                    raise RuntimeError("Cloud upload reservation did not include an expiry.")
+                parsed_expiry = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                if parsed_expiry.tzinfo is None or parsed_expiry <= _utc_now():
+                    raise RuntimeError("Cloud upload reservation is already expired.")
+                if not isinstance(required_headers, dict) or not all(
+                    isinstance(name, str) and isinstance(value, str)
+                    for name, value in required_headers.items()
+                ):
+                    raise RuntimeError("Cloud upload reservation headers were malformed.")
+
+                put_file(put_url, bundle, required_headers)
+                finalized = client.finalize_upload(store_id, upload_id)
+                finalized_snapshot = finalized.get("snapshot_id")
+                if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
+                    raise RuntimeError("Cloud upload finalize response was malformed.")
+
+            uploaded_at = _utc_now()
+            next_state = _state_after_backup(state)
+            update_state(
+                store_id,
+                memory_dir=settings.memory_dir,
+                last_upload_at=uploaded_at,
+                last_upload_snapshot_id=snapshot_id,
+                last_upload_error=None,
+                last_successful_upload_at=uploaded_at,
+                last_successful_backup_snapshot_id=snapshot_id,
+                protection_state=next_state,
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.BACKUP,
+                last_operation_phase=ProtectionOperationPhase.COMPLETED,
+                last_error_code=None,
+                last_error_message=None,
+                last_error_at=None,
+            )
+            logger.info("Uploaded encrypted Ormah Cloud snapshot %s", self._message(snapshot_id))
+            return ProtectionOperation(
+                operation_id,
+                ProtectionOperationKind.BACKUP,
+                ProtectionOperationPhase.COMPLETED,
+                next_state,
+                snapshot_id=snapshot_id,
+            )
+        except Exception as exc:
+            return self._backup_failure(operation_id, exc, store_id=store_id)
+        finally:
+            self._close_client(client)
+
+    def _backup_failure(
+        self,
+        operation_id: str,
+        error: object,
+        *,
+        store_id: str | None = None,
+        reason_code: ProtectionReasonCode = ProtectionReasonCode.UPLOAD_FAILED,
+        phase: ProtectionOperationPhase = ProtectionOperationPhase.FAILED,
+        protection_state: ProtectionState = ProtectionState.ATTENTION_REQUIRED,
+    ) -> ProtectionOperation:
+        message = self._message(error)
+        logger.warning("Ormah Cloud backup skipped or failed: %s", message)
+        if store_id is not None:
+            try:
+                current = _load_writable_state(store_id)
+                persisted_state = _state_after_failure(current, protection_state)
+                update_state(
+                    store_id,
+                    memory_dir=self.settings.memory_dir,
+                    last_upload_error=message,
+                    protection_state=persisted_state,
+                    last_operation_id=operation_id,
+                    last_operation_kind=ProtectionOperationKind.BACKUP,
+                    last_operation_phase=phase,
+                    last_error_code=reason_code,
+                    last_error_message=message,
+                    last_error_at=_utc_now(),
+                )
+                protection_state = persisted_state
+            except Exception as exc:
+                logger.warning("Could not persist Ormah Cloud state: %s", self._message(exc))
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.BACKUP,
+            phase,
+            protection_state,
+            reason_code,
+            message,
+        )
+
+    def verify_now(self, snapshot_id: str | None = None) -> ProtectionOperation:
+        """Download and prove one committed snapshot entirely in scratch space."""
+
+        operation_id = str(uuid.uuid4())
+        try:
+            with StoreLock(self.settings.memory_dir):
+                return self._verify_now(operation_id, requested_snapshot_id=snapshot_id)
+        except Exception as exc:
+            return self._verification_failure(operation_id, exc, snapshot_id=snapshot_id)
+
+    def _verify_now(
+        self, operation_id: str, *, requested_snapshot_id: str | None
+    ) -> ProtectionOperation:
+        settings = self.settings
+        store_id: str | None = None
+        snapshot_id: str | None = requested_snapshot_id
+        client = None
+        tmp_root: Path | None = None
+        try:
+            if not key_file_exists():
+                raise _VerificationPrerequisiteError(
+                    "Cloud encryption key is missing; cannot verify restore.",
+                    ProtectionReasonCode.KEY_MISSING,
+                )
+            store_id = _existing_store_id(settings.memory_dir)
+            if store_id is None:
+                raise _VerificationPrerequisiteError(
+                    "Cloud store id is missing; cannot verify restore.",
+                    ProtectionReasonCode.NOT_ENABLED,
+                )
+            if not settings.account_token:
+                raise _VerificationPrerequisiteError(
+                    "Ormah Cloud login is required to verify restore.",
+                    ProtectionReasonCode.SIGN_IN_REQUIRED,
+                )
+
+            state = _load_writable_state(store_id)
+            client = client_from_settings(settings)
+            listing = client.list_blobs(store_id)
+            blobs = listing.get("blobs")
+            if not isinstance(blobs, list) or not blobs:
+                raise RuntimeError("No committed cloud snapshot is available to verify.")
+            selected = (
+                blobs[0]
+                if requested_snapshot_id is None
+                else next(
+                    (
+                        blob
+                        for blob in blobs
+                        if isinstance(blob, dict)
+                        and blob.get("snapshot_id") == requested_snapshot_id
+                    ),
+                    None,
+                )
+            )
+            if not isinstance(selected, dict):
+                raise RuntimeError("The requested cloud snapshot is not available to verify.")
+            snapshot_id = selected.get("snapshot_id")
+            if not isinstance(snapshot_id, str) or not snapshot_id:
+                raise RuntimeError("Cloud snapshot listing was malformed.")
+            size_bytes = selected.get("size_bytes")
+            if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
+                raise RuntimeError("Cloud snapshot listing did not include a valid size.")
+            if size_bytes > client.processing_limit(require_hardened_write=False):
+                raise CloudError("Cloud snapshot exceeds this client's safe processing limit.")
+
+            presigned = client.presign_download(store_id, snapshot_id)
+            get_url = presigned.get("get_url")
+            if not isinstance(get_url, str) or not get_url:
+                raise RuntimeError("Cloud download response was malformed.")
+
+            tmp_root = Path(tempfile.mkdtemp(prefix="ormah-restore-verify-"))
+            bundle = tmp_root / f"{snapshot_id}.age"
+            extracted = tmp_root / "snapshot"
+            download_file(get_url, bundle)
+            info = open_bundle(bundle, extracted, load_identities())
+            _verify_extracted_bundle(extracted, store_id, info)
+
+            verified_at = _utc_now()
+            next_state = _state_after_verification(state, snapshot_id)
+            update_state(
+                store_id,
+                memory_dir=settings.memory_dir,
+                last_verify_at=verified_at,
+                last_verify_ok=True,
+                last_verify_snapshot_id=snapshot_id,
+                last_verify_error=None,
+                last_successful_verify_at=verified_at,
+                last_verified_snapshot_id=snapshot_id,
+                protection_state=next_state,
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.VERIFY,
+                last_operation_phase=ProtectionOperationPhase.COMPLETED,
+                last_error_code=None,
+                last_error_message=None,
+                last_error_at=None,
+            )
+            logger.info(
+                "Verified Ormah Cloud snapshot %s is restorable", self._message(snapshot_id)
+            )
+            return ProtectionOperation(
+                operation_id,
+                ProtectionOperationKind.VERIFY,
+                ProtectionOperationPhase.COMPLETED,
+                next_state,
+                snapshot_id=snapshot_id,
+            )
+        except Exception as exc:
+            reason_code = (
+                exc.reason_code
+                if isinstance(exc, _VerificationPrerequisiteError)
+                else ProtectionReasonCode.BUNDLE_CORRUPT
+                if isinstance(exc, BundleError)
+                else ProtectionReasonCode.VERIFICATION_FAILED
+            )
+            return self._verification_failure(
+                operation_id,
+                exc,
+                store_id=store_id,
+                snapshot_id=snapshot_id,
+                reason_code=reason_code,
+            )
+        finally:
+            self._close_client(client)
+            if tmp_root is not None:
+                shutil.rmtree(tmp_root, ignore_errors=True)
+
+    def _verification_failure(
+        self,
+        operation_id: str,
+        error: object,
+        *,
+        store_id: str | None = None,
+        snapshot_id: str | None = None,
+        reason_code: ProtectionReasonCode = ProtectionReasonCode.VERIFICATION_FAILED,
+    ) -> ProtectionOperation:
+        message = self._message(error)
+        logger.warning("Ormah Cloud restore verification failed: %s", message)
+        if store_id is None:
+            try:
+                store_id = _existing_store_id(self.settings.memory_dir)
+            except Exception:
+                store_id = None
+        if store_id is not None:
+            try:
+                current = _load_writable_state(store_id)
+                persisted_state = _state_after_failure(current, ProtectionState.ATTENTION_REQUIRED)
+                update_state(
+                    store_id,
+                    memory_dir=self.settings.memory_dir,
+                    last_verify_at=_utc_now(),
+                    last_verify_ok=False,
+                    last_verify_snapshot_id=snapshot_id,
+                    last_verify_error=message,
+                    protection_state=persisted_state,
+                    last_operation_id=operation_id,
+                    last_operation_kind=ProtectionOperationKind.VERIFY,
+                    last_operation_phase=ProtectionOperationPhase.FAILED,
+                    last_error_code=reason_code,
+                    last_error_message=message,
+                    last_error_at=_utc_now(),
+                )
+                failure_state = persisted_state
+            except Exception as exc:
+                logger.warning("Could not persist Ormah Cloud state: %s", self._message(exc))
+                failure_state = ProtectionState.ATTENTION_REQUIRED
+        else:
+            failure_state = ProtectionState.ATTENTION_REQUIRED
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.VERIFY,
+            ProtectionOperationPhase.FAILED,
+            failure_state,
+            reason_code,
+            message,
+            snapshot_id,
+        )
+
+    @staticmethod
+    def _close_client(client) -> None:
+        close = getattr(client, "close", None) if client is not None else None
+        if close is not None:
+            try:
+                close()
+            except Exception:
+                pass
+
+
+class _VerificationPrerequisiteError(RuntimeError):
+    def __init__(self, message: str, reason_code: ProtectionReasonCode) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import logging
 from pathlib import Path
@@ -41,7 +40,7 @@ from ormah.cloud.state import (
     load_state,
     update_state,
 )
-from ormah.cloud.store_lock import StoreLock
+from ormah.cloud.store_lock import StoreLock, StoreLockTimeout
 from ormah.cloud.transfer import download_file, put_file, sha256_file
 from ormah.index.builder import IndexBuilder
 from ormah.index.db import Database
@@ -57,30 +56,11 @@ _BEARER_RE = re.compile(r"\bBearer\s+[^\s]+", re.IGNORECASE)
 _AGE_SECRET_RE = re.compile(r"AGE-SECRET-KEY-[A-Z0-9]+", re.IGNORECASE)
 
 
-@dataclass(frozen=True)
-class CloudProtectionStatus:
-    """Typed, credential-free cloud protection health for one memory store."""
-
-    enabled: bool
-    store_id: str | None
-    protection_state: ProtectionState
-    entitlement: EntitlementStatus
-    state_error: str | None = None
-    last_upload_at: datetime | None = None
-    last_upload_snapshot_id: str | None = None
-    last_upload_error: str | None = None
-    last_verify_at: datetime | None = None
-    last_verify_ok: bool | None = None
-    last_verify_snapshot_id: str | None = None
-    last_verify_error: str | None = None
-    warnings: tuple[str, ...] = ()
-
-
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _safe_message(value: object, *sensitive_values: str | None) -> str:
+def safe_error_message(value: object, *sensitive_values: str | None) -> str:
     """Return a useful error without returning or logging credential-bearing material."""
 
     message = str(value)
@@ -244,60 +224,7 @@ class CloudProtectionService:
         return cls(engine.settings)
 
     def _message(self, value: object) -> str:
-        return _safe_message(value, getattr(self.settings, "account_token", None))
-
-    def status(self) -> CloudProtectionStatus:
-        """Return typed health without exposing account or recovery credentials."""
-
-        settings = self.settings
-        store_id: str | None = None
-        state = CloudState()
-        state_error: str | None = None
-        warnings: list[str] = []
-        try:
-            store_id = _existing_store_id(settings.memory_dir)
-            if store_id is not None:
-                state = load_state(store_id)
-        except Exception as exc:
-            state_error = self._message(exc)
-            warnings.append(
-                f"Cloud protection state could not be read and was not overwritten: {state_error}"
-            )
-
-        entitlement = check_entitlement(settings)
-        if settings.cloud_backup_enabled and store_id is None and state_error is None:
-            warnings.append("Cloud backup is enabled but this memory store is not initialized.")
-        if state.last_upload_at is not None:
-            age = max(_utc_now() - state.last_upload_at, timedelta(0))
-            if age > timedelta(hours=settings.cloud_backup_interval_hours * 2):
-                warnings.append("Cloud backup is stale.")
-        if state.last_verify_ok is False:
-            warnings.append("Cloud restore verification failed.")
-
-        protection_state = (
-            ProtectionState.ATTENTION_REQUIRED
-            if state_error is not None or not isinstance(state.protection_state, ProtectionState)
-            else state.protection_state
-        )
-        return CloudProtectionStatus(
-            enabled=settings.cloud_backup_enabled,
-            store_id=store_id,
-            protection_state=protection_state,
-            entitlement=entitlement,
-            state_error=state_error,
-            last_upload_at=state.last_upload_at,
-            last_upload_snapshot_id=state.last_upload_snapshot_id,
-            last_upload_error=(
-                self._message(state.last_upload_error) if state.last_upload_error else None
-            ),
-            last_verify_at=state.last_verify_at,
-            last_verify_ok=state.last_verify_ok,
-            last_verify_snapshot_id=state.last_verify_snapshot_id,
-            last_verify_error=(
-                self._message(state.last_verify_error) if state.last_verify_error else None
-            ),
-            warnings=tuple(warnings),
-        )
+        return safe_error_message(value, getattr(self.settings, "account_token", None))
 
     def backup_now(
         self,
@@ -315,6 +242,11 @@ class CloudProtectionService:
                     reason=reason,
                     only_if_due=only_if_due,
                 )
+        except StoreLockTimeout:
+            return self._store_busy_operation(
+                operation_id,
+                ProtectionOperationKind.BACKUP,
+            )
         except Exception as exc:
             return self._backup_failure(operation_id, exc)
 
@@ -340,8 +272,19 @@ class CloudProtectionService:
                     "Cloud backup is disabled.",
                 )
 
+            store_id = _existing_store_id(settings.memory_dir)
+            state = _load_writable_state(store_id) if store_id is not None else None
+            if state is not None and state.protection_state is ProtectionState.STOPPED:
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                    ProtectionOperationPhase.CANCELED,
+                    ProtectionState.STOPPED,
+                    ProtectionReasonCode.PROTECTION_STOPPED,
+                    "Cloud protection is stopped for this memory store.",
+                )
+
             if not key_file_exists():
-                store_id = _existing_store_id(settings.memory_dir)
                 return self._backup_failure(
                     operation_id,
                     "Cloud encryption key is missing; run `ormah cloud init`.",
@@ -349,7 +292,6 @@ class CloudProtectionService:
                     reason_code=ProtectionReasonCode.KEY_MISSING,
                 )
 
-            store_id = _existing_store_id(settings.memory_dir)
             if store_id is None:
                 return self._backup_failure(
                     operation_id,
@@ -357,7 +299,7 @@ class CloudProtectionService:
                     reason_code=ProtectionReasonCode.NOT_ENABLED,
                 )
 
-            state = _load_writable_state(store_id)
+            assert state is not None
             entitlement = check_entitlement(settings)
             if entitlement not in {EntitlementStatus.ACTIVE, EntitlementStatus.GRACE}:
                 return self._backup_failure(
@@ -404,7 +346,7 @@ class CloudProtectionService:
                     bundle,
                     [current_recipient()],
                     store_id=store_id,
-                    reason="cloud-backup",
+                    reason=reason,
                 )
                 size = bundle.stat().st_size
                 digest = sha256_file(bundle)
@@ -514,6 +456,12 @@ class CloudProtectionService:
         try:
             with StoreLock(self.settings.memory_dir):
                 return self._verify_now(operation_id, requested_snapshot_id=snapshot_id)
+        except StoreLockTimeout:
+            return self._store_busy_operation(
+                operation_id,
+                ProtectionOperationKind.VERIFY,
+                snapshot_id=snapshot_id,
+            )
         except Exception as exc:
             return self._verification_failure(operation_id, exc, snapshot_id=snapshot_id)
 
@@ -523,6 +471,7 @@ class CloudProtectionService:
         settings = self.settings
         store_id: str | None = None
         snapshot_id: str | None = requested_snapshot_id
+        tracks_latest_snapshot = requested_snapshot_id is None
         client = None
         tmp_root: Path | None = None
         try:
@@ -549,6 +498,11 @@ class CloudProtectionService:
             blobs = listing.get("blobs")
             if not isinstance(blobs, list) or not blobs:
                 raise RuntimeError("No committed cloud snapshot is available to verify.")
+            latest_snapshot_id = (
+                blobs[0].get("snapshot_id") if isinstance(blobs[0], dict) else None
+            )
+            if not isinstance(latest_snapshot_id, str) or not latest_snapshot_id:
+                raise RuntimeError("Cloud snapshot listing was malformed.")
             selected = (
                 blobs[0]
                 if requested_snapshot_id is None
@@ -567,6 +521,12 @@ class CloudProtectionService:
             snapshot_id = selected.get("snapshot_id")
             if not isinstance(snapshot_id, str) or not snapshot_id:
                 raise RuntimeError("Cloud snapshot listing was malformed.")
+            expected_latest_snapshot_id = (
+                state.last_successful_backup_snapshot_id or latest_snapshot_id
+            )
+            tracks_latest_snapshot = (
+                requested_snapshot_id is None or snapshot_id == expected_latest_snapshot_id
+            )
             size_bytes = selected.get("size_bytes")
             if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
                 raise RuntimeError("Cloud snapshot listing did not include a valid size.")
@@ -587,23 +547,25 @@ class CloudProtectionService:
 
             verified_at = _utc_now()
             next_state = _state_after_verification(state, snapshot_id)
-            update_state(
-                store_id,
-                memory_dir=settings.memory_dir,
-                last_verify_at=verified_at,
-                last_verify_ok=True,
-                last_verify_snapshot_id=snapshot_id,
-                last_verify_error=None,
-                last_successful_verify_at=verified_at,
-                last_verified_snapshot_id=snapshot_id,
-                protection_state=next_state,
-                last_operation_id=operation_id,
-                last_operation_kind=ProtectionOperationKind.VERIFY,
-                last_operation_phase=ProtectionOperationPhase.COMPLETED,
-                last_error_code=None,
-                last_error_message=None,
-                last_error_at=None,
-            )
+            changes: dict[str, object] = {
+                "last_operation_id": operation_id,
+                "last_operation_kind": ProtectionOperationKind.VERIFY,
+                "last_operation_phase": ProtectionOperationPhase.COMPLETED,
+                "last_error_code": None,
+                "last_error_message": None,
+                "last_error_at": None,
+            }
+            if tracks_latest_snapshot:
+                changes.update(
+                    last_verify_at=verified_at,
+                    last_verify_ok=True,
+                    last_verify_snapshot_id=snapshot_id,
+                    last_verify_error=None,
+                    last_successful_verify_at=verified_at,
+                    last_verified_snapshot_id=snapshot_id,
+                    protection_state=next_state,
+                )
+            update_state(store_id, memory_dir=settings.memory_dir, **changes)
             logger.info(
                 "Verified Ormah Cloud snapshot %s is restorable", self._message(snapshot_id)
             )
@@ -628,6 +590,7 @@ class CloudProtectionService:
                 store_id=store_id,
                 snapshot_id=snapshot_id,
                 reason_code=reason_code,
+                record_health=tracks_latest_snapshot,
             )
         finally:
             self._close_client(client)
@@ -642,6 +605,7 @@ class CloudProtectionService:
         store_id: str | None = None,
         snapshot_id: str | None = None,
         reason_code: ProtectionReasonCode = ProtectionReasonCode.VERIFICATION_FAILED,
+        record_health: bool = True,
     ) -> ProtectionOperation:
         message = self._message(error)
         logger.warning("Ormah Cloud restore verification failed: %s", message)
@@ -653,22 +617,29 @@ class CloudProtectionService:
         if store_id is not None:
             try:
                 current = _load_writable_state(store_id)
-                persisted_state = _state_after_failure(current, ProtectionState.ATTENTION_REQUIRED)
-                update_state(
-                    store_id,
-                    memory_dir=self.settings.memory_dir,
-                    last_verify_at=_utc_now(),
-                    last_verify_ok=False,
-                    last_verify_snapshot_id=snapshot_id,
-                    last_verify_error=message,
-                    protection_state=persisted_state,
-                    last_operation_id=operation_id,
-                    last_operation_kind=ProtectionOperationKind.VERIFY,
-                    last_operation_phase=ProtectionOperationPhase.FAILED,
-                    last_error_code=reason_code,
-                    last_error_message=message,
-                    last_error_at=_utc_now(),
+                persisted_state = (
+                    _state_after_failure(current, ProtectionState.ATTENTION_REQUIRED)
+                    if record_health
+                    else _known_state(current)
                 )
+                failed_at = _utc_now()
+                changes: dict[str, object] = {
+                    "last_operation_id": operation_id,
+                    "last_operation_kind": ProtectionOperationKind.VERIFY,
+                    "last_operation_phase": ProtectionOperationPhase.FAILED,
+                    "last_error_code": reason_code,
+                    "last_error_message": message,
+                    "last_error_at": failed_at,
+                }
+                if record_health:
+                    changes.update(
+                        last_verify_at=failed_at,
+                        last_verify_ok=False,
+                        last_verify_snapshot_id=snapshot_id,
+                        last_verify_error=message,
+                        protection_state=persisted_state,
+                    )
+                update_state(store_id, memory_dir=self.settings.memory_dir, **changes)
                 failure_state = persisted_state
             except Exception as exc:
                 logger.warning("Could not persist Ormah Cloud state: %s", self._message(exc))
@@ -682,6 +653,35 @@ class CloudProtectionService:
             failure_state,
             reason_code,
             message,
+            snapshot_id,
+        )
+
+    def _store_busy_operation(
+        self,
+        operation_id: str,
+        kind: ProtectionOperationKind,
+        *,
+        snapshot_id: str | None = None,
+    ) -> ProtectionOperation:
+        """Return transient contention without changing durable protection health."""
+
+        current_state = ProtectionState.ATTENTION_REQUIRED
+        try:
+            store_id = _existing_store_id(self.settings.memory_dir)
+            if store_id is None:
+                current_state = ProtectionState.LOCAL_ONLY
+            else:
+                current_state = _known_state(load_state(store_id))
+        except Exception:
+            pass
+        logger.info("Ormah Cloud operation canceled because the memory store is busy")
+        return ProtectionOperation(
+            operation_id,
+            kind,
+            ProtectionOperationPhase.CANCELED,
+            current_state,
+            ProtectionReasonCode.STORE_BUSY,
+            "Memory store is busy; try again shortly.",
             snapshot_id,
         )
 

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -11,6 +11,8 @@ import tempfile
 from typing import Any
 import uuid
 
+import httpx
+
 from ormah.backup import (
     BackupError,
     BackupInfo,
@@ -54,6 +56,11 @@ logger = logging.getLogger(__name__)
 _URL_RE = re.compile(r"https?://[^\s]+", re.IGNORECASE)
 _BEARER_RE = re.compile(r"\bBearer\s+[^\s]+", re.IGNORECASE)
 _AGE_SECRET_RE = re.compile(r"AGE-SECRET-KEY-[A-Z0-9]+", re.IGNORECASE)
+_QUERY_SECRET_RE = re.compile(
+    r"(?i)((?:^|[?&\s])(?:x-amz-signature|x-amz-credential|x-amz-security-token|"
+    r"access_token|token|signature)=)[^&\s]+"
+)
+_SNAPSHOT_ID_RE = re.compile(r"[0-7][0-9A-HJKMNP-TV-Z]{25}")
 
 
 def _utc_now() -> datetime:
@@ -65,6 +72,7 @@ def safe_error_message(value: object, *sensitive_values: str | None) -> str:
 
     message = str(value)
     message = _URL_RE.sub("<redacted-url>", message)
+    message = _QUERY_SECRET_RE.sub(r"\1<redacted>", message)
     message = _BEARER_RE.sub("Bearer <redacted>", message)
     message = _AGE_SECRET_RE.sub("<redacted-age-key>", message)
     for sensitive in sensitive_values:
@@ -140,8 +148,10 @@ def _known_state(state: CloudState) -> ProtectionState:
 
 def _state_after_backup(state: CloudState) -> ProtectionState:
     current = _known_state(state)
-    if current in {ProtectionState.LOCAL_ONLY, ProtectionState.STOPPED}:
-        return current
+    if current is ProtectionState.LOCAL_ONLY:
+        return ProtectionState.VERIFYING_FIRST_BACKUP
+    if current is ProtectionState.STOPPED:
+        return ProtectionState.STOPPED
     if current is ProtectionState.UPLOADING_FIRST_BACKUP:
         return ProtectionState.VERIFYING_FIRST_BACKUP
     return ProtectionState.CHANGES_PENDING
@@ -167,9 +177,21 @@ def _state_after_failure(
     requested: ProtectionState,
 ) -> ProtectionState:
     current = _known_state(state)
-    if current in {ProtectionState.LOCAL_ONLY, ProtectionState.STOPPED}:
-        return current
+    if current is ProtectionState.STOPPED:
+        return ProtectionState.STOPPED
     return requested
+
+
+def _is_offline_error(error: object) -> bool:
+    return isinstance(error, httpx.RequestError) or (
+        isinstance(error, CloudError) and error.status_code is None
+    )
+
+
+def _validated_snapshot_id(value: object) -> str:
+    if not isinstance(value, str) or _SNAPSHOT_ID_RE.fullmatch(value) is None:
+        raise RuntimeError("Cloud response contained an invalid snapshot id.")
+    return value
 
 
 def _probe_search(database: Database, nodes: list[Any]) -> None:
@@ -261,19 +283,31 @@ class CloudProtectionService:
         store_id: str | None = None
         client = None
         try:
+            store_id = _existing_store_id(settings.memory_dir)
+            try:
+                state = _load_writable_state(store_id) if store_id is not None else None
+            except CloudStateVersionError:
+                return self._client_update_required_operation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                )
+            if state is not None and not isinstance(state.protection_state, ProtectionState):
+                return self._client_update_required_operation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                )
+
             if not settings.cloud_backup_enabled:
                 logger.debug("Ormah Cloud backup is disabled")
                 return ProtectionOperation(
                     operation_id,
                     ProtectionOperationKind.BACKUP,
                     ProtectionOperationPhase.CANCELED,
-                    ProtectionState.LOCAL_ONLY,
+                    state.protection_state if state is not None else ProtectionState.LOCAL_ONLY,
                     ProtectionReasonCode.NOT_ENABLED,
                     "Cloud backup is disabled.",
                 )
 
-            store_id = _existing_store_id(settings.memory_dir)
-            state = _load_writable_state(store_id) if store_id is not None else None
             if state is not None and state.protection_state is ProtectionState.STOPPED:
                 return ProtectionOperation(
                     operation_id,
@@ -321,6 +355,7 @@ class CloudProtectionService:
                     state.protection_state
                     if isinstance(state.protection_state, ProtectionState)
                     else ProtectionState.ATTENTION_REQUIRED,
+                    ProtectionReasonCode.NO_BACKUPABLE_MEMORY,
                     message="No memory nodes are available to back up.",
                 )
 
@@ -334,6 +369,7 @@ class CloudProtectionService:
                     state.protection_state
                     if isinstance(state.protection_state, ProtectionState)
                     else ProtectionState.ATTENTION_REQUIRED,
+                    ProtectionReasonCode.NOT_DUE,
                     message="The latest cloud backup is still fresh.",
                     snapshot_id=state.last_upload_snapshot_id,
                 )
@@ -353,12 +389,12 @@ class CloudProtectionService:
                 client = client_from_settings(settings)
                 upload = client.create_upload(store_id, size, digest)
                 upload_id = upload.get("upload_id")
-                snapshot_id = upload.get("snapshot_id")
+                snapshot_id = _validated_snapshot_id(upload.get("snapshot_id"))
                 put_url = upload.get("put_url")
                 expires_at = upload.get("expires_at")
                 required_headers = upload.get("required_headers", {})
                 if not all(
-                    isinstance(value, str) and value for value in (upload_id, snapshot_id, put_url)
+                    isinstance(value, str) and value for value in (upload_id, put_url)
                 ):
                     raise RuntimeError("Cloud upload reservation response was malformed.")
                 if not isinstance(expires_at, str):
@@ -374,7 +410,7 @@ class CloudProtectionService:
 
                 put_file(put_url, bundle, required_headers)
                 finalized = client.finalize_upload(store_id, upload_id)
-                finalized_snapshot = finalized.get("snapshot_id")
+                finalized_snapshot = _validated_snapshot_id(finalized.get("snapshot_id"))
                 if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
                     raise RuntimeError("Cloud upload finalize response was malformed.")
 
@@ -405,6 +441,14 @@ class CloudProtectionService:
                 snapshot_id=snapshot_id,
             )
         except Exception as exc:
+            if _is_offline_error(exc):
+                return self._backup_failure(
+                    operation_id,
+                    exc,
+                    store_id=store_id,
+                    reason_code=ProtectionReasonCode.OFFLINE,
+                    protection_state=ProtectionState.OFFLINE,
+                )
             return self._backup_failure(operation_id, exc, store_id=store_id)
         finally:
             self._close_client(client)
@@ -424,6 +468,11 @@ class CloudProtectionService:
         if store_id is not None:
             try:
                 current = _load_writable_state(store_id)
+                if not isinstance(current.protection_state, ProtectionState):
+                    return self._client_update_required_operation(
+                        operation_id,
+                        ProtectionOperationKind.BACKUP,
+                    )
                 persisted_state = _state_after_failure(current, protection_state)
                 update_state(
                     store_id,
@@ -438,6 +487,11 @@ class CloudProtectionService:
                     last_error_at=_utc_now(),
                 )
                 protection_state = persisted_state
+            except CloudStateVersionError:
+                return self._client_update_required_operation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                )
             except Exception as exc:
                 logger.warning("Could not persist Ormah Cloud state: %s", self._message(exc))
         return ProtectionOperation(
@@ -475,16 +529,30 @@ class CloudProtectionService:
         client = None
         tmp_root: Path | None = None
         try:
-            if not key_file_exists():
-                raise _VerificationPrerequisiteError(
-                    "Cloud encryption key is missing; cannot verify restore.",
-                    ProtectionReasonCode.KEY_MISSING,
-                )
             store_id = _existing_store_id(settings.memory_dir)
             if store_id is None:
                 raise _VerificationPrerequisiteError(
                     "Cloud store id is missing; cannot verify restore.",
                     ProtectionReasonCode.NOT_ENABLED,
+                )
+            try:
+                state = _load_writable_state(store_id)
+            except CloudStateVersionError:
+                return self._client_update_required_operation(
+                    operation_id,
+                    ProtectionOperationKind.VERIFY,
+                    snapshot_id=requested_snapshot_id,
+                )
+            if not isinstance(state.protection_state, ProtectionState):
+                return self._client_update_required_operation(
+                    operation_id,
+                    ProtectionOperationKind.VERIFY,
+                    snapshot_id=requested_snapshot_id,
+                )
+            if not key_file_exists():
+                raise _VerificationPrerequisiteError(
+                    "Cloud encryption key is missing; cannot verify restore.",
+                    ProtectionReasonCode.KEY_MISSING,
                 )
             if not settings.account_token:
                 raise _VerificationPrerequisiteError(
@@ -492,17 +560,14 @@ class CloudProtectionService:
                     ProtectionReasonCode.SIGN_IN_REQUIRED,
                 )
 
-            state = _load_writable_state(store_id)
             client = client_from_settings(settings)
             listing = client.list_blobs(store_id)
             blobs = listing.get("blobs")
             if not isinstance(blobs, list) or not blobs:
                 raise RuntimeError("No committed cloud snapshot is available to verify.")
-            latest_snapshot_id = (
+            latest_snapshot_id = _validated_snapshot_id(
                 blobs[0].get("snapshot_id") if isinstance(blobs[0], dict) else None
             )
-            if not isinstance(latest_snapshot_id, str) or not latest_snapshot_id:
-                raise RuntimeError("Cloud snapshot listing was malformed.")
             selected = (
                 blobs[0]
                 if requested_snapshot_id is None
@@ -518,9 +583,7 @@ class CloudProtectionService:
             )
             if not isinstance(selected, dict):
                 raise RuntimeError("The requested cloud snapshot is not available to verify.")
-            snapshot_id = selected.get("snapshot_id")
-            if not isinstance(snapshot_id, str) or not snapshot_id:
-                raise RuntimeError("Cloud snapshot listing was malformed.")
+            snapshot_id = _validated_snapshot_id(selected.get("snapshot_id"))
             expected_latest_snapshot_id = (
                 state.last_successful_backup_snapshot_id or latest_snapshot_id
             )
@@ -577,9 +640,12 @@ class CloudProtectionService:
                 snapshot_id=snapshot_id,
             )
         except Exception as exc:
+            offline = _is_offline_error(exc)
             reason_code = (
                 exc.reason_code
                 if isinstance(exc, _VerificationPrerequisiteError)
+                else ProtectionReasonCode.OFFLINE
+                if offline
                 else ProtectionReasonCode.BUNDLE_CORRUPT
                 if isinstance(exc, BundleError)
                 else ProtectionReasonCode.VERIFICATION_FAILED
@@ -590,7 +656,14 @@ class CloudProtectionService:
                 store_id=store_id,
                 snapshot_id=snapshot_id,
                 reason_code=reason_code,
-                record_health=tracks_latest_snapshot,
+                record_health=tracks_latest_snapshot and not offline,
+                protection_state=(
+                    ProtectionState.OFFLINE
+                    if offline
+                    else ProtectionState.ATTENTION_REQUIRED
+                    if tracks_latest_snapshot
+                    else None
+                ),
             )
         finally:
             self._close_client(client)
@@ -606,6 +679,7 @@ class CloudProtectionService:
         snapshot_id: str | None = None,
         reason_code: ProtectionReasonCode = ProtectionReasonCode.VERIFICATION_FAILED,
         record_health: bool = True,
+        protection_state: ProtectionState | None = ProtectionState.ATTENTION_REQUIRED,
     ) -> ProtectionOperation:
         message = self._message(error)
         logger.warning("Ormah Cloud restore verification failed: %s", message)
@@ -617,9 +691,15 @@ class CloudProtectionService:
         if store_id is not None:
             try:
                 current = _load_writable_state(store_id)
+                if not isinstance(current.protection_state, ProtectionState):
+                    return self._client_update_required_operation(
+                        operation_id,
+                        ProtectionOperationKind.VERIFY,
+                        snapshot_id=snapshot_id,
+                    )
                 persisted_state = (
-                    _state_after_failure(current, ProtectionState.ATTENTION_REQUIRED)
-                    if record_health
+                    _state_after_failure(current, protection_state)
+                    if protection_state is not None
                     else _known_state(current)
                 )
                 failed_at = _utc_now()
@@ -637,10 +717,17 @@ class CloudProtectionService:
                         last_verify_ok=False,
                         last_verify_snapshot_id=snapshot_id,
                         last_verify_error=message,
-                        protection_state=persisted_state,
                     )
+                if protection_state is not None:
+                    changes["protection_state"] = persisted_state
                 update_state(store_id, memory_dir=self.settings.memory_dir, **changes)
                 failure_state = persisted_state
+            except CloudStateVersionError:
+                return self._client_update_required_operation(
+                    operation_id,
+                    ProtectionOperationKind.VERIFY,
+                    snapshot_id=snapshot_id,
+                )
             except Exception as exc:
                 logger.warning("Could not persist Ormah Cloud state: %s", self._message(exc))
                 failure_state = ProtectionState.ATTENTION_REQUIRED
@@ -653,6 +740,25 @@ class CloudProtectionService:
             failure_state,
             reason_code,
             message,
+            snapshot_id,
+        )
+
+    def _client_update_required_operation(
+        self,
+        operation_id: str,
+        kind: ProtectionOperationKind,
+        *,
+        snapshot_id: str | None = None,
+    ) -> ProtectionOperation:
+        """Fail closed when durable state belongs to a newer client."""
+
+        return ProtectionOperation(
+            operation_id,
+            kind,
+            ProtectionOperationPhase.CANCELED,
+            ProtectionState.ATTENTION_REQUIRED,
+            ProtectionReasonCode.CLIENT_UPDATE_REQUIRED,
+            "This cloud state requires a newer Ormah version.",
             snapshot_id,
         )
 

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -97,6 +97,9 @@ class ProtectionReasonCode(StrEnum):
     OPERATION_INTERRUPTED = "operation_interrupted"
     STORE_BUSY = "store_busy"
     PROTECTION_STOPPED = "protection_stopped"
+    CLIENT_UPDATE_REQUIRED = "client_update_required"
+    NO_BACKUPABLE_MEMORY = "no_backupable_memory"
+    NOT_DUE = "not_due"
 
 
 @dataclass(frozen=True)

--- a/src/ormah/cloud/store_lock.py
+++ b/src/ormah/cloud/store_lock.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 import threading
+import time
 
 from filelock import FileLock, Timeout as FileLockTimeout
 
@@ -67,12 +68,24 @@ class StoreLock:
         self._depth = 0
 
     def acquire(self) -> StoreLock:
-        self._entry.thread_lock.acquire()
+        deadline = None if self.timeout < 0 else time.monotonic() + self.timeout
+        if deadline is None:
+            thread_acquired = self._entry.thread_lock.acquire()
+        else:
+            thread_acquired = self._entry.thread_lock.acquire(timeout=self.timeout)
+        if not thread_acquired:
+            raise StoreLockTimeout(
+                f"Memory store is busy; timed out waiting for {self.path}."
+            )
+
         process_acquired = False
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             try:
-                self._entry.process_lock.acquire(timeout=self.timeout)
+                process_timeout = (
+                    -1 if deadline is None else max(0.0, deadline - time.monotonic())
+                )
+                self._entry.process_lock.acquire(timeout=process_timeout)
                 process_acquired = True
             except FileLockTimeout as exc:
                 raise StoreLockTimeout(

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -22,6 +22,7 @@ from ormah.store.file_store import FileStore
 
 
 NOW = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+SNAPSHOT_ID = "01J00000000000000000000000"
 
 
 class FakeCloudClient:
@@ -35,7 +36,7 @@ class FakeCloudClient:
         self.created.append((store_id, size, sha256))
         return {
             "upload_id": "upload-1",
-            "snapshot_id": "01SNAPSHOT",
+            "snapshot_id": SNAPSHOT_ID,
             "put_url": "https://objects.example/put",
             "expires_at": (NOW + timedelta(minutes=15)).isoformat(),
             "required_headers": {"x-amz-checksum-sha256": "signed-checksum"},
@@ -43,11 +44,11 @@ class FakeCloudClient:
 
     def finalize_upload(self, *args):
         self.finalized.append(args)
-        return {"snapshot_id": "01SNAPSHOT", "status": "committed", "head": {"seq": 0}}
+        return {"snapshot_id": SNAPSHOT_ID, "status": "committed", "head": {"seq": 0}}
 
     def list_blobs(self, store_id):
         return {
-            "blobs": [{"snapshot_id": "01SNAPSHOT", "created_at": NOW.isoformat(), "size_bytes": 1}]
+            "blobs": [{"snapshot_id": SNAPSHOT_ID, "created_at": NOW.isoformat(), "size_bytes": 1}]
         }
 
     def presign_download(self, store_id, snapshot_id):
@@ -238,11 +239,11 @@ def test_successful_upload_finalizes_without_advancing_sync_head(
 
     result = jobs.run_cloud_backup(SimpleNamespace(settings=settings))
 
-    assert result == "01SNAPSHOT"
+    assert result == SNAPSHOT_ID
     assert client.finalized == [(store_id, "upload-1")]
     state = load_state(store_id)
     assert state.last_upload_at == NOW
-    assert state.last_upload_snapshot_id == "01SNAPSHOT"
+    assert state.last_upload_snapshot_id == SNAPSHOT_ID
     assert state.last_upload_error is None
 
 
@@ -308,8 +309,8 @@ def test_two_stores_upload_under_their_own_ids(tmp_path, monkeypatch, cloud_stat
     jobs.run_cloud_backup(SimpleNamespace(settings=second_settings))
 
     assert [call[0] for call in client.created] == [first_id, second_id]
-    assert load_state(first_id).last_upload_snapshot_id == "01SNAPSHOT"
-    assert load_state(second_id).last_upload_snapshot_id == "01SNAPSHOT"
+    assert load_state(first_id).last_upload_snapshot_id == SNAPSHOT_ID
+    assert load_state(second_id).last_upload_snapshot_id == SNAPSHOT_ID
 
 
 def _verification_bundle(tmp_path: Path, settings: Settings, store_id: str):
@@ -356,7 +357,7 @@ def test_restore_verification_rebuilds_search_and_leaves_live_store_untouched(
 
     state = load_state(store_id)
     assert state.last_verify_ok is True
-    assert state.last_verify_snapshot_id == "01SNAPSHOT"
+    assert state.last_verify_snapshot_id == SNAPSHOT_ID
     assert state.last_verify_error is None
     assert {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in live_files} == live_files
 
@@ -408,7 +409,7 @@ def test_restore_verification_records_bundle_failures(
 
     state = load_state(store_id)
     assert state.last_verify_ok is False
-    assert state.last_verify_snapshot_id == "01SNAPSHOT"
+    assert state.last_verify_snapshot_id == SNAPSHOT_ID
     expected = "Hash mismatch" if failure == "hash-mismatch" else "decrypt"
     assert expected.lower() in state.last_verify_error.lower()
 

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -10,6 +10,7 @@ import uuid
 import pytest
 
 from ormah.backup import run_auto_backup, service_from_settings
+from ormah.cloud import protection
 from ormah.cloud.bundle import build_bundle
 from ormah.cloud.crypto import generate_identity
 from ormah.cloud.entitlements import EntitlementStatus
@@ -46,9 +47,7 @@ class FakeCloudClient:
 
     def list_blobs(self, store_id):
         return {
-            "blobs": [
-                {"snapshot_id": "01SNAPSHOT", "created_at": NOW.isoformat(), "size_bytes": 1}
-            ]
+            "blobs": [{"snapshot_id": "01SNAPSHOT", "created_at": NOW.isoformat(), "size_bytes": 1}]
         }
 
     def presign_download(self, store_id, snapshot_id):
@@ -100,20 +99,18 @@ def cloud_state_dir(tmp_path, monkeypatch):
 
 
 def _patch_upload_prerequisites(monkeypatch, client: FakeCloudClient):
-    from ormah.cloud import jobs
-
-    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
-    monkeypatch.setattr(jobs, "check_entitlement", lambda settings: EntitlementStatus.ACTIVE)
-    monkeypatch.setattr(jobs, "current_recipient", lambda: object())
-    monkeypatch.setattr(jobs, "client_from_settings", lambda settings: client)
-    monkeypatch.setattr(jobs, "_utc_now", lambda: NOW)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "check_entitlement", lambda settings: EntitlementStatus.ACTIVE)
+    monkeypatch.setattr(protection, "current_recipient", lambda: object())
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: client)
+    monkeypatch.setattr(protection, "_utc_now", lambda: NOW)
 
     def fake_bundle(backup_dir, out_path, recipients, **kwargs):
         out_path.write_bytes(b"age-encrypted-bundle")
         return out_path
 
-    monkeypatch.setattr(jobs, "build_bundle", fake_bundle)
-    monkeypatch.setattr(jobs, "put_file", lambda url, path, headers: None)
+    monkeypatch.setattr(protection, "build_bundle", fake_bundle)
+    monkeypatch.setattr(protection, "put_file", lambda url, path, headers: None)
 
 
 def test_cloud_backup_disabled_is_first_guard(tmp_path, monkeypatch):
@@ -122,7 +119,7 @@ def test_cloud_backup_disabled_is_first_guard(tmp_path, monkeypatch):
     settings, _ = _settings(tmp_path)
     settings.cloud_backup_enabled = False
     monkeypatch.setattr(
-        jobs,
+        protection,
         "key_file_exists",
         lambda: (_ for _ in ()).throw(AssertionError("key guard should not run")),
     )
@@ -134,7 +131,7 @@ def test_cloud_backup_missing_key_records_error(tmp_path, monkeypatch, cloud_sta
     from ormah.cloud import jobs
 
     settings, store_id = _settings(tmp_path)
-    monkeypatch.setattr(jobs, "key_file_exists", lambda: False)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: False)
 
     assert jobs.run_cloud_backup(SimpleNamespace(settings=settings)) is None
     assert "key is missing" in load_state(store_id).last_upload_error
@@ -145,9 +142,9 @@ def test_cloud_backup_missing_store_short_circuits_entitlement(tmp_path, monkeyp
 
     settings, _ = _settings(tmp_path)
     (settings.memory_dir / ".store_id").unlink()
-    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
     monkeypatch.setattr(
-        jobs,
+        protection,
         "check_entitlement",
         lambda settings: (_ for _ in ()).throw(AssertionError("entitlement should not run")),
     )
@@ -162,10 +159,10 @@ def test_expired_entitlement_skips_cloud_but_not_local_backup(
     from ormah.cloud import jobs
 
     settings, store_id = _settings(tmp_path)
-    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
-    monkeypatch.setattr(jobs, "check_entitlement", lambda settings: EntitlementStatus.EXPIRED)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "check_entitlement", lambda settings: EntitlementStatus.EXPIRED)
     monkeypatch.setattr(
-        jobs,
+        protection,
         "build_bundle",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("upload should not run")),
     )
@@ -175,16 +172,14 @@ def test_expired_entitlement_skips_cloud_but_not_local_backup(
     assert run_auto_backup(SimpleNamespace(settings=settings)) is not None
 
 
-def test_cloud_backup_empty_store_short_circuits_bundle(
-    tmp_path, monkeypatch, cloud_state_dir
-):
+def test_cloud_backup_empty_store_short_circuits_bundle(tmp_path, monkeypatch, cloud_state_dir):
     from ormah.cloud import jobs
 
     settings, _ = _settings(tmp_path, with_node=False)
     client = FakeCloudClient()
     _patch_upload_prerequisites(monkeypatch, client)
     monkeypatch.setattr(
-        jobs,
+        protection,
         "build_bundle",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("bundle should not build")),
     )
@@ -193,9 +188,7 @@ def test_cloud_backup_empty_store_short_circuits_bundle(
     assert client.created == []
 
 
-def test_cloud_backup_fresh_upload_short_circuits_bundle(
-    tmp_path, monkeypatch, cloud_state_dir
-):
+def test_cloud_backup_fresh_upload_short_circuits_bundle(tmp_path, monkeypatch, cloud_state_dir):
     from ormah.cloud import jobs
 
     settings, store_id = _settings(tmp_path)
@@ -207,7 +200,7 @@ def test_cloud_backup_fresh_upload_short_circuits_bundle(
     client = FakeCloudClient()
     _patch_upload_prerequisites(monkeypatch, client)
     monkeypatch.setattr(
-        jobs,
+        protection,
         "build_bundle",
         lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("bundle should not build")),
     )
@@ -216,16 +209,14 @@ def test_cloud_backup_fresh_upload_short_circuits_bundle(
     assert client.created == []
 
 
-def test_failed_put_records_error_and_never_finalizes(
-    tmp_path, monkeypatch, cloud_state_dir
-):
+def test_failed_put_records_error_and_never_finalizes(tmp_path, monkeypatch, cloud_state_dir):
     from ormah.cloud import jobs
 
     settings, store_id = _settings(tmp_path)
     client = FakeCloudClient()
     _patch_upload_prerequisites(monkeypatch, client)
     monkeypatch.setattr(
-        jobs,
+        protection,
         "put_file",
         lambda url, path, headers: (_ for _ in ()).throw(OSError("PUT failed")),
     )
@@ -256,15 +247,13 @@ def test_successful_upload_finalizes_without_advancing_sync_head(
 
 
 def test_cloud_backup_never_reuses_newer_safety_backup_with_different_contents(tmp_path):
-    from ormah.cloud import jobs
-
     settings, _ = _settings(tmp_path)
     service = service_from_settings(settings)
     stale = service.create(reason="pre-restore", prune=False)
     for path in (stale.path / "nodes").glob("*.md"):
         path.unlink()
 
-    selected = jobs._backup_for_upload(service)
+    selected = protection._backup_for_upload(service)
 
     assert selected.name != stale.name
     assert selected.node_count == 1
@@ -272,8 +261,6 @@ def test_cloud_backup_never_reuses_newer_safety_backup_with_different_contents(t
 
 
 def test_cloud_backup_does_not_reuse_snapshot_with_different_active_self(tmp_path):
-    from ormah.cloud import jobs
-
     settings, _ = _settings(tmp_path, with_node=False)
     first = MemoryNode(type=NodeType.person, source="system:self", title="First Self")
     second = MemoryNode(type=NodeType.person, source="system:self", title="Second Self")
@@ -302,7 +289,7 @@ def test_cloud_backup_does_not_reuse_snapshot_with_different_active_self(tmp_pat
     finally:
         database.close()
 
-    selected = jobs._backup_for_upload(service)
+    selected = protection._backup_for_upload(service)
 
     assert selected.name != first_backup.name
     manifest = json.loads((selected.path / "backup.json").read_text(encoding="utf-8"))
@@ -341,13 +328,13 @@ def _verification_bundle(tmp_path: Path, settings: Settings, store_id: str):
 
 
 def _patch_verification(monkeypatch, client, bundle: Path, identity):
-    from ormah.cloud import jobs
-
-    monkeypatch.setattr(jobs, "key_file_exists", lambda: True)
-    monkeypatch.setattr(jobs, "client_from_settings", lambda settings: client)
-    monkeypatch.setattr(jobs, "load_identities", lambda: [identity])
-    monkeypatch.setattr(jobs, "_utc_now", lambda: NOW)
-    monkeypatch.setattr(jobs, "download_file", lambda url, path: shutil.copyfile(bundle, path))
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: client)
+    monkeypatch.setattr(protection, "load_identities", lambda: [identity])
+    monkeypatch.setattr(protection, "_utc_now", lambda: NOW)
+    monkeypatch.setattr(
+        protection, "download_file", lambda url, path: shutil.copyfile(bundle, path)
+    )
 
 
 def test_restore_verification_rebuilds_search_and_leaves_live_store_untouched(
@@ -371,9 +358,7 @@ def test_restore_verification_rebuilds_search_and_leaves_live_store_untouched(
     assert state.last_verify_ok is True
     assert state.last_verify_snapshot_id == "01SNAPSHOT"
     assert state.last_verify_error is None
-    assert {
-        path: (path.read_bytes(), path.stat().st_mtime_ns) for path in live_files
-    } == live_files
+    assert {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in live_files} == live_files
 
 
 def test_restore_verification_search_probe_supports_unicode_nodes(
@@ -414,7 +399,7 @@ def test_restore_verification_records_bundle_failures(
         bundle.write_bytes(bundle.read_bytes()[:20])
     else:
         monkeypatch.setattr(
-            jobs,
+            protection,
             "open_bundle",
             lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Hash mismatch")),
         )
@@ -466,7 +451,7 @@ def test_restore_verification_cleans_temporary_tree_on_failure(
     client = FakeCloudClient(bundle=bundle)
     _patch_verification(monkeypatch, client, bundle, identity)
     root = tmp_path / "known-verification-root"
-    real_mkdtemp = jobs.tempfile.mkdtemp
+    real_mkdtemp = protection.tempfile.mkdtemp
 
     def controlled_mkdtemp(*args, prefix=None, **kwargs):
         if prefix == "ormah-restore-verify-":
@@ -474,9 +459,9 @@ def test_restore_verification_cleans_temporary_tree_on_failure(
             return str(root)
         return real_mkdtemp(*args, prefix=prefix, **kwargs)
 
-    monkeypatch.setattr(jobs.tempfile, "mkdtemp", controlled_mkdtemp)
+    monkeypatch.setattr(protection.tempfile, "mkdtemp", controlled_mkdtemp)
     monkeypatch.setattr(
-        jobs,
+        protection,
         "open_bundle",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("verification stopped")),
     )

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from ormah.cloud import jobs, protection, state
+from ormah.cloud.entitlements import EntitlementStatus
+from ormah.cloud.protection import CloudProtectionService, CloudProtectionStatus
+from ormah.cloud.state import (
+    ProtectionOperation,
+    ProtectionOperationKind,
+    ProtectionOperationPhase,
+    ProtectionReasonCode,
+    ProtectionState,
+    load_state,
+    state_path,
+)
+from tests.test_cloud_jobs import (
+    FakeCloudClient,
+    _patch_upload_prerequisites,
+    _patch_verification,
+    _settings,
+    _verification_bundle,
+)
+
+
+@pytest.fixture
+def cloud_state_dir(tmp_path, monkeypatch):
+    path = tmp_path / "cloud-state"
+    monkeypatch.setattr(state, "CLOUD_STATE_DIR", path)
+    return path
+
+
+def test_backup_now_returns_typed_completed_operation(tmp_path, monkeypatch, cloud_state_dir):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_upload_at=protection._utc_now(),
+        protection_state=ProtectionState.PROTECTED,
+    )
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert isinstance(result, ProtectionOperation)
+    assert result.kind is ProtectionOperationKind.BACKUP
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.state is ProtectionState.CHANGES_PENDING
+    assert result.snapshot_id == "01SNAPSHOT"
+    assert client.finalized == [(store_id, "upload-1")]
+    durable = load_state(store_id)
+    assert durable.last_operation_id == result.operation_id
+    assert durable.last_operation_phase is ProtectionOperationPhase.COMPLETED
+
+
+def test_failed_put_returns_typed_failure_and_never_finalizes(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, _store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    monkeypatch.setattr(
+        protection,
+        "put_file",
+        lambda url, path, headers: (_ for _ in ()).throw(OSError("PUT failed")),
+    )
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert isinstance(result, ProtectionOperation)
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.UPLOAD_FAILED
+    assert client.finalized == []
+
+
+def test_verify_now_accepts_snapshot_id_after_entitlement_lapse(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    settings.cloud_backup_enabled = False
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_successful_backup_snapshot_id="01SNAPSHOT",
+        protection_state=ProtectionState.CHANGES_PENDING,
+    )
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: (_ for _ in ()).throw(
+            AssertionError("downloads must not check upload entitlement")
+        ),
+    )
+
+    result = CloudProtectionService(settings).verify_now("01SNAPSHOT")
+
+    assert isinstance(result, ProtectionOperation)
+    assert result.kind is ProtectionOperationKind.VERIFY
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.state is ProtectionState.PROTECTED
+    assert result.snapshot_id == "01SNAPSHOT"
+    assert load_state(store_id).last_verified_snapshot_id == "01SNAPSHOT"
+
+
+def test_verifying_an_older_snapshot_does_not_claim_latest_backup_is_protected(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_successful_backup_snapshot_id="01NEWER",
+        protection_state=ProtectionState.CHANGES_PENDING,
+    )
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+
+    result = CloudProtectionService(settings).verify_now("01SNAPSHOT")
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.state is ProtectionState.CHANGES_PENDING
+    assert load_state(store_id).protection_state is ProtectionState.CHANGES_PENDING
+
+
+def test_expired_entitlement_pauses_only_direct_upload(tmp_path, monkeypatch, cloud_state_dir):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+    )
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "check_entitlement", lambda settings: EntitlementStatus.EXPIRED)
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: (_ for _ in ()).throw(AssertionError("upload should not start")),
+    )
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.state is ProtectionState.PAUSED
+    assert result.reason_code is ProtectionReasonCode.ENTITLEMENT_EXPIRED
+
+
+def test_corrupt_state_stops_backup_and_verification_before_network(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    path = state_path(store_id)
+    path.parent.mkdir(parents=True)
+    path.write_text("{not-json", encoding="utf-8")
+    before = path.read_bytes()
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: (_ for _ in ()).throw(AssertionError("entitlement should not run")),
+    )
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: (_ for _ in ()).throw(AssertionError("network should not run")),
+    )
+
+    backup = CloudProtectionService(settings).backup_now()
+    verification = CloudProtectionService(settings).verify_now()
+
+    assert backup.phase is ProtectionOperationPhase.FAILED
+    assert verification.phase is ProtectionOperationPhase.FAILED
+    assert path.read_bytes() == before
+
+
+def test_scheduler_adapters_delegate_and_keep_legacy_results(monkeypatch):
+    calls = []
+    backup = ProtectionOperation(
+        "backup-op",
+        ProtectionOperationKind.BACKUP,
+        ProtectionOperationPhase.COMPLETED,
+        ProtectionState.CHANGES_PENDING,
+        snapshot_id="01BACKUP",
+    )
+    verify = ProtectionOperation(
+        "verify-op",
+        ProtectionOperationKind.VERIFY,
+        ProtectionOperationPhase.COMPLETED,
+        ProtectionState.PROTECTED,
+        snapshot_id="01BACKUP",
+    )
+
+    class FakeService:
+        @classmethod
+        def from_engine(cls, engine):
+            calls.append(("engine", engine))
+            return cls()
+
+        def backup_now(self, reason="manual", *, only_if_due=False):
+            calls.append(("backup", reason, only_if_due))
+            return backup
+
+        def verify_now(self, snapshot_id=None):
+            calls.append(("verify", snapshot_id))
+            return verify
+
+    engine = SimpleNamespace(settings=SimpleNamespace(cloud_backup_enabled=True))
+    monkeypatch.setattr(jobs, "CloudProtectionService", FakeService)
+
+    assert jobs.run_cloud_backup(engine) == "01BACKUP"
+    assert jobs.run_restore_verification(engine) is True
+    assert calls == [
+        ("engine", engine),
+        ("backup", "cloud", True),
+        ("engine", engine),
+        ("verify", None),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("adapter", "fallback"),
+    [(jobs.run_cloud_backup, None), (jobs.run_restore_verification, False)],
+)
+def test_scheduler_adapters_swallow_unexpected_exceptions(monkeypatch, caplog, adapter, fallback):
+    class BrokenService:
+        @classmethod
+        def from_engine(cls, engine):
+            raise RuntimeError("https://objects.example/secret?token=do-not-log")
+
+    monkeypatch.setattr(jobs, "CloudProtectionService", BrokenService)
+
+    engine = SimpleNamespace(settings=SimpleNamespace(cloud_backup_enabled=True))
+    with caplog.at_level(logging.WARNING):
+        assert adapter(engine) is fallback
+
+    assert "RuntimeError" in caplog.text
+    assert "objects.example" not in caplog.text
+    assert "do-not-log" not in caplog.text
+
+
+def test_status_is_typed_and_corrupt_state_fails_closed(tmp_path, monkeypatch, cloud_state_dir):
+    settings, store_id = _settings(tmp_path)
+    path = state_path(store_id)
+    path.parent.mkdir(parents=True)
+    path.write_text('{"protection_state":"protected","last_verify_ok":"yes"}', encoding="utf-8")
+    before = path.read_bytes()
+    monkeypatch.setattr(protection, "check_entitlement", lambda settings: EntitlementStatus.ACTIVE)
+
+    result = CloudProtectionService(settings).status()
+
+    assert isinstance(result, CloudProtectionStatus)
+    assert result.protection_state is ProtectionState.ATTENTION_REQUIRED
+    assert result.state_error is not None
+    assert result.last_verify_ok is None
+    assert path.read_bytes() == before
+    assert json.loads(path.read_text(encoding="utf-8"))["protection_state"] == "protected"
+
+
+def test_service_can_be_constructed_from_engine(tmp_path):
+    settings, _store_id = _settings(tmp_path)
+
+    service = CloudProtectionService.from_engine(SimpleNamespace(settings=settings))
+
+    assert service.settings is settings

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 from types import SimpleNamespace
 
@@ -8,7 +7,7 @@ import pytest
 
 from ormah.cloud import jobs, protection, state
 from ormah.cloud.entitlements import EntitlementStatus
-from ormah.cloud.protection import CloudProtectionService, CloudProtectionStatus
+from ormah.cloud.protection import CloudProtectionService
 from ormah.cloud.state import (
     ProtectionOperation,
     ProtectionOperationKind,
@@ -18,6 +17,7 @@ from ormah.cloud.state import (
     load_state,
     state_path,
 )
+from ormah.cloud.store_lock import StoreLockTimeout
 from tests.test_cloud_jobs import (
     FakeCloudClient,
     _patch_upload_prerequisites,
@@ -56,6 +56,27 @@ def test_backup_now_returns_typed_completed_operation(tmp_path, monkeypatch, clo
     durable = load_state(store_id)
     assert durable.last_operation_id == result.operation_id
     assert durable.last_operation_phase is ProtectionOperationPhase.COMPLETED
+
+
+def test_backup_now_passes_the_operation_reason_into_the_bundle(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, _store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    captured = {}
+
+    def capture_bundle(backup_dir, out_path, recipients, **kwargs):
+        captured.update(kwargs)
+        out_path.write_bytes(b"age-encrypted-bundle")
+        return out_path
+
+    monkeypatch.setattr(protection, "build_bundle", capture_bundle)
+
+    result = CloudProtectionService(settings).backup_now(reason="manual-ui")
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert captured["reason"] == "manual-ui"
 
 
 def test_failed_put_returns_typed_failure_and_never_finalizes(
@@ -114,10 +135,16 @@ def test_verifying_an_older_snapshot_does_not_claim_latest_backup_is_protected(
     tmp_path, monkeypatch, cloud_state_dir
 ):
     settings, store_id = _settings(tmp_path)
+    previous_verified_at = protection._utc_now()
     state.update_state(
         store_id,
         memory_dir=settings.memory_dir,
         last_successful_backup_snapshot_id="01NEWER",
+        last_verify_at=previous_verified_at,
+        last_verify_ok=True,
+        last_verify_snapshot_id="01NEWER",
+        last_successful_verify_at=previous_verified_at,
+        last_verified_snapshot_id="01NEWER",
         protection_state=ProtectionState.CHANGES_PENDING,
     )
     bundle, identity = _verification_bundle(tmp_path, settings, store_id)
@@ -128,7 +155,50 @@ def test_verifying_an_older_snapshot_does_not_claim_latest_backup_is_protected(
 
     assert result.phase is ProtectionOperationPhase.COMPLETED
     assert result.state is ProtectionState.CHANGES_PENDING
-    assert load_state(store_id).protection_state is ProtectionState.CHANGES_PENDING
+    durable = load_state(store_id)
+    assert durable.protection_state is ProtectionState.CHANGES_PENDING
+    assert durable.last_verify_at == previous_verified_at
+    assert durable.last_verify_ok is True
+    assert durable.last_verify_snapshot_id == "01NEWER"
+    assert durable.last_successful_verify_at == previous_verified_at
+    assert durable.last_verified_snapshot_id == "01NEWER"
+
+
+def test_failure_verifying_an_older_snapshot_preserves_latest_verification_health(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    previous_verified_at = protection._utc_now()
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_successful_backup_snapshot_id="01NEWER",
+        last_verify_at=previous_verified_at,
+        last_verify_ok=True,
+        last_verify_snapshot_id="01NEWER",
+        last_successful_verify_at=previous_verified_at,
+        last_verified_snapshot_id="01NEWER",
+        protection_state=ProtectionState.PROTECTED,
+    )
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    monkeypatch.setattr(
+        protection,
+        "open_bundle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(protection.BundleError("corrupt")),
+    )
+
+    result = CloudProtectionService(settings).verify_now("01SNAPSHOT")
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    durable = load_state(store_id)
+    assert durable.protection_state is ProtectionState.PROTECTED
+    assert durable.last_verify_at == previous_verified_at
+    assert durable.last_verify_ok is True
+    assert durable.last_verify_snapshot_id == "01NEWER"
+    assert durable.last_successful_verify_at == previous_verified_at
+    assert durable.last_verified_snapshot_id == "01NEWER"
 
 
 def test_expired_entitlement_pauses_only_direct_upload(tmp_path, monkeypatch, cloud_state_dir):
@@ -151,6 +221,71 @@ def test_expired_entitlement_pauses_only_direct_upload(tmp_path, monkeypatch, cl
     assert result.phase is ProtectionOperationPhase.CANCELED
     assert result.state is ProtectionState.PAUSED
     assert result.reason_code is ProtectionReasonCode.ENTITLEMENT_EXPIRED
+
+
+def test_stopped_protection_blocks_direct_upload_before_entitlement(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.STOPPED,
+    )
+    monkeypatch.setattr(
+        protection,
+        "key_file_exists",
+        lambda: (_ for _ in ()).throw(AssertionError("key guard should not run")),
+    )
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: (_ for _ in ()).throw(AssertionError("entitlement should not run")),
+    )
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.state is ProtectionState.STOPPED
+    assert result.reason_code is ProtectionReasonCode.PROTECTION_STOPPED
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kind"),
+    [
+        ("backup_now", ProtectionOperationKind.BACKUP),
+        ("verify_now", ProtectionOperationKind.VERIFY),
+    ],
+)
+def test_store_busy_is_transient_and_preserves_durable_health(
+    tmp_path, monkeypatch, cloud_state_dir, method_name, kind
+):
+    settings, store_id = _settings(tmp_path)
+    verified_at = protection._utc_now()
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_verify_at=verified_at,
+        last_verify_ok=True,
+        last_verify_snapshot_id="01VERIFIED",
+        last_successful_verify_at=verified_at,
+        last_verified_snapshot_id="01VERIFIED",
+        protection_state=ProtectionState.PROTECTED,
+    )
+    before = load_state(store_id).to_dict()
+    monkeypatch.setattr(
+        protection,
+        "StoreLock",
+        lambda *args, **kwargs: (_ for _ in ()).throw(StoreLockTimeout("busy")),
+    )
+
+    result = getattr(CloudProtectionService(settings), method_name)()
+
+    assert result.kind is kind
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.STORE_BUSY
+    assert result.state is ProtectionState.PROTECTED
+    assert load_state(store_id).to_dict() == before
 
 
 def test_corrupt_state_stops_backup_and_verification_before_network(
@@ -212,7 +347,9 @@ def test_scheduler_adapters_delegate_and_keep_legacy_results(monkeypatch):
             calls.append(("verify", snapshot_id))
             return verify
 
-    engine = SimpleNamespace(settings=SimpleNamespace(cloud_backup_enabled=True))
+    engine = SimpleNamespace(
+        settings=SimpleNamespace(cloud_backup_enabled=True, account_token="test-token")
+    )
     monkeypatch.setattr(jobs, "CloudProtectionService", FakeService)
 
     assert jobs.run_cloud_backup(engine) == "01BACKUP"
@@ -233,35 +370,25 @@ def test_scheduler_adapters_swallow_unexpected_exceptions(monkeypatch, caplog, a
     class BrokenService:
         @classmethod
         def from_engine(cls, engine):
-            raise RuntimeError("https://objects.example/secret?token=do-not-log")
+            raise RuntimeError(
+                "upstream failed with test-token at "
+                "https://objects.example/secret?token=do-not-log"
+            )
 
     monkeypatch.setattr(jobs, "CloudProtectionService", BrokenService)
 
-    engine = SimpleNamespace(settings=SimpleNamespace(cloud_backup_enabled=True))
+    engine = SimpleNamespace(
+        settings=SimpleNamespace(cloud_backup_enabled=True, account_token="test-token")
+    )
     with caplog.at_level(logging.WARNING):
         assert adapter(engine) is fallback
 
     assert "RuntimeError" in caplog.text
+    assert "upstream failed" in caplog.text
+    assert "<redacted-url>" in caplog.text
+    assert "test-token" not in caplog.text
     assert "objects.example" not in caplog.text
     assert "do-not-log" not in caplog.text
-
-
-def test_status_is_typed_and_corrupt_state_fails_closed(tmp_path, monkeypatch, cloud_state_dir):
-    settings, store_id = _settings(tmp_path)
-    path = state_path(store_id)
-    path.parent.mkdir(parents=True)
-    path.write_text('{"protection_state":"protected","last_verify_ok":"yes"}', encoding="utf-8")
-    before = path.read_bytes()
-    monkeypatch.setattr(protection, "check_entitlement", lambda settings: EntitlementStatus.ACTIVE)
-
-    result = CloudProtectionService(settings).status()
-
-    assert isinstance(result, CloudProtectionStatus)
-    assert result.protection_state is ProtectionState.ATTENTION_REQUIRED
-    assert result.state_error is not None
-    assert result.last_verify_ok is None
-    assert path.read_bytes() == before
-    assert json.loads(path.read_text(encoding="utf-8"))["protection_state"] == "protected"
 
 
 def test_service_can_be_constructed_from_engine(tmp_path):

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+import threading
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 from ormah.cloud import jobs, protection, state
@@ -17,9 +19,11 @@ from ormah.cloud.state import (
     load_state,
     state_path,
 )
-from ormah.cloud.store_lock import StoreLockTimeout
+from ormah.cloud.client import CloudError
+from ormah.cloud.store_lock import StoreLock, StoreLockTimeout
 from tests.test_cloud_jobs import (
     FakeCloudClient,
+    SNAPSHOT_ID,
     _patch_upload_prerequisites,
     _patch_verification,
     _settings,
@@ -51,11 +55,34 @@ def test_backup_now_returns_typed_completed_operation(tmp_path, monkeypatch, clo
     assert result.kind is ProtectionOperationKind.BACKUP
     assert result.phase is ProtectionOperationPhase.COMPLETED
     assert result.state is ProtectionState.CHANGES_PENDING
-    assert result.snapshot_id == "01SNAPSHOT"
+    assert result.snapshot_id == SNAPSHOT_ID
     assert client.finalized == [(store_id, "upload-1")]
     durable = load_state(store_id)
     assert durable.last_operation_id == result.operation_id
     assert durable.last_operation_phase is ProtectionOperationPhase.COMPLETED
+
+
+def test_legacy_opted_in_store_reaches_protected_after_first_backup_and_verification(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    upload_client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, upload_client)
+
+    backup = CloudProtectionService(settings).backup_now()
+
+    assert backup.state is ProtectionState.VERIFYING_FIRST_BACKUP
+    assert load_state(store_id).protection_state is ProtectionState.VERIFYING_FIRST_BACKUP
+
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    verification_client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, verification_client, bundle, identity)
+
+    verification = CloudProtectionService(settings).verify_now()
+
+    assert verification.phase is ProtectionOperationPhase.COMPLETED
+    assert verification.state is ProtectionState.PROTECTED
+    assert load_state(store_id).protection_state is ProtectionState.PROTECTED
 
 
 def test_backup_now_passes_the_operation_reason_into_the_bundle(
@@ -99,6 +126,160 @@ def test_failed_put_returns_typed_failure_and_never_finalizes(
     assert client.finalized == []
 
 
+def test_upload_rejects_invalid_server_snapshot_id_before_put(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, _store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    original_create = client.create_upload
+
+    def invalid_snapshot(*args):
+        response = original_create(*args)
+        response["snapshot_id"] = "../../escape"
+        return response
+
+    client.create_upload = invalid_snapshot
+    monkeypatch.setattr(
+        protection,
+        "put_file",
+        lambda *args: (_ for _ in ()).throw(AssertionError("PUT should not run")),
+    )
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.UPLOAD_FAILED
+    assert client.finalized == []
+
+
+def test_verification_rejects_invalid_server_snapshot_id_before_tempfile(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, _store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    client.list_blobs = lambda store_id: {
+        "blobs": [{"snapshot_id": "../../escape", "size_bytes": 1}]
+    }
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: client)
+    monkeypatch.setattr(
+        protection.tempfile,
+        "mkdtemp",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("tempfile should not be created")
+        ),
+    )
+
+    result = CloudProtectionService(settings).verify_now()
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.VERIFICATION_FAILED
+
+
+def test_offline_upload_preserves_verification_health_and_redacts_persisted_error(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    verified_at = protection._utc_now()
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_verify_at=verified_at,
+        last_verify_ok=True,
+        last_verify_snapshot_id="01J11111111111111111111111",
+        last_successful_verify_at=verified_at,
+        last_verified_snapshot_id="01J11111111111111111111111",
+        protection_state=ProtectionState.PROTECTED,
+    )
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    secret = "do-not-persist"
+    client.create_upload = lambda *args: (_ for _ in ()).throw(
+        CloudError(f"request failed X-Amz-Signature={secret}&token=also-secret")
+    )
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.OFFLINE
+    assert result.state is ProtectionState.OFFLINE
+    durable = load_state(store_id)
+    assert durable.protection_state is ProtectionState.OFFLINE
+    assert durable.last_verify_ok is True
+    assert durable.last_verified_snapshot_id == "01J11111111111111111111111"
+    assert secret not in durable.last_upload_error
+    assert "also-secret" not in durable.last_upload_error
+    assert durable.last_upload_error.count("<redacted>") == 2
+
+
+def test_first_backup_offline_moves_local_only_store_to_offline(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    client.create_upload = lambda *args: (_ for _ in ()).throw(CloudError("offline"))
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.OFFLINE
+    assert result.state is ProtectionState.OFFLINE
+    assert load_state(store_id).protection_state is ProtectionState.OFFLINE
+
+
+def test_first_backup_missing_key_moves_local_only_store_to_attention_required(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: False)
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.KEY_MISSING
+    assert result.state is ProtectionState.ATTENTION_REQUIRED
+    assert load_state(store_id).protection_state is ProtectionState.ATTENTION_REQUIRED
+
+
+def test_offline_verification_preserves_known_good_verification_health(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    verified_at = protection._utc_now()
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_verify_at=verified_at,
+        last_verify_ok=True,
+        last_verify_snapshot_id=SNAPSHOT_ID,
+        last_successful_verify_at=verified_at,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        protection_state=ProtectionState.PROTECTED,
+    )
+    client = FakeCloudClient()
+    request = httpx.Request("GET", "https://cloud.example/blobs")
+    client.list_blobs = lambda *args: (_ for _ in ()).throw(
+        httpx.ConnectError("offline", request=request)
+    )
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: client)
+
+    result = CloudProtectionService(settings).verify_now()
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.OFFLINE
+    assert result.state is ProtectionState.OFFLINE
+    durable = load_state(store_id)
+    assert durable.protection_state is ProtectionState.OFFLINE
+    assert durable.last_verify_at == verified_at
+    assert durable.last_verify_ok is True
+    assert durable.last_verify_snapshot_id == SNAPSHOT_ID
+    assert durable.last_successful_verify_at == verified_at
+    assert durable.last_verified_snapshot_id == SNAPSHOT_ID
+
+
 def test_verify_now_accepts_snapshot_id_after_entitlement_lapse(
     tmp_path, monkeypatch, cloud_state_dir
 ):
@@ -107,7 +288,7 @@ def test_verify_now_accepts_snapshot_id_after_entitlement_lapse(
     state.update_state(
         store_id,
         memory_dir=settings.memory_dir,
-        last_successful_backup_snapshot_id="01SNAPSHOT",
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
         protection_state=ProtectionState.CHANGES_PENDING,
     )
     bundle, identity = _verification_bundle(tmp_path, settings, store_id)
@@ -121,14 +302,14 @@ def test_verify_now_accepts_snapshot_id_after_entitlement_lapse(
         ),
     )
 
-    result = CloudProtectionService(settings).verify_now("01SNAPSHOT")
+    result = CloudProtectionService(settings).verify_now(SNAPSHOT_ID)
 
     assert isinstance(result, ProtectionOperation)
     assert result.kind is ProtectionOperationKind.VERIFY
     assert result.phase is ProtectionOperationPhase.COMPLETED
     assert result.state is ProtectionState.PROTECTED
-    assert result.snapshot_id == "01SNAPSHOT"
-    assert load_state(store_id).last_verified_snapshot_id == "01SNAPSHOT"
+    assert result.snapshot_id == SNAPSHOT_ID
+    assert load_state(store_id).last_verified_snapshot_id == SNAPSHOT_ID
 
 
 def test_verifying_an_older_snapshot_does_not_claim_latest_backup_is_protected(
@@ -151,7 +332,7 @@ def test_verifying_an_older_snapshot_does_not_claim_latest_backup_is_protected(
     client = FakeCloudClient(bundle=bundle)
     _patch_verification(monkeypatch, client, bundle, identity)
 
-    result = CloudProtectionService(settings).verify_now("01SNAPSHOT")
+    result = CloudProtectionService(settings).verify_now(SNAPSHOT_ID)
 
     assert result.phase is ProtectionOperationPhase.COMPLETED
     assert result.state is ProtectionState.CHANGES_PENDING
@@ -189,7 +370,7 @@ def test_failure_verifying_an_older_snapshot_preserves_latest_verification_healt
         lambda *args, **kwargs: (_ for _ in ()).throw(protection.BundleError("corrupt")),
     )
 
-    result = CloudProtectionService(settings).verify_now("01SNAPSHOT")
+    result = CloudProtectionService(settings).verify_now(SNAPSHOT_ID)
 
     assert result.phase is ProtectionOperationPhase.FAILED
     durable = load_state(store_id)
@@ -250,6 +431,86 @@ def test_stopped_protection_blocks_direct_upload_before_entitlement(
     assert result.reason_code is ProtectionReasonCode.PROTECTION_STOPPED
 
 
+def test_disabled_backup_reports_the_actual_durable_state(tmp_path, monkeypatch, cloud_state_dir):
+    settings, store_id = _settings(tmp_path)
+    settings.cloud_backup_enabled = False
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+    )
+    monkeypatch.setattr(
+        protection,
+        "key_file_exists",
+        lambda: (_ for _ in ()).throw(AssertionError("key guard should not run")),
+    )
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.NOT_ENABLED
+    assert result.state is ProtectionState.PROTECTED
+
+
+def test_empty_and_not_due_cancellations_have_stable_reason_codes(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    empty_settings, _empty_store_id = _settings(tmp_path / "empty", with_node=False)
+    empty_client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, empty_client)
+
+    empty = CloudProtectionService(empty_settings).backup_now()
+
+    assert empty.phase is ProtectionOperationPhase.CANCELED
+    assert empty.reason_code is ProtectionReasonCode.NO_BACKUPABLE_MEMORY
+
+    due_settings, due_store_id = _settings(tmp_path / "due")
+    state.update_state(
+        due_store_id,
+        memory_dir=due_settings.memory_dir,
+        last_upload_at=protection._utc_now(),
+        protection_state=ProtectionState.PROTECTED,
+    )
+    due_client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, due_client)
+
+    not_due = CloudProtectionService(due_settings).backup_now(only_if_due=True)
+
+    assert not_due.phase is ProtectionOperationPhase.CANCELED
+    assert not_due.reason_code is ProtectionReasonCode.NOT_DUE
+
+
+@pytest.mark.parametrize("method_name", ["backup_now", "verify_now"])
+def test_unknown_protection_state_requires_update_without_remote_work_or_write(
+    tmp_path, monkeypatch, cloud_state_dir, method_name
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state="future_protection_state",
+    )
+    path = state_path(store_id)
+    before = path.read_bytes()
+    monkeypatch.setattr(
+        protection,
+        "key_file_exists",
+        lambda: (_ for _ in ()).throw(AssertionError("key guard should not run")),
+    )
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: (_ for _ in ()).throw(AssertionError("network should not run")),
+    )
+
+    result = getattr(CloudProtectionService(settings), method_name)()
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.CLIENT_UPDATE_REQUIRED
+    assert result.state is ProtectionState.ATTENTION_REQUIRED
+    assert path.read_bytes() == before
+
+
 @pytest.mark.parametrize(
     ("method_name", "kind"),
     [
@@ -285,6 +546,46 @@ def test_store_busy_is_transient_and_preserves_durable_health(
     assert result.phase is ProtectionOperationPhase.CANCELED
     assert result.reason_code is ProtectionReasonCode.STORE_BUSY
     assert result.state is ProtectionState.PROTECTED
+    assert load_state(store_id).to_dict() == before
+
+
+def test_real_store_lock_contention_is_transient_through_the_service(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_verify_ok=True,
+        last_verify_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        protection_state=ProtectionState.PROTECTED,
+    )
+    before = load_state(store_id).to_dict()
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_lock():
+        with StoreLock(settings.memory_dir, timeout=1):
+            acquired.set()
+            release.wait(2)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    try:
+        assert acquired.wait(1)
+        monkeypatch.setattr(
+            protection,
+            "StoreLock",
+            lambda memory_dir: StoreLock(memory_dir, timeout=0.1),
+        )
+        result = CloudProtectionService(settings).verify_now()
+    finally:
+        release.set()
+        holder.join(2)
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.STORE_BUSY
     assert load_state(store_id).to_dict() == before
 
 
@@ -356,7 +657,7 @@ def test_scheduler_adapters_delegate_and_keep_legacy_results(monkeypatch):
     assert jobs.run_restore_verification(engine) is True
     assert calls == [
         ("engine", engine),
-        ("backup", "cloud", True),
+        ("backup", "scheduled", True),
         ("engine", engine),
         ("verify", None),
     ]

--- a/tests/test_cloud_store_lock.py
+++ b/tests/test_cloud_store_lock.py
@@ -5,6 +5,7 @@ from multiprocessing import get_context
 import os
 from pathlib import Path
 import stat
+import threading
 import time
 import uuid
 
@@ -133,6 +134,32 @@ def test_store_lock_is_reentrant_in_one_thread(tmp_path):
 
     with first, second:
         assert os.path.samefile(first.path, second.path)
+
+
+def test_store_lock_timeout_covers_another_thread_in_the_same_process(tmp_path):
+    memory_dir = tmp_path / "memory"
+    acquired = threading.Event()
+    release = threading.Event()
+
+    def hold_lock():
+        with StoreLock(memory_dir, timeout=1):
+            acquired.set()
+            assert release.wait(2)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    try:
+        assert acquired.wait(1)
+        started = time.monotonic()
+        with pytest.raises(StoreLockTimeout, match="Memory store is busy"):
+            with StoreLock(memory_dir, timeout=0.1):
+                pass
+        assert time.monotonic() - started < 0.5
+    finally:
+        release.set()
+        holder.join(2)
+
+    assert not holder.is_alive()
 
 
 def test_permission_failure_does_not_leave_store_locked(tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

Cloud backup and restore-verification orchestration still lived inside scheduler jobs. CLI, local REST, and the desktop Protect flow would otherwise have to duplicate it, and a direct "Back up now" action could accidentally inherit scheduler due-time semantics.

## Solution

- add typed backup and verification operations behind `CloudProtectionService`
- keep `cloud_status_payload()` as the single canonical status derivation
- reduce scheduler jobs to guarded, exception-swallowing adapters
- keep scheduled backups interval-aware while direct `backup_now()` always creates a recovery point
- enforce one timeout across in-process and cross-process store-lock contention
- return transient `STORE_BUSY` without corrupting durable verification health
- preserve latest verification health when explicitly checking a historical snapshot
- block uploads for a durably stopped store while retaining restore verification
- pass the operation reason into the encrypted bundle manifest
- redact credentials while retaining useful scheduler diagnostics
- keep verification in scratch space and retain existing zero-knowledge upload behavior

This is C02 implementation step 3. It does not add enable/disable orchestration, billing, UI, sync, content-fingerprint deduplication, or new restore behavior.

## Verification

- `uv run pytest -q`: 1541 passed, 1 deselected
- focused cloud suite: 149 passed
- `uv run ruff check src/ tests/`: passed
- `git diff --check`: passed

