### PR TITLE
feat(cloud): add durable protection enablement

### DIFF
--- a/docs/15 - Cloud Backup, Verification, and Restore.md
+++ b/docs/15 - Cloud Backup, Verification, and Restore.md
@@ -1,6 +1,6 @@
 # Cloud Backup, Verification, and Restore
 
-Verified against the current Ormah client and the hardened C01 cloud protocol on 2026-07-29.
+Verified against the current Ormah client and the hardened C01 cloud protocol on 2026-07-31.
 
 This guide explains what happens when Ormah protects a memory graph in the cloud. It starts with a
 small worked example, then adds the security and failure-handling details one layer at a time.
@@ -356,6 +356,26 @@ For this example it records the successful upload time, snapshot ID, and clears 
 error. State is keyed by `store_id`, so two different `ORMAH_MEMORY_DIR` values do not share backup
 health accidentally.
 
+The same file contains a two-phase upload journal:
+
+- `reserved` means the PUT has not crossed the ambiguous commit boundary and can be replaced after
+  interruption;
+- `finalizing` means the service may have committed the object even if the client did not receive
+  the response, so the client retries the same `upload_id` and never creates a second reservation;
+- a finalizing upload is abandoned only when the service returns its structured `upload_expired`
+  response and the locally recorded reservation lease has also expired.
+
+Writers serialize this state with the store lock and replace the JSON atomically. Schema version 3
+is deliberately fail-closed: an older client that encounters a newer state schema asks the user to
+update Ormah instead of rewriting fields it does not understand. Rolling the binary back therefore
+does not imply that protection state can safely be rolled back.
+
+Protection status distinguishes a proven recovery point from a newly uploaded one. A successful
+upload moves the store to `verification_pending` until that exact snapshot passes the restore
+rehearsal. An older verified snapshot still remains downloadable, but the UI must not describe the
+newest snapshot as protected yet. `finalizing` is different: its commit result is unknown, so status
+becomes `attention_required` until the same upload ID is reconciled.
+
 Upload success now proves:
 
 - an encrypted object was committed;
@@ -380,21 +400,28 @@ For the latest committed snapshot, the current verification path:
 
 1. asks the service to list committed snapshots;
 2. rejects an object larger than the client's advertised safe processing limit;
-3. requests a presigned GET URL;
-4. streams the ciphertext into a newly created temporary directory;
-5. decrypts it using all retained local age identities;
-6. accepts only regular allowlisted paths: `nodes/*.md`, `deleted/*.md`, `backup.json`, and
+3. requires the SHA-256 that the service verified during immutable promotion;
+4. requests a presigned GET URL;
+5. streams the ciphertext into a newly created temporary directory;
+6. recomputes the ciphertext SHA-256 and compares it with the committed metadata;
+7. decrypts it using all retained local age identities;
+8. accepts only regular allowlisted paths: `nodes/*.md`, `deleted/*.md`, `backup.json`, and
    `bundle-manifest.json`;
-7. rejects absolute paths, `..`, backslashes, links, duplicates, Unicode/case collisions, excess
+9. rejects absolute paths, `..`, backslashes, links, duplicates, Unicode/case collisions, excess
    members, and excess expanded bytes;
-8. recomputes every file size and SHA-256 and compares them with the encrypted manifest;
-9. validates that `backup.json`'s active Self pointer names the exact included `system:self` node;
-10. parses every active and deleted Markdown node;
-11. creates a throwaway SQLite database and rebuilds its index from the extracted active nodes;
-12. requires the rebuilt active-node count to equal `manifest.node_count`;
-13. runs an FTS search and requires it to return a known restored node;
-14. records `last_verify_ok=true` and the exact snapshot ID;
-15. deletes the temporary directory in `finally`, whether verification succeeds or fails.
+10. recomputes every file size and SHA-256 and compares them with the encrypted manifest;
+11. validates that `backup.json`'s active Self pointer names the exact included `system:self` node;
+12. parses every active and deleted Markdown node;
+13. creates a throwaway SQLite database and rebuilds its index from the extracted active nodes;
+14. requires the rebuilt active-node count to equal `manifest.node_count`;
+15. runs an FTS search and requires it to return a known restored node;
+16. records `last_verify_ok=true` and the exact snapshot ID;
+17. deletes the temporary directory in `finally`, whether verification succeeds or fails.
+
+Those checks are reported as seven stable proof stages: download, ciphertext hash, decryption,
+manifest/file hashes, Markdown parsing, scratch-index rebuild, and search probe. Error messages are
+privacy-safe: they can identify the failed stage but never persist a node filename or malformed
+frontmatter content.
 
 For our three-file example, the scratch index must rebuild exactly `2` active nodes. The deleted
 node is parsed and integrity-checked but correctly does not become an active search result.
@@ -493,7 +520,8 @@ the snapshot. Cancellation pauses new uploads; it does not turn recovery into a 
 | Bundle exceeds safe client limit | Client refuses before upload or download processing |
 | PUT fails or URL expires | Client does not finalize; pending reservation/object is cleaned later |
 | Finalize sees wrong size/checksum | Snapshot is not committed |
-| Process dies during promotion | Durable lease/state lets janitor reconcile safely rather than guessing |
+| Client loses the finalize response | Durable journal retries the same upload ID; no duplicate is reserved |
+| Process dies during promotion | Durable service lease/state lets janitor reconcile safely rather than guessing |
 | Ciphertext is truncated or altered | Age decryption or archive/manifest verification fails |
 | A Markdown file is malformed | Parse stage fails; snapshot is not marked verified |
 | Active Self pointer is missing, invalid, or ambiguous | Verification/restore fails closed before replacing the live graph |

--- a/docs/15 - Cloud Backup, Verification, and Restore.md
+++ b/docs/15 - Cloud Backup, Verification, and Restore.md
@@ -423,6 +423,11 @@ manifest/file hashes, Markdown parsing, scratch-index rebuild, and search probe.
 privacy-safe: they can identify the failed stage but never persist a node filename or malformed
 frontmatter content.
 
+The blob-list wire contract always includes `sha256`: a lowercase 64-character value for a
+service-verified ciphertext, or JSON `null` for an older blob whose checksum was never attested. A
+missing key identifies an older service deployment, not an unverified blob, and verification asks
+for the service to be updated rather than guessing.
+
 For our three-file example, the scratch index must rebuild exactly `2` active nodes. The deleted
 node is parsed and integrity-checked but correctly does not become an active search result.
 

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -93,12 +93,14 @@ def _backup_service_from_request(request: Request):
 
 
 def _persist_backup_settings(backup_dir: Path, retention_count: int) -> None:
-    from ormah.setup import _read_env_file, _write_env_file
+    from ormah.cloud.settings import update_settings_env
 
-    env = _read_env_file()
-    env["ORMAH_BACKUP_DIR"] = str(backup_dir)
-    env["ORMAH_BACKUP_RETENTION_COUNT"] = str(retention_count)
-    _write_env_file(env)
+    update_settings_env(
+        {
+            "ORMAH_BACKUP_DIR": str(backup_dir),
+            "ORMAH_BACKUP_RETENTION_COUNT": str(retention_count),
+        }
+    )
 
 
 @router.get("/health")

--- a/src/ormah/cloud/client.py
+++ b/src/ormah/cloud/client.py
@@ -123,24 +123,21 @@ def get_device_name() -> str:
 
 def persist_account_credentials(token: str, email: str) -> None:
     """Persist account credentials without dropping unrelated environment keys."""
-    from ormah.setup import _read_env_file, _write_env_file
+    from ormah.cloud.settings import update_settings_env
 
-    env = _read_env_file()
-    env[ACCOUNT_TOKEN_KEY] = token
-    env[ACCOUNT_EMAIL_KEY] = email.strip().lower()
-    _write_env_file(env)
+    update_settings_env(
+        {
+            ACCOUNT_TOKEN_KEY: token,
+            ACCOUNT_EMAIL_KEY: email.strip().lower(),
+        }
+    )
 
 
 def remove_account_credentials() -> None:
     """Remove only Ormah account credentials from the global environment file."""
-    from ormah.setup import _read_env_file, _write_env_file
+    from ormah.cloud.settings import update_settings_env
 
-    env = _read_env_file()
-    changed = ACCOUNT_TOKEN_KEY in env or ACCOUNT_EMAIL_KEY in env
-    env.pop(ACCOUNT_TOKEN_KEY, None)
-    env.pop(ACCOUNT_EMAIL_KEY, None)
-    if changed:
-        _write_env_file(env)
+    update_settings_env({}, remove=(ACCOUNT_TOKEN_KEY, ACCOUNT_EMAIL_KEY))
 
 
 class CloudClient:

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
+import errno
 import logging
 from pathlib import Path
 import re
