### PR TITLE
feat(cloud): add account billing handoffs

### DIFF
--- a/docs/08 - API Surface.md
+++ b/docs/08 - API Surface.md
@@ -152,6 +152,27 @@ importance_scorer
 
 `index_updater` is part of the run-all path even though it is not a standalone imported background module in `_TASK_RUNNERS`.
 
+## Account Billing Routes
+
+**Code**: `src/ormah/api/routes_account.py`
+
+These loopback routes are thin adapters over the authenticated Ormah Cloud client:
+
+- `GET /admin/account/offer`
+- `POST /admin/account/checkout`
+- `POST /admin/account/portal`
+
+They require a locally configured Ormah account token. Checkout accepts only a canonical
+`protection_intent_id` UUIDv4; callers cannot supply an email, Stripe customer, price, or return
+URL. Offer responses contain only `name`, `unit_amount`, `currency`, `interval`, and
+`interval_count`. Checkout and Portal return a short-lived, purpose-specific `url`; the cloud
+client accepts only exact `checkout.stripe.com` or `billing.stripe.com` HTTPS hosts with no
+embedded credentials.
+
+The routes never run backup or verification work and never return account tokens or Stripe
+provider identifiers. Stripe webhooks and reconciliation remain authoritative for entitlement;
+receiving a Checkout URL does not activate cloud backup.
+
 ## Ingest Routes
 
 **Code**: `src/ormah/api/routes_ingest.py`

--- a/docs/local-admin-auth.md
+++ b/docs/local-admin-auth.md
@@ -1,0 +1,11 @@
+# Local admin API authentication
+
+Sensitive desktop-only routes require an installation-local capability in the
+`X-Ormah-Local-Token` header and reject non-loopback peers. The server creates the capability at
+`~/.local/share/ormah/local_api_token` with mode `0600`. It is independent of the Ormah Cloud
+account token.
+
+The desktop integration must keep this boundary native: Tauri reads the owner-only capability and
+adds the header to requests it makes to the local Python server. React asks a narrow Tauri command
+to perform the request; React never receives either the local capability or
+`ORMAH_ACCOUNT_TOKEN`. Browser-only callers cannot use these billing routes.

--- a/docs/local-admin-auth.md
+++ b/docs/local-admin-auth.md
@@ -9,3 +9,7 @@ The desktop integration must keep this boundary native: Tauri reads the owner-on
 adds the header to requests it makes to the local Python server. React asks a narrow Tauri command
 to perform the request; React never receives either the local capability or
 `ORMAH_ACCOUNT_TOKEN`. Browser-only callers cannot use these billing routes.
+
+`POST /admin/account/portal` requires an explicit empty JSON object (`{}`). The body carries no
+customer or redirect input; requiring JSON ensures browser requests are preflighted before the
+owner-only capability is checked.