@@ -52,6 +53,7 @@ from ormah.cloud.state import (
     ProtectionOperationPhase,
     ProtectionReasonCode,
     ProtectionState,
+    UploadJournalPhase,
     is_protected_and_verified,
     load_state,
     update_state,
@@ -75,6 +77,8 @@ _QUERY_SECRET_RE = re.compile(
     r"access_token|token|signature)=)[^&\s]+"
 )
 _SNAPSHOT_ID_RE = re.compile(r"[0-7][0-9A-HJKMNP-TV-Z]{25}")
+_NODE_PATH_RE = re.compile(r"\b(nodes|deleted)/[^\s'\",)\]]+\.md\b")
+_DISK_FULL_ERRNOS = {errno.ENOSPC, getattr(errno, "EDQUOT", errno.ENOSPC)}
 
 
 def _utc_now() -> datetime:
@@ -89,6 +93,7 @@ def safe_error_message(value: object, *sensitive_values: str | None) -> str:
     message = _QUERY_SECRET_RE.sub(r"\1<redacted>", message)
     message = _BEARER_RE.sub("Bearer <redacted>", message)
     message = _AGE_SECRET_RE.sub("<redacted-age-key>", message)
+    message = _NODE_PATH_RE.sub(r"\1/<redacted>.md", message)
     for sensitive in sensitive_values:
         if sensitive:
             message = message.replace(sensitive, "<redacted>")
@@ -160,19 +165,27 @@ def _known_state(state: CloudState) -> ProtectionState:
     return value if isinstance(value, ProtectionState) else ProtectionState.ATTENTION_REQUIRED
 
 
-def _state_after_backup(state: CloudState) -> ProtectionState:
+def _state_after_backup(
+    state: CloudState,
+    *,
+    protection_intent_id: str | None = None,
+) -> ProtectionState:
     current = _known_state(state)
+    if protection_intent_id is not None:
+        return ProtectionState.VERIFYING_FIRST_BACKUP
     if current is ProtectionState.LOCAL_ONLY:
         return ProtectionState.VERIFYING_FIRST_BACKUP
     if current is ProtectionState.STOPPED:
         return ProtectionState.STOPPED
     if current is ProtectionState.UPLOADING_FIRST_BACKUP:
         return ProtectionState.VERIFYING_FIRST_BACKUP
-    return ProtectionState.CHANGES_PENDING
+    return ProtectionState.VERIFICATION_PENDING
 
 
 def _state_after_verification(state: CloudState, snapshot_id: str) -> ProtectionState:
     current = _known_state(state)
+    if state.pending_upload_phase is UploadJournalPhase.FINALIZING:
+        return current
     if snapshot_id != state.last_successful_backup_snapshot_id:
         return current
     if (
@@ -190,6 +203,7 @@ def _state_after_verification(state: CloudState, snapshot_id: str) -> Protection
     if current in {
         ProtectionState.VERIFYING_FIRST_BACKUP,
         ProtectionState.CHANGES_PENDING,
+        ProtectionState.VERIFICATION_PENDING,
         ProtectionState.ATTENTION_REQUIRED,
         ProtectionState.OFFLINE,
         ProtectionState.PROTECTED,
@@ -208,10 +222,32 @@ def _state_after_failure(
     return requested
 
 
+def _cleared_upload_journal() -> dict[str, object]:
+    return {
+        "pending_upload_id": None,
+        "pending_upload_snapshot_id": None,
+        "pending_upload_operation_id": None,
+        "pending_upload_protection_intent_id": None,
+        "pending_upload_phase": None,
+        "pending_upload_expires_at": None,
+    }
+
+
 def _is_offline_error(error: object) -> bool:
     return isinstance(error, httpx.RequestError) or (
         isinstance(error, CloudError) and error.status_code is None
     )
+
+
+def _is_disk_full_error(error: object) -> bool:
+    return isinstance(error, OSError) and error.errno in _DISK_FULL_ERRNOS
+
+
+def _is_quota_error(error: object) -> bool:
+    if not isinstance(error, CloudError) or error.status_code != 413:
+        return False
+    detail = error.payload.get("detail") if isinstance(error.payload, dict) else error.payload
+    return "quota" in str(detail).lower()
 
 
 def _validated_snapshot_id(value: object) -> str:
@@ -249,8 +285,21 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
 
     database = Database(extracted / "scratch-index" / "index.db")
     try:
-        database.init_schema()
-        rebuilt = IndexBuilder(database, FileStore(extracted / "nodes")).full_rebuild()
+        try:
+            database.init_schema()
+            rebuilt = IndexBuilder(database, FileStore(extracted / "nodes")).full_rebuild()
+        except OSError as exc:
+            if _is_disk_full_error(exc):
+                raise
+            raise _VerificationStageError(
+                "The scratch search index could not be rebuilt in this environment.",
+                ProtectionReasonCode.INDEX_ENVIRONMENT_UNAVAILABLE,
+            ) from exc
+        except Exception as exc:
+            raise _VerificationStageError(
+                "The scratch search index could not be rebuilt in this environment.",
+                ProtectionReasonCode.INDEX_ENVIRONMENT_UNAVAILABLE,
+            ) from exc
         if rebuilt != info.node_count:
             raise RuntimeError(
                 f"Scratch index rebuilt {rebuilt} nodes; bundle manifest declares {info.node_count}."
@@ -288,6 +337,10 @@ class CloudProtectionService:
                     return self._client_update_required_operation(
                         operation_id, ProtectionOperationKind.ENABLE
                     )
+                signed_in = bool(
+                    isinstance(getattr(self.settings, "account_token", None), str)
+                    and self.settings.account_token.strip()
+                )
 
                 now = _utc_now()
                 if (
@@ -317,7 +370,7 @@ class CloudProtectionService:
                         protection_intent_id=state.pending_protection_intent_id,
                     )
 
-                if (
+                completed_protection = (
                     state.protection_state is ProtectionState.PROTECTED
                     and state.pending_protection_intent_id is not None
                     and state.pending_protection_status
@@ -326,6 +379,18 @@ class CloudProtectionService:
                         state,
                         enabled=bool(self.settings.cloud_backup_enabled),
                     )
+                )
+                completed_entitlement = (
+                    check_entitlement(self.settings)
+                    if completed_protection
+                    else None
+                )
+                if completed_entitlement in {
+                    EntitlementStatus.ACTIVE,
+                    EntitlementStatus.GRACE,
+                } or (
+                    signed_in
+                    and completed_entitlement is EntitlementStatus.NONE
                 ):
                     operation_id = state.pending_protection_intent_id
                     return ProtectionOperation(
@@ -338,12 +403,11 @@ class CloudProtectionService:
                     )
 
                 intent_id = operation_id
-                signed_in = bool(
-                    isinstance(getattr(self.settings, "account_token", None), str)
-                    and self.settings.account_token.strip()
-                )
                 next_state = (
-                    state.protection_state
+                    ProtectionState.PAUSED
+                    if signed_in
+                    and completed_entitlement is EntitlementStatus.EXPIRED
+                    else state.protection_state
                     if signed_in
                     else ProtectionState.SIGN_IN_REQUIRED
                 )
@@ -414,6 +478,11 @@ class CloudProtectionService:
             if exc.reason_code is ProtectionReasonCode.INTENT_CANCELED:
                 return self._invalid_intent_operation(operation_id, intent_id)
             return self._enable_failure(operation_id, exc, intent_id=intent_id)
+        except CloudStateVersionError:
+            return self._client_update_required_operation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+            )
         except Exception as exc:
             return self._enable_failure(operation_id, exc, intent_id=intent_id)
 
@@ -647,6 +716,11 @@ class CloudProtectionService:
             if exc.reason_code is ProtectionReasonCode.INTENT_CANCELED:
                 return self._invalid_intent_operation(operation_id, intent_id)
             return self._enable_failure(operation_id, exc, intent_id=intent_id)
+        except CloudStateVersionError:
+            return self._client_update_required_operation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+            )
         except Exception as exc:
             return self._enable_failure(operation_id, exc, intent_id=intent_id)
 
@@ -712,8 +786,6 @@ class CloudProtectionService:
                 state = _load_writable_state(store_id)
                 snapshot_id = self._retry_snapshot(state, intent_id)
                 if snapshot_id is None:
-                    if self._upload_status_is_unknown(state):
-                        return self._unknown_upload_operation(store_id, intent_id)
                     update_state(
                         store_id,
                         memory_dir=self.settings.memory_dir,
@@ -810,6 +882,11 @@ class CloudProtectionService:
                 intent_id=intent_id,
                 reason_code=exc.reason_code,
             )
+        except CloudStateVersionError:
+            return self._client_update_required_operation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+            )
         except Exception as exc:
             return self._enable_failure(operation_id, exc, intent_id=intent_id)
 
@@ -830,10 +907,13 @@ class CloudProtectionService:
                     pending_status = state.pending_protection_status
                     protection_started = (
                         bool(self.settings.cloud_backup_enabled)
+                        or state.protection_state is ProtectionState.STOPPED
+                        or state.protection_disabled_at is not None
+                        or state.last_successful_backup_snapshot_id is not None
                         or pending_status
                         in {
-                        ProtectionIntentStatus.RUNNING,
-                        ProtectionIntentStatus.COMPLETED,
+                            ProtectionIntentStatus.RUNNING,
+                            ProtectionIntentStatus.COMPLETED,
                         }
                         or state.protection_enabled_at is not None
                     )
@@ -877,6 +957,11 @@ class CloudProtectionService:
                 )
         except StoreLockTimeout:
             return self._store_busy_operation(operation_id, ProtectionOperationKind.DISABLE)
+        except CloudStateVersionError:
+            return self._client_update_required_operation(
+                operation_id,
+                ProtectionOperationKind.DISABLE,
+            )
         except Exception as exc:
             return self._enable_failure(
                 operation_id,
@@ -925,8 +1010,14 @@ class CloudProtectionService:
 
     @staticmethod
     def _new_intent_origin(state: CloudState) -> ProtectionState:
-        if state.protection_state is ProtectionState.STOPPED:
-            return ProtectionState.STOPPED
+        if isinstance(state.protection_state, ProtectionState) and state.protection_state not in {
+            ProtectionState.SIGN_IN_REQUIRED,
+            ProtectionState.SUBSCRIPTION_REQUIRED,
+            ProtectionState.INITIALIZING,
+            ProtectionState.UPLOADING_FIRST_BACKUP,
+            ProtectionState.VERIFYING_FIRST_BACKUP,
+        }:
+            return state.protection_state
         return ProtectionState.LOCAL_ONLY
 
     def _expire_intent_if_needed(self, store_id: str, state: CloudState) -> bool:
@@ -1007,42 +1098,8 @@ class CloudProtectionService:
     @staticmethod
     def _upload_status_is_unknown(state: CloudState) -> bool:
         return (
-            state.pending_protection_status is ProtectionIntentStatus.RUNNING
-            and state.pending_protection_snapshot_id is None
-            and (
-                state.protection_state is ProtectionState.UPLOADING_FIRST_BACKUP
-                or state.last_error_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
-            )
-        )
-
-    def _unknown_upload_operation(
-        self,
-        store_id: str,
-        intent_id: str,
-    ) -> ProtectionOperation:
-        message = (
-            "Ormah was interrupted while committing the first backup. "
-            "Upload status must be reconciled before retrying."
-        )
-        update_state(
-            store_id,
-            memory_dir=self.settings.memory_dir,
-            protection_state=ProtectionState.ATTENTION_REQUIRED,
-            last_operation_id=intent_id,
-            last_operation_kind=ProtectionOperationKind.ENABLE,
-            last_operation_phase=ProtectionOperationPhase.FAILED,
-            last_error_code=ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
-            last_error_message=message,
-            last_error_at=_utc_now(),
-        )
-        return ProtectionOperation(
-            intent_id,
-            ProtectionOperationKind.ENABLE,
-            ProtectionOperationPhase.FAILED,
-            ProtectionState.ATTENTION_REQUIRED,
-            ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
-            message,
-            protection_intent_id=intent_id,
+            state.pending_upload_phase is UploadJournalPhase.FINALIZING
+            or state.last_error_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
         )
 
     @staticmethod
@@ -1186,6 +1243,79 @@ class CloudProtectionService:
         except Exception as exc:
             return self._backup_failure(operation_id, exc)
 
+    def _record_upload_success(
+        self,
+        *,
+        store_id: str,
+        operation_id: str,
+        snapshot_id: str,
+        protection_intent_id: str | None,
+    ) -> ProtectionOperation:
+        state = _load_writable_state(store_id)
+        next_state = _state_after_backup(
+            state,
+            protection_intent_id=protection_intent_id,
+        )
+        uploaded_at = _utc_now()
+        changes: dict[str, object] = {
+            "last_upload_at": uploaded_at,
+            "last_upload_snapshot_id": snapshot_id,
+            "last_upload_error": None,
+            "last_successful_upload_at": uploaded_at,
+            "last_successful_backup_snapshot_id": snapshot_id,
+            "protection_state": next_state,
+            "last_operation_id": operation_id,
+            "last_operation_kind": ProtectionOperationKind.BACKUP,
+            "last_operation_phase": ProtectionOperationPhase.COMPLETED,
+            "last_error_code": None,
+            "last_error_message": None,
+            "last_error_at": None,
+            **_cleared_upload_journal(),
+        }
+        if protection_intent_id is not None:
+            changes["pending_protection_snapshot_id"] = snapshot_id
+        update_state(
+            store_id,
+            memory_dir=self.settings.memory_dir,
+            **changes,
+        )
+        logger.info("Uploaded encrypted Ormah Cloud snapshot %s", self._message(snapshot_id))
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.BACKUP,
+            ProtectionOperationPhase.COMPLETED,
+            next_state,
+            snapshot_id=snapshot_id,
+        )
+
+    def _reconcile_finalizing_upload(
+        self,
+        *,
+        store_id: str,
+        state: CloudState,
+        operation_id: str,
+        protection_intent_id: str | None,
+        client,
+    ) -> ProtectionOperation:
+        upload_id = state.pending_upload_id
+        snapshot_id = state.pending_upload_snapshot_id
+        if not isinstance(upload_id, str) or not upload_id:
+            raise RuntimeError("Finalizing upload is missing its upload id.")
+        snapshot_id = _validated_snapshot_id(snapshot_id)
+        finalized = client.finalize_upload(store_id, upload_id)
+        finalized_snapshot = _validated_snapshot_id(finalized.get("snapshot_id"))
+        if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
+            raise RuntimeError("Cloud upload finalize response was malformed.")
+        return self._record_upload_success(
+            store_id=store_id,
+            operation_id=operation_id,
+            snapshot_id=snapshot_id,
+            protection_intent_id=(
+                protection_intent_id
+                or state.pending_upload_protection_intent_id
+            ),
+        )
+
     def _backup_now(
         self,
         operation_id: str,
@@ -1233,6 +1363,27 @@ class CloudProtectionService:
                     ProtectionState.STOPPED,
                     ProtectionReasonCode.PROTECTION_STOPPED,
                     "Cloud protection is stopped for this memory store.",
+                )
+            if state is not None and state.pending_upload_phase is not None:
+                if not isinstance(state.pending_upload_phase, UploadJournalPhase):
+                    return self._client_update_required_operation(
+                        operation_id,
+                        ProtectionOperationKind.BACKUP,
+                    )
+                if state.pending_upload_phase is UploadJournalPhase.FINALIZING:
+                    client = client_from_settings(settings)
+                    finalize_attempted = True
+                    return self._reconcile_finalizing_upload(
+                        store_id=store_id,
+                        state=state,
+                        operation_id=operation_id,
+                        protection_intent_id=protection_intent_id,
+                        client=client,
+                    )
+                state = update_state(
+                    store_id,
+                    memory_dir=settings.memory_dir,
+                    **_cleared_upload_journal(),
                 )
             if (
                 state is not None
@@ -1341,45 +1492,57 @@ class CloudProtectionService:
                 ):
                     raise RuntimeError("Cloud upload reservation headers were malformed.")
 
+                update_state(
+                    store_id,
+                    memory_dir=settings.memory_dir,
+                    pending_upload_id=upload_id,
+                    pending_upload_snapshot_id=snapshot_id,
+                    pending_upload_operation_id=operation_id,
+                    pending_upload_protection_intent_id=protection_intent_id,
+                    pending_upload_phase=UploadJournalPhase.RESERVED,
+                    pending_upload_expires_at=parsed_expiry,
+                )
                 put_file(put_url, bundle, required_headers)
+                update_state(
+                    store_id,
+                    memory_dir=settings.memory_dir,
+                    pending_upload_phase=UploadJournalPhase.FINALIZING,
+                )
                 finalize_attempted = True
                 finalized = client.finalize_upload(store_id, upload_id)
                 finalized_snapshot = _validated_snapshot_id(finalized.get("snapshot_id"))
                 if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
                     raise RuntimeError("Cloud upload finalize response was malformed.")
 
-            uploaded_at = _utc_now()
-            next_state = _state_after_backup(state)
-            changes: dict[str, object] = {
-                "last_upload_at": uploaded_at,
-                "last_upload_snapshot_id": snapshot_id,
-                "last_upload_error": None,
-                "last_successful_upload_at": uploaded_at,
-                "last_successful_backup_snapshot_id": snapshot_id,
-                "protection_state": next_state,
-                "last_operation_id": operation_id,
-                "last_operation_kind": ProtectionOperationKind.BACKUP,
-                "last_operation_phase": ProtectionOperationPhase.COMPLETED,
-                "last_error_code": None,
-                "last_error_message": None,
-                "last_error_at": None,
-            }
-            if protection_intent_id is not None:
-                changes["pending_protection_snapshot_id"] = snapshot_id
-            update_state(
-                store_id,
-                memory_dir=settings.memory_dir,
-                **changes,
+            return self._record_upload_success(
+                store_id=store_id,
+                operation_id=operation_id,
+                snapshot_id=snapshot_id,
+                protection_intent_id=protection_intent_id,
             )
-            logger.info("Uploaded encrypted Ormah Cloud snapshot %s", self._message(snapshot_id))
-            return ProtectionOperation(
+        except CloudStateVersionError:
+            return self._client_update_required_operation(
                 operation_id,
                 ProtectionOperationKind.BACKUP,
-                ProtectionOperationPhase.COMPLETED,
-                next_state,
-                snapshot_id=snapshot_id,
             )
         except Exception as exc:
+            if not finalize_attempted and store_id is not None:
+                try:
+                    current = _load_writable_state(store_id)
+                    if (
+                        current.pending_upload_operation_id == operation_id
+                        and current.pending_upload_phase is UploadJournalPhase.RESERVED
+                    ):
+                        update_state(
+                            store_id,
+                            memory_dir=settings.memory_dir,
+                            **_cleared_upload_journal(),
+                        )
+                except Exception as cleanup_error:
+                    logger.warning(
+                        "Could not clear an abandoned upload reservation: %s",
+                        self._message(cleanup_error),
+                    )
             if finalize_attempted:
                 return self._backup_failure(
                     operation_id,
@@ -1395,6 +1558,20 @@ class CloudProtectionService:
                     store_id=store_id,
                     reason_code=ProtectionReasonCode.OFFLINE,
                     protection_state=ProtectionState.OFFLINE,
+                )
+            if _is_quota_error(exc):
+                return self._backup_failure(
+                    operation_id,
+                    exc,
+                    store_id=store_id,
+                    reason_code=ProtectionReasonCode.QUOTA_EXCEEDED,
+                )
+            if _is_disk_full_error(exc):
+                return self._backup_failure(
+                    operation_id,
+                    exc,
+                    store_id=store_id,
+                    reason_code=ProtectionReasonCode.DISK_SPACE_INSUFFICIENT,
                 )
             return self._backup_failure(operation_id, exc, store_id=store_id)
         finally:
@@ -1557,14 +1734,19 @@ class CloudProtectionService:
 
             verified_at = _utc_now()
             next_state = _state_after_verification(state, snapshot_id)
+            latest_state = _load_writable_state(store_id)
+            preserve_upload_ambiguity = self._upload_status_is_unknown(latest_state)
             changes: dict[str, object] = {
                 "last_operation_id": operation_id,
                 "last_operation_kind": ProtectionOperationKind.VERIFY,
                 "last_operation_phase": ProtectionOperationPhase.COMPLETED,
-                "last_error_code": None,
-                "last_error_message": None,
-                "last_error_at": None,
             }
+            if not preserve_upload_ambiguity:
+                changes.update(
+                    last_error_code=None,
+                    last_error_message=None,
+                    last_error_at=None,
+                )
             if tracks_latest_snapshot:
                 changes.update(
                     last_verify_at=verified_at,
@@ -1590,9 +1772,11 @@ class CloudProtectionService:
             offline = _is_offline_error(exc)
             reason_code = (
                 exc.reason_code
-                if isinstance(exc, _VerificationPrerequisiteError)
+                if isinstance(exc, (_VerificationPrerequisiteError, _VerificationStageError))
                 else ProtectionReasonCode.OFFLINE
                 if offline
+                else ProtectionReasonCode.DISK_SPACE_INSUFFICIENT
+                if _is_disk_full_error(exc)
                 else ProtectionReasonCode.BUNDLE_CORRUPT
                 if isinstance(exc, BundleError)
                 else ProtectionReasonCode.VERIFICATION_FAILED
@@ -1751,6 +1935,12 @@ class CloudProtectionService:
 
 
 class _VerificationPrerequisiteError(RuntimeError):
+    def __init__(self, message: str, reason_code: ProtectionReasonCode) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+class _VerificationStageError(RuntimeError):
     def __init__(self, message: str, reason_code: ProtectionReasonCode) -> None:
         super().__init__(message)
         self.reason_code = reason_code

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -1796,7 +1796,12 @@ class CloudProtectionService:
                     "Cloud snapshot exceeds this client's safe processing limit.",
                     ProtectionReasonCode.PROCESSING_LIMIT_EXCEEDED,
                 )
-            expected_sha256 = _validated_sha256(selected.get("sha256"))
+            if "sha256" not in selected:
+                raise _VerificationStageError(
+                    "Ormah Cloud must be updated before restore verification can continue.",
+                    ProtectionReasonCode.SERVICE_UPDATE_REQUIRED,
+                )
+            expected_sha256 = _validated_sha256(selected["sha256"])
 
             presigned = client.presign_download(store_id, snapshot_id)
             get_url = presigned.get("get_url")

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import logging
 from pathlib import Path
@@ -21,24 +22,37 @@ from ormah.backup import (
     service_from_settings,
 )
 from ormah.cloud.bundle import BundleError, build_bundle, open_bundle
+from ormah.cloud.billing import validate_protection_intent_id
 from ormah.cloud.client import CloudError, client_from_settings
-from ormah.cloud.entitlements import EntitlementStatus, check_entitlement
+from ormah.cloud.entitlements import (
+    EntitlementStatus,
+    cache_entitlements,
+    check_entitlement,
+)
 from ormah.cloud.keys import (
+    CloudKeyError,
+    RECOVERY_KIT_PATH,
     STORE_ID_NAME,
     current_recipient,
+    extract_store_id,
     get_or_create_store_id,
+    init_key,
     key_file_exists,
     load_identities,
+    write_recovery_kit,
 )
+from ormah.cloud.settings import set_cloud_backup_enabled
 from ormah.cloud.state import (
     CURRENT_CLOUD_STATE_SCHEMA_VERSION,
     CloudState,
     CloudStateVersionError,
+    ProtectionIntentStatus,
     ProtectionOperation,
     ProtectionOperationKind,
     ProtectionOperationPhase,
     ProtectionReasonCode,
     ProtectionState,
+    is_protected_and_verified,
     load_state,
     update_state,
 )
@@ -161,6 +175,18 @@ def _state_after_verification(state: CloudState, snapshot_id: str) -> Protection
     current = _known_state(state)
     if snapshot_id != state.last_successful_backup_snapshot_id:
         return current
+    if (
+        state.pending_protection_intent_id is not None
+        and state.pending_protection_status
+        in {
+            ProtectionIntentStatus.PENDING,
+            ProtectionIntentStatus.ACCOUNT_BOUND,
+            ProtectionIntentStatus.CHECKOUT_PENDING,
+            ProtectionIntentStatus.READY,
+            ProtectionIntentStatus.RUNNING,
+        }
+    ):
+        return current
     if current in {
         ProtectionState.VERIFYING_FIRST_BACKUP,
         ProtectionState.CHANGES_PENDING,
@@ -248,6 +274,893 @@ class CloudProtectionService:
     def _message(self, value: object) -> str:
         return safe_error_message(value, getattr(self.settings, "account_token", None))
 
+    def create_intent(self) -> ProtectionOperation:
+        """Create or resume a 30-minute durable Protect action."""
+
+        operation_id = str(uuid.uuid4())
+        try:
+            with StoreLock(self.settings.memory_dir):
+                memory_dir = Path(self.settings.memory_dir).expanduser()
+                created_store = not (memory_dir / STORE_ID_NAME).is_file()
+                store_id = get_or_create_store_id(memory_dir)
+                state = _load_writable_state(store_id)
+                if not isinstance(state.protection_state, ProtectionState):
+                    return self._client_update_required_operation(
+                        operation_id, ProtectionOperationKind.ENABLE
+                    )
+
+                now = _utc_now()
+                if (
+                    state.pending_protection_intent_id is not None
+                    and state.pending_protection_store_id == store_id
+                    and (
+                        state.pending_protection_status
+                        is ProtectionIntentStatus.RUNNING
+                        or (
+                            state.pending_protection_expires_at is not None
+                            and state.pending_protection_expires_at > now
+                        )
+                    )
+                    and state.pending_protection_status
+                    not in {
+                        ProtectionIntentStatus.COMPLETED,
+                        ProtectionIntentStatus.CANCELED,
+                        ProtectionIntentStatus.EXPIRED,
+                    }
+                ):
+                    operation_id = state.pending_protection_intent_id
+                    return ProtectionOperation(
+                        operation_id,
+                        ProtectionOperationKind.ENABLE,
+                        ProtectionOperationPhase.PENDING,
+                        _known_state(state),
+                        protection_intent_id=state.pending_protection_intent_id,
+                    )
+
+                if (
+                    state.protection_state is ProtectionState.PROTECTED
+                    and state.pending_protection_intent_id is not None
+                    and state.pending_protection_status
+                    is ProtectionIntentStatus.COMPLETED
+                    and is_protected_and_verified(
+                        state,
+                        enabled=bool(self.settings.cloud_backup_enabled),
+                    )
+                ):
+                    operation_id = state.pending_protection_intent_id
+                    return ProtectionOperation(
+                        operation_id,
+                        ProtectionOperationKind.ENABLE,
+                        ProtectionOperationPhase.COMPLETED,
+                        ProtectionState.PROTECTED,
+                        snapshot_id=state.last_verified_snapshot_id,
+                        protection_intent_id=state.pending_protection_intent_id,
+                    )
+
+                intent_id = operation_id
+                signed_in = bool(
+                    isinstance(getattr(self.settings, "account_token", None), str)
+                    and self.settings.account_token.strip()
+                )
+                next_state = (
+                    state.protection_state
+                    if signed_in
+                    else ProtectionState.SIGN_IN_REQUIRED
+                )
+                update_state(
+                    store_id,
+                    memory_dir=memory_dir,
+                    protection_state=next_state,
+                    pending_protection_intent_id=intent_id,
+                    pending_protection_account_id=None,
+                    pending_protection_store_id=store_id,
+                    pending_protection_created_at=now,
+                    pending_protection_expires_at=now + timedelta(minutes=30),
+                    pending_protection_status=ProtectionIntentStatus.PENDING,
+                    pending_protection_snapshot_id=None,
+                    pending_protection_created_store=(
+                        created_store
+                        or (
+                            state.pending_protection_created_store
+                            and state.last_successful_backup_snapshot_id is None
+                        )
+                    ),
+                    pending_protection_origin_state=self._new_intent_origin(state),
+                    last_operation_id=operation_id,
+                    last_operation_kind=ProtectionOperationKind.ENABLE,
+                    last_operation_phase=ProtectionOperationPhase.PENDING,
+                    last_error_code=(
+                        None if signed_in else ProtectionReasonCode.SIGN_IN_REQUIRED
+                    ),
+                    last_error_message=None,
+                    last_error_at=None,
+                )
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.ENABLE,
+                    ProtectionOperationPhase.PENDING,
+                    next_state,
+                    None if signed_in else ProtectionReasonCode.SIGN_IN_REQUIRED,
+                    protection_intent_id=intent_id,
+                )
+        except StoreLockTimeout:
+            return self._store_busy_operation(operation_id, ProtectionOperationKind.ENABLE)
+        except CloudStateVersionError:
+            return self._client_update_required_operation(
+                operation_id, ProtectionOperationKind.ENABLE
+            )
+        except Exception as exc:
+            return self._enable_failure(operation_id, exc)
+
+    def bind_intent(self, intent_id: str) -> ProtectionOperation:
+        """Bind an intent to the account from a fresh authenticated response."""
+
+        operation_id = str(uuid.uuid4())
+        try:
+            intent_id = validate_protection_intent_id(intent_id)
+            operation_id = intent_id
+        except ValueError:
+            return self._invalid_intent_operation(operation_id)
+        try:
+            with StoreLock(self.settings.memory_dir):
+                return self._bind_intent(operation_id, intent_id)
+        except StoreLockTimeout:
+            return self._store_busy_operation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                protection_intent_id=intent_id,
+            )
+        except _EnablePrerequisiteError as exc:
+            if exc.reason_code is ProtectionReasonCode.INTENT_CANCELED:
+                return self._invalid_intent_operation(operation_id, intent_id)
+            return self._enable_failure(operation_id, exc, intent_id=intent_id)
+        except Exception as exc:
+            return self._enable_failure(operation_id, exc, intent_id=intent_id)
+
+    def _bind_intent(
+        self, operation_id: str, intent_id: str
+    ) -> ProtectionOperation:
+        store_id, state = self._intent_state(intent_id)
+        terminal = self._terminal_intent_operation(operation_id, intent_id, state)
+        if terminal is not None:
+            return terminal
+        if self._expire_intent_if_needed(store_id, state):
+            return ProtectionOperation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                ProtectionOperationPhase.CANCELED,
+                self._intent_origin_state(state),
+                ProtectionReasonCode.INTENT_EXPIRED,
+                "This protection request has expired. Start again.",
+                protection_intent_id=intent_id,
+            )
+
+        token = getattr(self.settings, "account_token", None)
+        if not isinstance(token, str) or not token.strip():
+            update_state(
+                store_id,
+                memory_dir=self.settings.memory_dir,
+                protection_state=ProtectionState.SIGN_IN_REQUIRED,
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.ENABLE,
+                last_operation_phase=ProtectionOperationPhase.PENDING,
+                last_error_code=ProtectionReasonCode.SIGN_IN_REQUIRED,
+                last_error_message=None,
+                last_error_at=None,
+            )
+            return ProtectionOperation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                ProtectionOperationPhase.PENDING,
+                ProtectionState.SIGN_IN_REQUIRED,
+                ProtectionReasonCode.SIGN_IN_REQUIRED,
+                "Sign in to continue protecting this memory.",
+                protection_intent_id=intent_id,
+            )
+
+        client = None
+        try:
+            client = client_from_settings(self.settings)
+            entitlements = client.get_entitlements()
+        except Exception as exc:
+            reason = (
+                ProtectionReasonCode.SIGN_IN_REQUIRED
+                if isinstance(exc, CloudError) and exc.status_code == 401
+                else ProtectionReasonCode.OFFLINE
+                if _is_offline_error(exc)
+                else ProtectionReasonCode.OPERATION_INTERRUPTED
+            )
+            next_state = (
+                ProtectionState.SIGN_IN_REQUIRED
+                if reason is ProtectionReasonCode.SIGN_IN_REQUIRED
+                else ProtectionState.OFFLINE
+                if reason is ProtectionReasonCode.OFFLINE
+                else ProtectionState.ATTENTION_REQUIRED
+            )
+            return self._enable_failure(
+                operation_id,
+                exc,
+                store_id=store_id,
+                intent_id=intent_id,
+                reason_code=reason,
+                protection_state=next_state,
+            )
+        finally:
+            self._close_client(client)
+
+        if not isinstance(entitlements, dict):
+            return self._enable_failure(
+                operation_id,
+                "Ormah Cloud returned malformed account metadata.",
+                store_id=store_id,
+                intent_id=intent_id,
+            )
+        try:
+            account_id = self._validated_account_id(entitlements.get("account_id"))
+        except ValueError as exc:
+            return self._enable_failure(
+                operation_id,
+                exc,
+                store_id=store_id,
+                intent_id=intent_id,
+            )
+        try:
+            cache_entitlements(entitlements, fetched_at=_utc_now())
+        except OSError as exc:
+            logger.warning(
+                "Could not cache fresh Ormah Cloud entitlement state: %s",
+                self._message(exc),
+            )
+
+        # Re-read after the network boundary even though this process retains the
+        # canonical lock; another process may have completed a pre-existing state write.
+        state = _load_writable_state(store_id)
+        terminal = self._terminal_intent_operation(operation_id, intent_id, state)
+        if terminal is not None:
+            return terminal
+        if state.pending_protection_account_id not in {None, account_id}:
+            origin = self._intent_origin_state(state)
+            update_state(
+                store_id,
+                memory_dir=self.settings.memory_dir,
+                protection_state=origin,
+                pending_protection_status=ProtectionIntentStatus.CANCELED,
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.ENABLE,
+                last_operation_phase=ProtectionOperationPhase.CANCELED,
+                last_error_code=ProtectionReasonCode.ACCOUNT_CHANGED,
+                last_error_message="This protection request belongs to another account.",
+                last_error_at=_utc_now(),
+            )
+            return ProtectionOperation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                ProtectionOperationPhase.CANCELED,
+                origin,
+                ProtectionReasonCode.ACCOUNT_CHANGED,
+                "This protection request was canceled because the account changed.",
+                protection_intent_id=intent_id,
+            )
+
+        has_subscription = entitlements.get("backup") is True
+        if state.pending_protection_status is ProtectionIntentStatus.RUNNING:
+            status = ProtectionIntentStatus.RUNNING
+            next_state = _known_state(state)
+        elif has_subscription:
+            status = ProtectionIntentStatus.READY
+            next_state = self._intent_origin_state(state)
+        else:
+            status = ProtectionIntentStatus.ACCOUNT_BOUND
+            next_state = ProtectionState.SUBSCRIPTION_REQUIRED
+        changes: dict[str, object] = {
+            "protection_state": next_state,
+            "pending_protection_account_id": account_id,
+            "pending_protection_status": status,
+        }
+        if status is not ProtectionIntentStatus.RUNNING:
+            changes.update(
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.ENABLE,
+                last_operation_phase=ProtectionOperationPhase.PENDING,
+                last_error_code=(
+                    None
+                    if has_subscription
+                    else ProtectionReasonCode.SUBSCRIPTION_REQUIRED
+                ),
+                last_error_message=None,
+                last_error_at=None,
+            )
+        update_state(
+            store_id,
+            memory_dir=self.settings.memory_dir,
+            **changes,
+        )
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.ENABLE,
+            ProtectionOperationPhase.PENDING,
+            next_state,
+            None if has_subscription else ProtectionReasonCode.SUBSCRIPTION_REQUIRED,
+            protection_intent_id=intent_id,
+        )
+
+    def cancel_intent(self, intent_id: str) -> ProtectionOperation:
+        """Cancel a pending Protect action without removing recovery material."""
+
+        operation_id = str(uuid.uuid4())
+        try:
+            intent_id = validate_protection_intent_id(intent_id)
+            operation_id = intent_id
+        except ValueError:
+            return self._invalid_intent_operation(operation_id)
+        try:
+            with StoreLock(self.settings.memory_dir):
+                store_id, state = self._intent_state(intent_id)
+                terminal = self._terminal_intent_operation(operation_id, intent_id, state)
+                if terminal is not None:
+                    return terminal
+                if self._expire_intent_if_needed(store_id, state):
+                    return ProtectionOperation(
+                        operation_id,
+                        ProtectionOperationKind.ENABLE,
+                        ProtectionOperationPhase.CANCELED,
+                        self._intent_origin_state(state),
+                        ProtectionReasonCode.INTENT_EXPIRED,
+                        protection_intent_id=intent_id,
+                    )
+                if state.pending_protection_status is ProtectionIntentStatus.RUNNING:
+                    return self._enable_failure(
+                        operation_id,
+                        "Protection has already started; stop cloud protection instead.",
+                        store_id=store_id,
+                        intent_id=intent_id,
+                        reason_code=ProtectionReasonCode.OPERATION_INTERRUPTED,
+                    )
+                origin = self._intent_origin_state(state)
+                update_state(
+                    store_id,
+                    memory_dir=self.settings.memory_dir,
+                    protection_state=origin,
+                    pending_protection_status=ProtectionIntentStatus.CANCELED,
+                    last_operation_id=operation_id,
+                    last_operation_kind=ProtectionOperationKind.ENABLE,
+                    last_operation_phase=ProtectionOperationPhase.CANCELED,
+                    last_error_code=ProtectionReasonCode.INTENT_CANCELED,
+                    last_error_message=None,
+                    last_error_at=None,
+                )
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.ENABLE,
+                    ProtectionOperationPhase.CANCELED,
+                    origin,
+                    ProtectionReasonCode.INTENT_CANCELED,
+                    protection_intent_id=intent_id,
+                )
+        except StoreLockTimeout:
+            return self._store_busy_operation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                protection_intent_id=intent_id,
+            )
+        except _EnablePrerequisiteError as exc:
+            if exc.reason_code is ProtectionReasonCode.INTENT_CANCELED:
+                return self._invalid_intent_operation(operation_id, intent_id)
+            return self._enable_failure(operation_id, exc, intent_id=intent_id)
+        except Exception as exc:
+            return self._enable_failure(operation_id, exc, intent_id=intent_id)
+
+    def enable(self, intent_id: str) -> ProtectionOperation:
+        """Enable protection, upload immediately, and verify the exact snapshot."""
+
+        operation_id = str(uuid.uuid4())
+        try:
+            intent_id = validate_protection_intent_id(intent_id)
+            operation_id = intent_id
+        except ValueError:
+            return self._invalid_intent_operation(operation_id)
+        try:
+            with StoreLock(self.settings.memory_dir):
+                bound = self._bind_intent(operation_id, intent_id)
+                store_id, state = self._intent_state(intent_id)
+                if bound.reason_code is not None or state.pending_protection_status not in {
+                    ProtectionIntentStatus.READY,
+                    ProtectionIntentStatus.RUNNING,
+                }:
+                    return bound
+
+                if state.pending_protection_status is ProtectionIntentStatus.READY:
+                    update_state(
+                        store_id,
+                        memory_dir=self.settings.memory_dir,
+                        protection_state=ProtectionState.INITIALIZING,
+                        pending_protection_status=ProtectionIntentStatus.RUNNING,
+                        last_operation_id=operation_id,
+                        last_operation_kind=ProtectionOperationKind.ENABLE,
+                        last_operation_phase=ProtectionOperationPhase.RUNNING,
+                        last_error_code=None,
+                        last_error_message=None,
+                        last_error_at=None,
+                    )
+
+                try:
+                    if not key_file_exists():
+                        if not state.pending_protection_created_store:
+                            raise _EnablePrerequisiteError(
+                                "Cloud encryption key is missing; import the recovery kit first.",
+                                ProtectionReasonCode.KEY_MISSING,
+                            )
+                        init_key()
+                    load_identities()
+                    self._validate_recovery_kit_store(store_id)
+                    write_recovery_kit(
+                        store_id,
+                        account_email=getattr(self.settings, "account_email", None),
+                    )
+                except _EnablePrerequisiteError:
+                    raise
+                except CloudKeyError as exc:
+                    raise _EnablePrerequisiteError(
+                        str(exc), ProtectionReasonCode.KEY_INVALID
+                    ) from exc
+                except Exception as exc:
+                    raise _EnablePrerequisiteError(
+                        str(exc), ProtectionReasonCode.KEY_INVALID
+                    ) from exc
+
+                set_cloud_backup_enabled(self.settings, True)
+                state = _load_writable_state(store_id)
+                snapshot_id = self._retry_snapshot(state, intent_id)
+                if snapshot_id is None:
+                    if self._upload_status_is_unknown(state):
+                        return self._unknown_upload_operation(store_id, intent_id)
+                    update_state(
+                        store_id,
+                        memory_dir=self.settings.memory_dir,
+                        protection_state=ProtectionState.UPLOADING_FIRST_BACKUP,
+                        last_operation_id=operation_id,
+                        last_operation_kind=ProtectionOperationKind.ENABLE,
+                        last_operation_phase=ProtectionOperationPhase.UPLOADING,
+                    )
+                    backup = self._backup_now(
+                        operation_id,
+                        reason="protection-enable",
+                        only_if_due=False,
+                        entitlement_verified=True,
+                        protection_intent_id=intent_id,
+                    )
+                    if backup.phase is not ProtectionOperationPhase.COMPLETED:
+                        return self._enable_stage_result(
+                            store_id,
+                            intent_id,
+                            backup,
+                        )
+                    snapshot_id = backup.snapshot_id
+                assert snapshot_id is not None
+
+                update_state(
+                    store_id,
+                    memory_dir=self.settings.memory_dir,
+                    protection_state=ProtectionState.VERIFYING_FIRST_BACKUP,
+                    last_operation_id=operation_id,
+                    last_operation_kind=ProtectionOperationKind.ENABLE,
+                    last_operation_phase=ProtectionOperationPhase.VERIFYING,
+                )
+                verification = self._verify_now(
+                    operation_id, requested_snapshot_id=snapshot_id
+                )
+                if verification.phase is not ProtectionOperationPhase.COMPLETED:
+                    return self._enable_stage_result(
+                        store_id,
+                        intent_id,
+                        verification,
+                    )
+
+                final = _load_writable_state(store_id)
+                if (
+                    final.pending_protection_intent_id != intent_id
+                    or final.pending_protection_status is not ProtectionIntentStatus.RUNNING
+                    or final.last_successful_backup_snapshot_id != snapshot_id
+                    or final.pending_protection_snapshot_id != snapshot_id
+                    or final.last_verified_snapshot_id != snapshot_id
+                    or final.last_verify_ok is not True
+                ):
+                    return self._enable_failure(
+                        operation_id,
+                        "Protection verification did not match the uploaded snapshot.",
+                        store_id=store_id,
+                        intent_id=intent_id,
+                        reason_code=ProtectionReasonCode.VERIFICATION_FAILED,
+                    )
+                now = _utc_now()
+                update_state(
+                    store_id,
+                    memory_dir=self.settings.memory_dir,
+                    protection_enabled_at=final.protection_enabled_at or now,
+                    protection_disabled_at=None,
+                    protection_state=ProtectionState.PROTECTED,
+                    pending_protection_status=ProtectionIntentStatus.COMPLETED,
+                    last_operation_id=operation_id,
+                    last_operation_kind=ProtectionOperationKind.ENABLE,
+                    last_operation_phase=ProtectionOperationPhase.COMPLETED,
+                    last_error_code=None,
+                    last_error_message=None,
+                    last_error_at=None,
+                )
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.ENABLE,
+                    ProtectionOperationPhase.COMPLETED,
+                    ProtectionState.PROTECTED,
+                    snapshot_id=snapshot_id,
+                    protection_intent_id=intent_id,
+                )
+        except StoreLockTimeout:
+            return self._store_busy_operation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                protection_intent_id=intent_id,
+            )
+        except _EnablePrerequisiteError as exc:
+            if exc.reason_code is ProtectionReasonCode.INTENT_CANCELED:
+                return self._invalid_intent_operation(operation_id, intent_id)
+            return self._enable_failure(
+                operation_id,
+                exc,
+                intent_id=intent_id,
+                reason_code=exc.reason_code,
+            )
+        except Exception as exc:
+            return self._enable_failure(operation_id, exc, intent_id=intent_id)
+
+    def disable(self) -> ProtectionOperation:
+        """Stop future uploads while preserving account and recovery history."""
+
+        operation_id = str(uuid.uuid4())
+        try:
+            with StoreLock(self.settings.memory_dir):
+                store_id = _existing_store_id(self.settings.memory_dir)
+                result_state = ProtectionState.LOCAL_ONLY
+                if store_id is not None:
+                    state = _load_writable_state(store_id)
+                    if not isinstance(state.protection_state, ProtectionState):
+                        return self._client_update_required_operation(
+                            operation_id, ProtectionOperationKind.DISABLE
+                        )
+                    pending_status = state.pending_protection_status
+                    protection_started = (
+                        bool(self.settings.cloud_backup_enabled)
+                        or pending_status
+                        in {
+                        ProtectionIntentStatus.RUNNING,
+                        ProtectionIntentStatus.COMPLETED,
+                        }
+                        or state.protection_enabled_at is not None
+                    )
+                    target_state = (
+                        ProtectionState.STOPPED
+                        if protection_started
+                        else self._intent_origin_state(state)
+                    )
+                    if pending_status not in {
+                        None,
+                        ProtectionIntentStatus.COMPLETED,
+                        ProtectionIntentStatus.CANCELED,
+                        ProtectionIntentStatus.EXPIRED,
+                    }:
+                        pending_status = ProtectionIntentStatus.CANCELED
+                    update_state(
+                        store_id,
+                        memory_dir=self.settings.memory_dir,
+                        protection_state=target_state,
+                        protection_disabled_at=(
+                            state.protection_disabled_at
+                            if target_state is not ProtectionState.STOPPED
+                            or state.protection_state is ProtectionState.STOPPED
+                            else _utc_now()
+                        ),
+                        pending_protection_status=pending_status,
+                        last_operation_id=operation_id,
+                        last_operation_kind=ProtectionOperationKind.DISABLE,
+                        last_operation_phase=ProtectionOperationPhase.COMPLETED,
+                        last_error_code=None,
+                        last_error_message=None,
+                        last_error_at=None,
+                    )
+                    result_state = target_state
+                set_cloud_backup_enabled(self.settings, False)
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.DISABLE,
+                    ProtectionOperationPhase.COMPLETED,
+                    result_state,
+                )
+        except StoreLockTimeout:
+            return self._store_busy_operation(operation_id, ProtectionOperationKind.DISABLE)
+        except Exception as exc:
+            return self._enable_failure(
+                operation_id,
+                exc,
+                kind=ProtectionOperationKind.DISABLE,
+            )
+
+    def _intent_state(self, intent_id: str) -> tuple[str, CloudState]:
+        store_id = _existing_store_id(self.settings.memory_dir)
+        if store_id is None:
+            raise _EnablePrerequisiteError(
+                "This protection request does not belong to this memory store.",
+                ProtectionReasonCode.INTENT_CANCELED,
+            )
+        state = _load_writable_state(store_id)
+        if not isinstance(state.protection_state, ProtectionState):
+            raise CloudStateVersionError("Unknown protection state")
+        if (
+            state.pending_protection_intent_id != intent_id
+            or state.pending_protection_store_id != store_id
+        ):
+            raise _EnablePrerequisiteError(
+                "This protection request does not belong to this memory store.",
+                ProtectionReasonCode.INTENT_CANCELED,
+            )
+        return store_id, state
+
+    @staticmethod
+    def _validated_account_id(value: object) -> str:
+        if not isinstance(value, str):
+            raise ValueError("Ormah Cloud did not return a valid account identifier.")
+        try:
+            parsed = uuid.UUID(value)
+        except ValueError as exc:
+            raise ValueError(
+                "Ormah Cloud did not return a valid account identifier."
+            ) from exc
+        if parsed.version != 4 or parsed.variant != uuid.RFC_4122:
+            raise ValueError("Ormah Cloud did not return a valid account identifier.")
+        return str(parsed)
+
+    @staticmethod
+    def _intent_origin_state(state: CloudState) -> ProtectionState:
+        origin = state.pending_protection_origin_state
+        return origin if isinstance(origin, ProtectionState) else ProtectionState.LOCAL_ONLY
+
+    @staticmethod
+    def _new_intent_origin(state: CloudState) -> ProtectionState:
+        if state.protection_state is ProtectionState.STOPPED:
+            return ProtectionState.STOPPED
+        return ProtectionState.LOCAL_ONLY
+
+    def _expire_intent_if_needed(self, store_id: str, state: CloudState) -> bool:
+        if state.pending_protection_status is ProtectionIntentStatus.RUNNING:
+            return False
+        expires_at = state.pending_protection_expires_at
+        if expires_at is not None and expires_at > _utc_now():
+            return False
+        update_state(
+            store_id,
+            memory_dir=self.settings.memory_dir,
+            protection_state=self._intent_origin_state(state),
+            pending_protection_status=ProtectionIntentStatus.EXPIRED,
+            last_error_code=ProtectionReasonCode.INTENT_EXPIRED,
+            last_error_message=None,
+            last_error_at=None,
+        )
+        return True
+
+    def _terminal_intent_operation(
+        self,
+        operation_id: str,
+        intent_id: str,
+        state: CloudState,
+    ) -> ProtectionOperation | None:
+        status = state.pending_protection_status
+        if status is ProtectionIntentStatus.COMPLETED:
+            current_state = _known_state(state)
+            if (
+                current_state is ProtectionState.PROTECTED
+                and not is_protected_and_verified(
+                    state,
+                    enabled=bool(self.settings.cloud_backup_enabled),
+                )
+            ):
+                current_state = ProtectionState.ATTENTION_REQUIRED
+            return ProtectionOperation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                ProtectionOperationPhase.COMPLETED,
+                current_state,
+                snapshot_id=state.last_verified_snapshot_id,
+                protection_intent_id=intent_id,
+            )
+        if status in {ProtectionIntentStatus.CANCELED, ProtectionIntentStatus.EXPIRED}:
+            reason = (
+                ProtectionReasonCode.INTENT_EXPIRED
+                if status is ProtectionIntentStatus.EXPIRED
+                else ProtectionReasonCode.INTENT_CANCELED
+            )
+            return ProtectionOperation(
+                operation_id,
+                ProtectionOperationKind.ENABLE,
+                ProtectionOperationPhase.CANCELED,
+                _known_state(state),
+                reason,
+                protection_intent_id=intent_id,
+            )
+        return None
+
+    @staticmethod
+    def _retry_snapshot(state: CloudState, intent_id: str) -> str | None:
+        if state.pending_protection_status is not ProtectionIntentStatus.RUNNING:
+            return None
+        if state.last_operation_id != intent_id:
+            return None
+        snapshot_id = state.pending_protection_snapshot_id
+        if snapshot_id is None:
+            return None
+        if snapshot_id != state.last_successful_backup_snapshot_id:
+            return None
+        if state.protection_state is ProtectionState.VERIFYING_FIRST_BACKUP:
+            return snapshot_id
+        if state.last_verify_snapshot_id == snapshot_id:
+            return snapshot_id
+        return None
+
+    @staticmethod
+    def _upload_status_is_unknown(state: CloudState) -> bool:
+        return (
+            state.pending_protection_status is ProtectionIntentStatus.RUNNING
+            and state.pending_protection_snapshot_id is None
+            and (
+                state.protection_state is ProtectionState.UPLOADING_FIRST_BACKUP
+                or state.last_error_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+            )
+        )
+
+    def _unknown_upload_operation(
+        self,
+        store_id: str,
+        intent_id: str,
+    ) -> ProtectionOperation:
+        message = (
+            "Ormah was interrupted while committing the first backup. "
+            "Upload status must be reconciled before retrying."
+        )
+        update_state(
+            store_id,
+            memory_dir=self.settings.memory_dir,
+            protection_state=ProtectionState.ATTENTION_REQUIRED,
+            last_operation_id=intent_id,
+            last_operation_kind=ProtectionOperationKind.ENABLE,
+            last_operation_phase=ProtectionOperationPhase.FAILED,
+            last_error_code=ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
+            last_error_message=message,
+            last_error_at=_utc_now(),
+        )
+        return ProtectionOperation(
+            intent_id,
+            ProtectionOperationKind.ENABLE,
+            ProtectionOperationPhase.FAILED,
+            ProtectionState.ATTENTION_REQUIRED,
+            ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
+            message,
+            protection_intent_id=intent_id,
+        )
+
+    @staticmethod
+    def _validate_recovery_kit_store(store_id: str) -> None:
+        kit_path = RECOVERY_KIT_PATH.expanduser()
+        if not kit_path.is_file():
+            return
+        existing_store_id = extract_store_id(str(kit_path))
+        if existing_store_id != store_id:
+            raise _EnablePrerequisiteError(
+                "This Ormah installation already has recovery material for another "
+                "memory store. Version 1 supports one protected primary memory.",
+                ProtectionReasonCode.KEY_INVALID,
+            )
+
+    def _enable_stage_result(
+        self,
+        store_id: str,
+        intent_id: str,
+        result: ProtectionOperation,
+    ) -> ProtectionOperation:
+        """Keep child backup/verify failures attached to the stable Protect operation."""
+
+        update_state(
+            store_id,
+            memory_dir=self.settings.memory_dir,
+            last_operation_id=intent_id,
+            last_operation_kind=ProtectionOperationKind.ENABLE,
+            last_operation_phase=result.phase,
+            last_error_code=result.reason_code,
+            last_error_message=result.message,
+            last_error_at=_utc_now(),
+        )
+        return replace(
+            result,
+            operation_id=intent_id,
+            kind=ProtectionOperationKind.ENABLE,
+            protection_intent_id=intent_id,
+        )
+
+    def _enable_failure(
+        self,
+        operation_id: str,
+        error: object,
+        *,
+        store_id: str | None = None,
+        intent_id: str | None = None,
+        kind: ProtectionOperationKind = ProtectionOperationKind.ENABLE,
+        reason_code: ProtectionReasonCode = ProtectionReasonCode.OPERATION_INTERRUPTED,
+        protection_state: ProtectionState = ProtectionState.ATTENTION_REQUIRED,
+    ) -> ProtectionOperation:
+        if isinstance(error, _EnablePrerequisiteError):
+            reason_code = error.reason_code
+        message = self._message(error)
+        if store_id is None:
+            try:
+                store_id = _existing_store_id(self.settings.memory_dir)
+            except Exception:
+                store_id = None
+        if store_id is not None:
+            try:
+                state = _load_writable_state(store_id)
+                if isinstance(state.protection_state, ProtectionState):
+                    if (
+                        kind is ProtectionOperationKind.DISABLE
+                        and state.protection_state is ProtectionState.STOPPED
+                    ):
+                        protection_state = ProtectionState.STOPPED
+                    update_state(
+                        store_id,
+                        memory_dir=self.settings.memory_dir,
+                        protection_state=protection_state,
+                        last_operation_id=operation_id,
+                        last_operation_kind=kind,
+                        last_operation_phase=ProtectionOperationPhase.FAILED,
+                        last_error_code=reason_code,
+                        last_error_message=message,
+                        last_error_at=_utc_now(),
+                    )
+            except Exception as state_error:
+                logger.warning(
+                    "Could not persist Ormah Cloud enablement failure: %s",
+                    self._message(state_error),
+                )
+        return ProtectionOperation(
+            operation_id,
+            kind,
+            ProtectionOperationPhase.FAILED,
+            protection_state,
+            reason_code,
+            message,
+            protection_intent_id=intent_id,
+        )
+
+    def _invalid_intent_operation(
+        self,
+        operation_id: str,
+        intent_id: str | None = None,
+    ) -> ProtectionOperation:
+        """Reject a stale or foreign intent without changing current store health."""
+
+        current_state = ProtectionState.LOCAL_ONLY
+        try:
+            store_id = _existing_store_id(self.settings.memory_dir)
+            if store_id is not None:
+                current_state = _known_state(load_state(store_id))
+        except Exception:
+            current_state = ProtectionState.ATTENTION_REQUIRED
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.ENABLE,
+            ProtectionOperationPhase.CANCELED,
+            current_state,
+            ProtectionReasonCode.INTENT_CANCELED,
+            "This protection request is no longer active. Start again.",
+            protection_intent_id=intent_id,
+        )
+
     def backup_now(
         self,
         reason: str = "manual",
@@ -263,6 +1176,7 @@ class CloudProtectionService:
                     operation_id,
                     reason=reason,
                     only_if_due=only_if_due,
+                    entitlement_verified=False,
                 )
         except StoreLockTimeout:
             return self._store_busy_operation(
@@ -278,10 +1192,13 @@ class CloudProtectionService:
         *,
         reason: str,
         only_if_due: bool,
+        entitlement_verified: bool = False,
+        protection_intent_id: str | None = None,
     ) -> ProtectionOperation:
         settings = self.settings
         store_id: str | None = None
         client = None
+        finalize_attempted = False
         try:
             store_id = _existing_store_id(settings.memory_dir)
             try:
@@ -317,6 +1234,18 @@ class CloudProtectionService:
                     ProtectionReasonCode.PROTECTION_STOPPED,
                     "Cloud protection is stopped for this memory store.",
                 )
+            if (
+                state is not None
+                and state.last_error_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+            ):
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                    ProtectionOperationPhase.FAILED,
+                    ProtectionState.ATTENTION_REQUIRED,
+                    ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
+                    "A previous upload has an unknown commit status and must be reconciled.",
+                )
 
             if not key_file_exists():
                 return self._backup_failure(
@@ -334,7 +1263,11 @@ class CloudProtectionService:
                 )
 
             assert state is not None
-            entitlement = check_entitlement(settings)
+            entitlement = (
+                EntitlementStatus.ACTIVE
+                if entitlement_verified
+                else check_entitlement(settings)
+            )
             if entitlement not in {EntitlementStatus.ACTIVE, EntitlementStatus.GRACE}:
                 return self._backup_failure(
                     operation_id,
@@ -409,6 +1342,7 @@ class CloudProtectionService:
                     raise RuntimeError("Cloud upload reservation headers were malformed.")
 
                 put_file(put_url, bundle, required_headers)
+                finalize_attempted = True
                 finalized = client.finalize_upload(store_id, upload_id)
                 finalized_snapshot = _validated_snapshot_id(finalized.get("snapshot_id"))
                 if finalized.get("status") != "committed" or finalized_snapshot != snapshot_id:
@@ -416,21 +1350,26 @@ class CloudProtectionService:
 
             uploaded_at = _utc_now()
             next_state = _state_after_backup(state)
+            changes: dict[str, object] = {
+                "last_upload_at": uploaded_at,
+                "last_upload_snapshot_id": snapshot_id,
+                "last_upload_error": None,
+                "last_successful_upload_at": uploaded_at,
+                "last_successful_backup_snapshot_id": snapshot_id,
+                "protection_state": next_state,
+                "last_operation_id": operation_id,
+                "last_operation_kind": ProtectionOperationKind.BACKUP,
+                "last_operation_phase": ProtectionOperationPhase.COMPLETED,
+                "last_error_code": None,
+                "last_error_message": None,
+                "last_error_at": None,
+            }
+            if protection_intent_id is not None:
+                changes["pending_protection_snapshot_id"] = snapshot_id
             update_state(
                 store_id,
                 memory_dir=settings.memory_dir,
-                last_upload_at=uploaded_at,
-                last_upload_snapshot_id=snapshot_id,
-                last_upload_error=None,
-                last_successful_upload_at=uploaded_at,
-                last_successful_backup_snapshot_id=snapshot_id,
-                protection_state=next_state,
-                last_operation_id=operation_id,
-                last_operation_kind=ProtectionOperationKind.BACKUP,
-                last_operation_phase=ProtectionOperationPhase.COMPLETED,
-                last_error_code=None,
-                last_error_message=None,
-                last_error_at=None,
+                **changes,
             )
             logger.info("Uploaded encrypted Ormah Cloud snapshot %s", self._message(snapshot_id))
             return ProtectionOperation(
@@ -441,6 +1380,14 @@ class CloudProtectionService:
                 snapshot_id=snapshot_id,
             )
         except Exception as exc:
+            if finalize_attempted:
+                return self._backup_failure(
+                    operation_id,
+                    exc,
+                    store_id=store_id,
+                    reason_code=ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
+                    protection_state=ProtectionState.ATTENTION_REQUIRED,
+                )
             if _is_offline_error(exc):
                 return self._backup_failure(
                     operation_id,
@@ -768,6 +1715,7 @@ class CloudProtectionService:
         kind: ProtectionOperationKind,
         *,
         snapshot_id: str | None = None,
+        protection_intent_id: str | None = None,
     ) -> ProtectionOperation:
         """Return transient contention without changing durable protection health."""
 
@@ -789,6 +1737,7 @@ class CloudProtectionService:
             ProtectionReasonCode.STORE_BUSY,
             "Memory store is busy; try again shortly.",
             snapshot_id,
+            protection_intent_id,
         )
 
     @staticmethod