--- a/src/ormah/api/local_auth.py
+++ b/src/ormah/api/local_auth.py
@@ -68,6 +68,8 @@ async def require_local_admin(
     if (
         not isinstance(expected, str)
         or not isinstance(provided, str)
+        or not expected.isascii()
+        or not provided.isascii()
         or not secrets.compare_digest(provided, expected)
     ):
         raise HTTPException(status_code=401, detail="Local admin authentication required.")

--- a/src/ormah/api/local_auth.py
+++ b/src/ormah/api/local_auth.py
@@ -1,0 +1,73 @@
+"""Owner-only capability authentication for sensitive local API routes."""
+
+from __future__ import annotations
+
+import re
+import secrets
+import stat
+from ipaddress import ip_address
+from pathlib import Path
+
+from fastapi import Depends, Header, HTTPException, Request
+
+
+LOCAL_ADMIN_TOKEN_PATH = Path.home() / ".local" / "share" / "ormah" / "local_api_token"
+LOCAL_ADMIN_HEADER = "X-Ormah-Local-Token"
+_TOKEN_RE = re.compile(r"[0-9a-f]{64}")
+
+
+def load_or_create_local_admin_token(path: Path | None = None) -> str:
+    """Load this installation's local API capability, creating it mode 0600."""
+    path = (path or LOCAL_ADMIN_TOKEN_PATH).expanduser()
+    try:
+        file_stat = path.lstat()
+    except FileNotFoundError:
+        from ormah.setup import _atomic_write
+
+        token = secrets.token_hex(32)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write(str(path), token + "\n", mode=0o600)
+        return token
+    except OSError as exc:
+        raise RuntimeError(f"Could not inspect local API capability {path}: {exc}") from exc
+    try:
+        if path.is_symlink() or not stat.S_ISREG(file_stat.st_mode):
+            raise RuntimeError(f"Local API capability {path} is not a regular file")
+        if stat.S_IMODE(file_stat.st_mode) != 0o600:
+            path.chmod(0o600)
+    except OSError as exc:
+        raise RuntimeError(f"Could not secure local API capability {path}: {exc}") from exc
+    try:
+        token = path.read_text(encoding="ascii").strip()
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError(f"Could not read local API capability {path}: {exc}") from exc
+
+    if _TOKEN_RE.fullmatch(token) is None:
+        raise RuntimeError(f"Local API capability {path} is invalid; refusing to replace it")
+    return token
+
+
+async def require_loopback(request: Request) -> None:
+    """Reject sensitive requests that did not originate on this machine."""
+    peer = request.client.host if request.client is not None else ""
+    try:
+        is_loopback = ip_address(peer.split("%", 1)[0]).is_loopback
+    except ValueError:
+        is_loopback = False
+    if not is_loopback:
+        raise HTTPException(status_code=403, detail="Local admin routes are loopback-only.")
+
+
+async def require_local_admin(
+    request: Request,
+    provided: str | None = Header(default=None, alias=LOCAL_ADMIN_HEADER),
+    _loopback: None = Depends(require_loopback),
+) -> None:
+    """Authenticate a native local caller without exposing the cloud account token."""
+    expected = getattr(request.app.state, "local_admin_token", None)
+    if (
+        not isinstance(expected, str)
+        or not isinstance(provided, str)
+        or not secrets.compare_digest(provided, expected)
+    ):
+        raise HTTPException(status_code=401, detail="Local admin authentication required.")

--- a/src/ormah/api/routes_account.py
+++ b/src/ormah/api/routes_account.py
@@ -9,9 +9,10 @@ handoff — never a backup or verification run.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from ormah.api.local_auth import require_local_admin
 from ormah.cloud.billing import (
     BillingError,
     BillingErrorCode,
@@ -21,7 +22,11 @@ from ormah.cloud.billing import (
     validate_protection_intent_id,
 )
 
-router = APIRouter(prefix="/admin/account", tags=["account"])
+router = APIRouter(
+    prefix="/admin/account",
+    tags=["account"],
+    dependencies=[Depends(require_local_admin)],
+)
 
 _ERROR_STATUS: dict[BillingErrorCode, int] = {
     BillingErrorCode.SIGN_IN_REQUIRED: 401,
@@ -67,6 +72,11 @@ def _cloud_client(request: Request):
     return getattr(request.app.state, "cloud_client", None)
 
 
+def _cloud_state_dir(request: Request):
+    """Optional test seam; production uses the canonical per-user state directory."""
+    return getattr(request.app.state, "cloud_state_dir", None)
+
+
 def _http_error(exc: BillingError) -> HTTPException:
     """Map a stable billing reason code onto a local HTTP error."""
     return HTTPException(
@@ -96,6 +106,7 @@ def account_checkout(body: CheckoutRequest, request: Request):
             _settings(request),
             body.protection_intent_id,
             client=_cloud_client(request),
+            state_dir=_cloud_state_dir(request),
         )
     except BillingError as exc:
         raise _http_error(exc) from exc
@@ -103,7 +114,7 @@ def account_checkout(body: CheckoutRequest, request: Request):
 
 
 @router.post("/portal")
-def account_portal(request: Request, body: PortalRequest | None = None):
+def account_portal(body: PortalRequest, request: Request):
     """Create a hosted billing-portal handoff for the signed-in account."""
     try:
         handoff = open_portal(_settings(request), client=_cloud_client(request))

--- a/src/ormah/api/routes_account.py
+++ b/src/ormah/api/routes_account.py
@@ -1,0 +1,112 @@
+"""Local admin routes for account-linked hosted billing handoffs.
+
+Handlers here are thin wrappers over ``ormah.cloud.billing``: they authenticate
+the local request against the signed-in account, validate input, delegate, and
+translate stable billing reason codes into HTTP status codes. No remote request
+is constructed in this module, and each route only creates a short-lived hosted
+handoff — never a backup or verification run.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from ormah.cloud.billing import (
+    BillingError,
+    BillingErrorCode,
+    get_offer,
+    open_portal,
+    start_checkout,
+    validate_protection_intent_id,
+)
+
+router = APIRouter(prefix="/admin/account", tags=["account"])
+
+_ERROR_STATUS: dict[BillingErrorCode, int] = {
+    BillingErrorCode.SIGN_IN_REQUIRED: 401,
+    BillingErrorCode.ACCOUNT_FORBIDDEN: 403,
+    BillingErrorCode.INVALID_REQUEST: 400,
+    BillingErrorCode.NOT_FOUND: 404,
+    BillingErrorCode.CONFLICT: 409,
+    BillingErrorCode.RATE_LIMITED: 429,
+    BillingErrorCode.CLOUD_UNREACHABLE: 503,
+    BillingErrorCode.BILLING_UNAVAILABLE: 502,
+}
+
+
+class CheckoutRequest(BaseModel):
+    """The only accepted Checkout input: which protection intent to pay for."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    protection_intent_id: str
+
+    @field_validator("protection_intent_id")
+    @classmethod
+    def _canonical_uuid(cls, value: str) -> str:
+        return validate_protection_intent_id(value)
+
+
+class PortalRequest(BaseModel):
+    """Portal sessions take no client input: no customer, no return URL."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def _settings(request: Request):
+    return request.app.state.engine.settings
+
+
+def _cloud_client(request: Request):
+    """Injection seam for tests and the desktop shell.
+
+    Production leaves this unset, and the billing adapter builds its own
+    short-lived authenticated client from settings.
+    """
+    return getattr(request.app.state, "cloud_client", None)
+
+
+def _http_error(exc: BillingError) -> HTTPException:
+    """Map a stable billing reason code onto a local HTTP error."""
+    return HTTPException(
+        status_code=_ERROR_STATUS.get(exc.code, 502),
+        detail={"error": exc.code.value, "message": str(exc)},
+    )
+
+
+@router.get("/offer")
+def account_offer(request: Request):
+    """Return the hosted plan offer for the signed-in account.
+
+    Carries no hosted URL, price ID, or customer ID.
+    """
+    try:
+        offer = get_offer(_settings(request), client=_cloud_client(request))
+    except BillingError as exc:
+        raise _http_error(exc) from exc
+    return offer.to_payload()
+
+
+@router.post("/checkout")
+def account_checkout(body: CheckoutRequest, request: Request):
+    """Create a hosted Checkout handoff for one protection intent."""
+    try:
+        handoff = start_checkout(
+            _settings(request),
+            body.protection_intent_id,
+            client=_cloud_client(request),
+        )
+    except BillingError as exc:
+        raise _http_error(exc) from exc
+    return handoff.to_payload()
+
+
+@router.post("/portal")
+def account_portal(request: Request, body: PortalRequest | None = None):
+    """Create a hosted billing-portal handoff for the signed-in account."""
+    try:
+        handoff = open_portal(_settings(request), client=_cloud_client(request))
+    except BillingError as exc:
+        raise _http_error(exc) from exc
+    return handoff.to_payload()

--- a/src/ormah/api/routes_account.py
+++ b/src/ormah/api/routes_account.py
@@ -37,6 +37,7 @@ _ERROR_STATUS: dict[BillingErrorCode, int] = {
     BillingErrorCode.RATE_LIMITED: 429,
     BillingErrorCode.CLOUD_UNREACHABLE: 503,
     BillingErrorCode.BILLING_UNAVAILABLE: 502,
+    BillingErrorCode.STATE_UNAVAILABLE: 503,
 }
 
 

--- a/src/ormah/cloud/billing.py
+++ b/src/ormah/cloud/billing.py
@@ -3,12 +3,21 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import StrEnum
 import logging
-from typing import Any
+from pathlib import Path
+from typing import Any, Callable
 import uuid
 
 from ormah.cloud.client import CloudClient, CloudError, client_from_settings
+from ormah.cloud.keys import STORE_ID_NAME, get_or_create_store_id
+from ormah.cloud.state import (
+    CloudState,
+    CloudStateError,
+    ProtectionIntentStatus,
+    load_state,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +126,19 @@ def validate_protection_intent_id(value: Any) -> str:
     return str(parsed)
 
 
+def _canonical_account_id(value: Any) -> str:
+    """Validate the opaque account identifier returned by authenticated cloud metadata."""
+    if not isinstance(value, str):
+        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError:
+        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE) from None
+    if parsed.version != 4 or parsed.variant != uuid.RFC_4122 or str(parsed) != value.lower():
+        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
+    return str(parsed)
+
+
 def _map_cloud_error(exc: CloudError) -> BillingError:
     if exc.status_code is None:
         return BillingError(BillingErrorCode.CLOUD_UNREACHABLE)
@@ -134,17 +156,13 @@ def _require_account(settings) -> None:
 def _invoke(
     settings,
     client: CloudClient | None,
-    method_name: str,
-    *args: Any,
+    operation: Callable[[CloudClient], dict[str, Any]],
 ) -> dict[str, Any]:
     _require_account(settings)
     owned_client = client is None
     client = client or client_from_settings(settings)
     try:
-        method = getattr(client, method_name, None)
-        if not callable(method):
-            raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
-        payload = method(*args)
+        payload = operation(client)
     except CloudError as exc:
         raise _map_cloud_error(exc) from exc
     finally:
@@ -155,10 +173,44 @@ def _invoke(
     return payload
 
 
+def _pending_checkout_state(
+    settings,
+    protection_intent_id: str,
+    *,
+    state_dir: Path | None,
+) -> CloudState:
+    """Load and validate the store-bound half of a durable Checkout intent."""
+    memory_dir = Path(settings.memory_dir).expanduser()
+    if not (memory_dir / STORE_ID_NAME).is_file():
+        raise BillingError(BillingErrorCode.CONFLICT)
+    try:
+        store_id = get_or_create_store_id(memory_dir)
+        state = load_state(store_id, state_dir=state_dir)
+    except (OSError, ValueError, CloudStateError):
+        raise BillingError(BillingErrorCode.CONFLICT) from None
+
+    now = datetime.now(timezone.utc)
+    if (
+        state.pending_protection_intent_id != protection_intent_id
+        or state.pending_protection_store_id != store_id
+        or state.pending_protection_account_id is None
+        or state.pending_protection_created_at is None
+        or state.pending_protection_expires_at is None
+        or state.pending_protection_expires_at <= now
+        or state.pending_protection_status
+        not in {
+            ProtectionIntentStatus.ACCOUNT_BOUND,
+            ProtectionIntentStatus.CHECKOUT_PENDING,
+        }
+    ):
+        raise BillingError(BillingErrorCode.CONFLICT)
+    return state
+
+
 def get_offer(settings, *, client: CloudClient | None = None) -> BillingOffer:
     """Return the authenticated account's configured subscription offer."""
 
-    payload = _invoke(settings, client, "get_billing_offer")
+    payload = _invoke(settings, client, lambda cloud: cloud.get_billing_offer())
     try:
         offer = BillingOffer(
             name=payload["name"],
@@ -178,11 +230,27 @@ def start_checkout(
     protection_intent_id: str,
     *,
     client: CloudClient | None = None,
+    state_dir: Path | None = None,
 ) -> CheckoutHandoff:
     """Create or resume Checkout for one durable protection intent."""
 
-    intent_id = validate_protection_intent_id(protection_intent_id)
-    payload = _invoke(settings, client, "create_checkout_session", intent_id)
+    try:
+        intent_id = validate_protection_intent_id(protection_intent_id)
+    except ValueError:
+        raise BillingError(BillingErrorCode.INVALID_REQUEST) from None
+    _require_account(settings)
+    state = _pending_checkout_state(settings, intent_id, state_dir=state_dir)
+
+    def create_for_bound_account(cloud: CloudClient) -> dict[str, Any]:
+        entitlements = cloud.get_entitlements()
+        if not isinstance(entitlements, dict):
+            raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
+        account_id = _canonical_account_id(entitlements.get("account_id"))
+        if account_id != state.pending_protection_account_id:
+            raise BillingError(BillingErrorCode.CONFLICT)
+        return cloud.create_checkout_session(intent_id)
+
+    payload = _invoke(settings, client, create_for_bound_account)
     try:
         status = CheckoutStatus(payload["status"])
         if status is CheckoutStatus.CHECKOUT_REQUIRED:
@@ -202,7 +270,7 @@ def start_checkout(
 def open_portal(settings, *, client: CloudClient | None = None) -> PortalHandoff:
     """Create a Stripe Customer Portal handoff for the signed-in account."""
 
-    payload = _invoke(settings, client, "create_portal_session")
+    payload = _invoke(settings, client, lambda cloud: cloud.create_portal_session())
     try:
         handoff = PortalHandoff(url=payload["url"])
     except (KeyError, TypeError):

--- a/src/ormah/cloud/billing.py
+++ b/src/ormah/cloud/billing.py
@@ -1,0 +1,211 @@
+"""Shared account-linked billing handoffs for local Ormah callers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import logging
+from typing import Any
+import uuid
+
+from ormah.cloud.client import CloudClient, CloudError, client_from_settings
+
+logger = logging.getLogger(__name__)
+
+
+class BillingErrorCode(StrEnum):
+    """Stable failures exposed to CLI, REST, and desktop callers."""
+
+    SIGN_IN_REQUIRED = "sign_in_required"
+    ACCOUNT_FORBIDDEN = "account_forbidden"
+    INVALID_REQUEST = "invalid_request"
+    NOT_FOUND = "not_found"
+    CONFLICT = "conflict"
+    RATE_LIMITED = "rate_limited"
+    CLOUD_UNREACHABLE = "cloud_unreachable"
+    BILLING_UNAVAILABLE = "billing_unavailable"
+
+
+_ERROR_MESSAGES = {
+    BillingErrorCode.SIGN_IN_REQUIRED: "Sign in to your Ormah account first.",
+    BillingErrorCode.ACCOUNT_FORBIDDEN: "This Ormah account may not manage billing.",
+    BillingErrorCode.INVALID_REQUEST: "Ormah Cloud rejected the billing request.",
+    BillingErrorCode.NOT_FOUND: "Ormah Cloud has no such billing resource.",
+    BillingErrorCode.CONFLICT: "This billing request conflicts with the account's current state.",
+    BillingErrorCode.RATE_LIMITED: "Too many billing requests; try again shortly.",
+    BillingErrorCode.CLOUD_UNREACHABLE: "Could not reach Ormah Cloud.",
+    BillingErrorCode.BILLING_UNAVAILABLE: "Ormah Cloud billing is unavailable right now.",
+}
+
+_STATUS_ERROR_CODES = {
+    400: BillingErrorCode.INVALID_REQUEST,
+    401: BillingErrorCode.SIGN_IN_REQUIRED,
+    403: BillingErrorCode.ACCOUNT_FORBIDDEN,
+    404: BillingErrorCode.NOT_FOUND,
+    409: BillingErrorCode.CONFLICT,
+    422: BillingErrorCode.INVALID_REQUEST,
+    429: BillingErrorCode.RATE_LIMITED,
+}
+
+
+class BillingError(RuntimeError):
+    def __init__(self, code: BillingErrorCode) -> None:
+        super().__init__(_ERROR_MESSAGES[code])
+        self.code = code
+
+
+class CheckoutStatus(StrEnum):
+    CHECKOUT_REQUIRED = "checkout_required"
+    ALREADY_SUBSCRIBED = "already_subscribed"
+    SUBSCRIPTION_PENDING = "subscription_pending"
+
+
+@dataclass(frozen=True)
+class BillingOffer:
+    """Display-safe fields returned by the configured Stripe Price."""
+
+    name: str
+    unit_amount: int
+    currency: str
+    interval: str
+    interval_count: int
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "unit_amount": self.unit_amount,
+            "currency": self.currency,
+            "interval": self.interval,
+            "interval_count": self.interval_count,
+        }
+
+
+@dataclass(frozen=True)
+class CheckoutHandoff:
+    status: CheckoutStatus
+    url: str | None = None
+    expires_at: int | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"status": self.status.value}
+        if self.url is not None:
+            payload["url"] = self.url
+            payload["expires_at"] = self.expires_at
+        return payload
+
+
+@dataclass(frozen=True)
+class PortalHandoff:
+    url: str
+
+    def to_payload(self) -> dict[str, str]:
+        return {"url": self.url}
+
+
+def validate_protection_intent_id(value: Any) -> str:
+    """Accept only the canonical dashed UUIDv4 used by durable protection state."""
+
+    message = "protection_intent_id must be a canonical UUIDv4 string"
+    if not isinstance(value, str):
+        raise ValueError(message)
+    try:
+        parsed = uuid.UUID(value)
+    except ValueError as exc:
+        raise ValueError(message) from exc
+    if parsed.version != 4 or parsed.variant != uuid.RFC_4122 or str(parsed) != value.lower():
+        raise ValueError(message)
+    return str(parsed)
+
+
+def _map_cloud_error(exc: CloudError) -> BillingError:
+    if exc.status_code is None:
+        return BillingError(BillingErrorCode.CLOUD_UNREACHABLE)
+    return BillingError(
+        _STATUS_ERROR_CODES.get(exc.status_code, BillingErrorCode.BILLING_UNAVAILABLE)
+    )
+
+
+def _require_account(settings) -> None:
+    token = getattr(settings, "account_token", None)
+    if not isinstance(token, str) or not token.strip():
+        raise BillingError(BillingErrorCode.SIGN_IN_REQUIRED)
+
+
+def _invoke(
+    settings,
+    client: CloudClient | None,
+    method_name: str,
+    *args: Any,
+) -> dict[str, Any]:
+    _require_account(settings)
+    owned_client = client is None
+    client = client or client_from_settings(settings)
+    try:
+        method = getattr(client, method_name, None)
+        if not callable(method):
+            raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
+        payload = method(*args)
+    except CloudError as exc:
+        raise _map_cloud_error(exc) from exc
+    finally:
+        if owned_client:
+            client.close()
+    if not isinstance(payload, dict):
+        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
+    return payload
+
+
+def get_offer(settings, *, client: CloudClient | None = None) -> BillingOffer:
+    """Return the authenticated account's configured subscription offer."""
+
+    payload = _invoke(settings, client, "get_billing_offer")
+    try:
+        offer = BillingOffer(
+            name=payload["name"],
+            unit_amount=payload["unit_amount"],
+            currency=payload["currency"],
+            interval=payload["interval"],
+            interval_count=payload["interval_count"],
+        )
+    except (KeyError, TypeError):
+        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE) from None
+    logger.debug("Ormah Cloud billing offer read")
+    return offer
+
+
+def start_checkout(
+    settings,
+    protection_intent_id: str,
+    *,
+    client: CloudClient | None = None,
+) -> CheckoutHandoff:
+    """Create or resume Checkout for one durable protection intent."""
+
+    intent_id = validate_protection_intent_id(protection_intent_id)
+    payload = _invoke(settings, client, "create_checkout_session", intent_id)
+    try:
+        status = CheckoutStatus(payload["status"])
+        if status is CheckoutStatus.CHECKOUT_REQUIRED:
+            handoff = CheckoutHandoff(
+                status=status,
+                url=payload["url"],
+                expires_at=payload["expires_at"],
+            )
+        else:
+            handoff = CheckoutHandoff(status=status)
+    except (KeyError, TypeError, ValueError):
+        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE) from None
+    logger.debug("Ormah Cloud checkout handoff: status=%s", handoff.status.value)
+    return handoff
+
+
+def open_portal(settings, *, client: CloudClient | None = None) -> PortalHandoff:
+    """Create a Stripe Customer Portal handoff for the signed-in account."""
+
+    payload = _invoke(settings, client, "create_portal_session")
+    try:
+        handoff = PortalHandoff(url=payload["url"])
+    except (KeyError, TypeError):
+        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE) from None
+    logger.debug("Ormah Cloud billing portal handoff created")
+    return handoff

--- a/src/ormah/cloud/billing.py
+++ b/src/ormah/cloud/billing.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from enum import StrEnum
 import logging
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 import uuid
 
 from ormah.cloud.client import CloudClient, CloudError, client_from_settings
@@ -17,6 +17,7 @@ from ormah.cloud.state import (
     CloudStateError,
     ProtectionIntentStatus,
     load_state,
+    mutate_state,
 )
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class BillingErrorCode(StrEnum):
     RATE_LIMITED = "rate_limited"
     CLOUD_UNREACHABLE = "cloud_unreachable"
     BILLING_UNAVAILABLE = "billing_unavailable"
+    STATE_UNAVAILABLE = "state_unavailable"
 
 
 _ERROR_MESSAGES = {
@@ -44,6 +46,7 @@ _ERROR_MESSAGES = {
     BillingErrorCode.RATE_LIMITED: "Too many billing requests; try again shortly.",
     BillingErrorCode.CLOUD_UNREACHABLE: "Could not reach Ormah Cloud.",
     BillingErrorCode.BILLING_UNAVAILABLE: "Ormah Cloud billing is unavailable right now.",
+    BillingErrorCode.STATE_UNAVAILABLE: "Local protection state is unavailable right now.",
 }
 
 _STATUS_ERROR_CODES = {
@@ -111,32 +114,41 @@ class PortalHandoff:
         return {"url": self.url}
 
 
-def validate_protection_intent_id(value: Any) -> str:
-    """Accept only the canonical dashed UUIDv4 used by durable protection state."""
-
-    message = "protection_intent_id must be a canonical UUIDv4 string"
+def _canonical_uuid4(value: Any, message: str, *, require_canonical: bool) -> str:
     if not isinstance(value, str):
         raise ValueError(message)
     try:
         parsed = uuid.UUID(value)
     except ValueError as exc:
         raise ValueError(message) from exc
-    if parsed.version != 4 or parsed.variant != uuid.RFC_4122 or str(parsed) != value.lower():
+    if (
+        parsed.version != 4
+        or parsed.variant != uuid.RFC_4122
+        or (require_canonical and str(parsed) != value)
+    ):
         raise ValueError(message)
     return str(parsed)
 
 
+def validate_protection_intent_id(value: Any) -> str:
+    """Accept only the canonical dashed UUIDv4 used by durable protection state."""
+    return _canonical_uuid4(
+        value,
+        "protection_intent_id must be a canonical UUIDv4 string",
+        require_canonical=True,
+    )
+
+
 def _canonical_account_id(value: Any) -> str:
     """Validate the opaque account identifier returned by authenticated cloud metadata."""
-    if not isinstance(value, str):
-        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
     try:
-        parsed = uuid.UUID(value)
+        return _canonical_uuid4(
+            value,
+            "account_id must be a UUIDv4 string",
+            require_canonical=False,
+        )
     except ValueError:
         raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE) from None
-    if parsed.version != 4 or parsed.variant != uuid.RFC_4122 or str(parsed) != value.lower():
-        raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
-    return str(parsed)
 
 
 def _map_cloud_error(exc: CloudError) -> BillingError:
@@ -178,17 +190,36 @@ def _pending_checkout_state(
     protection_intent_id: str,
     *,
     state_dir: Path | None,
-) -> CloudState:
+) -> tuple[str, CloudState]:
     """Load and validate the store-bound half of a durable Checkout intent."""
     memory_dir = Path(settings.memory_dir).expanduser()
     if not (memory_dir / STORE_ID_NAME).is_file():
-        raise BillingError(BillingErrorCode.CONFLICT)
+        _raise_state_unavailable(FileNotFoundError())
     try:
         store_id = get_or_create_store_id(memory_dir)
         state = load_state(store_id, state_dir=state_dir)
-    except (OSError, ValueError, CloudStateError):
-        raise BillingError(BillingErrorCode.CONFLICT) from None
+    except (OSError, ValueError, CloudStateError) as exc:
+        _raise_state_unavailable(exc)
 
+    _validate_pending_checkout(state, protection_intent_id, store_id)
+    return store_id, state
+
+
+def _raise_state_unavailable(exc: BaseException) -> NoReturn:
+    logger.warning(
+        "Durable protection state is unavailable; error_type=%s",
+        type(exc).__name__,
+    )
+    raise BillingError(BillingErrorCode.STATE_UNAVAILABLE) from None
+
+
+def _validate_pending_checkout(
+    state: CloudState,
+    protection_intent_id: str,
+    store_id: str,
+    *,
+    account_id: str | None = None,
+) -> None:
     now = datetime.now(timezone.utc)
     if (
         state.pending_protection_intent_id != protection_intent_id
@@ -204,7 +235,53 @@ def _pending_checkout_state(
         }
     ):
         raise BillingError(BillingErrorCode.CONFLICT)
-    return state
+
+    try:
+        stored_account_id = _canonical_uuid4(
+            state.pending_protection_account_id,
+            "pending account binding must be a UUIDv4 string",
+            require_canonical=False,
+        )
+    except ValueError as exc:
+        _raise_state_unavailable(exc)
+    if account_id is not None and stored_account_id != account_id:
+        raise BillingError(BillingErrorCode.CONFLICT)
+
+
+def _mark_checkout_pending(
+    settings,
+    store_id: str,
+    protection_intent_id: str,
+    account_id: str,
+    *,
+    state_dir: Path | None,
+) -> CloudState:
+    """Atomically revalidate and reserve this durable intent for Checkout."""
+
+    def transition(state: CloudState) -> CloudState:
+        _validate_pending_checkout(
+            state,
+            protection_intent_id,
+            store_id,
+            account_id=account_id,
+        )
+        return replace(
+            state,
+            pending_protection_account_id=account_id,
+            pending_protection_status=ProtectionIntentStatus.CHECKOUT_PENDING,
+        )
+
+    try:
+        return mutate_state(
+            store_id,
+            transition,
+            memory_dir=Path(settings.memory_dir),
+            state_dir=state_dir,
+        )
+    except BillingError:
+        raise
+    except (OSError, ValueError, CloudStateError, TimeoutError) as exc:
+        _raise_state_unavailable(exc)
 
 
 def get_offer(settings, *, client: CloudClient | None = None) -> BillingOffer:
@@ -239,15 +316,20 @@ def start_checkout(
     except ValueError:
         raise BillingError(BillingErrorCode.INVALID_REQUEST) from None
     _require_account(settings)
-    state = _pending_checkout_state(settings, intent_id, state_dir=state_dir)
+    store_id, _ = _pending_checkout_state(settings, intent_id, state_dir=state_dir)
 
     def create_for_bound_account(cloud: CloudClient) -> dict[str, Any]:
         entitlements = cloud.get_entitlements()
         if not isinstance(entitlements, dict):
             raise BillingError(BillingErrorCode.BILLING_UNAVAILABLE)
         account_id = _canonical_account_id(entitlements.get("account_id"))
-        if account_id != state.pending_protection_account_id:
-            raise BillingError(BillingErrorCode.CONFLICT)
+        _mark_checkout_pending(
+            settings,
+            store_id,
+            intent_id,
+            account_id,
+            state_dir=state_dir,
+        )
         return cloud.create_checkout_session(intent_id)
 
     payload = _invoke(settings, client, create_for_bound_account)

--- a/src/ormah/cloud/client.py
+++ b/src/ormah/cloud/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import socket
 import time
 import uuid
+from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,8 @@ DEFAULT_MAX_CIPHERTEXT_BYTES = 512 * 1024 * 1024
 CHECKOUT_HOST = "checkout.stripe.com"
 PORTAL_HOST = "billing.stripe.com"
 MAX_HOSTED_URL_CHARS = 2048
+MAX_CHECKOUT_SESSION_SECONDS = 24 * 60 * 60
+HOSTED_SESSION_CLOCK_SKEW_SECONDS = 5 * 60
 _BILLING_INTERVALS = {"day", "week", "month", "year"}
 _CHECKOUT_STATUSES = {"checkout_required", "already_subscribed", "subscription_pending"}
 
@@ -88,7 +91,13 @@ def _validate_stripe_url(url: Any, expected_host: str) -> str:
 
 
 def _validate_expiry(value: Any) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+    now = int(datetime.now(timezone.utc).timestamp())
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or value <= now
+        or value > now + MAX_CHECKOUT_SESSION_SECONDS + HOSTED_SESSION_CLOCK_SKEW_SECONDS
+    ):
         raise CloudError("Ormah Cloud returned an invalid billing expiry.", status_code=200)
     return value
 

--- a/src/ormah/cloud/client.py
+++ b/src/ormah/cloud/client.py
@@ -8,6 +8,7 @@ import uuid
 from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -17,6 +18,11 @@ ACCOUNT_TOKEN_KEY = "ORMAH_ACCOUNT_TOKEN"
 ACCOUNT_EMAIL_KEY = "ORMAH_ACCOUNT_EMAIL"
 PROTOCOL_CACHE_SECONDS = 300
 DEFAULT_MAX_CIPHERTEXT_BYTES = 512 * 1024 * 1024
+CHECKOUT_HOST = "checkout.stripe.com"
+PORTAL_HOST = "billing.stripe.com"
+MAX_HOSTED_URL_CHARS = 2048
+_BILLING_INTERVALS = {"day", "week", "month", "year"}
+_CHECKOUT_STATUSES = {"checkout_required", "already_subscribed", "subscription_pending"}
 
 
 def _client_version() -> str:
@@ -41,14 +47,49 @@ class CloudError(RuntimeError):
         self.payload = payload
 
 
-def _uuid4(value: str, path: Path) -> str:
+def _validate_uuid4(value: Any, label: str) -> str:
     try:
         parsed = uuid.UUID(value)
-    except ValueError as exc:
-        raise CloudError(f"Invalid device id at {path}; expected UUIDv4.") from exc
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise CloudError(f"Invalid {label}; expected UUIDv4.") from exc
     if parsed.version != 4 or parsed.variant != uuid.RFC_4122:
-        raise CloudError(f"Invalid device id at {path}; expected UUIDv4.")
+        raise CloudError(f"Invalid {label}; expected UUIDv4.")
     return str(parsed)
+
+
+def _uuid4(value: str, path: Path) -> str:
+    return _validate_uuid4(value, f"device id at {path}")
+
+
+def _validate_stripe_url(url: Any, expected_host: str) -> str:
+    """Fail closed unless url is an https URL for exactly expected_host on the default port."""
+    if (
+        not isinstance(url, str)
+        or not url
+        or len(url) > MAX_HOSTED_URL_CHARS
+        or any(char.isspace() for char in url)
+    ):
+        raise CloudError("Ormah Cloud returned an invalid billing URL.", status_code=200)
+    try:
+        parts = urlsplit(url)
+        port = parts.port
+    except ValueError as exc:
+        raise CloudError("Ormah Cloud returned an invalid billing URL.", status_code=200) from exc
+    if (
+        parts.scheme != "https"
+        or parts.username
+        or parts.password
+        or port not in (None, 443)
+        or parts.hostname != expected_host
+    ):
+        raise CloudError("Ormah Cloud returned an invalid billing URL.", status_code=200)
+    return url
+
+
+def _validate_expiry(value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise CloudError("Ormah Cloud returned an invalid billing expiry.", status_code=200)
+    return value
 
 
 def get_or_create_device_id(path: Path | None = None) -> str:
@@ -212,6 +253,73 @@ class CloudClient:
 
     def get_entitlements(self) -> dict[str, Any]:
         return self._request_json("GET", "me/entitlements")
+
+    def get_billing_offer(self) -> dict[str, Any]:
+        """Return validated, display-safe subscription price metadata."""
+        payload = self._request_json("GET", "billing/offer")
+        name = payload.get("name")
+        unit_amount = payload.get("unit_amount")
+        currency = payload.get("currency")
+        interval = payload.get("interval")
+        interval_count = payload.get("interval_count")
+        if not isinstance(name, str) or not name.strip():
+            raise CloudError("Ormah Cloud returned an invalid billing offer name.", status_code=200)
+        if not isinstance(unit_amount, int) or isinstance(unit_amount, bool) or unit_amount < 0:
+            raise CloudError(
+                "Ormah Cloud returned an invalid billing offer amount.", status_code=200
+            )
+        if (
+            not isinstance(currency, str)
+            or len(currency) != 3
+            or not currency.isascii()
+            or not currency.isalpha()
+        ):
+            raise CloudError(
+                "Ormah Cloud returned an invalid billing offer currency.", status_code=200
+            )
+        if interval not in _BILLING_INTERVALS:
+            raise CloudError(
+                "Ormah Cloud returned an invalid billing offer interval.", status_code=200
+            )
+        if (
+            not isinstance(interval_count, int)
+            or isinstance(interval_count, bool)
+            or interval_count < 1
+        ):
+            raise CloudError(
+                "Ormah Cloud returned an invalid billing offer interval count.", status_code=200
+            )
+        return {
+            "name": name.strip(),
+            "unit_amount": unit_amount,
+            "currency": currency.lower(),
+            "interval": interval,
+            "interval_count": interval_count,
+        }
+
+    def create_checkout_session(self, protection_intent_id: str) -> dict[str, Any]:
+        """Start or resolve a Stripe Checkout session for a pending Protect intent."""
+        intent_id = _validate_uuid4(protection_intent_id, "protection_intent_id")
+        payload = self._request_json(
+            "POST",
+            "billing/checkout-session",
+            json={"protection_intent_id": intent_id},
+        )
+        status = payload.get("status")
+        if status not in _CHECKOUT_STATUSES:
+            raise CloudError(
+                "Ormah Cloud returned an unrecognized checkout status.", status_code=200
+            )
+        result: dict[str, Any] = {"status": status}
+        if status == "checkout_required":
+            result["url"] = _validate_stripe_url(payload.get("url"), CHECKOUT_HOST)
+            result["expires_at"] = _validate_expiry(payload.get("expires_at"))
+        return result
+
+    def create_portal_session(self) -> dict[str, Any]:
+        """Return a validated Stripe-hosted billing Portal URL."""
+        payload = self._request_json("POST", "billing/portal-session")
+        return {"url": _validate_stripe_url(payload.get("url"), PORTAL_HOST)}
 
     def get_protocol(self, *, refresh: bool = False) -> dict[str, Any]:
         now = time.monotonic()

--- a/src/ormah/cloud/client.py
+++ b/src/ormah/cloud/client.py
@@ -51,9 +51,9 @@ def _validate_uuid4(value: Any, label: str) -> str:
     try:
         parsed = uuid.UUID(value)
     except (ValueError, AttributeError, TypeError) as exc:
-        raise CloudError(f"Invalid {label}; expected UUIDv4.") from exc
+        raise CloudError(f"Invalid {label}; expected UUIDv4.", status_code=400) from exc
     if parsed.version != 4 or parsed.variant != uuid.RFC_4122:
-        raise CloudError(f"Invalid {label}; expected UUIDv4.")
+        raise CloudError(f"Invalid {label}; expected UUIDv4.", status_code=400)
     return str(parsed)
 
 
@@ -67,7 +67,7 @@ def _validate_stripe_url(url: Any, expected_host: str) -> str:
         not isinstance(url, str)
         or not url
         or len(url) > MAX_HOSTED_URL_CHARS
-        or any(char.isspace() for char in url)
+        or any(ord(char) < 0x21 or ord(char) > 0x7E for char in url)
     ):
         raise CloudError("Ormah Cloud returned an invalid billing URL.", status_code=200)
     try:
@@ -77,10 +77,11 @@ def _validate_stripe_url(url: Any, expected_host: str) -> str:
         raise CloudError("Ormah Cloud returned an invalid billing URL.", status_code=200) from exc
     if (
         parts.scheme != "https"
-        or parts.username
-        or parts.password
+        or parts.username is not None
+        or parts.password is not None
         or port not in (None, 443)
         or parts.hostname != expected_host
+        or not parts.path.startswith("/")
     ):
         raise CloudError("Ormah Cloud returned an invalid billing URL.", status_code=200)
     return url

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -13,6 +13,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from ormah.api.middleware import AgentMiddleware
+from ormah.api.routes_account import router as account_router
 from ormah.api.routes_admin import router as admin_router
 from ormah.api.routes_agent import router as agent_router
 from ormah.api.routes_ingest import router as ingest_router
@@ -143,6 +144,7 @@ app.add_middleware(AgentMiddleware)
 
 app.include_router(agent_router)
 app.include_router(admin_router)
+app.include_router(account_router)
 app.include_router(stats_router)
 app.include_router(ui_router)
 app.include_router(ingest_router)

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -13,6 +13,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from ormah.api.middleware import AgentMiddleware
+from ormah.api.local_auth import load_or_create_local_admin_token
 from ormah.api.routes_account import router as account_router
 from ormah.api.routes_admin import router as admin_router
 from ormah.api.routes_agent import router as agent_router
@@ -46,10 +47,23 @@ except PackageNotFoundError:
     APP_VERSION = "0.0.0"
 
 
+def _initialize_local_admin(app: FastAPI) -> None:
+    """Enable sensitive local routes without making them a core-server dependency."""
+    try:
+        app.state.local_admin_token = load_or_create_local_admin_token()
+    except RuntimeError:
+        app.state.local_admin_token = None
+        logger.warning(
+            "Local account and billing routes are disabled because their capability "
+            "could not be secured."
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
     logger.info("Starting ormah server on port %d...", settings.port)
+    _initialize_local_admin(app)
     logger.info("Initializing memory engine...")
     engine = MemoryEngine(settings)
     engine.startup()

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -51,7 +51,7 @@ def _initialize_local_admin(app: FastAPI) -> None:
     """Enable sensitive local routes without making them a core-server dependency."""
     try:
         app.state.local_admin_token = load_or_create_local_admin_token()
-    except RuntimeError:
+    except (OSError, RuntimeError):
         app.state.local_admin_token = None
         logger.warning(
             "Local account and billing routes are disabled because their capability "

--- a/tests/test_api/test_account_billing_routes.py
+++ b/tests/test_api/test_account_billing_routes.py
@@ -5,19 +5,30 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from ormah.api import routes_account
+from ormah.api.local_auth import LOCAL_ADMIN_HEADER, require_loopback
 from ormah.api.routes_account import router as account_router
 from ormah.cloud import billing
 from ormah.cloud.client import CloudError
+from ormah.cloud.keys import get_or_create_store_id
+from ormah.cloud.state import (
+    CloudState,
+    ProtectionIntentStatus,
+    save_state,
+)
 from ormah.config import Settings
 from ormah.engine.memory_engine import MemoryEngine
 
 INTENT_ID = "3f1a6c4e-4b0a-4d5f-9a2b-8c7d6e5f4a3b"
+ACCOUNT_ID = "d6f89fd3-69a2-4de7-9b30-9d5932db663c"
+LOCAL_ADMIN_TOKEN = "a" * 64
+LOCAL_ADMIN_HEADERS = {LOCAL_ADMIN_HEADER: LOCAL_ADMIN_TOKEN}
 CHECKOUT_URL = "https://checkout.stripe.com/c/session-abc123"
 PORTAL_URL = "https://billing.stripe.com/p/portal-abc123"
 EXPIRES_AT = 4_000_000_000
@@ -41,11 +52,12 @@ OFFER_PAYLOAD = {
 
 
 class FakeCloudClient:
-    def __init__(self, *, offer=None, checkout=None, portal=None, error=None):
+    def __init__(self, *, offer=None, checkout=None, portal=None, entitlements=None, error=None):
         self._results = {
             "get_billing_offer": offer,
             "create_checkout_session": checkout,
             "create_portal_session": portal,
+            "get_entitlements": entitlements or {"account_id": ACCOUNT_ID},
         }
         self._error = error
         self.calls: list[tuple] = []
@@ -63,6 +75,9 @@ class FakeCloudClient:
     def create_checkout_session(self, protection_intent_id):
         return self._respond("create_checkout_session", protection_intent_id)
 
+    def get_entitlements(self):
+        return self._respond("get_entitlements")
+
     def create_portal_session(self):
         return self._respond("create_portal_session")
 
@@ -70,16 +85,54 @@ class FakeCloudClient:
         self.closed = True
 
 
-def build_client(tmp_memory_dir, *, account_token="local-account-token", cloud_client=None):
+def build_client(
+    tmp_memory_dir,
+    *,
+    account_token="local-account-token",
+    cloud_client=None,
+    intent_state: CloudState | None = None,
+):
+    async def allow_test_client():
+        return None
+
     settings = Settings(memory_dir=tmp_memory_dir, account_token=account_token)
+    store_id = get_or_create_store_id(tmp_memory_dir)
+    state_dir = tmp_memory_dir.parent / "cloud-state"
+    now = datetime.now(timezone.utc)
+    state = intent_state or CloudState(
+        pending_protection_intent_id=INTENT_ID,
+        pending_protection_account_id=ACCOUNT_ID,
+        pending_protection_store_id=store_id,
+        pending_protection_created_at=now,
+        pending_protection_expires_at=now + timedelta(minutes=30),
+        pending_protection_status=ProtectionIntentStatus.ACCOUNT_BOUND,
+    )
+    save_state(store_id, state, memory_dir=tmp_memory_dir, state_dir=state_dir)
     engine = MemoryEngine(settings)
     engine.startup()
     test_app = FastAPI()
     test_app.include_router(account_router)
+    test_app.dependency_overrides[require_loopback] = allow_test_client
     test_app.state.engine = engine
+    test_app.state.local_admin_token = LOCAL_ADMIN_TOKEN
+    test_app.state.cloud_state_dir = state_dir
     if cloud_client is not None:
         test_app.state.cloud_client = cloud_client
     return engine, test_app
+
+
+def bound_intent_state(tmp_memory_dir, **changes):
+    now = datetime.now(timezone.utc)
+    values = {
+        "pending_protection_intent_id": INTENT_ID,
+        "pending_protection_account_id": ACCOUNT_ID,
+        "pending_protection_store_id": get_or_create_store_id(tmp_memory_dir),
+        "pending_protection_created_at": now,
+        "pending_protection_expires_at": now + timedelta(minutes=30),
+        "pending_protection_status": ProtectionIntentStatus.ACCOUNT_BOUND,
+    }
+    values.update(changes)
+    return CloudState(**values)
 
 
 @pytest.fixture
@@ -98,26 +151,41 @@ def fake_client():
 @pytest.fixture
 def client(tmp_memory_dir, fake_client):
     engine, test_app = build_client(tmp_memory_dir, cloud_client=fake_client)
-    with TestClient(test_app) as http:
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
         yield http
     engine.shutdown()
 
 
 def test_routes_require_a_signed_in_account(tmp_memory_dir, fake_client):
     engine, test_app = build_client(tmp_memory_dir, account_token=None, cloud_client=fake_client)
-    with TestClient(test_app) as http:
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
         responses = [
             http.get("/admin/account/offer"),
             http.post(
                 "/admin/account/checkout",
                 json={"protection_intent_id": INTENT_ID},
             ),
-            http.post("/admin/account/portal"),
+            http.post("/admin/account/portal", json={}),
         ]
     engine.shutdown()
 
     assert {response.status_code for response in responses} == {401}
     assert all(response.json()["detail"]["error"] == "sign_in_required" for response in responses)
+    assert fake_client.calls == []
+
+
+def test_routes_require_the_owner_only_local_capability(tmp_memory_dir, fake_client):
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake_client)
+    with TestClient(test_app) as http:
+        missing = http.get("/admin/account/offer")
+        wrong = http.get(
+            "/admin/account/offer",
+            headers={LOCAL_ADMIN_HEADER: "b" * 64},
+        )
+    engine.shutdown()
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
     assert fake_client.calls == []
 
 
@@ -145,7 +213,10 @@ def test_checkout_returns_validated_hosted_handoff(client, fake_client):
         "url": CHECKOUT_URL,
         "expires_at": EXPIRES_AT,
     }
-    assert fake_client.calls == [("create_checkout_session", INTENT_ID)]
+    assert fake_client.calls == [
+        ("get_entitlements",),
+        ("create_checkout_session", INTENT_ID),
+    ]
 
 
 @pytest.mark.parametrize("status", ["already_subscribed", "subscription_pending"])
@@ -154,7 +225,7 @@ def test_checkout_non_handoff_statuses_drop_urls(tmp_memory_dir, status):
         checkout={"status": status, "url": CHECKOUT_URL, "expires_at": EXPIRES_AT}
     )
     engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
-    with TestClient(test_app) as http:
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
         response = http.post("/admin/account/checkout", json={"protection_intent_id": INTENT_ID})
     engine.shutdown()
 
@@ -192,6 +263,75 @@ def test_checkout_rejects_client_controlled_fields(client, fake_client):
     assert fake_client.calls == []
 
 
+@pytest.mark.parametrize(
+    "state_changes",
+    [
+        {"pending_protection_intent_id": "6a9c9c64-f146-44f3-a733-48374d9ac3fc"},
+        {"pending_protection_store_id": "9896d588-b84a-4f6e-a76e-83b491357f2b"},
+        {"pending_protection_status": ProtectionIntentStatus.CANCELED},
+        {
+            "pending_protection_expires_at": datetime.now(timezone.utc)
+            - timedelta(seconds=1)
+        },
+    ],
+)
+def test_checkout_rejects_intent_not_bound_to_current_store_and_account(
+    tmp_memory_dir, fake_client, state_changes
+):
+    state = bound_intent_state(tmp_memory_dir, **state_changes)
+    engine, test_app = build_client(
+        tmp_memory_dir,
+        cloud_client=fake_client,
+        intent_state=state,
+    )
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"] == "conflict"
+    assert fake_client.calls == []
+
+
+def test_checkout_rejects_authenticated_cloud_account_mismatch(tmp_memory_dir):
+    fake = FakeCloudClient(
+        entitlements={"account_id": "9896d588-b84a-4f6e-a76e-83b491357f2b"},
+        checkout={
+            "status": "checkout_required",
+            "url": CHECKOUT_URL,
+            "expires_at": EXPIRES_AT,
+        },
+    )
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 409
+    assert fake.calls == [("get_entitlements",)]
+
+
+def test_checkout_fails_closed_when_service_omits_authenticated_account_id(tmp_memory_dir):
+    fake = FakeCloudClient(entitlements={"backup": False})
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 502
+    assert response.json()["detail"]["error"] == "billing_unavailable"
+    assert fake.calls == [("get_entitlements",)]
+
+
 def test_checkout_never_logs_hosted_url(client, caplog):
     with caplog.at_level(logging.DEBUG):
         response = client.post("/admin/account/checkout", json={"protection_intent_id": INTENT_ID})
@@ -201,11 +341,21 @@ def test_checkout_never_logs_hosted_url(client, caplog):
 
 
 def test_portal_returns_hosted_handoff(client, fake_client):
-    response = client.post("/admin/account/portal")
+    response = client.post("/admin/account/portal", json={})
 
     assert response.status_code == 200
     assert response.json() == {"url": PORTAL_URL}
     assert fake_client.calls == [("create_portal_session",)]
+
+
+def test_portal_requires_json_body_before_any_billing_side_effect(client, fake_client):
+    assert client.post("/admin/account/portal").status_code == 422
+    assert client.post(
+        "/admin/account/portal",
+        content="{}",
+        headers={"content-type": "text/plain"},
+    ).status_code == 422
+    assert fake_client.calls == []
 
 
 def test_portal_rejects_client_controlled_fields(client, fake_client):
@@ -242,7 +392,7 @@ def test_cloud_errors_map_to_static_local_errors(
     )
     fake = FakeCloudClient(error=error)
     engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
-    with TestClient(test_app) as http:
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
         response = http.get("/admin/account/offer")
     engine.shutdown()
 
@@ -267,7 +417,7 @@ def test_injected_client_contract_violations_fail_closed(tmp_memory_dir, method,
         portal=result if method == "portal" else None,
     )
     engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
-    with TestClient(test_app) as http:
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
         if method == "offer":
             response = http.get("/admin/account/offer")
         elif method == "checkout":
@@ -276,7 +426,7 @@ def test_injected_client_contract_violations_fail_closed(tmp_memory_dir, method,
                 json={"protection_intent_id": INTENT_ID},
             )
         else:
-            response = http.post("/admin/account/portal")
+            response = http.post("/admin/account/portal", json={})
     engine.shutdown()
 
     assert response.status_code == 502
@@ -306,7 +456,7 @@ def test_owned_client_is_closed(tmp_memory_dir, monkeypatch):
 
     monkeypatch.setattr(billing, "client_from_settings", fake_factory)
     engine, test_app = build_client(tmp_memory_dir)
-    with TestClient(test_app) as http:
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
         response = http.get("/admin/account/offer")
     engine.shutdown()
 
@@ -319,7 +469,7 @@ def test_route_payloads_never_include_account_or_provider_secrets(client):
     bodies = [
         client.get("/admin/account/offer").text,
         client.post("/admin/account/checkout", json={"protection_intent_id": INTENT_ID}).text,
-        client.post("/admin/account/portal").text,
+        client.post("/admin/account/portal", json={}).text,
     ]
 
     for body in bodies:

--- a/tests/test_api/test_account_billing_routes.py
+++ b/tests/test_api/test_account_billing_routes.py
@@ -1,0 +1,337 @@
+"""Tests for local account-linked billing handoffs."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api import routes_account
+from ormah.api.routes_account import router as account_router
+from ormah.cloud import billing
+from ormah.cloud.client import CloudError
+from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+
+INTENT_ID = "3f1a6c4e-4b0a-4d5f-9a2b-8c7d6e5f4a3b"
+CHECKOUT_URL = "https://checkout.stripe.com/c/session-abc123"
+PORTAL_URL = "https://billing.stripe.com/p/portal-abc123"
+EXPIRES_AT = 4_000_000_000
+
+SECRETS = {
+    "price_id": "price_1SecretPriceId",
+    "stripe_customer_id": "cus_1SecretCustomerId",
+    "secret_key": "sk_live_1SecretKey",
+    "token": "account-bearer-token-value",
+    "presigned_url": "https://blobs.example.com/store?signature=leak",
+}
+
+OFFER_PAYLOAD = {
+    "name": "Ormah Protection",
+    "unit_amount": 500,
+    "currency": "usd",
+    "interval": "month",
+    "interval_count": 1,
+    **SECRETS,
+}
+
+
+class FakeCloudClient:
+    def __init__(self, *, offer=None, checkout=None, portal=None, error=None):
+        self._results = {
+            "get_billing_offer": offer,
+            "create_checkout_session": checkout,
+            "create_portal_session": portal,
+        }
+        self._error = error
+        self.calls: list[tuple] = []
+        self.closed = False
+
+    def _respond(self, name: str, *args):
+        self.calls.append((name, *args))
+        if self._error is not None:
+            raise self._error
+        return self._results[name]
+
+    def get_billing_offer(self):
+        return self._respond("get_billing_offer")
+
+    def create_checkout_session(self, protection_intent_id):
+        return self._respond("create_checkout_session", protection_intent_id)
+
+    def create_portal_session(self):
+        return self._respond("create_portal_session")
+
+    def close(self):
+        self.closed = True
+
+
+def build_client(tmp_memory_dir, *, account_token="local-account-token", cloud_client=None):
+    settings = Settings(memory_dir=tmp_memory_dir, account_token=account_token)
+    engine = MemoryEngine(settings)
+    engine.startup()
+    test_app = FastAPI()
+    test_app.include_router(account_router)
+    test_app.state.engine = engine
+    if cloud_client is not None:
+        test_app.state.cloud_client = cloud_client
+    return engine, test_app
+
+
+@pytest.fixture
+def fake_client():
+    return FakeCloudClient(
+        offer=dict(OFFER_PAYLOAD),
+        checkout={
+            "status": "checkout_required",
+            "url": CHECKOUT_URL,
+            "expires_at": EXPIRES_AT,
+        },
+        portal={"url": PORTAL_URL},
+    )
+
+
+@pytest.fixture
+def client(tmp_memory_dir, fake_client):
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake_client)
+    with TestClient(test_app) as http:
+        yield http
+    engine.shutdown()
+
+
+def test_routes_require_a_signed_in_account(tmp_memory_dir, fake_client):
+    engine, test_app = build_client(tmp_memory_dir, account_token=None, cloud_client=fake_client)
+    with TestClient(test_app) as http:
+        responses = [
+            http.get("/admin/account/offer"),
+            http.post(
+                "/admin/account/checkout",
+                json={"protection_intent_id": INTENT_ID},
+            ),
+            http.post("/admin/account/portal"),
+        ]
+    engine.shutdown()
+
+    assert {response.status_code for response in responses} == {401}
+    assert all(response.json()["detail"]["error"] == "sign_in_required" for response in responses)
+    assert fake_client.calls == []
+
+
+def test_offer_returns_only_service_contract_fields(client, fake_client):
+    response = client.get("/admin/account/offer")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "name": "Ormah Protection",
+        "unit_amount": 500,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+    }
+    assert fake_client.calls == [("get_billing_offer",)]
+    assert not any(value in response.text for value in SECRETS.values())
+
+
+def test_checkout_returns_validated_hosted_handoff(client, fake_client):
+    response = client.post("/admin/account/checkout", json={"protection_intent_id": INTENT_ID})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "checkout_required",
+        "url": CHECKOUT_URL,
+        "expires_at": EXPIRES_AT,
+    }
+    assert fake_client.calls == [("create_checkout_session", INTENT_ID)]
+
+
+@pytest.mark.parametrize("status", ["already_subscribed", "subscription_pending"])
+def test_checkout_non_handoff_statuses_drop_urls(tmp_memory_dir, status):
+    fake = FakeCloudClient(
+        checkout={"status": status, "url": CHECKOUT_URL, "expires_at": EXPIRES_AT}
+    )
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
+    with TestClient(test_app) as http:
+        response = http.post("/admin/account/checkout", json={"protection_intent_id": INTENT_ID})
+    engine.shutdown()
+
+    assert response.json() == {"status": status}
+    assert CHECKOUT_URL not in response.text
+
+
+@pytest.mark.parametrize(
+    "intent_id",
+    [
+        "not-a-uuid",
+        "00000000-0000-0000-0000-000000000000",
+        "3f1a6c4e4b0a4d5f9a2b8c7d6e5f4a3b",
+        "urn:uuid:3f1a6c4e-4b0a-4d5f-9a2b-8c7d6e5f4a3b",
+        12345,
+    ],
+)
+def test_checkout_rejects_noncanonical_uuid4(client, fake_client, intent_id):
+    response = client.post("/admin/account/checkout", json={"protection_intent_id": intent_id})
+
+    assert response.status_code == 422
+    assert fake_client.calls == []
+
+
+def test_checkout_rejects_client_controlled_fields(client, fake_client):
+    response = client.post(
+        "/admin/account/checkout",
+        json={
+            "protection_intent_id": INTENT_ID,
+            "return_url": "https://evil.example.com",
+        },
+    )
+
+    assert response.status_code == 422
+    assert fake_client.calls == []
+
+
+def test_checkout_never_logs_hosted_url(client, caplog):
+    with caplog.at_level(logging.DEBUG):
+        response = client.post("/admin/account/checkout", json={"protection_intent_id": INTENT_ID})
+
+    assert response.status_code == 200
+    assert CHECKOUT_URL not in caplog.text
+
+
+def test_portal_returns_hosted_handoff(client, fake_client):
+    response = client.post("/admin/account/portal")
+
+    assert response.status_code == 200
+    assert response.json() == {"url": PORTAL_URL}
+    assert fake_client.calls == [("create_portal_session",)]
+
+
+def test_portal_rejects_client_controlled_fields(client, fake_client):
+    for body in (
+        {"return_url": "https://evil.example.com"},
+        {"customer_id": "cus_123"},
+    ):
+        assert client.post("/admin/account/portal", json=body).status_code == 422
+    assert fake_client.calls == []
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected_status", "expected_error"),
+    [
+        (None, 503, "cloud_unreachable"),
+        (400, 400, "invalid_request"),
+        (401, 401, "sign_in_required"),
+        (403, 403, "account_forbidden"),
+        (404, 404, "not_found"),
+        (409, 409, "conflict"),
+        (422, 400, "invalid_request"),
+        (429, 429, "rate_limited"),
+        (200, 502, "billing_unavailable"),
+        (503, 502, "billing_unavailable"),
+    ],
+)
+def test_cloud_errors_map_to_static_local_errors(
+    tmp_memory_dir, status_code, expected_status, expected_error
+):
+    error = CloudError(
+        "server leaked sk_live_secret",
+        status_code=status_code,
+        payload={"token": SECRETS["token"]},
+    )
+    fake = FakeCloudClient(error=error)
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
+    with TestClient(test_app) as http:
+        response = http.get("/admin/account/offer")
+    engine.shutdown()
+
+    assert response.status_code == expected_status
+    assert response.json()["detail"]["error"] == expected_error
+    assert "sk_live_secret" not in response.text
+    assert SECRETS["token"] not in response.text
+
+
+@pytest.mark.parametrize(
+    ("method", "result"),
+    [
+        ("offer", {}),
+        ("checkout", {"status": "checkout_required"}),
+        ("portal", {}),
+    ],
+)
+def test_injected_client_contract_violations_fail_closed(tmp_memory_dir, method, result):
+    fake = FakeCloudClient(
+        offer=result if method == "offer" else None,
+        checkout=result if method == "checkout" else None,
+        portal=result if method == "portal" else None,
+    )
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
+    with TestClient(test_app) as http:
+        if method == "offer":
+            response = http.get("/admin/account/offer")
+        elif method == "checkout":
+            response = http.post(
+                "/admin/account/checkout",
+                json={"protection_intent_id": INTENT_ID},
+            )
+        else:
+            response = http.post("/admin/account/portal")
+    engine.shutdown()
+
+    assert response.status_code == 502
+    assert response.json()["detail"]["error"] == "billing_unavailable"
+
+
+def test_handlers_are_thin_local_adapters():
+    source = inspect.getsource(routes_account)
+
+    for forbidden in (
+        "httpx",
+        "https://",
+        "Bearer",
+        "run_cloud_backup",
+        "run_restore_verification",
+    ):
+        assert forbidden not in source
+
+
+def test_owned_client_is_closed(tmp_memory_dir, monkeypatch):
+    built: list[FakeCloudClient] = []
+
+    def fake_factory(settings):
+        fake = FakeCloudClient(offer=dict(OFFER_PAYLOAD))
+        built.append(fake)
+        return fake
+
+    monkeypatch.setattr(billing, "client_from_settings", fake_factory)
+    engine, test_app = build_client(tmp_memory_dir)
+    with TestClient(test_app) as http:
+        response = http.get("/admin/account/offer")
+    engine.shutdown()
+
+    assert response.status_code == 200
+    assert len(built) == 1
+    assert built[0].closed is True
+
+
+def test_route_payloads_never_include_account_or_provider_secrets(client):
+    bodies = [
+        client.get("/admin/account/offer").text,
+        client.post("/admin/account/checkout", json={"protection_intent_id": INTENT_ID}).text,
+        client.post("/admin/account/portal").text,
+    ]
+
+    for body in bodies:
+        payload = json.loads(body)
+        assert not any(value in body for value in SECRETS.values())
+        assert set(payload) <= {
+            "name",
+            "unit_amount",
+            "currency",
+            "interval",
+            "interval_count",
+            "status",
+            "url",
+            "expires_at",
+        }

--- a/tests/test_api/test_account_billing_routes.py
+++ b/tests/test_api/test_account_billing_routes.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -19,7 +20,10 @@ from ormah.cloud.client import CloudError
 from ormah.cloud.keys import get_or_create_store_id
 from ormah.cloud.state import (
     CloudState,
+    CloudStateLoadError,
     ProtectionIntentStatus,
+    load_state,
+    mutate_state,
     save_state,
 )
 from ormah.config import Settings
@@ -52,14 +56,28 @@ OFFER_PAYLOAD = {
 
 
 class FakeCloudClient:
-    def __init__(self, *, offer=None, checkout=None, portal=None, entitlements=None, error=None):
+    def __init__(
+        self,
+        *,
+        offer=None,
+        checkout=None,
+        portal=None,
+        entitlements=None,
+        error=None,
+        checkout_error=None,
+        entitlements_hook=None,
+    ):
         self._results = {
             "get_billing_offer": offer,
             "create_checkout_session": checkout,
             "create_portal_session": portal,
-            "get_entitlements": entitlements or {"account_id": ACCOUNT_ID},
+            "get_entitlements": (
+                {"account_id": ACCOUNT_ID} if entitlements is None else entitlements
+            ),
         }
         self._error = error
+        self._checkout_error = checkout_error
+        self._entitlements_hook = entitlements_hook
         self.calls: list[tuple] = []
         self.closed = False
 
@@ -73,9 +91,16 @@ class FakeCloudClient:
         return self._respond("get_billing_offer")
 
     def create_checkout_session(self, protection_intent_id):
+        if self._checkout_error is not None:
+            self.calls.append(("create_checkout_session", protection_intent_id))
+            raise self._checkout_error
         return self._respond("create_checkout_session", protection_intent_id)
 
     def get_entitlements(self):
+        if self._entitlements_hook is not None:
+            self.calls.append(("get_entitlements",))
+            self._entitlements_hook()
+            return self._results["get_entitlements"]
         return self._respond("get_entitlements")
 
     def create_portal_session(self):
@@ -237,6 +262,7 @@ def test_checkout_non_handoff_statuses_drop_urls(tmp_memory_dir, status):
     "intent_id",
     [
         "not-a-uuid",
+        INTENT_ID.upper(),
         "00000000-0000-0000-0000-000000000000",
         "3f1a6c4e4b0a4d5f9a2b8c7d6e5f4a3b",
         "urn:uuid:3f1a6c4e-4b0a-4d5f-9a2b-8c7d6e5f4a3b",
@@ -330,6 +356,162 @@ def test_checkout_fails_closed_when_service_omits_authenticated_account_id(tmp_m
     assert response.status_code == 502
     assert response.json()["detail"]["error"] == "billing_unavailable"
     assert fake.calls == [("get_entitlements",)]
+
+
+def test_checkout_rechecks_cancellation_after_entitlement_fetch(tmp_memory_dir):
+    store_id = get_or_create_store_id(tmp_memory_dir)
+    state_dir = tmp_memory_dir.parent / "cloud-state"
+
+    def cancel_intent():
+        mutate_state(
+            store_id,
+            lambda state: replace(
+                state,
+                pending_protection_status=ProtectionIntentStatus.CANCELED,
+            ),
+            memory_dir=tmp_memory_dir,
+            state_dir=state_dir,
+        )
+
+    fake = FakeCloudClient(
+        entitlements_hook=cancel_intent,
+        checkout={
+            "status": "checkout_required",
+            "url": CHECKOUT_URL,
+            "expires_at": EXPIRES_AT,
+        },
+    )
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 409
+    assert fake.calls == [("get_entitlements",)]
+    assert load_state(store_id, state_dir=state_dir).pending_protection_status is (
+        ProtectionIntentStatus.CANCELED
+    )
+
+
+def test_failed_checkout_stays_pending_for_idempotent_retry(tmp_memory_dir):
+    fake = FakeCloudClient(
+        checkout_error=CloudError("provider detail", status_code=None),
+    )
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake)
+    store_id = get_or_create_store_id(tmp_memory_dir)
+    state_dir = test_app.state.cloud_state_dir
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error"] == "cloud_unreachable"
+    assert fake.calls == [
+        ("get_entitlements",),
+        ("create_checkout_session", INTENT_ID),
+    ]
+    state = load_state(store_id, state_dir=state_dir)
+    assert state.pending_protection_status is ProtectionIntentStatus.CHECKOUT_PENDING
+    assert state.pending_protection_account_id == ACCOUNT_ID
+
+
+def test_checkout_canonicalizes_stored_account_binding(tmp_memory_dir):
+    state = bound_intent_state(
+        tmp_memory_dir,
+        pending_protection_account_id=ACCOUNT_ID.upper(),
+    )
+    fake = FakeCloudClient(
+        checkout={
+            "status": "checkout_required",
+            "url": CHECKOUT_URL,
+            "expires_at": EXPIRES_AT,
+        }
+    )
+    engine, test_app = build_client(
+        tmp_memory_dir,
+        cloud_client=fake,
+        intent_state=state,
+    )
+    store_id = get_or_create_store_id(tmp_memory_dir)
+    state_dir = test_app.state.cloud_state_dir
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 200
+    persisted = load_state(store_id, state_dir=state_dir)
+    assert persisted.pending_protection_account_id == ACCOUNT_ID
+    assert persisted.pending_protection_status is ProtectionIntentStatus.CHECKOUT_PENDING
+
+
+def test_invalid_durable_account_binding_is_state_unavailable(tmp_memory_dir, fake_client):
+    state = bound_intent_state(
+        tmp_memory_dir,
+        pending_protection_account_id="not-an-account-id",
+    )
+    engine, test_app = build_client(
+        tmp_memory_dir,
+        cloud_client=fake_client,
+        intent_state=state,
+    )
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error"] == "state_unavailable"
+    assert fake_client.calls == []
+
+
+def test_missing_store_identity_is_state_unavailable(tmp_memory_dir, fake_client):
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake_client)
+    (tmp_memory_dir / ".store_id").unlink()
+    with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+        response = http.post(
+            "/admin/account/checkout",
+            json={"protection_intent_id": INTENT_ID},
+        )
+    engine.shutdown()
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error"] == "state_unavailable"
+    assert fake_client.calls == []
+
+
+def test_state_load_failure_is_sanitized_and_not_reported_as_conflict(
+    tmp_memory_dir, fake_client, monkeypatch, caplog
+):
+    engine, test_app = build_client(tmp_memory_dir, cloud_client=fake_client)
+
+    def fail_load(*args, **kwargs):
+        raise CloudStateLoadError("secret path /home/person/cloud-state.json")
+
+    monkeypatch.setattr(billing, "load_state", fail_load)
+    with caplog.at_level(logging.WARNING):
+        with TestClient(test_app, headers=LOCAL_ADMIN_HEADERS) as http:
+            response = http.post(
+                "/admin/account/checkout",
+                json={"protection_intent_id": INTENT_ID},
+            )
+    engine.shutdown()
+
+    assert response.status_code == 503
+    assert response.json()["detail"]["error"] == "state_unavailable"
+    assert "error_type=CloudStateLoadError" in caplog.text
+    assert "secret path" not in caplog.text
+    assert fake_client.calls == []
 
 
 def test_checkout_never_logs_hosted_url(client, caplog):

--- a/tests/test_api/test_local_auth.py
+++ b/tests/test_api/test_local_auth.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import stat
+from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
 from starlette.requests import Request
 
-from ormah.api.local_auth import load_or_create_local_admin_token, require_loopback
+from ormah.api.local_auth import (
+    load_or_create_local_admin_token,
+    require_local_admin,
+    require_loopback,
+)
 
 
 def test_local_admin_token_is_stable_and_owner_only(tmp_path):
@@ -65,3 +70,15 @@ async def test_loopback_dependency_rejects_lan_peers():
         await require_loopback(request)
 
     assert exc_info.value.status_code == 403
+
+
+async def test_local_admin_rejects_non_ascii_header_without_compare_digest_error():
+    app = SimpleNamespace(state=SimpleNamespace(local_admin_token="a" * 64))
+    request = Request(
+        {"type": "http", "client": ("127.0.0.1", 50000), "app": app}
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_local_admin(request, "é" * 64, None)
+
+    assert exc_info.value.status_code == 401

--- a/tests/test_api/test_local_auth.py
+++ b/tests/test_api/test_local_auth.py
@@ -1,0 +1,67 @@
+"""Tests for the owner-only local admin capability."""
+
+from __future__ import annotations
+
+import stat
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from ormah.api.local_auth import load_or_create_local_admin_token, require_loopback
+
+
+def test_local_admin_token_is_stable_and_owner_only(tmp_path):
+    path = tmp_path / "ormah" / "local_api_token"
+
+    first = load_or_create_local_admin_token(path)
+    second = load_or_create_local_admin_token(path)
+
+    assert first == second
+    assert len(first) == 64
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_invalid_existing_local_admin_token_is_never_replaced(tmp_path):
+    path = tmp_path / "local_api_token"
+    path.write_text("too-short\n", encoding="ascii")
+
+    with pytest.raises(RuntimeError, match="invalid; refusing to replace"):
+        load_or_create_local_admin_token(path)
+
+    assert path.read_text(encoding="ascii") == "too-short\n"
+
+
+def test_existing_local_admin_token_permissions_are_repaired(tmp_path):
+    path = tmp_path / "local_api_token"
+    path.write_text("a" * 64 + "\n", encoding="ascii")
+    path.chmod(0o644)
+
+    assert load_or_create_local_admin_token(path) == "a" * 64
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_local_admin_token_rejects_symlinks(tmp_path):
+    target = tmp_path / "target"
+    target.write_text("a" * 64 + "\n", encoding="ascii")
+    path = tmp_path / "local_api_token"
+    path.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="not a regular file"):
+        load_or_create_local_admin_token(path)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1"])
+async def test_loopback_dependency_accepts_only_local_peers(host):
+    request = Request({"type": "http", "client": (host, 50000)})
+
+    assert await require_loopback(request) is None
+
+
+async def test_loopback_dependency_rejects_lan_peers():
+    request = Request({"type": "http", "client": ("192.168.1.50", 50000)})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_loopback(request)
+
+    assert exc_info.value.status_code == 403

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -382,8 +382,9 @@ def test_create_checkout_session_sends_only_intent_id():
 @respx.mock
 def test_create_checkout_session_rejects_non_uuid_intent():
     with CloudClient(BASE_URL, TOKEN) as client:
-        with pytest.raises(CloudError, match="protection_intent_id"):
+        with pytest.raises(CloudError, match="protection_intent_id") as exc_info:
             client.create_checkout_session("not-a-uuid")
+    assert exc_info.value.status_code == 400
 
 
 @pytest.mark.parametrize("status", ["already_subscribed", "subscription_pending"])
@@ -449,7 +450,13 @@ def test_create_checkout_session_fails_closed_on_malformed_checkout_required(pay
         "https://evilcheckout.stripe.com/c/pay/cs_test",
         "https://checkout.stripe.com.evil.com/c/pay/cs_test",
         "https://attacker@checkout.stripe.com/c/pay/cs_test",
+        "https://@checkout.stripe.com/c/pay/cs_test",
+        "https://:@checkout.stripe.com/c/pay/cs_test",
         "https://user:pass@checkout.stripe.com/c/pay/cs_test",
+        "https://checkout.stripe.com/c/pay/cs_test\x00ignored",
+        "https://checkout.stripe.com/c/pay/cs_test\u200b",
+        "https://checkout.stripe.com/c/pay/cs_tést",
+        "https://checkout.stripe.com",
         "https://billing.stripe.com/c/pay/cs_test",
         "https://[invalid/c/pay/cs_test",
         "not-a-url",
@@ -509,7 +516,10 @@ def test_create_portal_session_returns_validated_url():
         "https://billing.stripe.com:8443/session/xyz",
         "https://evilbilling.stripe.com/session/xyz",
         "https://billing.stripe.com.evil.com/session/xyz",
+        "https://@billing.stripe.com/session/xyz",
         "https://user:pass@billing.stripe.com/session/xyz",
+        "https://billing.stripe.com/session/xyz\x1f",
+        "https://billing.stripe.com/session/xyz\u2060",
         "https://checkout.stripe.com/session/xyz",
         None,
         123,

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import stat
+import time
 import uuid
 from types import SimpleNamespace
 
@@ -37,9 +38,7 @@ def test_auth_and_entitlement_requests_match_service_shapes():
 
     with CloudClient(BASE_URL) as client:
         client.request_code("Person@Example.com")
-        assert client.verify_code(
-            "Person@Example.com", "123456", device_id, "Test laptop"
-        ) == TOKEN
+        assert client.verify_code("Person@Example.com", "123456", device_id, "Test laptop") == TOKEN
         assert client.get_entitlements()["plan_status"] == "active"
 
     assert request_route.calls[0].request.content == b'{"email":"person@example.com"}'
@@ -96,9 +95,7 @@ def test_upload_blob_and_head_methods_match_service_shapes():
             json={"upload_id": "upload", "snapshot_id": "snapshot", "put_url": "https://put"},
         )
     )
-    finalize_route = respx.post(
-        f"{BASE_URL}/stores/{store_id}/uploads/upload/finalize"
-    ).mock(
+    finalize_route = respx.post(f"{BASE_URL}/stores/{store_id}/uploads/upload/finalize").mock(
         return_value=httpx.Response(
             200,
             json={
@@ -224,9 +221,7 @@ def test_upload_rejects_bundle_above_negotiated_limit_before_reservation():
 
 @respx.mock
 def test_network_errors_are_wrapped():
-    respx.get(f"{BASE_URL}/me/entitlements").mock(
-        side_effect=httpx.ConnectError("offline")
-    )
+    respx.get(f"{BASE_URL}/me/entitlements").mock(side_effect=httpx.ConnectError("offline"))
     with CloudClient(BASE_URL, TOKEN) as client:
         with pytest.raises(CloudError, match="Could not reach"):
             client.get_entitlements()
@@ -259,10 +254,291 @@ def test_corrupt_device_id_fails_closed(tmp_path):
         get_or_create_device_id(path)
 
 
-def test_client_factory_reads_settings():
-    client = client_from_settings(
-        SimpleNamespace(cloud_api_url=BASE_URL, account_token=TOKEN)
+@respx.mock
+def test_get_billing_offer_returns_safe_display_metadata():
+    respx.get(f"{BASE_URL}/billing/offer").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "name": "Ormah Protection",
+                "unit_amount": 900,
+                "currency": "USD",
+                "interval": "month",
+                "interval_count": 1,
+                "stripe_price_id": "price_internal_do_not_expose",
+            },
+        )
     )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        offer = client.get_billing_offer()
+
+    assert offer == {
+        "name": "Ormah Protection",
+        "unit_amount": 900,
+        "currency": "usd",
+        "interval": "month",
+        "interval_count": 1,
+    }
+    assert "stripe_price_id" not in offer
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {
+            "name": "",
+            "unit_amount": 900,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+        },
+        {
+            "name": "Ormah",
+            "unit_amount": "900",
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+        },
+        {
+            "name": "Ormah",
+            "unit_amount": -1,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+        },
+        {
+            "name": "Ormah",
+            "unit_amount": True,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 1,
+        },
+        {
+            "name": "Ormah",
+            "unit_amount": 900,
+            "currency": "us",
+            "interval": "month",
+            "interval_count": 1,
+        },
+        {
+            "name": "Ormah",
+            "unit_amount": 900,
+            "currency": "u\u0455d",
+            "interval": "month",
+            "interval_count": 1,
+        },
+        {
+            "name": "Ormah",
+            "unit_amount": 900,
+            "currency": "usd",
+            "interval": "fortnight",
+            "interval_count": 1,
+        },
+        {
+            "name": "Ormah",
+            "unit_amount": 900,
+            "currency": "usd",
+            "interval": "month",
+            "interval_count": 0,
+        },
+    ],
+)
+@respx.mock
+def test_get_billing_offer_fails_closed_on_malformed_payload(payload):
+    respx.get(f"{BASE_URL}/billing/offer").mock(return_value=httpx.Response(200, json=payload))
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="billing offer"):
+            client.get_billing_offer()
+
+
+@respx.mock
+def test_create_checkout_session_sends_only_intent_id():
+    intent_id = str(uuid.uuid4())
+    expires_at = int(time.time()) + 3600
+    route = respx.post(f"{BASE_URL}/billing/checkout-session").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "status": "checkout_required",
+                "url": "https://checkout.stripe.com/c/pay/cs_test_abc",
+                "expires_at": expires_at,
+            },
+        )
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        result = client.create_checkout_session(intent_id)
+
+    assert result == {
+        "status": "checkout_required",
+        "url": "https://checkout.stripe.com/c/pay/cs_test_abc",
+        "expires_at": expires_at,
+    }
+    assert route.calls[0].request.content == (
+        b'{"protection_intent_id":"' + intent_id.encode() + b'"}'
+    )
+
+
+@respx.mock
+def test_create_checkout_session_rejects_non_uuid_intent():
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="protection_intent_id"):
+            client.create_checkout_session("not-a-uuid")
+
+
+@pytest.mark.parametrize("status", ["already_subscribed", "subscription_pending"])
+@respx.mock
+def test_create_checkout_session_handles_non_checkout_statuses(status):
+    intent_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/billing/checkout-session").mock(
+        return_value=httpx.Response(200, json={"status": status})
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        result = client.create_checkout_session(intent_id)
+
+    assert result == {"status": status}
+    assert "url" not in result
+    assert "expires_at" not in result
+
+
+@respx.mock
+def test_create_checkout_session_rejects_unrecognized_status():
+    intent_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/billing/checkout-session").mock(
+        return_value=httpx.Response(200, json={"status": "mystery_status"})
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="checkout status"):
+            client.create_checkout_session(intent_id)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"status": "checkout_required"},
+        {"status": "checkout_required", "url": "https://checkout.stripe.com/c/x"},
+        {"status": "checkout_required", "expires_at": 4_000_000_000},
+        {
+            "status": "checkout_required",
+            "url": "https://checkout.stripe.com/c/x",
+            "expires_at": "not-a-timestamp",
+        },
+        {
+            "status": "checkout_required",
+            "url": "https://checkout.stripe.com/c/x",
+            "expires_at": 0,
+        },
+    ],
+)
+@respx.mock
+def test_create_checkout_session_fails_closed_on_malformed_checkout_required(payload):
+    intent_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/billing/checkout-session").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError):
+            client.create_checkout_session(intent_id)
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://checkout.stripe.com/c/pay/cs_test",
+        "https://checkout.stripe.com:8443/c/pay/cs_test",
+        "https://evilcheckout.stripe.com/c/pay/cs_test",
+        "https://checkout.stripe.com.evil.com/c/pay/cs_test",
+        "https://attacker@checkout.stripe.com/c/pay/cs_test",
+        "https://user:pass@checkout.stripe.com/c/pay/cs_test",
+        "https://billing.stripe.com/c/pay/cs_test",
+        "https://[invalid/c/pay/cs_test",
+        "not-a-url",
+        "",
+    ],
+)
+@respx.mock
+def test_create_checkout_session_rejects_unsafe_checkout_urls(bad_url):
+    intent_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/billing/checkout-session").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "status": "checkout_required",
+                "url": bad_url,
+                "expires_at": int(time.time()) + 3600,
+            },
+        )
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="billing URL"):
+            client.create_checkout_session(intent_id)
+
+
+@respx.mock
+def test_create_checkout_session_propagates_rate_limit():
+    intent_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/billing/checkout-session").mock(
+        return_value=httpx.Response(
+            429,
+            json={"detail": "billing_rate_limited"},
+        )
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="billing_rate_limited") as exc_info:
+            client.create_checkout_session(intent_id)
+
+    assert exc_info.value.status_code == 429
+
+
+@respx.mock
+def test_create_portal_session_returns_validated_url():
+    route = respx.post(f"{BASE_URL}/billing/portal-session").mock(
+        return_value=httpx.Response(200, json={"url": "https://billing.stripe.com/session/xyz"})
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        result = client.create_portal_session()
+
+    assert result == {"url": "https://billing.stripe.com/session/xyz"}
+    assert route.calls[0].request.content == b""
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        "http://billing.stripe.com/session/xyz",
+        "https://billing.stripe.com:8443/session/xyz",
+        "https://evilbilling.stripe.com/session/xyz",
+        "https://billing.stripe.com.evil.com/session/xyz",
+        "https://user:pass@billing.stripe.com/session/xyz",
+        "https://checkout.stripe.com/session/xyz",
+        None,
+        123,
+    ],
+)
+@respx.mock
+def test_create_portal_session_rejects_unsafe_urls(bad_url):
+    respx.post(f"{BASE_URL}/billing/portal-session").mock(
+        return_value=httpx.Response(200, json={"url": bad_url})
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="billing URL"):
+            client.create_portal_session()
+
+
+@respx.mock
+def test_create_portal_session_propagates_rate_limit():
+    respx.post(f"{BASE_URL}/billing/portal-session").mock(
+        return_value=httpx.Response(429, json={"detail": "billing_rate_limited"})
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="billing_rate_limited") as exc_info:
+            client.create_portal_session()
+
+    assert exc_info.value.status_code == 429
+
+
+def test_client_factory_reads_settings():
+    client = client_from_settings(SimpleNamespace(cloud_api_url=BASE_URL, account_token=TOKEN))
     try:
         assert client.base_url == f"{BASE_URL}/"
         assert client.token == TOKEN

--- a/tests/test_cloud_client.py
+++ b/tests/test_cloud_client.py
@@ -442,6 +442,25 @@ def test_create_checkout_session_fails_closed_on_malformed_checkout_required(pay
             client.create_checkout_session(intent_id)
 
 
+@pytest.mark.parametrize("offset_seconds", [-60, 2 * 24 * 60 * 60])
+@respx.mock
+def test_create_checkout_session_rejects_past_or_absurd_expiry(offset_seconds):
+    intent_id = str(uuid.uuid4())
+    respx.post(f"{BASE_URL}/billing/checkout-session").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "status": "checkout_required",
+                "url": "https://checkout.stripe.com/c/pay/cs_test_abc",
+                "expires_at": int(time.time()) + offset_seconds,
+            },
+        )
+    )
+    with CloudClient(BASE_URL, TOKEN) as client:
+        with pytest.raises(CloudError, match="billing expiry"):
+            client.create_checkout_session(intent_id)
+
+
 @pytest.mark.parametrize(
     "bad_url",
     [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,8 @@ import logging
 import re
 from types import SimpleNamespace
 
+import pytest
+
 from ormah import main
 from ormah.main import _LOCAL_CORS_ORIGIN_REGEX, _is_reserved_api_path
 
@@ -28,11 +30,12 @@ def test_cors_regex_allows_only_loopback_origins():
     assert not re.match(_LOCAL_CORS_ORIGIN_REGEX, "https://evil.example")
 
 
-def test_local_admin_failure_disables_only_sensitive_routes(monkeypatch, caplog):
+@pytest.mark.parametrize("error", [RuntimeError("corrupt"), OSError("unwritable")])
+def test_local_admin_failure_disables_only_sensitive_routes(monkeypatch, caplog, error):
     app = SimpleNamespace(state=SimpleNamespace())
 
     def fail_closed():
-        raise RuntimeError("secret path and filesystem detail")
+        raise error
 
     monkeypatch.setattr(main, "load_or_create_local_admin_token", fail_closed)
     with caplog.at_level(logging.WARNING):
@@ -40,4 +43,4 @@ def test_local_admin_failure_disables_only_sensitive_routes(monkeypatch, caplog)
 
     assert app.state.local_admin_token is None
     assert "routes are disabled" in caplog.text
-    assert "secret path" not in caplog.text
+    assert str(error) not in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,10 @@
 """Tests for the FastAPI app shell."""
 
+import logging
 import re
+from types import SimpleNamespace
 
+from ormah import main
 from ormah.main import _LOCAL_CORS_ORIGIN_REGEX, _is_reserved_api_path
 
 
@@ -23,3 +26,18 @@ def test_cors_regex_allows_only_loopback_origins():
     assert re.match(_LOCAL_CORS_ORIGIN_REGEX, "http://127.0.0.1:8787")
     assert re.match(_LOCAL_CORS_ORIGIN_REGEX, "https://[::1]:8787")
     assert not re.match(_LOCAL_CORS_ORIGIN_REGEX, "https://evil.example")
+
+
+def test_local_admin_failure_disables_only_sensitive_routes(monkeypatch, caplog):
+    app = SimpleNamespace(state=SimpleNamespace())
+
+    def fail_closed():
+        raise RuntimeError("secret path and filesystem detail")
+
+    monkeypatch.setattr(main, "load_or_create_local_admin_token", fail_closed)
+    with caplog.at_level(logging.WARNING):
+        main._initialize_local_admin(app)
+
+    assert app.state.local_admin_token is None
+    assert "routes are disabled" in caplog.text
+    assert "secret path" not in caplog.text


### PR DESCRIPTION
## Problem

The client and local app server had no account-linked way to retrieve the configured price or obtain Stripe-hosted Checkout and Customer Portal handoffs. The initial implementation also treated "a cloud token exists" as local authentication and accepted an arbitrary canonical protection-intent UUID, which was not sufficient for a sensitive desktop boundary.

## Solution

- add `CloudClient` methods matching `/billing/offer`, `/billing/checkout-session`, and `/billing/portal-session`
- validate Checkout and Portal URLs against exact Stripe HTTPS hosts and reject all userinfo, control/invisible/non-ASCII characters, lookalike hosts, invalid ports, and malformed payloads
- protect every `/admin/account/*` route with a separate 256-bit installation-local capability stored atomically at `~/.local/share/ormah/local_api_token` with mode `0600`
- reject non-loopback callers even when they present the capability
- keep the capability and `ORMAH_ACCOUNT_TOKEN` out of React; the future Tauri native layer reads and injects the local header
- require JSON for the Portal POST, preventing a simple bodyless or `text/plain` cross-origin request
- bind Checkout to the current durable intent, current store, allowed intent phase, expiry, and authenticated cloud `account_id`
- fail closed before Stripe when the intent, store, account, or wire identity does not match
- replace reflective client dispatch with direct typed calls and map local UUID errors correctly
- keep Stripe webhooks/reconciliation authoritative for entitlement

This is C02 implementation step 4 on the Ormah client. It does not open a browser, enable protection, poll entitlement, grant entitlement, or add desktop UI.

## Rollout dependency

Companion `r-spade/ormah-cloud` PR #11 adds the authenticated opaque `account_id` to `GET /me/entitlements`. Deploy that additive service response before releasing this client; Checkout deliberately fails closed when the field is absent.

## Configuration

No new environment setting is required. The local capability is generated by the Python server and is independent of the cloud bearer token.

## Verification

- `uv run pytest -q`: 1621 passed, 1 deselected
- focused client/API regression suite: 114 passed
- `uv run ruff check src/ tests/`: passed
- `git diff --check`: passed