@@ -802,6 +1751,12 @@ class CloudProtectionService:
 
 
 class _VerificationPrerequisiteError(RuntimeError):
+    def __init__(self, message: str, reason_code: ProtectionReasonCode) -> None:
+        super().__init__(message)
+        self.reason_code = reason_code
+
+
+class _EnablePrerequisiteError(RuntimeError):
     def __init__(self, message: str, reason_code: ProtectionReasonCode) -> None:
         super().__init__(message)
         self.reason_code = reason_code

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -301,14 +301,6 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
         )
 
     try:
-        resolve_backup_user_node_id(extracted)
-    except Exception as exc:
-        raise _VerificationStageError(
-            "The backup's active Self pointer does not match the restored memory graph.",
-            ProtectionReasonCode.SELF_POINTER_INVALID,
-        ) from exc
-
-    try:
         active_nodes = []
         for dirname in ("nodes", "deleted"):
             for path in sorted((extracted / dirname).glob("*.md")):
@@ -328,6 +320,20 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
             ProtectionReasonCode.NODE_PARSE_FAILED,
         ) from exc
 
+    try:
+        resolve_backup_user_node_id(extracted)
+    except OSError as exc:
+        if _is_disk_full_error(exc):
+            raise
+        raise _VerificationStageError(
+            "The backup's active Self pointer does not match the restored memory graph.",
+            ProtectionReasonCode.SELF_POINTER_INVALID,
+        ) from exc
+    except Exception as exc:
+        raise _VerificationStageError(
+            "The backup's active Self pointer does not match the restored memory graph.",
+            ProtectionReasonCode.SELF_POINTER_INVALID,
+        ) from exc
     database = Database(extracted / "scratch-index" / "index.db")
     try:
         try:

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -25,6 +25,7 @@ from ormah.backup import (
 from ormah.cloud.bundle import BundleError, build_bundle, open_bundle
 from ormah.cloud.billing import validate_protection_intent_id
 from ormah.cloud.client import CloudError, client_from_settings
+from ormah.cloud.crypto import CloudCryptoError
 from ormah.cloud.entitlements import (
     EntitlementStatus,
     cache_entitlements,
@@ -77,7 +78,8 @@ _QUERY_SECRET_RE = re.compile(
     r"access_token|token|signature)=)[^&\s]+"
 )
 _SNAPSHOT_ID_RE = re.compile(r"[0-7][0-9A-HJKMNP-TV-Z]{25}")
-_NODE_PATH_RE = re.compile(r"\b(nodes|deleted)/[^\s'\",)\]]+\.md\b")
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_NODE_PATH_RE = re.compile(r"\b(nodes|deleted)[/\\][^\s'\",)\]]+\.md\b")
 _DISK_FULL_ERRNOS = {errno.ENOSPC, getattr(errno, "EDQUOT", errno.ENOSPC)}
 
 
@@ -250,9 +252,39 @@ def _is_quota_error(error: object) -> bool:
     return "quota" in str(detail).lower()
 
 
+def _cloud_error_code(error: object) -> str | None:
+    if not isinstance(error, CloudError) or not isinstance(error.payload, dict):
+        return None
+    detail = error.payload.get("detail")
+    if not isinstance(detail, dict):
+        return None
+    code = detail.get("code")
+    return code if isinstance(code, str) else None
+
+
+def _finalize_is_definitively_expired(state: CloudState, error: object) -> bool:
+    """Return whether replacing a failed finalize cannot create a duplicate snapshot."""
+
+    expires_at = state.pending_upload_expires_at
+    return (
+        _cloud_error_code(error) == "upload_expired"
+        and expires_at is not None
+        and expires_at <= _utc_now()
+    )
+
+
 def _validated_snapshot_id(value: object) -> str:
     if not isinstance(value, str) or _SNAPSHOT_ID_RE.fullmatch(value) is None:
         raise RuntimeError("Cloud response contained an invalid snapshot id.")
+    return value
+
+
+def _validated_sha256(value: object) -> str:
+    if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+        raise _VerificationStageError(
+            "Cloud metadata does not contain a verified ciphertext hash.",
+            ProtectionReasonCode.CIPHERTEXT_HASH_UNAVAILABLE,
+        )
     return value
 
 
@@ -274,14 +306,26 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
             f"Bundle store id {info.store_id!r} does not match local store {expected_store_id!r}."
         )
 
-    resolve_backup_user_node_id(extracted)
-
-    active_nodes = []
-    for dirname in ("nodes", "deleted"):
-        for path in sorted((extracted / dirname).glob("*.md")):
-            node = parse_node(path.read_text(encoding="utf-8"))
-            if dirname == "nodes":
-                active_nodes.append(node)
+    try:
+        resolve_backup_user_node_id(extracted)
+        active_nodes = []
+        for dirname in ("nodes", "deleted"):
+            for path in sorted((extracted / dirname).glob("*.md")):
+                node = parse_node(path.read_text(encoding="utf-8"))
+                if dirname == "nodes":
+                    active_nodes.append(node)
+    except OSError as exc:
+        if _is_disk_full_error(exc):
+            raise
+        raise _VerificationStageError(
+            "A restored memory node could not be parsed.",
+            ProtectionReasonCode.NODE_PARSE_FAILED,
+        ) from exc
+    except Exception as exc:
+        raise _VerificationStageError(
+            "A restored memory node could not be parsed.",
+            ProtectionReasonCode.NODE_PARSE_FAILED,
+        ) from exc
 
     database = Database(extracted / "scratch-index" / "index.db")
     try:
@@ -301,10 +345,17 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
                 ProtectionReasonCode.INDEX_ENVIRONMENT_UNAVAILABLE,
             ) from exc
         if rebuilt != info.node_count:
-            raise RuntimeError(
-                f"Scratch index rebuilt {rebuilt} nodes; bundle manifest declares {info.node_count}."
+            raise _VerificationStageError(
+                "The scratch index node count did not match the verified manifest.",
+                ProtectionReasonCode.INDEX_REBUILD_FAILED,
             )
-        _probe_search(database, active_nodes)
+        try:
+            _probe_search(database, active_nodes)
+        except Exception as exc:
+            raise _VerificationStageError(
+                "The scratch search probe did not return a restored memory.",
+                ProtectionReasonCode.SEARCH_PROBE_FAILED,
+            ) from exc
         return rebuilt
     finally:
         database.close()
@@ -1010,6 +1061,12 @@ class CloudProtectionService:
 
     @staticmethod
     def _new_intent_origin(state: CloudState) -> ProtectionState:
+        if (
+            state.pending_protection_intent_id is not None
+            and state.pending_protection_status is not ProtectionIntentStatus.COMPLETED
+            and isinstance(state.pending_protection_origin_state, ProtectionState)
+        ):
+            return state.pending_protection_origin_state
         if isinstance(state.protection_state, ProtectionState) and state.protection_state not in {
             ProtectionState.SIGN_IN_REQUIRED,
             ProtectionState.SUBSCRIPTION_REQUIRED,
@@ -1373,13 +1430,29 @@ class CloudProtectionService:
                 if state.pending_upload_phase is UploadJournalPhase.FINALIZING:
                     client = client_from_settings(settings)
                     finalize_attempted = True
-                    return self._reconcile_finalizing_upload(
-                        store_id=store_id,
-                        state=state,
-                        operation_id=operation_id,
-                        protection_intent_id=protection_intent_id,
-                        client=client,
-                    )
+                    try:
+                        return self._reconcile_finalizing_upload(
+                            store_id=store_id,
+                            state=state,
+                            operation_id=operation_id,
+                            protection_intent_id=protection_intent_id,
+                            client=client,
+                        )
+                    except CloudError as exc:
+                        if not _finalize_is_definitively_expired(state, exc):
+                            raise
+                        self._close_client(client)
+                        client = None
+                        finalize_attempted = False
+                        state = update_state(
+                            store_id,
+                            memory_dir=settings.memory_dir,
+                            last_upload_error=None,
+                            last_error_code=None,
+                            last_error_message=None,
+                            last_error_at=None,
+                            **_cleared_upload_journal(),
+                        )
                 state = update_state(
                     store_id,
                     memory_dir=settings.memory_dir,
@@ -1719,6 +1792,7 @@ class CloudProtectionService:
                 raise RuntimeError("Cloud snapshot listing did not include a valid size.")
             if size_bytes > client.processing_limit(require_hardened_write=False):
                 raise CloudError("Cloud snapshot exceeds this client's safe processing limit.")
+            expected_sha256 = _validated_sha256(selected.get("sha256"))
 
             presigned = client.presign_download(store_id, snapshot_id)
             get_url = presigned.get("get_url")
@@ -1728,8 +1802,44 @@ class CloudProtectionService:
             tmp_root = Path(tempfile.mkdtemp(prefix="ormah-restore-verify-"))
             bundle = tmp_root / f"{snapshot_id}.age"
             extracted = tmp_root / "snapshot"
-            download_file(get_url, bundle)
-            info = open_bundle(bundle, extracted, load_identities())
+            try:
+                download_file(get_url, bundle)
+            except httpx.RequestError:
+                raise
+            except OSError as exc:
+                if _is_disk_full_error(exc):
+                    raise
+                raise _VerificationStageError(
+                    "The encrypted snapshot could not be downloaded.",
+                    ProtectionReasonCode.DOWNLOAD_FAILED,
+                ) from exc
+            except Exception as exc:
+                raise _VerificationStageError(
+                    "The encrypted snapshot could not be downloaded.",
+                    ProtectionReasonCode.DOWNLOAD_FAILED,
+                ) from exc
+            if sha256_file(bundle) != expected_sha256:
+                raise _VerificationStageError(
+                    "The downloaded ciphertext hash did not match cloud metadata.",
+                    ProtectionReasonCode.CIPHERTEXT_HASH_MISMATCH,
+                )
+            try:
+                info = open_bundle(bundle, extracted, load_identities())
+            except CloudCryptoError as exc:
+                raise _VerificationStageError(
+                    "The encrypted snapshot could not be decrypted with this recovery key.",
+                    ProtectionReasonCode.DECRYPT_FAILED,
+                ) from exc
+            except BundleError as exc:
+                raise _VerificationStageError(
+                    "The decrypted snapshot failed manifest and file-integrity verification.",
+                    ProtectionReasonCode.MANIFEST_VERIFICATION_FAILED,
+                ) from exc
+            except (KeyError, TypeError, ValueError, UnicodeError) as exc:
+                raise _VerificationStageError(
+                    "The decrypted snapshot failed manifest and file-integrity verification.",
+                    ProtectionReasonCode.MANIFEST_VERIFICATION_FAILED,
+                ) from exc
             _verify_extracted_bundle(extracted, store_id, info)
 
             verified_at = _utc_now()

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -322,18 +322,12 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
 
     try:
         resolve_backup_user_node_id(extracted)
-    except OSError as exc:
-        if _is_disk_full_error(exc):
-            raise
-        raise _VerificationStageError(
-            "The backup's active Self pointer does not match the restored memory graph.",
-            ProtectionReasonCode.SELF_POINTER_INVALID,
-        ) from exc
     except Exception as exc:
         raise _VerificationStageError(
             "The backup's active Self pointer does not match the restored memory graph.",
             ProtectionReasonCode.SELF_POINTER_INVALID,
         ) from exc
+
     database = Database(extracted / "scratch-index" / "index.db")
     try:
         try:

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -54,6 +54,7 @@ from ormah.cloud.state import (
     ProtectionOperationPhase,
     ProtectionReasonCode,
     ProtectionState,
+    TERMINAL_PROTECTION_INTENT_STATUSES,
     UploadJournalPhase,
     is_protected_and_verified,
     load_state,
@@ -192,14 +193,7 @@ def _state_after_verification(state: CloudState, snapshot_id: str) -> Protection
         return current
     if (
         state.pending_protection_intent_id is not None
-        and state.pending_protection_status
-        in {
-            ProtectionIntentStatus.PENDING,
-            ProtectionIntentStatus.ACCOUNT_BOUND,
-            ProtectionIntentStatus.CHECKOUT_PENDING,
-            ProtectionIntentStatus.READY,
-            ProtectionIntentStatus.RUNNING,
-        }
+        and state.pending_protection_status not in TERMINAL_PROTECTION_INTENT_STATUSES
     ):
         return current
     if current in {
@@ -308,6 +302,13 @@ def _verify_extracted_bundle(extracted: Path, expected_store_id: str, info) -> i
 
     try:
         resolve_backup_user_node_id(extracted)
+    except Exception as exc:
+        raise _VerificationStageError(
+            "The backup's active Self pointer does not match the restored memory graph.",
+            ProtectionReasonCode.SELF_POINTER_INVALID,
+        ) from exc
+
+    try:
         active_nodes = []
         for dirname in ("nodes", "deleted"):
             for path in sorted((extracted / dirname).glob("*.md")):
@@ -423,9 +424,6 @@ class CloudProtectionService:
 
                 completed_protection = (
                     state.protection_state is ProtectionState.PROTECTED
-                    and state.pending_protection_intent_id is not None
-                    and state.pending_protection_status
-                    is ProtectionIntentStatus.COMPLETED
                     and is_protected_and_verified(
                         state,
                         enabled=bool(self.settings.cloud_backup_enabled),
@@ -443,7 +441,7 @@ class CloudProtectionService:
                     signed_in
                     and completed_entitlement is EntitlementStatus.NONE
                 ):
-                    operation_id = state.pending_protection_intent_id
+                    operation_id = state.pending_protection_intent_id or operation_id
                     return ProtectionOperation(
                         operation_id,
                         ProtectionOperationKind.ENABLE,
@@ -669,6 +667,9 @@ class CloudProtectionService:
         elif has_subscription:
             status = ProtectionIntentStatus.READY
             next_state = self._intent_origin_state(state)
+        elif state.pending_protection_status is ProtectionIntentStatus.CHECKOUT_PENDING:
+            status = ProtectionIntentStatus.CHECKOUT_PENDING
+            next_state = ProtectionState.SUBSCRIPTION_REQUIRED
         else:
             status = ProtectionIntentStatus.ACCOUNT_BOUND
             next_state = ProtectionState.SUBSCRIPTION_REQUIRED
@@ -1791,7 +1792,10 @@ class CloudProtectionService:
             if not isinstance(size_bytes, int) or isinstance(size_bytes, bool) or size_bytes <= 0:
                 raise RuntimeError("Cloud snapshot listing did not include a valid size.")
             if size_bytes > client.processing_limit(require_hardened_write=False):
-                raise CloudError("Cloud snapshot exceeds this client's safe processing limit.")
+                raise _VerificationStageError(
+                    "Cloud snapshot exceeds this client's safe processing limit.",
+                    ProtectionReasonCode.PROCESSING_LIMIT_EXCEEDED,
+                )
             expected_sha256 = _validated_sha256(selected.get("sha256"))
 
             presigned = client.presign_download(store_id, snapshot_id)

--- a/src/ormah/cloud/settings.py
+++ b/src/ormah/cloud/settings.py
@@ -1,0 +1,40 @@
+"""Structured persistence for cloud protection settings."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable, Mapping
+
+from filelock import FileLock
+
+
+CLOUD_BACKUP_ENABLED_KEY = "ORMAH_CLOUD_BACKUP_ENABLED"
+
+
+def update_settings_env(
+    values: Mapping[str, str],
+    *,
+    remove: Iterable[str] = (),
+) -> None:
+    """Serialize read-modify-writes to Ormah's shared environment file."""
+
+    from ormah import setup
+
+    setup.ENV_PATH.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = setup.ENV_PATH.parent / ".env.lock"
+    with FileLock(str(lock_path), timeout=30):
+        os.chmod(lock_path, 0o600)
+        env = setup._read_env_file()
+        env.update(values)
+        for key in remove:
+            env.pop(key, None)
+        setup._write_env_file(env)
+
+
+def set_cloud_backup_enabled(settings, enabled: bool) -> None:
+    """Persist and apply cloud protection without dropping unrelated settings."""
+
+    update_settings_env(
+        {CLOUD_BACKUP_ENABLED_KEY: "true" if enabled else "false"},
+    )
+    settings.cloud_backup_enabled = enabled

--- a/src/ormah/cloud/settings.py
+++ b/src/ormah/cloud/settings.py
@@ -31,6 +31,21 @@ def update_settings_env(
         setup._write_env_file(env)
 
 
+def persist_settings_delta(
+    before: Mapping[str, str],
+    after: Mapping[str, str],
+) -> None:
+    """Persist only keys changed by a caller, serialized with every other writer."""
+
+    updates = {
+        key: value
+        for key, value in after.items()
+        if before.get(key) != value
+    }
+    removed = set(before) - set(after)
+    update_settings_env(updates, remove=removed)
+
+
 def set_cloud_backup_enabled(settings, enabled: bool) -> None:
     """Persist and apply cloud protection without dropping unrelated settings."""
 

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -40,6 +40,7 @@ class ProtectionState(StrEnum):
     VERIFYING_FIRST_BACKUP = "verifying_first_backup"
     PROTECTED = "protected"
     CHANGES_PENDING = "changes_pending"
+    VERIFICATION_PENDING = "verification_pending"
     OFFLINE = "offline"
     PAUSED = "paused"
     STOPPED = "stopped"
@@ -76,6 +77,13 @@ class ProtectionOperationPhase(StrEnum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELED = "canceled"
+
+
+class UploadJournalPhase(StrEnum):
+    """Durable client phases around the only ambiguous upload boundary."""
+
+    RESERVED = "reserved"
+    FINALIZING = "finalizing"
 
 
 class ProtectionReasonCode(StrEnum):
@@ -216,6 +224,12 @@ class CloudState:
     recovery_kit_verified_at: datetime | None = None
     next_scheduled_upload_at: datetime | None = None
     next_scheduled_verify_at: datetime | None = None
+    pending_upload_id: str | None = None
+    pending_upload_snapshot_id: str | None = None
+    pending_upload_operation_id: str | None = None
+    pending_upload_protection_intent_id: str | None = None
+    pending_upload_phase: UploadJournalPhase | str | None = None
+    pending_upload_expires_at: datetime | None = None
     extra: dict[str, Any] = field(default_factory=dict, repr=False)
 
     def to_dict(self) -> dict[str, Any]:
@@ -266,6 +280,16 @@ class CloudState:
                 "recovery_kit_verified_at": _serialize_time(self.recovery_kit_verified_at),
                 "next_scheduled_upload_at": _serialize_time(self.next_scheduled_upload_at),
                 "next_scheduled_verify_at": _serialize_time(self.next_scheduled_verify_at),
+                "pending_upload_id": self.pending_upload_id,
+                "pending_upload_snapshot_id": self.pending_upload_snapshot_id,
+                "pending_upload_operation_id": self.pending_upload_operation_id,
+                "pending_upload_protection_intent_id": (
+                    self.pending_upload_protection_intent_id
+                ),
+                "pending_upload_phase": _serialize_enum(self.pending_upload_phase),
+                "pending_upload_expires_at": _serialize_time(
+                    self.pending_upload_expires_at
+                ),
             }
         )
         return payload
@@ -302,6 +326,7 @@ class CloudState:
             "recovery_kit_verified_at",
             "next_scheduled_upload_at",
             "next_scheduled_verify_at",
+            "pending_upload_expires_at",
         )
         for key in time_fields:
             values[key] = _parse_time(values.get(key))
@@ -320,6 +345,10 @@ class CloudState:
             "last_verified_snapshot_id",
             "last_error_message",
             "local_graph_fingerprint_at_upload",
+            "pending_upload_id",
+            "pending_upload_snapshot_id",
+            "pending_upload_operation_id",
+            "pending_upload_protection_intent_id",
         )
         for key in string_fields:
             value = values.get(key)
@@ -342,6 +371,7 @@ class CloudState:
             "last_operation_kind": ProtectionOperationKind,
             "last_operation_phase": ProtectionOperationPhase,
             "last_error_code": ProtectionReasonCode,
+            "pending_upload_phase": UploadJournalPhase,
         }
         for key, enum_type in enum_fields.items():
             if key in values:
@@ -487,6 +517,7 @@ def is_protected_and_verified(state: CloudState, *, enabled: bool) -> bool:
     return (
         enabled
         and intent_complete
+        and state.pending_upload_phase is None
         and snapshot_id is not None
         and snapshot_id == state.last_verified_snapshot_id
         and state.last_verify_ok is True
@@ -573,6 +604,7 @@ def cloud_status_payload(
     if protection_state in {
         ProtectionState.PROTECTED,
         ProtectionState.CHANGES_PENDING,
+        ProtectionState.VERIFICATION_PENDING,
     }:
         if entitlement == "expired":
             protection_state = ProtectionState.PAUSED

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -60,6 +60,15 @@ class ProtectionIntentStatus(StrEnum):
     EXPIRED = "expired"
 
 
+TERMINAL_PROTECTION_INTENT_STATUSES = frozenset(
+    {
+        ProtectionIntentStatus.COMPLETED,
+        ProtectionIntentStatus.CANCELED,
+        ProtectionIntentStatus.EXPIRED,
+    }
+)
+
+
 class ProtectionOperationKind(StrEnum):
     ENABLE = "enable"
     DISABLE = "disable"
@@ -109,6 +118,8 @@ class ProtectionReasonCode(StrEnum):
     INDEX_ENVIRONMENT_UNAVAILABLE = "index_environment_unavailable"
     INDEX_REBUILD_FAILED = "index_rebuild_failed"
     SEARCH_PROBE_FAILED = "search_probe_failed"
+    SELF_POINTER_INVALID = "self_pointer_invalid"
+    PROCESSING_LIMIT_EXCEEDED = "processing_limit_exceeded"
     DISK_SPACE_INSUFFICIENT = "disk_space_insufficient"
     OPERATION_INTERRUPTED = "operation_interrupted"
     STORE_BUSY = "store_busy"
@@ -519,7 +530,7 @@ def is_protected_and_verified(state: CloudState, *, enabled: bool) -> bool:
 
     intent_complete = (
         state.pending_protection_intent_id is None
-        or state.pending_protection_status is ProtectionIntentStatus.COMPLETED
+        or state.pending_protection_status in TERMINAL_PROTECTION_INTENT_STATUSES
     )
     snapshot_id = state.last_successful_backup_snapshot_id
     return (

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -125,6 +125,7 @@ class ProtectionReasonCode(StrEnum):
     STORE_BUSY = "store_busy"
     PROTECTION_STOPPED = "protection_stopped"
     CLIENT_UPDATE_REQUIRED = "client_update_required"
+    SERVICE_UPDATE_REQUIRED = "service_update_required"
     NO_BACKUPABLE_MEMORY = "no_backupable_memory"
     NOT_DUE = "not_due"
     INTENT_EXPIRED = "intent_expired"

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -13,7 +13,7 @@ import uuid
 
 
 CLOUD_STATE_DIR = Path.home() / ".local" / "share" / "ormah" / "cloud"
-CURRENT_CLOUD_STATE_SCHEMA_VERSION = 2
+CURRENT_CLOUD_STATE_SCHEMA_VERSION = 3
 _STATE_LOCK = threading.RLock()
 
 
@@ -100,6 +100,10 @@ class ProtectionReasonCode(StrEnum):
     CLIENT_UPDATE_REQUIRED = "client_update_required"
     NO_BACKUPABLE_MEMORY = "no_backupable_memory"
     NOT_DUE = "not_due"
+    INTENT_EXPIRED = "intent_expired"
+    INTENT_CANCELED = "intent_canceled"
+    ACCOUNT_CHANGED = "account_changed"
+    UPLOAD_STATUS_UNKNOWN = "upload_status_unknown"
 
 
 @dataclass(frozen=True)
@@ -113,6 +117,7 @@ class ProtectionOperation:
     reason_code: ProtectionReasonCode | None = None
     message: str | None = None
     snapshot_id: str | None = None
+    protection_intent_id: str | None = None
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -193,6 +198,9 @@ class CloudState:
     pending_protection_created_at: datetime | None = None
     pending_protection_expires_at: datetime | None = None
     pending_protection_status: ProtectionIntentStatus | str | None = None
+    pending_protection_snapshot_id: str | None = None
+    pending_protection_created_store: bool = False
+    pending_protection_origin_state: ProtectionState | str | None = None
     protection_disabled_at: datetime | None = None
     last_operation_id: str | None = None
     last_operation_kind: ProtectionOperationKind | str | None = None
@@ -235,6 +243,11 @@ class CloudState:
                 ),
                 "pending_protection_status": _serialize_enum(
                     self.pending_protection_status
+                ),
+                "pending_protection_snapshot_id": self.pending_protection_snapshot_id,
+                "pending_protection_created_store": self.pending_protection_created_store,
+                "pending_protection_origin_state": _serialize_enum(
+                    self.pending_protection_origin_state
                 ),
                 "protection_disabled_at": _serialize_time(self.protection_disabled_at),
                 "last_operation_id": self.last_operation_id,
@@ -301,6 +314,7 @@ class CloudState:
             "pending_protection_intent_id",
             "pending_protection_account_id",
             "pending_protection_store_id",
+            "pending_protection_snapshot_id",
             "last_operation_id",
             "last_successful_backup_snapshot_id",
             "last_verified_snapshot_id",
@@ -316,9 +330,15 @@ class CloudState:
         if verify_ok is not None and not isinstance(verify_ok, bool):
             raise ValueError("last_verify_ok must be a boolean or null")
 
+        created_store = values.get("pending_protection_created_store", False)
+        if not isinstance(created_store, bool):
+            raise ValueError("pending_protection_created_store must be a boolean")
+        values["pending_protection_created_store"] = created_store
+
         enum_fields = {
             "protection_state": ProtectionState,
             "pending_protection_status": ProtectionIntentStatus,
+            "pending_protection_origin_state": ProtectionState,
             "last_operation_kind": ProtectionOperationKind,
             "last_operation_phase": ProtectionOperationPhase,
             "last_error_code": ProtectionReasonCode,
@@ -456,6 +476,23 @@ def _existing_store_id(memory_dir: Path) -> str | None:
     return get_or_create_store_id(Path(memory_dir))
 
 
+def is_protected_and_verified(state: CloudState, *, enabled: bool) -> bool:
+    """Return whether durable metadata satisfies the user-facing protection claim."""
+
+    intent_complete = (
+        state.pending_protection_intent_id is None
+        or state.pending_protection_status is ProtectionIntentStatus.COMPLETED
+    )
+    snapshot_id = state.last_successful_backup_snapshot_id
+    return (
+        enabled
+        and intent_complete
+        and snapshot_id is not None
+        and snapshot_id == state.last_verified_snapshot_id
+        and state.last_verify_ok is True
+    )
+
+
 def cloud_status_payload(
     settings,
     *,
@@ -509,6 +546,43 @@ def cloud_status_payload(
         detail = f": {state.last_verify_error}" if state.last_verify_error else "."
         warnings.append(f"Cloud restore verification failed{detail}")
 
+    raw_protection_state = (
+        ProtectionState.ATTENTION_REQUIRED
+        if state_error is not None or store_error is not None
+        else state.protection_state
+    )
+    protection_state = raw_protection_state
+    if not isinstance(protection_state, ProtectionState):
+        protection_state = ProtectionState.ATTENTION_REQUIRED
+        warnings.append(
+            "Cloud protection state requires a newer Ormah version."
+        )
+    protected_invariant_failed = (
+        protection_state is ProtectionState.PROTECTED
+        and not is_protected_and_verified(
+            state,
+            enabled=settings.cloud_backup_enabled,
+        )
+    )
+    if protected_invariant_failed:
+        protection_state = ProtectionState.ATTENTION_REQUIRED
+        warnings.append(
+            "Cloud protection metadata is incomplete; verification must finish before "
+            "this memory can be reported as protected."
+        )
+    if protection_state in {
+        ProtectionState.PROTECTED,
+        ProtectionState.CHANGES_PENDING,
+    }:
+        if entitlement == "expired":
+            protection_state = ProtectionState.PAUSED
+        elif entitlement == "none":
+            protection_state = (
+                ProtectionState.OFFLINE
+                if getattr(settings, "account_token", None)
+                else ProtectionState.SIGN_IN_REQUIRED
+            )
+
     return {
         "schema_version": state.schema_version,
         "enabled": settings.cloud_backup_enabled,
@@ -516,6 +590,20 @@ def cloud_status_payload(
         "state_error": state_error,
         "interval_hours": settings.cloud_backup_interval_hours,
         "entitlement": entitlement,
+        "protection_state": _serialize_enum(protection_state),
+        "protection_enabled_at": _serialize_time(state.protection_enabled_at),
+        "protection_disabled_at": _serialize_time(state.protection_disabled_at),
+        "protection_intent_id": state.pending_protection_intent_id,
+        "protection_intent_status": _serialize_enum(state.pending_protection_status),
+        "protection_intent_created_at": _serialize_time(
+            state.pending_protection_created_at
+        ),
+        "protection_intent_expires_at": _serialize_time(
+            state.pending_protection_expires_at
+        ),
+        "last_operation_id": state.last_operation_id,
+        "last_operation_kind": _serialize_enum(state.last_operation_kind),
+        "last_operation_phase": _serialize_enum(state.last_operation_phase),
         "last_upload_at": (
             state.last_upload_at.isoformat() if state.last_upload_at is not None else None
         ),

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -99,8 +99,16 @@ class ProtectionReasonCode(StrEnum):
     KEY_INVALID = "key_invalid"
     UPLOAD_FAILED = "upload_failed"
     VERIFICATION_FAILED = "verification_failed"
+    DOWNLOAD_FAILED = "download_failed"
+    CIPHERTEXT_HASH_UNAVAILABLE = "ciphertext_hash_unavailable"
+    CIPHERTEXT_HASH_MISMATCH = "ciphertext_hash_mismatch"
+    DECRYPT_FAILED = "decrypt_failed"
+    MANIFEST_VERIFICATION_FAILED = "manifest_verification_failed"
+    NODE_PARSE_FAILED = "node_parse_failed"
     BUNDLE_CORRUPT = "bundle_corrupt"
     INDEX_ENVIRONMENT_UNAVAILABLE = "index_environment_unavailable"
+    INDEX_REBUILD_FAILED = "index_rebuild_failed"
+    SEARCH_PROBE_FAILED = "search_probe_failed"
     DISK_SPACE_INSUFFICIENT = "disk_space_insufficient"
     OPERATION_INTERRUPTED = "operation_interrupted"
     STORE_BUSY = "store_busy"
@@ -517,7 +525,7 @@ def is_protected_and_verified(state: CloudState, *, enabled: bool) -> bool:
     return (
         enabled
         and intent_complete
-        and state.pending_upload_phase is None
+        and state.pending_upload_phase is not UploadJournalPhase.FINALIZING
         and snapshot_id is not None
         and snapshot_id == state.last_verified_snapshot_id
         and state.last_verify_ok is True

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -1230,6 +1230,14 @@ def _disable_llm(env: dict[str, str]) -> None:
         env.pop(key, None)
 
 
+def _persist_env_delta(before: dict[str, str], after: dict[str, str]) -> None:
+    """Apply this setup action's changes without overwriting concurrent writers."""
+
+    from ormah.cloud.settings import persist_settings_delta
+
+    persist_settings_delta(before, after)
+
+
 def _enable_llm(
     env: dict[str, str],
     provider: str,
@@ -1262,8 +1270,9 @@ def configure_llm() -> None:
         answer = ""
     if answer not in ("y", "yes"):
         env = _read_env_file()
+        before = dict(env)
         _disable_llm(env)
-        _write_env_file(env)
+        _persist_env_delta(before, env)
         print()
         info("Server-side LLM disabled — core memory works without one")
         info("Run 'ormah setup' again to enable later")
@@ -1282,14 +1291,16 @@ def configure_llm() -> None:
     # Handle "None" selection
     if provider == "none":
         env = _read_env_file()
+        before = dict(env)
         _disable_llm(env)
-        _write_env_file(env)
+        _persist_env_delta(before, env)
         print()
         info("No LLM configured \u2014 core memory works without one")
         info("Run 'ormah setup' again to add an LLM later")
         return
 
     env = _read_env_file()
+    before = dict(env)
 
     if api_key_var:
         hint = _cost_hint(default_model)
@@ -1332,7 +1343,7 @@ def configure_llm() -> None:
         ok(f"Using {display_name} with model '{default_model}'")
         info("Make sure Ollama is running: https://ollama.com")
 
-    _write_env_file(env)
+    _persist_env_delta(before, env)
 
 
 _COST_PER_MTOK: dict[str, tuple[float, float]] = {
@@ -1548,8 +1559,9 @@ def configure_agent_maintenance(agents: list[AgentDescriptor]) -> bool:
         answer = ""
     if answer not in ("n", "no"):
         env = _read_env_file()
+        before = dict(env)
         env["ORMAH_CLAUDE_MAINTENANCE_ENABLED"] = "true"
-        _write_env_file(env)
+        _persist_env_delta(before, env)
         if any(agent.id == "codex" for agent in agents):
             _enable_codex_feature("multi_agent")
         ok(f"Automatic maintenance enabled — {agent_label} can run run_maintenance when signalled")
@@ -2791,8 +2803,9 @@ def run_setup(
     # 3. Configure LLM — skip if agent-backed maintenance is handling background jobs
     if ci:
         env = _read_env_file()
+        before = dict(env)
         _disable_llm(env)
-        _write_env_file(env)
+        _persist_env_delta(before, env)
         info("CI mode — LLM set to none")
     elif update:
         env = _read_env_file()
@@ -2803,8 +2816,9 @@ def run_setup(
             info("Cloud LLM key inheritance is disabled; run 'ormah setup' to opt in")
     elif agent_maintenance:
         env = _read_env_file()
+        before = dict(env)
         _disable_llm(env)
-        _write_env_file(env)
+        _persist_env_delta(before, env)
     else:
         configure_llm()
 

--- a/tests/test_cloud_enablement.py
+++ b/tests/test_cloud_enablement.py
@@ -1,0 +1,787 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+import uuid
+
+import pytest
+
+from ormah.cloud import protection, state
+from ormah.cloud.client import CloudError
+from ormah.cloud.protection import CloudProtectionService
+from ormah.cloud.state import (
+    ProtectionIntentStatus,
+    ProtectionOperation,
+    ProtectionOperationKind,
+    ProtectionOperationPhase,
+    ProtectionReasonCode,
+    ProtectionState,
+    load_state,
+    update_state,
+)
+
+
+NOW = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+ACCOUNT_ID = "37b89c91-c3b8-4f64-9c73-d73ea469abc0"
+OTHER_ACCOUNT_ID = "bb86b869-6675-4ec5-a6ea-f17571d0ba57"
+SNAPSHOT_ID = "01J00000000000000000000000"
+
+
+class FakeClient:
+    def __init__(self, account_id: str = ACCOUNT_ID, *, backup: bool = True) -> None:
+        self.response = {
+            "account_id": account_id,
+            "backup": backup,
+            "plan_status": "active" if backup else "none",
+        }
+        self.calls = 0
+        self.closed = False
+
+    def get_entitlements(self):
+        self.calls += 1
+        return self.response
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def cloud_state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "CLOUD_STATE_DIR", tmp_path / "cloud-state")
+    monkeypatch.setattr(protection, "_utc_now", lambda: NOW)
+    monkeypatch.setattr(protection, "cache_entitlements", lambda *args, **kwargs: None)
+    monkeypatch.setattr(protection, "RECOVERY_KIT_PATH", tmp_path / "recovery-kit.md")
+
+
+def _settings(tmp_path: Path, *, token: str | None = "token"):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    return SimpleNamespace(
+        memory_dir=memory_dir,
+        backup_dir=tmp_path / "backups",
+        cloud_backup_enabled=False,
+        cloud_backup_interval_hours=24,
+        account_token=token,
+        account_email="person@example.com" if token else None,
+    )
+
+
+def _store_id(settings) -> str:
+    return (settings.memory_dir / ".store_id").read_text(encoding="utf-8").strip()
+
+
+def _ready_intent(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    assert intent is not None
+    client = FakeClient()
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: client)
+    bound = service.bind_intent(intent)
+    assert bound.reason_code is None
+    assert load_state(_store_id(settings)).pending_protection_status is ProtectionIntentStatus.READY
+    return settings, service, intent, client
+
+
+def test_create_intent_is_durable_for_signed_out_store(tmp_path):
+    settings = _settings(tmp_path, token=None)
+
+    result = CloudProtectionService(settings).create_intent()
+
+    assert result.phase is ProtectionOperationPhase.PENDING
+    assert result.state is ProtectionState.SIGN_IN_REQUIRED
+    assert result.reason_code is ProtectionReasonCode.SIGN_IN_REQUIRED
+    durable = load_state(_store_id(settings))
+    assert durable.pending_protection_intent_id == result.protection_intent_id
+    assert durable.pending_protection_status is ProtectionIntentStatus.PENDING
+    assert durable.pending_protection_created_store is True
+    assert durable.pending_protection_origin_state is ProtectionState.LOCAL_ONLY
+    assert durable.pending_protection_expires_at == NOW + timedelta(minutes=30)
+
+
+def test_repeated_create_and_bind_keep_one_stable_operation_id(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    first = CloudProtectionService(settings).create_intent()
+    restarted = CloudProtectionService(settings)
+    second = restarted.create_intent()
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: FakeClient(),
+    )
+    bound = restarted.bind_intent(first.protection_intent_id)
+
+    assert first.operation_id == first.protection_intent_id
+    assert second.operation_id == first.operation_id
+    assert bound.operation_id == first.operation_id
+
+
+def test_create_after_completed_protection_is_idempotent(tmp_path):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    first = service.create_intent()
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+    settings.cloud_backup_enabled = True
+
+    repeated = service.create_intent()
+
+    assert repeated.operation_id == first.operation_id
+    assert repeated.phase is ProtectionOperationPhase.COMPLETED
+    assert repeated.snapshot_id == SNAPSHOT_ID
+
+
+def test_completed_enable_never_returns_false_protected_state(tmp_path):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+        last_successful_backup_snapshot_id="snapshot-a",
+        last_verified_snapshot_id="snapshot-b",
+        last_verify_ok=True,
+    )
+
+    result = service.enable(intent)
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.state is ProtectionState.ATTENTION_REQUIRED
+
+
+def test_running_intent_survives_checkout_expiry_on_restart(tmp_path):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    first = service.create_intent()
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+        pending_protection_expires_at=NOW - timedelta(minutes=1),
+    )
+
+    resumed = CloudProtectionService(settings).create_intent()
+
+    assert resumed.operation_id == first.operation_id
+    assert resumed.protection_intent_id == first.protection_intent_id
+    assert load_state(store_id).pending_protection_status is ProtectionIntentStatus.RUNNING
+
+
+def test_new_intent_never_reuses_an_old_verified_snapshot(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    old_intent = service.create_intent()
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.STOPPED,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+        pending_protection_snapshot_id=SNAPSHOT_ID,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verify_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+    intent = service.create_intent().protection_intent_id
+    assert intent != old_intent.protection_intent_id
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: FakeClient())
+    service.bind_intent(intent)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "load_identities", lambda: [object()])
+    monkeypatch.setattr(
+        protection,
+        "write_recovery_kit",
+        lambda store_id, **kwargs: Path("kit"),
+    )
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
+    )
+    upload_called = False
+
+    def fail_new_upload(operation_id, **kwargs):
+        nonlocal upload_called
+        upload_called = True
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.BACKUP,
+            ProtectionOperationPhase.FAILED,
+            ProtectionState.ATTENTION_REQUIRED,
+            ProtectionReasonCode.UPLOAD_FAILED,
+        )
+
+    monkeypatch.setattr(service, "_backup_now", fail_new_upload)
+    monkeypatch.setattr(
+        service,
+        "_verify_now",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("an old snapshot must not be verified for the new intent")
+        ),
+    )
+
+    result = service.enable(intent)
+
+    assert upload_called is True
+    assert result.reason_code is ProtectionReasonCode.UPLOAD_FAILED
+    assert load_state(store_id).pending_protection_snapshot_id is None
+
+
+def test_canceled_first_enrollment_can_still_create_its_key_on_retry(tmp_path):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    first = service.create_intent()
+    service.cancel_intent(first.protection_intent_id)
+
+    second = service.create_intent()
+
+    assert second.protection_intent_id != first.protection_intent_id
+    durable = load_state(_store_id(settings))
+    assert durable.pending_protection_created_store is True
+
+
+def test_bind_uses_live_account_and_is_same_account_idempotent(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    client = FakeClient()
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: client)
+
+    first = service.bind_intent(intent)
+    second = service.bind_intent(intent)
+
+    assert first.reason_code is None
+    assert second.reason_code is None
+    assert client.calls == 2
+    durable = load_state(_store_id(settings))
+    assert durable.pending_protection_account_id == ACCOUNT_ID
+    assert durable.pending_protection_status is ProtectionIntentStatus.READY
+
+
+def test_bind_requires_subscription_without_canceling_intent(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: FakeClient(backup=False),
+    )
+
+    result = service.bind_intent(intent)
+
+    assert result.phase is ProtectionOperationPhase.PENDING
+    assert result.state is ProtectionState.SUBSCRIPTION_REQUIRED
+    assert result.reason_code is ProtectionReasonCode.SUBSCRIPTION_REQUIRED
+    durable = load_state(_store_id(settings))
+    assert durable.pending_protection_status is ProtectionIntentStatus.ACCOUNT_BOUND
+
+
+def test_cloud_service_failure_is_not_misreported_as_missing_subscription(
+    tmp_path, monkeypatch
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+
+    class BrokenClient:
+        def get_entitlements(self):
+            raise CloudError("service unavailable", status_code=503)
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: BrokenClient())
+
+    result = service.enable(intent)
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.OPERATION_INTERRUPTED
+    assert result.state is ProtectionState.ATTENTION_REQUIRED
+
+
+def test_different_live_account_cancels_bound_intent(tmp_path, monkeypatch):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: FakeClient(OTHER_ACCOUNT_ID),
+    )
+
+    result = service.bind_intent(intent)
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.ACCOUNT_CHANGED
+    durable = load_state(_store_id(settings))
+    assert durable.pending_protection_status is ProtectionIntentStatus.CANCELED
+    assert durable.pending_protection_account_id == ACCOUNT_ID
+
+
+def test_enable_fails_closed_on_missing_key_for_preexisting_store(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    store_id = str(uuid.uuid4())
+    (settings.memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    monkeypatch.setattr(protection, "client_from_settings", lambda settings: FakeClient())
+    monkeypatch.setattr(protection, "key_file_exists", lambda: False)
+    monkeypatch.setattr(
+        protection,
+        "init_key",
+        lambda: (_ for _ in ()).throw(AssertionError("must not create a replacement key")),
+    )
+
+    result = service.enable(intent)
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.KEY_MISSING
+    assert settings.cloud_backup_enabled is False
+    durable = load_state(store_id)
+    assert durable.pending_protection_status is ProtectionIntentStatus.RUNNING
+    assert durable.protection_state is ProtectionState.ATTENTION_REQUIRED
+
+
+def test_enable_only_claims_protected_after_exact_snapshot_verification(
+    tmp_path, monkeypatch
+):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    store_id = _store_id(settings)
+    order: list[str] = []
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+
+    def load_key():
+        assert load_state(store_id).protection_state is ProtectionState.INITIALIZING
+        return [object()]
+
+    monkeypatch.setattr(protection, "load_identities", load_key)
+    kit_args = []
+
+    def write_kit(store_id, **kwargs):
+        kit_args.append((store_id, kwargs))
+        return Path("kit")
+
+    monkeypatch.setattr(protection, "write_recovery_kit", write_kit)
+
+    def enable_setting(settings, enabled):
+        assert load_state(store_id).protection_state is ProtectionState.INITIALIZING
+        order.append("settings")
+        settings.cloud_backup_enabled = enabled
+
+    def upload(
+        operation_id,
+        *,
+        reason,
+        only_if_due,
+        entitlement_verified,
+        protection_intent_id,
+    ):
+        assert reason == "protection-enable"
+        assert entitlement_verified is True
+        assert protection_intent_id == intent
+        assert load_state(store_id).protection_state is ProtectionState.UPLOADING_FIRST_BACKUP
+        assert (
+            load_state(store_id).last_operation_phase
+            is ProtectionOperationPhase.UPLOADING
+        )
+        order.append("upload")
+        update_state(
+            store_id,
+            memory_dir=settings.memory_dir,
+            last_successful_backup_snapshot_id=SNAPSHOT_ID,
+            pending_protection_snapshot_id=SNAPSHOT_ID,
+            protection_state=ProtectionState.VERIFYING_FIRST_BACKUP,
+        )
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.BACKUP,
+            ProtectionOperationPhase.COMPLETED,
+            ProtectionState.VERIFYING_FIRST_BACKUP,
+            snapshot_id=SNAPSHOT_ID,
+        )
+
+    def verify(operation_id, *, requested_snapshot_id):
+        assert requested_snapshot_id == SNAPSHOT_ID
+        assert load_state(store_id).protection_state is not ProtectionState.PROTECTED
+        assert (
+            load_state(store_id).last_operation_phase
+            is ProtectionOperationPhase.VERIFYING
+        )
+        order.append("verify")
+        update_state(
+            store_id,
+            memory_dir=settings.memory_dir,
+            last_verify_ok=True,
+            last_verify_snapshot_id=SNAPSHOT_ID,
+            last_verified_snapshot_id=SNAPSHOT_ID,
+        )
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.VERIFY,
+            ProtectionOperationPhase.COMPLETED,
+            ProtectionState.VERIFYING_FIRST_BACKUP,
+            snapshot_id=SNAPSHOT_ID,
+        )
+
+    monkeypatch.setattr(protection, "set_cloud_backup_enabled", enable_setting)
+    monkeypatch.setattr(service, "_backup_now", upload)
+    monkeypatch.setattr(service, "_verify_now", verify)
+
+    result = service.enable(intent)
+
+    assert order == ["settings", "upload", "verify"]
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.operation_id == intent
+    assert result.snapshot_id == SNAPSHOT_ID
+    assert kit_args == [(store_id, {"account_email": "person@example.com"})]
+    durable = load_state(store_id)
+    assert durable.protection_state is ProtectionState.PROTECTED
+    assert durable.pending_protection_status is ProtectionIntentStatus.COMPLETED
+    assert durable.recovery_kit_verified_at is None
+
+
+def test_running_intent_retries_verification_without_reupload(tmp_path, monkeypatch):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+        protection_state=ProtectionState.ATTENTION_REQUIRED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        pending_protection_snapshot_id=SNAPSHOT_ID,
+        last_verify_snapshot_id=SNAPSHOT_ID,
+        last_operation_kind=ProtectionOperationKind.VERIFY,
+    )
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "load_identities", lambda: [object()])
+    monkeypatch.setattr(
+        protection,
+        "write_recovery_kit",
+        lambda store_id, **kwargs: Path("kit"),
+    )
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
+    )
+    monkeypatch.setattr(
+        service,
+        "_backup_now",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not reupload")),
+    )
+
+    def verify(operation_id, *, requested_snapshot_id):
+        update_state(
+            store_id,
+            memory_dir=settings.memory_dir,
+            last_verify_ok=True,
+            last_verified_snapshot_id=requested_snapshot_id,
+        )
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.VERIFY,
+            ProtectionOperationPhase.COMPLETED,
+            ProtectionState.ATTENTION_REQUIRED,
+            snapshot_id=requested_snapshot_id,
+        )
+
+    monkeypatch.setattr(service, "_verify_now", verify)
+
+    result = service.enable(intent)
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert load_state(store_id).pending_protection_status is ProtectionIntentStatus.COMPLETED
+
+
+def test_verification_failure_keeps_committed_snapshot_but_never_protected(
+    tmp_path, monkeypatch
+):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    store_id = _store_id(settings)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "load_identities", lambda: [object()])
+    monkeypatch.setattr(
+        protection,
+        "write_recovery_kit",
+        lambda store_id, **kwargs: Path("kit"),
+    )
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
+    )
+
+    def upload(operation_id, **kwargs):
+        update_state(
+            store_id,
+            memory_dir=settings.memory_dir,
+            last_successful_backup_snapshot_id=SNAPSHOT_ID,
+            pending_protection_snapshot_id=SNAPSHOT_ID,
+            protection_state=ProtectionState.VERIFYING_FIRST_BACKUP,
+        )
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.BACKUP,
+            ProtectionOperationPhase.COMPLETED,
+            ProtectionState.VERIFYING_FIRST_BACKUP,
+            snapshot_id=SNAPSHOT_ID,
+        )
+
+    def fail_verification(operation_id, *, requested_snapshot_id):
+        return ProtectionOperation(
+            operation_id,
+            ProtectionOperationKind.VERIFY,
+            ProtectionOperationPhase.FAILED,
+            ProtectionState.ATTENTION_REQUIRED,
+            ProtectionReasonCode.VERIFICATION_FAILED,
+            "scratch rebuild failed",
+            requested_snapshot_id,
+        )
+
+    monkeypatch.setattr(service, "_backup_now", upload)
+    monkeypatch.setattr(service, "_verify_now", fail_verification)
+
+    result = service.enable(intent)
+
+    durable = load_state(store_id)
+    assert result.kind is ProtectionOperationKind.ENABLE
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.operation_id == intent
+    assert durable.pending_protection_status is ProtectionIntentStatus.RUNNING
+    assert durable.last_successful_backup_snapshot_id == SNAPSHOT_ID
+    assert durable.protection_state is not ProtectionState.PROTECTED
+    assert durable.last_operation_kind is ProtectionOperationKind.ENABLE
+    assert durable.last_operation_phase is ProtectionOperationPhase.FAILED
+
+
+def test_ambiguous_upload_is_not_automatically_retried(tmp_path, monkeypatch):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+        protection_state=ProtectionState.UPLOADING_FIRST_BACKUP,
+        last_operation_id=intent,
+        last_operation_kind=ProtectionOperationKind.ENABLE,
+        last_operation_phase=ProtectionOperationPhase.UPLOADING,
+    )
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "load_identities", lambda: [object()])
+    monkeypatch.setattr(
+        protection,
+        "write_recovery_kit",
+        lambda store_id, **kwargs: Path("kit"),
+    )
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
+    )
+    monkeypatch.setattr(
+        service,
+        "_backup_now",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("ambiguous upload must not be retried")
+        ),
+    )
+
+    first = service.enable(intent)
+    second = service.enable(intent)
+
+    assert first.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    assert second.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    assert load_state(store_id).pending_protection_status is ProtectionIntentStatus.RUNNING
+
+
+def test_second_store_cannot_replace_canonical_recovery_kit(tmp_path, monkeypatch):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    other_store_id = str(uuid.uuid4())
+    protection.RECOVERY_KIT_PATH.write_text(
+        f"# Ormah Recovery Kit\nstore_id: {other_store_id}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "load_identities", lambda: [object()])
+    monkeypatch.setattr(
+        protection,
+        "write_recovery_kit",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("canonical kit must not be overwritten")
+        ),
+    )
+
+    result = service.enable(intent)
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.KEY_INVALID
+    assert other_store_id in protection.RECOVERY_KIT_PATH.read_text(encoding="utf-8")
+
+
+def test_disable_persists_stopped_before_setting_and_preserves_history(
+    tmp_path, monkeypatch
+):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    store_id = _store_id(settings)
+    verified_at = NOW - timedelta(days=1)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+        protection_state=ProtectionState.PROTECTED,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_successful_verify_at=verified_at,
+    )
+    settings.cloud_backup_enabled = True
+
+    def disable_setting(settings, enabled):
+        durable = load_state(store_id)
+        assert durable.protection_state is ProtectionState.STOPPED
+        assert durable.pending_protection_account_id == ACCOUNT_ID
+        assert durable.last_verified_snapshot_id == SNAPSHOT_ID
+        settings.cloud_backup_enabled = enabled
+
+    monkeypatch.setattr(protection, "set_cloud_backup_enabled", disable_setting)
+
+    first = service.disable()
+    disabled_at = load_state(store_id).protection_disabled_at
+    second = service.disable()
+
+    assert first.phase is ProtectionOperationPhase.COMPLETED
+    assert second.phase is ProtectionOperationPhase.COMPLETED
+    durable = load_state(store_id)
+    assert durable.protection_state is ProtectionState.STOPPED
+    assert durable.protection_disabled_at == disabled_at
+    assert durable.last_successful_verify_at == verified_at
+    assert durable.pending_protection_intent_id == intent
+
+
+def test_disable_before_enrollment_remains_local_only(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
+    )
+
+    result = CloudProtectionService(settings).disable()
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.state is ProtectionState.LOCAL_ONLY
+    assert not (settings.memory_dir / ".store_id").exists()
+
+
+def test_disable_pending_intent_cancels_without_claiming_previously_protected(
+    tmp_path, monkeypatch
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    service.create_intent()
+    store_id = _store_id(settings)
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
+    )
+
+    result = service.disable()
+
+    durable = load_state(store_id)
+    assert result.state is ProtectionState.LOCAL_ONLY
+    assert durable.protection_state is ProtectionState.LOCAL_ONLY
+    assert durable.pending_protection_status is ProtectionIntentStatus.CANCELED
+    assert durable.protection_disabled_at is None
+
+
+def test_disable_setting_failure_preserves_fail_closed_stopped_state(
+    tmp_path, monkeypatch
+):
+    settings, service, _, _ = _ready_intent(tmp_path, monkeypatch)
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+    )
+    settings.cloud_backup_enabled = True
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    result = service.disable()
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.state is ProtectionState.STOPPED
+    assert load_state(store_id).protection_state is ProtectionState.STOPPED
+
+
+def test_running_intent_does_not_expire_or_allow_pending_cancel(tmp_path, monkeypatch):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+        pending_protection_expires_at=NOW - timedelta(seconds=1),
+    )
+
+    rebound = service.bind_intent(intent)
+    canceled = service.cancel_intent(intent)
+
+    assert rebound.reason_code is None
+    assert canceled.phase is ProtectionOperationPhase.FAILED
+    assert canceled.reason_code is ProtectionReasonCode.OPERATION_INTERRUPTED
+    assert load_state(store_id).pending_protection_status is ProtectionIntentStatus.RUNNING
+
+
+@pytest.mark.parametrize("method_name", ["bind_intent", "cancel_intent", "enable"])
+def test_invalid_intent_does_not_mutate_current_store_health(
+    tmp_path, method_name
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    valid = service.create_intent()
+    store_id = _store_id(settings)
+    before = load_state(store_id)
+
+    result = getattr(service, method_name)("not-an-intent")
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.INTENT_CANCELED
+    assert load_state(store_id) == before
+    assert valid.protection_intent_id == before.pending_protection_intent_id
+
+
+def test_active_intent_blocks_legacy_verification_promotion():
+    active = state.CloudState(
+        protection_state=ProtectionState.VERIFYING_FIRST_BACKUP,
+        pending_protection_intent_id=str(uuid.uuid4()),
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+    )
+    legacy = state.CloudState(
+        protection_state=ProtectionState.VERIFYING_FIRST_BACKUP,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+    )
+
+    assert protection._state_after_verification(active, SNAPSHOT_ID) is (
+        ProtectionState.VERIFYING_FIRST_BACKUP
+    )
+    assert protection._state_after_verification(legacy, SNAPSHOT_ID) is ProtectionState.PROTECTED

--- a/tests/test_cloud_enablement.py
+++ b/tests/test_cloud_enablement.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import json
 from pathlib import Path
 from types import SimpleNamespace
 import uuid
@@ -17,6 +18,7 @@ from ormah.cloud.state import (
     ProtectionOperationPhase,
     ProtectionReasonCode,
     ProtectionState,
+    UploadJournalPhase,
     load_state,
     update_state,
 )
@@ -117,7 +119,7 @@ def test_repeated_create_and_bind_keep_one_stable_operation_id(tmp_path, monkeyp
     assert bound.operation_id == first.operation_id
 
 
-def test_create_after_completed_protection_is_idempotent(tmp_path):
+def test_create_after_completed_protection_is_idempotent(tmp_path, monkeypatch):
     settings = _settings(tmp_path)
     service = CloudProtectionService(settings)
     first = service.create_intent()
@@ -132,12 +134,47 @@ def test_create_after_completed_protection_is_idempotent(tmp_path):
         last_verify_ok=True,
     )
     settings.cloud_backup_enabled = True
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: protection.EntitlementStatus.ACTIVE,
+    )
 
     repeated = service.create_intent()
 
     assert repeated.operation_id == first.operation_id
     assert repeated.phase is ProtectionOperationPhase.COMPLETED
     assert repeated.snapshot_id == SNAPSHOT_ID
+
+
+def test_offline_entitlement_lookup_does_not_replace_completed_intent(
+    tmp_path, monkeypatch
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    first = service.create_intent()
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+    settings.cloud_backup_enabled = True
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: protection.EntitlementStatus.NONE,
+    )
+
+    repeated = service.create_intent()
+
+    assert repeated.operation_id == first.operation_id
+    assert repeated.phase is ProtectionOperationPhase.COMPLETED
+    assert load_state(store_id).pending_protection_status is ProtectionIntentStatus.COMPLETED
 
 
 def test_completed_enable_never_returns_false_protected_state(tmp_path):
@@ -568,7 +605,7 @@ def test_verification_failure_keeps_committed_snapshot_but_never_protected(
     assert durable.last_operation_phase is ProtectionOperationPhase.FAILED
 
 
-def test_ambiguous_upload_is_not_automatically_retried(tmp_path, monkeypatch):
+def test_interruption_before_upload_reservation_resumes_cleanly(tmp_path, monkeypatch):
     settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
     store_id = _store_id(settings)
     update_state(
@@ -592,20 +629,44 @@ def test_ambiguous_upload_is_not_automatically_retried(tmp_path, monkeypatch):
         "set_cloud_backup_enabled",
         lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
     )
-    monkeypatch.setattr(
-        service,
-        "_backup_now",
-        lambda *args, **kwargs: (_ for _ in ()).throw(
-            AssertionError("ambiguous upload must not be retried")
-        ),
+    calls = []
+
+    def resumed_backup(*args, **kwargs):
+        calls.append(kwargs)
+        return ProtectionOperation(
+            intent,
+            ProtectionOperationKind.BACKUP,
+            ProtectionOperationPhase.FAILED,
+            ProtectionState.ATTENTION_REQUIRED,
+            ProtectionReasonCode.UPLOAD_FAILED,
+            "probe stopped after proving retry",
+        )
+
+    monkeypatch.setattr(service, "_backup_now", resumed_backup)
+
+    result = service.enable(intent)
+
+    assert result.reason_code is ProtectionReasonCode.UPLOAD_FAILED
+    assert len(calls) == 1
+    assert load_state(store_id).pending_protection_status is ProtectionIntentStatus.RUNNING
+
+
+def test_finalizing_upload_journal_is_the_only_ambiguous_marker(tmp_path):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_upload_id="upload-id",
+        pending_upload_snapshot_id=SNAPSHOT_ID,
+        pending_upload_operation_id=intent,
+        pending_upload_protection_intent_id=intent,
+        pending_upload_phase=UploadJournalPhase.FINALIZING,
     )
 
-    first = service.enable(intent)
-    second = service.enable(intent)
-
-    assert first.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
-    assert second.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
-    assert load_state(store_id).pending_protection_status is ProtectionIntentStatus.RUNNING
+    assert service._upload_status_is_unknown(load_state(store_id)) is True
 
 
 def test_second_store_cannot_replace_canonical_recovery_kit(tmp_path, monkeypatch):
@@ -668,6 +729,78 @@ def test_disable_persists_stopped_before_setting_and_preserves_history(
     assert durable.protection_disabled_at == disabled_at
     assert durable.last_successful_verify_at == verified_at
     assert durable.pending_protection_intent_id == intent
+
+
+def test_disable_is_idempotent_for_legacy_enrolled_store(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    store_id = protection.get_or_create_store_id(settings.memory_dir)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+    )
+    settings.cloud_backup_enabled = True
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda settings, enabled: setattr(settings, "cloud_backup_enabled", enabled),
+    )
+    service = CloudProtectionService(settings)
+
+    first = service.disable()
+    second = service.disable()
+
+    assert first.state is ProtectionState.STOPPED
+    assert second.state is ProtectionState.STOPPED
+    assert load_state(store_id).protection_state is ProtectionState.STOPPED
+
+
+def test_expired_protected_store_gets_reactivation_intent_and_preserves_origin(
+    tmp_path, monkeypatch
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    original = service.create_intent().protection_intent_id
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+    settings.cloud_backup_enabled = True
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: protection.EntitlementStatus.EXPIRED,
+    )
+
+    replacement = service.create_intent()
+
+    assert replacement.protection_intent_id != original
+    assert replacement.state is ProtectionState.PAUSED
+    durable = load_state(store_id)
+    assert durable.pending_protection_origin_state is ProtectionState.PROTECTED
+
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: FakeClient(backup=False),
+    )
+    bound = service.bind_intent(replacement.protection_intent_id)
+    assert bound.state is ProtectionState.SUBSCRIPTION_REQUIRED
+    assert (
+        load_state(store_id).pending_protection_status
+        is ProtectionIntentStatus.ACCOUNT_BOUND
+    )
+
+    canceled = service.cancel_intent(replacement.protection_intent_id)
+    assert canceled.state is ProtectionState.PROTECTED
+    assert load_state(store_id).protection_state is ProtectionState.PROTECTED
 
 
 def test_disable_before_enrollment_remains_local_only(tmp_path, monkeypatch):
@@ -767,6 +900,45 @@ def test_invalid_intent_does_not_mutate_current_store_health(
     assert result.reason_code is ProtectionReasonCode.INTENT_CANCELED
     assert load_state(store_id) == before
     assert valid.protection_intent_id == before.pending_protection_intent_id
+
+
+@pytest.mark.parametrize("method_name", ["bind_intent", "cancel_intent", "enable"])
+def test_intent_methods_report_client_update_required_for_newer_state(
+    tmp_path, method_name
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    store_id = _store_id(settings)
+    path = state.state_path(store_id)
+    payload = load_state(store_id).to_dict()
+    payload["schema_version"] = 99
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    before = path.read_bytes()
+
+    result = getattr(service, method_name)(intent)
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.CLIENT_UPDATE_REQUIRED
+    assert path.read_bytes() == before
+
+
+def test_disable_reports_client_update_required_for_newer_state(tmp_path):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    service.create_intent()
+    store_id = _store_id(settings)
+    path = state.state_path(store_id)
+    payload = load_state(store_id).to_dict()
+    payload["schema_version"] = 99
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    before = path.read_bytes()
+
+    result = service.disable()
+
+    assert result.phase is ProtectionOperationPhase.CANCELED
+    assert result.reason_code is ProtectionReasonCode.CLIENT_UPDATE_REQUIRED
+    assert path.read_bytes() == before
 
 
 def test_active_intent_blocks_legacy_verification_promotion():

--- a/tests/test_cloud_enablement.py
+++ b/tests/test_cloud_enablement.py
@@ -19,6 +19,7 @@ from ormah.cloud.state import (
     ProtectionReasonCode,
     ProtectionState,
     UploadJournalPhase,
+    cloud_status_payload,
     load_state,
     update_state,
 )
@@ -145,6 +146,32 @@ def test_create_after_completed_protection_is_idempotent(tmp_path, monkeypatch):
     assert repeated.operation_id == first.operation_id
     assert repeated.phase is ProtectionOperationPhase.COMPLETED
     assert repeated.snapshot_id == SNAPSHOT_ID
+
+
+def test_create_is_idempotent_for_legacy_protected_store(tmp_path, monkeypatch):
+    settings = _settings(tmp_path)
+    store_id = protection.get_or_create_store_id(settings.memory_dir)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+    settings.cloud_backup_enabled = True
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: protection.EntitlementStatus.ACTIVE,
+    )
+
+    result = CloudProtectionService(settings).create_intent()
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.state is ProtectionState.PROTECTED
+    assert result.protection_intent_id is None
+    assert load_state(store_id).pending_protection_intent_id is None
 
 
 def test_offline_entitlement_lookup_does_not_replace_completed_intent(
@@ -326,6 +353,33 @@ def test_bind_requires_subscription_without_canceling_intent(tmp_path, monkeypat
     assert result.reason_code is ProtectionReasonCode.SUBSCRIPTION_REQUIRED
     durable = load_state(_store_id(settings))
     assert durable.pending_protection_status is ProtectionIntentStatus.ACCOUNT_BOUND
+
+
+def test_rebinding_while_checkout_is_pending_preserves_checkout_status(
+    tmp_path, monkeypatch
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    intent = service.create_intent().protection_intent_id
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_protection_status=ProtectionIntentStatus.CHECKOUT_PENDING,
+        protection_state=ProtectionState.SUBSCRIPTION_REQUIRED,
+    )
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: FakeClient(backup=False),
+    )
+
+    service.bind_intent(intent)
+
+    assert (
+        load_state(store_id).pending_protection_status
+        is ProtectionIntentStatus.CHECKOUT_PENDING
+    )
 
 
 def test_cloud_service_failure_is_not_misreported_as_missing_subscription(
@@ -801,6 +855,36 @@ def test_expired_protected_store_gets_reactivation_intent_and_preserves_origin(
     canceled = service.cancel_intent(replacement.protection_intent_id)
     assert canceled.state is ProtectionState.PROTECTED
     assert load_state(store_id).protection_state is ProtectionState.PROTECTED
+    assert cloud_status_payload(settings, entitlement="active")["protection_state"] == (
+        ProtectionState.PROTECTED.value
+    )
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    [ProtectionIntentStatus.CANCELED, ProtectionIntentStatus.EXPIRED],
+)
+def test_terminal_intent_does_not_invalidate_verified_protection(
+    tmp_path, terminal_status
+):
+    settings = _settings(tmp_path)
+    store_id = protection.get_or_create_store_id(settings.memory_dir)
+    settings.cloud_backup_enabled = True
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_intent_id=str(uuid.uuid4()),
+        pending_protection_status=terminal_status,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+
+    payload = cloud_status_payload(settings, entitlement="active")
+
+    assert payload["protection_state"] == ProtectionState.PROTECTED.value
+    assert not any("metadata is incomplete" in warning for warning in payload["warnings"])
 
 
 def test_replacing_expired_subscription_intent_preserves_protected_origin(

--- a/tests/test_cloud_enablement.py
+++ b/tests/test_cloud_enablement.py
@@ -803,6 +803,52 @@ def test_expired_protected_store_gets_reactivation_intent_and_preserves_origin(
     assert load_state(store_id).protection_state is ProtectionState.PROTECTED
 
 
+def test_replacing_expired_subscription_intent_preserves_protected_origin(
+    tmp_path, monkeypatch
+):
+    settings = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    service.create_intent()
+    store_id = _store_id(settings)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_status=ProtectionIntentStatus.COMPLETED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+    settings.cloud_backup_enabled = True
+    monkeypatch.setattr(
+        protection,
+        "check_entitlement",
+        lambda settings: protection.EntitlementStatus.EXPIRED,
+    )
+    first = service.create_intent()
+    monkeypatch.setattr(
+        protection,
+        "client_from_settings",
+        lambda settings: FakeClient(backup=False),
+    )
+    service.bind_intent(first.protection_intent_id)
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_protection_expires_at=NOW - timedelta(seconds=1),
+    )
+
+    replacement = service.create_intent()
+
+    assert replacement.protection_intent_id != first.protection_intent_id
+    assert (
+        load_state(store_id).pending_protection_origin_state
+        is ProtectionState.PROTECTED
+    )
+    canceled = service.cancel_intent(replacement.protection_intent_id)
+    assert canceled.state is ProtectionState.PROTECTED
+
+
 def test_disable_before_enrollment_remains_local_only(tmp_path, monkeypatch):
     settings = _settings(tmp_path)
     monkeypatch.setattr(

--- a/tests/test_cloud_enablement.py
+++ b/tests/test_cloud_enablement.py
@@ -887,6 +887,40 @@ def test_terminal_intent_does_not_invalidate_verified_protection(
     assert not any("metadata is incomplete" in warning for warning in payload["warnings"])
 
 
+@pytest.mark.parametrize(
+    "active_or_unknown_status",
+    [
+        ProtectionIntentStatus.PENDING,
+        ProtectionIntentStatus.ACCOUNT_BOUND,
+        ProtectionIntentStatus.CHECKOUT_PENDING,
+        ProtectionIntentStatus.READY,
+        ProtectionIntentStatus.RUNNING,
+        "future_intent_status",
+    ],
+)
+def test_active_or_unknown_intent_blocks_verified_protection_claim(
+    tmp_path, active_or_unknown_status
+):
+    settings = _settings(tmp_path)
+    store_id = protection.get_or_create_store_id(settings.memory_dir)
+    settings.cloud_backup_enabled = True
+    update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.PROTECTED,
+        pending_protection_intent_id=str(uuid.uuid4()),
+        pending_protection_status=active_or_unknown_status,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_verified_snapshot_id=SNAPSHOT_ID,
+        last_verify_ok=True,
+    )
+
+    payload = cloud_status_payload(settings, entitlement="active")
+
+    assert payload["protection_state"] == ProtectionState.ATTENTION_REQUIRED.value
+    assert any("metadata is incomplete" in warning for warning in payload["warnings"])
+
+
 def test_replacing_expired_subscription_intent_preserves_protected_origin(
     tmp_path, monkeypatch
 ):

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -448,8 +448,10 @@ def test_restore_verification_rejects_invalid_active_self_pointer(
 
     assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is False
     durable = load_state(store_id)
-    assert durable.last_error_code is ProtectionReasonCode.NODE_PARSE_FAILED
-    assert durable.last_verify_error == "A restored memory node could not be parsed."
+    assert durable.last_error_code is ProtectionReasonCode.SELF_POINTER_INVALID
+    assert durable.last_verify_error == (
+        "The backup's active Self pointer does not match the restored memory graph."
+    )
 
 
 def test_restore_verification_cleans_temporary_tree_on_failure(

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -14,7 +14,8 @@ from ormah.cloud import protection
 from ormah.cloud.bundle import build_bundle
 from ormah.cloud.crypto import generate_identity
 from ormah.cloud.entitlements import EntitlementStatus
-from ormah.cloud.state import load_state, save_state, CloudState
+from ormah.cloud.state import CloudState, ProtectionReasonCode, load_state, save_state
+from ormah.cloud.transfer import sha256_file
 from ormah.config import Settings
 from ormah.index.db import Database
 from ormah.models.node import MemoryNode, NodeType
@@ -48,7 +49,14 @@ class FakeCloudClient:
 
     def list_blobs(self, store_id):
         return {
-            "blobs": [{"snapshot_id": SNAPSHOT_ID, "created_at": NOW.isoformat(), "size_bytes": 1}]
+            "blobs": [
+                {
+                    "snapshot_id": SNAPSHOT_ID,
+                    "created_at": NOW.isoformat(),
+                    "size_bytes": 1,
+                    "sha256": sha256_file(self.bundle) if self.bundle is not None else "0" * 64,
+                }
+            ]
         }
 
     def presign_download(self, store_id, snapshot_id):
@@ -439,7 +447,9 @@ def test_restore_verification_rejects_invalid_active_self_pointer(
     _patch_verification(monkeypatch, client, bundle, identity)
 
     assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is False
-    assert "exact system:self node is not present" in load_state(store_id).last_verify_error
+    durable = load_state(store_id)
+    assert durable.last_error_code is ProtectionReasonCode.NODE_PARSE_FAILED
+    assert durable.last_verify_error == "A restored memory node could not be parsed."
 
 
 def test_restore_verification_cleans_temporary_tree_on_failure(

--- a/tests/test_cloud_jobs.py
+++ b/tests/test_cloud_jobs.py
@@ -454,6 +454,42 @@ def test_restore_verification_rejects_invalid_active_self_pointer(
     )
 
 
+def test_restore_verification_reports_malformed_self_node_as_parse_failure(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    from ormah.cloud import jobs
+
+    settings, store_id = _settings(tmp_path, with_node=False)
+    self_node = MemoryNode(
+        title="Self",
+        content="The active user identity.",
+        type=NodeType.person,
+        source="system:self",
+    )
+    FileStore(settings.memory_dir / "nodes").save(self_node)
+    backup = service_from_settings(settings).create(reason="malformed-self-fixture")
+    node_path = next((backup.path / "nodes").glob("*.md"))
+    secret = "private-self-frontmatter"
+    node_path.write_text(f"---\ntags: [\n---\n{secret}\n", encoding="utf-8")
+    identity = generate_identity()
+    bundle = tmp_path / "malformed-self.age"
+    build_bundle(
+        backup.path,
+        bundle,
+        [identity.to_public()],
+        store_id=store_id,
+        reason="cloud-backup",
+    )
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+
+    assert jobs.run_restore_verification(SimpleNamespace(settings=settings)) is False
+    durable = load_state(store_id)
+    assert durable.last_error_code is ProtectionReasonCode.NODE_PARSE_FAILED
+    assert durable.last_verify_error == "A restored memory node could not be parsed."
+    assert secret not in durable.last_verify_error
+
+
 def test_restore_verification_cleans_temporary_tree_on_failure(
     tmp_path, monkeypatch, cloud_state_dir
 ):

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -482,7 +482,7 @@ def test_verification_reports_the_failed_restore_stage(
     assert secret not in (durable.last_verify_error or "")
 
 
-def test_verification_requires_server_attested_ciphertext_hash(
+def test_verification_distinguishes_old_service_from_unverified_legacy_blob(
     tmp_path, monkeypatch, cloud_state_dir
 ):
     settings, store_id = _settings(tmp_path)
@@ -493,9 +493,23 @@ def test_verification_requires_server_attested_ciphertext_hash(
         "blobs": [{"snapshot_id": SNAPSHOT_ID, "size_bytes": bundle.stat().st_size}]
     }
 
-    result = CloudProtectionService(settings).verify_now()
+    old_service = CloudProtectionService(settings).verify_now()
+    client.list_blobs = lambda store_id: {
+        "blobs": [
+            {
+                "snapshot_id": SNAPSHOT_ID,
+                "size_bytes": bundle.stat().st_size,
+                "sha256": None,
+            }
+        ]
+    }
+    unverified_legacy = CloudProtectionService(settings).verify_now()
 
-    assert result.reason_code is ProtectionReasonCode.CIPHERTEXT_HASH_UNAVAILABLE
+    assert old_service.reason_code is ProtectionReasonCode.SERVICE_UPDATE_REQUIRED
+    assert (
+        unverified_legacy.reason_code
+        is ProtectionReasonCode.CIPHERTEXT_HASH_UNAVAILABLE
+    )
 
 
 def test_verification_reports_local_processing_limit_as_local_failure(

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -195,6 +195,77 @@ def test_uncertain_finalize_retries_the_same_upload_without_new_reservation(
     assert durable.pending_upload_phase is None
 
 
+def test_definitively_expired_finalize_is_replaced_after_local_expiry(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_upload_id="expired-upload",
+        pending_upload_snapshot_id="01J11111111111111111111111",
+        pending_upload_operation_id="expired-operation",
+        pending_upload_phase=UploadJournalPhase.FINALIZING,
+        pending_upload_expires_at=protection._utc_now() - protection.timedelta(seconds=1),
+        last_error_code=ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
+    )
+    real_finalize = client.finalize_upload
+
+    def finalize(store_id, upload_id):
+        if upload_id == "expired-upload":
+            raise CloudError(
+                "Upload expired.",
+                status_code=409,
+                payload={"detail": {"code": "upload_expired"}},
+            )
+        return real_finalize(store_id, upload_id)
+
+    client.finalize_upload = finalize
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert len(client.created) == 1
+    assert client.finalized == [(store_id, "upload-1")]
+    durable = load_state(store_id)
+    assert durable.pending_upload_phase is None
+    assert durable.last_error_code is None
+
+
+def test_server_expiry_before_local_expiry_keeps_ambiguous_upload(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_upload_id="ambiguous-upload",
+        pending_upload_snapshot_id="01J11111111111111111111111",
+        pending_upload_operation_id="ambiguous-operation",
+        pending_upload_phase=UploadJournalPhase.FINALIZING,
+        pending_upload_expires_at=protection._utc_now() + protection.timedelta(minutes=1),
+    )
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    client.create_upload = lambda *args: (_ for _ in ()).throw(
+        AssertionError("an ambiguous upload must not be replaced")
+    )
+    client.finalize_upload = lambda *args: (_ for _ in ()).throw(
+        CloudError(
+            "Upload expired.",
+            status_code=409,
+            payload={"detail": {"code": "upload_expired"}},
+        )
+    )
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    assert load_state(store_id).pending_upload_phase is UploadJournalPhase.FINALIZING
+
+
 def test_reserved_upload_from_interrupted_put_is_safe_to_replace(
     tmp_path, monkeypatch, cloud_state_dir
 ):
@@ -331,6 +402,102 @@ def test_index_rebuild_failure_is_not_reported_as_backup_corruption(
     )
 
 
+@pytest.mark.parametrize(
+    ("failure", "reason_code"),
+    [
+        ("download", ProtectionReasonCode.DOWNLOAD_FAILED),
+        ("ciphertext", ProtectionReasonCode.CIPHERTEXT_HASH_MISMATCH),
+        ("decrypt", ProtectionReasonCode.DECRYPT_FAILED),
+        ("manifest", ProtectionReasonCode.MANIFEST_VERIFICATION_FAILED),
+        ("node", ProtectionReasonCode.NODE_PARSE_FAILED),
+        ("search", ProtectionReasonCode.SEARCH_PROBE_FAILED),
+    ],
+)
+def test_verification_reports_the_failed_restore_stage(
+    tmp_path, monkeypatch, cloud_state_dir, failure, reason_code
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        protection_state=ProtectionState.VERIFICATION_PENDING,
+    )
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    secret = "private-frontmatter-must-not-escape"
+
+    if failure == "download":
+        monkeypatch.setattr(
+            protection,
+            "download_file",
+            lambda *args: (_ for _ in ()).throw(RuntimeError("object unavailable")),
+        )
+    elif failure == "ciphertext":
+        client.list_blobs = lambda store_id: {
+            "blobs": [
+                {
+                    "snapshot_id": SNAPSHOT_ID,
+                    "size_bytes": bundle.stat().st_size,
+                    "sha256": "0" * 64,
+                }
+            ]
+        }
+    elif failure == "decrypt":
+        monkeypatch.setattr(
+            protection,
+            "open_bundle",
+            lambda *args: (_ for _ in ()).throw(
+                protection.CloudCryptoError("wrong recovery key")
+            ),
+        )
+    elif failure == "manifest":
+        monkeypatch.setattr(
+            protection,
+            "open_bundle",
+            lambda *args: (_ for _ in ()).throw(
+                TypeError(f"nodes\\{secret}.md manifest entry is malformed")
+            ),
+        )
+    elif failure == "node":
+        monkeypatch.setattr(
+            protection,
+            "parse_node",
+            lambda *args: (_ for _ in ()).throw(ValueError(secret)),
+        )
+    else:
+        monkeypatch.setattr(
+            protection,
+            "_probe_search",
+            lambda *args: (_ for _ in ()).throw(RuntimeError("probe failed")),
+        )
+
+    result = CloudProtectionService(settings).verify_now(SNAPSHOT_ID)
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is reason_code
+    durable = load_state(store_id)
+    assert durable.last_error_code is reason_code
+    assert secret not in (durable.last_verify_error or "")
+
+
+def test_verification_requires_server_attested_ciphertext_hash(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    client.list_blobs = lambda store_id: {
+        "blobs": [{"snapshot_id": SNAPSHOT_ID, "size_bytes": bundle.stat().st_size}]
+    }
+
+    result = CloudProtectionService(settings).verify_now()
+
+    assert result.reason_code is ProtectionReasonCode.CIPHERTEXT_HASH_UNAVAILABLE
+
+
 def test_safe_error_message_redacts_plaintext_node_slugs():
     message = protection.safe_error_message(
         "Hash mismatch for 'nodes/fact_my-therapist-said-secret_a1b2.md' "
@@ -342,6 +509,14 @@ def test_safe_error_message_redacts_plaintext_node_slugs():
     assert message == (
         "Hash mismatch for 'nodes/<redacted>.md' and deleted/<redacted>.md"
     )
+
+
+def test_safe_error_message_redacts_windows_node_paths():
+    message = protection.safe_error_message(
+        r"Hash mismatch for nodes\fact_private-diagnosis_a1b2.md"
+    )
+
+    assert message == "Hash mismatch for nodes/<redacted>.md"
 
 
 def test_offline_upload_preserves_verification_health_and_redacts_persisted_error(

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import errno
 import logging
 import threading
 from types import SimpleNamespace
@@ -16,6 +17,7 @@ from ormah.cloud.state import (
     ProtectionOperationPhase,
     ProtectionReasonCode,
     ProtectionState,
+    UploadJournalPhase,
     load_state,
     state_path,
 )
@@ -54,12 +56,13 @@ def test_backup_now_returns_typed_completed_operation(tmp_path, monkeypatch, clo
     assert isinstance(result, ProtectionOperation)
     assert result.kind is ProtectionOperationKind.BACKUP
     assert result.phase is ProtectionOperationPhase.COMPLETED
-    assert result.state is ProtectionState.CHANGES_PENDING
+    assert result.state is ProtectionState.VERIFICATION_PENDING
     assert result.snapshot_id == SNAPSHOT_ID
     assert client.finalized == [(store_id, "upload-1")]
     durable = load_state(store_id)
     assert durable.last_operation_id == result.operation_id
     assert durable.last_operation_phase is ProtectionOperationPhase.COMPLETED
+    assert durable.pending_upload_phase is None
 
 
 def test_legacy_opted_in_store_reaches_protected_after_first_backup_and_verification(
@@ -126,7 +129,40 @@ def test_failed_put_returns_typed_failure_and_never_finalizes(
     assert client.finalized == []
 
 
-def test_uncertain_finalize_blocks_automatic_reupload(
+def test_quota_and_disk_failures_have_actionable_reason_codes(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    quota_settings, _ = _settings(tmp_path / "quota")
+    quota_client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, quota_client)
+    quota_client.create_upload = lambda *args: (_ for _ in ()).throw(
+        CloudError(
+            "Account storage quota exceeded.",
+            status_code=413,
+            payload={"detail": "Account storage quota exceeded."},
+        )
+    )
+
+    quota = CloudProtectionService(quota_settings).backup_now()
+
+    disk_settings, _ = _settings(tmp_path / "disk")
+    disk_client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, disk_client)
+    monkeypatch.setattr(
+        protection,
+        "build_bundle",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            OSError(errno.ENOSPC, "No space left on device")
+        ),
+    )
+
+    disk = CloudProtectionService(disk_settings).backup_now()
+
+    assert quota.reason_code is ProtectionReasonCode.QUOTA_EXCEEDED
+    assert disk.reason_code is ProtectionReasonCode.DISK_SPACE_INSUFFICIENT
+
+
+def test_uncertain_finalize_retries_the_same_upload_without_new_reservation(
     tmp_path, monkeypatch, cloud_state_dir
 ):
     settings, store_id = _settings(tmp_path)
@@ -141,6 +177,7 @@ def test_uncertain_finalize_blocks_automatic_reupload(
     client.finalize_upload = timeout_after_commit
 
     first = CloudProtectionService(settings).backup_now()
+    client.finalize_upload = real_finalize
     monkeypatch.setattr(
         client,
         "create_upload",
@@ -151,9 +188,66 @@ def test_uncertain_finalize_blocks_automatic_reupload(
     second = CloudProtectionService(settings).backup_now()
 
     assert first.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
-    assert second.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    assert second.phase is ProtectionOperationPhase.COMPLETED
+    assert client.finalized == [(store_id, "upload-1"), (store_id, "upload-1")]
+    durable = load_state(store_id)
+    assert durable.last_error_code is None
+    assert durable.pending_upload_phase is None
+
+
+def test_reserved_upload_from_interrupted_put_is_safe_to_replace(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        pending_upload_id="abandoned-upload",
+        pending_upload_snapshot_id="01J11111111111111111111111",
+        pending_upload_operation_id="abandoned-operation",
+        pending_upload_phase=UploadJournalPhase.RESERVED,
+        pending_upload_expires_at=protection._utc_now() + protection.timedelta(minutes=10),
+    )
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert len(client.created) == 1
     assert client.finalized == [(store_id, "upload-1")]
-    assert load_state(store_id).last_error_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    durable = load_state(store_id)
+    assert durable.pending_upload_phase is None
+    assert durable.last_successful_backup_snapshot_id == SNAPSHOT_ID
+
+
+def test_successful_verification_does_not_clear_ambiguous_upload_journal(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        protection_state=ProtectionState.ATTENTION_REQUIRED,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        last_error_code=ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN,
+        last_error_message="finalize response lost",
+        pending_upload_id="upload-1",
+        pending_upload_snapshot_id=SNAPSHOT_ID,
+        pending_upload_operation_id="operation-1",
+        pending_upload_phase=UploadJournalPhase.FINALIZING,
+    )
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+
+    result = CloudProtectionService(settings).verify_now(SNAPSHOT_ID)
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    durable = load_state(store_id)
+    assert durable.protection_state is ProtectionState.ATTENTION_REQUIRED
+    assert durable.last_error_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    assert durable.pending_upload_phase is UploadJournalPhase.FINALIZING
 
 
 def test_upload_rejects_invalid_server_snapshot_id_before_put(
@@ -205,6 +299,49 @@ def test_verification_rejects_invalid_server_snapshot_id_before_tempfile(
 
     assert result.phase is ProtectionOperationPhase.FAILED
     assert result.reason_code is ProtectionReasonCode.VERIFICATION_FAILED
+
+
+def test_index_rebuild_failure_is_not_reported_as_backup_corruption(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    state.update_state(
+        store_id,
+        memory_dir=settings.memory_dir,
+        last_successful_backup_snapshot_id=SNAPSHOT_ID,
+        protection_state=ProtectionState.VERIFICATION_PENDING,
+    )
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    monkeypatch.setattr(
+        protection,
+        "IndexBuilder",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            RuntimeError("embedding model is unavailable")
+        ),
+    )
+
+    result = CloudProtectionService(settings).verify_now(SNAPSHOT_ID)
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert (
+        result.reason_code
+        is ProtectionReasonCode.INDEX_ENVIRONMENT_UNAVAILABLE
+    )
+
+
+def test_safe_error_message_redacts_plaintext_node_slugs():
+    message = protection.safe_error_message(
+        "Hash mismatch for 'nodes/fact_my-therapist-said-secret_a1b2.md' "
+        "and deleted/event_private-diagnosis_c3d4.md"
+    )
+
+    assert "therapist" not in message
+    assert "diagnosis" not in message
+    assert message == (
+        "Hash mismatch for 'nodes/<redacted>.md' and deleted/<redacted>.md"
+    )
 
 
 def test_offline_upload_preserves_verification_health_and_redacts_persisted_error(

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -498,6 +498,22 @@ def test_verification_requires_server_attested_ciphertext_hash(
     assert result.reason_code is ProtectionReasonCode.CIPHERTEXT_HASH_UNAVAILABLE
 
 
+def test_verification_reports_local_processing_limit_as_local_failure(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    bundle, identity = _verification_bundle(tmp_path, settings, store_id)
+    client = FakeCloudClient(bundle=bundle)
+    _patch_verification(monkeypatch, client, bundle, identity)
+    client.processing_limit = lambda **kwargs: 0
+
+    result = CloudProtectionService(settings).verify_now()
+
+    assert result.reason_code is ProtectionReasonCode.PROCESSING_LIMIT_EXCEEDED
+    assert result.state is ProtectionState.ATTENTION_REQUIRED
+    assert load_state(store_id).last_verify_ok is False
+
+
 def test_safe_error_message_redacts_plaintext_node_slugs():
     message = protection.safe_error_message(
         "Hash mismatch for 'nodes/fact_my-therapist-said-secret_a1b2.md' "

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -126,6 +126,36 @@ def test_failed_put_returns_typed_failure_and_never_finalizes(
     assert client.finalized == []
 
 
+def test_uncertain_finalize_blocks_automatic_reupload(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    real_finalize = client.finalize_upload
+
+    def timeout_after_commit(store_id, upload_id):
+        real_finalize(store_id, upload_id)
+        raise CloudError("finalize response lost")
+
+    client.finalize_upload = timeout_after_commit
+
+    first = CloudProtectionService(settings).backup_now()
+    monkeypatch.setattr(
+        client,
+        "create_upload",
+        lambda *args: (_ for _ in ()).throw(
+            AssertionError("unknown finalize must block a new upload")
+        ),
+    )
+    second = CloudProtectionService(settings).backup_now()
+
+    assert first.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    assert second.reason_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+    assert client.finalized == [(store_id, "upload-1")]
+    assert load_state(store_id).last_error_code is ProtectionReasonCode.UPLOAD_STATUS_UNKNOWN
+
+
 def test_upload_rejects_invalid_server_snapshot_id_before_put(
     tmp_path, monkeypatch, cloud_state_dir
 ):

--- a/tests/test_cloud_settings.py
+++ b/tests/test_cloud_settings.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import stat
+import threading
+import time
+
+import pytest
+
+from ormah import setup
+from ormah.cloud.client import persist_account_credentials
+from ormah.cloud.settings import set_cloud_backup_enabled
+from ormah.config import Settings
+
+
+@pytest.fixture
+def env_path(tmp_path, monkeypatch):
+    path = tmp_path / "config" / ".env"
+    monkeypatch.setattr(setup, "ENV_PATH", path)
+    monkeypatch.setattr(setup, "ENV_DIR", path.parent)
+    return path
+
+
+def test_cloud_setting_preserves_unrelated_env_lines_and_updates_runtime(env_path):
+    original = "# user setting\nMANUAL = spaced  # preserve\nORMAH_LLM_PROVIDER=none\n"
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text(original, encoding="utf-8")
+    settings = Settings(cloud_backup_enabled=False)
+
+    set_cloud_backup_enabled(settings, True)
+
+    text = env_path.read_text(encoding="utf-8")
+    assert text.startswith(original)
+    assert "ORMAH_CLOUD_BACKUP_ENABLED=true\n" in text
+    assert settings.cloud_backup_enabled is True
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE((env_path.parent / ".env.lock").stat().st_mode) == 0o600
+
+
+def test_cloud_setting_does_not_change_runtime_when_persistence_fails(
+    env_path, monkeypatch
+):
+    settings = Settings(cloud_backup_enabled=False)
+    monkeypatch.setattr(
+        setup,
+        "_write_env_file",
+        lambda env: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    with pytest.raises(OSError, match="disk full"):
+        set_cloud_backup_enabled(settings, True)
+
+    assert settings.cloud_backup_enabled is False
+
+
+def test_account_and_protection_updates_are_serialized_without_lost_keys(
+    env_path, monkeypatch
+):
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text("ORMAH_LLM_PROVIDER=none\n", encoding="utf-8")
+    settings = Settings(cloud_backup_enabled=False)
+    first_read_started = threading.Event()
+    release_first_read = threading.Event()
+    real_read = setup._read_env_file
+    read_count = 0
+    read_guard = threading.Lock()
+
+    def delayed_read():
+        nonlocal read_count
+        with read_guard:
+            read_count += 1
+            current = read_count
+        result = real_read()
+        if current == 1:
+            first_read_started.set()
+            assert release_first_read.wait(2)
+        return result
+
+    monkeypatch.setattr(setup, "_read_env_file", delayed_read)
+    protection = threading.Thread(
+        target=set_cloud_backup_enabled,
+        args=(settings, True),
+    )
+    account = threading.Thread(
+        target=persist_account_credentials,
+        args=("account-token", "person@example.com"),
+    )
+
+    protection.start()
+    assert first_read_started.wait(1)
+    account.start()
+    time.sleep(0.05)
+    assert account.is_alive()
+    release_first_read.set()
+    protection.join(2)
+    account.join(2)
+
+    assert not protection.is_alive()
+    assert not account.is_alive()
+    text = env_path.read_text(encoding="utf-8")
+    assert "ORMAH_LLM_PROVIDER=none" in text
+    assert "ORMAH_CLOUD_BACKUP_ENABLED=true" in text
+    assert "ORMAH_ACCOUNT_TOKEN=account-token" in text
+    assert "ORMAH_ACCOUNT_EMAIL=person@example.com" in text
+
+
+def test_admin_backup_settings_use_the_shared_serialized_writer(monkeypatch, tmp_path):
+    from ormah.api import routes_admin
+    from ormah.cloud import settings as cloud_settings
+
+    captured = {}
+    monkeypatch.setattr(
+        cloud_settings,
+        "update_settings_env",
+        lambda values: captured.update(values),
+    )
+
+    routes_admin._persist_backup_settings(tmp_path / "backups", 12)
+
+    assert captured == {
+        "ORMAH_BACKUP_DIR": str(tmp_path / "backups"),
+        "ORMAH_BACKUP_RETENTION_COUNT": "12",
+    }

--- a/tests/test_cloud_settings.py
+++ b/tests/test_cloud_settings.py
@@ -8,7 +8,7 @@ import pytest
 
 from ormah import setup
 from ormah.cloud.client import persist_account_credentials
-from ormah.cloud.settings import set_cloud_backup_enabled
+from ormah.cloud.settings import persist_settings_delta, set_cloud_backup_enabled
 from ormah.config import Settings
 
 
@@ -101,6 +101,22 @@ def test_account_and_protection_updates_are_serialized_without_lost_keys(
     assert "ORMAH_CLOUD_BACKUP_ENABLED=true" in text
     assert "ORMAH_ACCOUNT_TOKEN=account-token" in text
     assert "ORMAH_ACCOUNT_EMAIL=person@example.com" in text
+
+
+def test_setup_delta_does_not_overwrite_a_concurrent_protection_setting(env_path):
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text("ORMAH_LLM_PROVIDER=none\n", encoding="utf-8")
+    stale_before = setup._read_env_file()
+    desired = dict(stale_before)
+    desired["ORMAH_LLM_PROVIDER"] = "ollama"
+
+    settings = Settings(cloud_backup_enabled=False)
+    set_cloud_backup_enabled(settings, True)
+    persist_settings_delta(stale_before, desired)
+
+    persisted = setup._read_env_file()
+    assert persisted["ORMAH_LLM_PROVIDER"] == "ollama"
+    assert persisted["ORMAH_CLOUD_BACKUP_ENABLED"] == "true"
 
 
 def test_admin_backup_settings_use_the_shared_serialized_writer(monkeypatch, tmp_path):

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -19,6 +19,7 @@ from ormah.cloud.state import (
     ProtectionOperationPhase,
     ProtectionReasonCode,
     ProtectionState,
+    UploadJournalPhase,
     cloud_status_payload,
     load_state,
     save_state,
@@ -49,6 +50,12 @@ def test_state_round_trip_is_atomic_and_owner_only(tmp_path):
         last_operation_kind=ProtectionOperationKind.VERIFY,
         last_operation_phase=ProtectionOperationPhase.FAILED,
         last_error_code=ProtectionReasonCode.VERIFICATION_FAILED,
+        pending_upload_id="upload-1",
+        pending_upload_snapshot_id="01PENDING",
+        pending_upload_operation_id="operation-1",
+        pending_upload_protection_intent_id="intent-1",
+        pending_upload_phase=UploadJournalPhase.FINALIZING,
+        pending_upload_expires_at=now + timedelta(minutes=15),
     )
 
     save_state(store_id, state, memory_dir=tmp_path / "memory", state_dir=tmp_path)
@@ -440,6 +447,33 @@ def test_cloud_status_derives_paused_when_upload_entitlement_ends(tmp_path):
     )
 
     assert payload["protection_state"] == ProtectionState.PAUSED.value
+
+
+def test_cloud_status_reports_uploaded_snapshot_awaiting_verification(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.VERIFICATION_PENDING,
+            last_successful_backup_snapshot_id="snapshot-new",
+            last_verified_snapshot_id="snapshot-old",
+            last_verify_ok=True,
+        ),
+        memory_dir=memory_dir,
+        state_dir=tmp_path / "state",
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=True),
+        entitlement="active",
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["protection_state"] == ProtectionState.VERIFICATION_PENDING.value
+    assert not any("changes pending" in item.lower() for item in payload["warnings"])
 
 
 def test_cloud_status_requires_sign_in_after_logout_of_protected_store(tmp_path):

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -21,6 +21,7 @@ from ormah.cloud.state import (
     ProtectionState,
     UploadJournalPhase,
     cloud_status_payload,
+    is_protected_and_verified,
     load_state,
     save_state,
     state_path,
@@ -64,6 +65,23 @@ def test_state_round_trip_is_atomic_and_owner_only(tmp_path):
     assert load_state(store_id, state_dir=tmp_path) == state
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
     assert not list(tmp_path.glob("*.tmp"))
+
+
+def test_reserved_upload_does_not_hide_last_verified_protection():
+    values = {
+        "last_successful_backup_snapshot_id": "01J00000000000000000000000",
+        "last_verified_snapshot_id": "01J00000000000000000000000",
+        "last_verify_ok": True,
+    }
+
+    assert is_protected_and_verified(
+        CloudState(**values, pending_upload_phase=UploadJournalPhase.RESERVED),
+        enabled=True,
+    )
+    assert not is_protected_and_verified(
+        CloudState(**values, pending_upload_phase=UploadJournalPhase.FINALIZING),
+        enabled=True,
+    )
 
 
 def test_update_preserves_unmodified_fields(tmp_path):

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -42,6 +42,9 @@ def test_state_round_trip_is_atomic_and_owner_only(tmp_path):
         protection_state=ProtectionState.ATTENTION_REQUIRED,
         pending_protection_intent_id="intent-1",
         pending_protection_status=ProtectionIntentStatus.RUNNING,
+        pending_protection_snapshot_id="snapshot-1",
+        pending_protection_created_store=True,
+        pending_protection_origin_state=ProtectionState.STOPPED,
         last_operation_id="operation-1",
         last_operation_kind=ProtectionOperationKind.VERIFY,
         last_operation_phase=ProtectionOperationPhase.FAILED,
@@ -261,6 +264,7 @@ def test_cloud_status_derives_stale_and_verification_warnings(tmp_path):
             last_verify_at=now - timedelta(days=1),
             last_verify_ok=False,
             last_verify_error="bundle truncated",
+            protection_state=ProtectionState.ATTENTION_REQUIRED,
         ),
         memory_dir=memory_dir,
         state_dir=tmp_path / "state",
@@ -281,7 +285,7 @@ def test_cloud_status_derives_stale_and_verification_warnings(tmp_path):
     assert payload["store_id"] == store_id
     assert payload["last_upload_age_seconds"] == 49 * 3600
     assert payload["entitlement"] == "expired"
-    assert "protection_state" not in payload
+    assert payload["protection_state"] == ProtectionState.ATTENTION_REQUIRED.value
     assert payload["state_error"] is None
     assert any("stale" in warning for warning in payload["warnings"])
     assert any("bundle truncated" in warning for warning in payload["warnings"])
@@ -304,9 +308,168 @@ def test_cloud_status_reports_corrupt_state_without_claiming_protection(tmp_path
     )
 
     assert payload["state_error"] is not None
-    assert "protection_state" not in payload
+    assert payload["protection_state"] == ProtectionState.ATTENTION_REQUIRED.value
     assert any("was not overwritten" in warning for warning in payload["warnings"])
     assert json.loads(path.read_text(encoding="utf-8"))["protection_state"] == "protected"
+
+
+def test_cloud_status_exposes_pollable_intent_without_account_binding(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    intent_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    now = datetime(2026, 7, 13, 12, 0, tzinfo=timezone.utc)
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.SUBSCRIPTION_REQUIRED,
+            pending_protection_intent_id=intent_id,
+            pending_protection_account_id=str(uuid.uuid4()),
+            pending_protection_store_id=store_id,
+            pending_protection_created_at=now,
+            pending_protection_expires_at=now + timedelta(minutes=30),
+            pending_protection_status=ProtectionIntentStatus.ACCOUNT_BOUND,
+            last_operation_id=intent_id,
+            last_operation_kind=ProtectionOperationKind.ENABLE,
+            last_operation_phase=ProtectionOperationPhase.PENDING,
+        ),
+        memory_dir=memory_dir,
+        state_dir=tmp_path / "state",
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir),
+        entitlement="expired",
+        now=now,
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["protection_state"] == ProtectionState.SUBSCRIPTION_REQUIRED.value
+    assert payload["protection_intent_id"] == intent_id
+    assert payload["protection_intent_status"] == ProtectionIntentStatus.ACCOUNT_BOUND.value
+    assert payload["last_operation_id"] == intent_id
+    serialized = json.dumps(payload)
+    assert "pending_protection_account_id" not in serialized
+
+
+def test_cloud_status_never_reports_protected_when_invariant_is_incomplete(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    intent_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.PROTECTED,
+            pending_protection_intent_id=intent_id,
+            pending_protection_status=ProtectionIntentStatus.COMPLETED,
+            last_successful_backup_snapshot_id="snapshot-a",
+            last_verified_snapshot_id="snapshot-b",
+            last_verify_ok=True,
+        ),
+        memory_dir=memory_dir,
+        state_dir=tmp_path / "state",
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=True),
+        entitlement="active",
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["protection_state"] == ProtectionState.ATTENTION_REQUIRED.value
+    assert any("verification must finish" in item for item in payload["warnings"])
+
+
+def test_cloud_status_fails_closed_for_future_protection_state(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    path = state_path(store_id, state_dir=tmp_path / "state")
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": CURRENT_CLOUD_STATE_SCHEMA_VERSION + 1,
+                "protection_state": "future_protected",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=True),
+        entitlement="active",
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["protection_state"] == ProtectionState.ATTENTION_REQUIRED.value
+    assert any("newer Ormah version" in item for item in payload["warnings"])
+    assert json.loads(path.read_text(encoding="utf-8"))["protection_state"] == (
+        "future_protected"
+    )
+
+
+def test_cloud_status_derives_paused_when_upload_entitlement_ends(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    intent_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.PROTECTED,
+            pending_protection_intent_id=intent_id,
+            pending_protection_status=ProtectionIntentStatus.COMPLETED,
+            last_successful_backup_snapshot_id="snapshot-a",
+            last_verified_snapshot_id="snapshot-a",
+            last_verify_ok=True,
+        ),
+        memory_dir=memory_dir,
+        state_dir=tmp_path / "state",
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=True),
+        entitlement="expired",
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["protection_state"] == ProtectionState.PAUSED.value
+
+
+def test_cloud_status_requires_sign_in_after_logout_of_protected_store(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.PROTECTED,
+            last_successful_backup_snapshot_id="snapshot-a",
+            last_verified_snapshot_id="snapshot-a",
+            last_verify_ok=True,
+        ),
+        memory_dir=memory_dir,
+        state_dir=tmp_path / "state",
+    )
+
+    payload = cloud_status_payload(
+        Settings(
+            memory_dir=memory_dir,
+            cloud_backup_enabled=True,
+            account_token=None,
+        ),
+        entitlement="none",
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["protection_state"] == ProtectionState.SIGN_IN_REQUIRED.value
 
 
 def test_cloud_state_json_contains_only_plain_metadata(tmp_path):


### PR DESCRIPTION
## Problem

E02-E05 can upload and verify encrypted backups, but paid protection still lacks one explicit, durable product operation. Login or payment must never silently enable uploads, and Ormah must never claim a memory is protected before the exact first recovery point has passed full restore verification.

## Solution

- add durable create/bind/cancel/enable/disable protection-intent transitions to `CloudProtectionService`
- bind intents only from fresh authenticated `/me/entitlements` account metadata
- persist a stable operation ID and every externally visible upload/verify phase
- initialize/validate keys and enforce the one-primary-store recovery-kit contract
- run the first encrypted upload immediately, without advancing the sync head, then verify that exact intent-specific snapshot
- make ambiguous finalize outcomes fail closed pending C02 startup reconciliation instead of creating duplicate committed blobs
- preserve remote history, keys, kit, account, subscription, and restore access when protection is stopped
- serialize `.env` read-modify-writes across account, protection, and admin backup settings
- publish token-free intent/operation status and enforce the shared `Protected and verified` invariant
- derive truthful paused, offline, sign-in-required, and client-update states

## Safety properties

- payment, login, an upload, or verification of an older snapshot cannot independently produce `protected`
- a new intent cannot reuse a historical verified snapshot after local changes
- unknown finalize status blocks automatic retry until reconciliation
- a second memory store cannot overwrite the canonical recovery kit
- invalid/stale intents and future/corrupt state fail closed without overwriting current health
- stopping protection never deletes recovery material or retained recovery points

## Verification

- `1696 passed, 1 deselected`
- `ruff check src/ tests/`
- `git diff --check`
- independent review completed twice; all findings resolved

## Follow-up scope

C02 startup reconciliation, remaining local API/CLI adapters, recovery-point selection, resource-envelope measurement, and the C06 desktop flow remain separate planned slices.