### PR TITLE
feat(desktop): add paid cloud protection flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,34 @@ jobs:
       - name: Ruff
         run: uv run ruff check src/ tests/
 
+  desktop:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux desktop dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libayatana-appindicator3-dev librsvg2-dev
+      - name: Test and build product UI
+        working-directory: ui
+        run: |
+          npm ci
+          npm test
+          npm run build
+      - name: Test and check native desktop bridge
+        working-directory: desktop/src-tauri
+        run: |
+          cargo test --locked
+          cargo check --locked
+
   # Eval gating is deliberately NOT in CI yet: the corpora are local-only
   # (real data, gitignored) and still growing, so fail-below bars would be
   # noise. Run `make eval` locally. Promote to CI once the corpus stabilises

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,9 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: ui/package-lock.json
+          cache-dependency-path: |
+            ui/package-lock.json
+            desktop/ui/package-lock.json
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Linux desktop dependencies
         run: |
@@ -86,6 +88,18 @@ jobs:
           npm ci
           npm test
           npm run build
+      - name: Build desktop bootstrap UI
+        working-directory: desktop/ui
+        run: npm ci && npm run build
+      - name: Download uv sidecar
+        run: |
+          curl -fsSL \
+            https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /tmp
+          mkdir -p desktop/src-tauri/binaries
+          cp /tmp/uv-x86_64-unknown-linux-gnu/uv \
+            desktop/src-tauri/binaries/uv-x86_64-unknown-linux-gnu
+          chmod +x desktop/src-tauri/binaries/uv-x86_64-unknown-linux-gnu
       - name: Test and check native desktop bridge
         working-directory: desktop/src-tauri
         run: |

--- a/README.md
+++ b/README.md
@@ -143,8 +143,13 @@ gate local backups or cloud downloads.
 ### Cloud Backup (Paid)
 
 Ormah can encrypt local memory backups on your machine and upload only the
-ciphertext to Ormah Cloud. Sign in, initialize the store key, and enable the
-scheduled uploader:
+ciphertext to Ormah Cloud. In Ormah Desktop, open **Protection** and select
+**Protect this memory**. The app guides email-code sign-in, opens Stripe
+Checkout in the system browser when a subscription is needed, then immediately
+creates an encrypted backup and proves it restorable in scratch space. It does
+not report the memory as protected until that exact snapshot passes verification.
+
+The equivalent CLI setup remains available:
 
 ```bash
 ormah account login

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2524,6 +2524,8 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,8 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 tokio = { version = "1", features = ["time", "rt", "macros"] }
 once_cell = "1"
 semver = "1"
+url = "2"
+uuid = { version = "1", features = ["v4"] }
 
 # Single-instance guard: macOS uses this plugin (Unix socket). On Linux the
 # plugin relies on claiming a D-Bus name, which fails silently and lets

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -19,5 +19,8 @@ fn main() {
     println!("cargo:rustc-env=ORMAH_PY_VERSION={version}");
     println!("cargo:rerun-if-changed={}", pyproject.display());
 
-    tauri_build::build()
+    tauri_build::try_build(
+        tauri_build::Attributes::new().app_manifest(tauri_build::AppManifest::new()),
+    )
+    .expect("failed to build Tauri context")
 }

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -19,8 +19,5 @@ fn main() {
     println!("cargo:rustc-env=ORMAH_PY_VERSION={version}");
     println!("cargo:rerun-if-changed={}", pyproject.display());
 
-    tauri_build::try_build(
-        tauri_build::Attributes::new().app_manifest(tauri_build::AppManifest::new()),
-    )
-    .expect("failed to build Tauri context")
+    tauri_build::build()
 }

--- a/desktop/src-tauri/capabilities/default.json
+++ b/desktop/src-tauri/capabilities/default.json
@@ -20,6 +20,7 @@
     },
     "autostart:default",
     "updater:default",
-    "notification:default"
+    "notification:default",
+    "desktop-bootstrap"
   ]
 }

--- a/desktop/src-tauri/capabilities/graph.json
+++ b/desktop/src-tauri/capabilities/graph.json
@@ -3,6 +3,7 @@
   "identifier": "graph-window-controls",
   "description": "Lets the graph page (served from localhost) drive the custom window title bar.",
   "windows": ["main"],
+  "local": false,
   "remote": {
     "urls": ["http://localhost:*", "http://127.0.0.1:*"]
   },
@@ -10,6 +11,7 @@
     "core:window:allow-minimize",
     "core:window:allow-close",
     "core:window:allow-toggle-maximize",
-    "core:window:allow-start-dragging"
+    "core:window:allow-start-dragging",
+    "desktop-product-bridge"
   ]
 }

--- a/desktop/src-tauri/permissions/desktop.toml
+++ b/desktop/src-tauri/permissions/desktop.toml
@@ -1,0 +1,39 @@
+[[permission]]
+identifier = "desktop-bootstrap"
+description = "Allows the bundled bootstrap UI to manage the local runtime and onboarding."
+commands.allow = [
+  "setup_agents",
+  "fetch_stats",
+  "detect_agents",
+  "open_graph_cmd",
+  "graph_url",
+  "mark_onboarded",
+  "is_onboarded",
+  "start_server",
+  "stop_server",
+  "server_status",
+  "desktop_bridge_info",
+]
+
+[[permission]]
+identifier = "desktop-product-bridge"
+description = "Allows the local Ormah product UI to invoke the narrow account and protection bridge."
+commands.allow = [
+  "desktop_bridge_info",
+  "account_status",
+  "request_account_code",
+  "verify_account_code",
+  "logout_account",
+  "billing_offer",
+  "protection_status",
+  "create_protection_intent",
+  "bind_protection_intent",
+  "cancel_protection_intent",
+  "enable_protection",
+  "disable_protection",
+  "backup_now",
+  "verify_now",
+  "operation_status",
+  "open_checkout",
+  "open_billing_portal",
+]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@
 //! No global hotkey, no native graph, no settings beyond start-at-login.
 
 mod commands;
+mod product_bridge;
 mod sidecar;
 mod stats;
 mod tray;
@@ -166,6 +167,23 @@ pub fn run() {
             commands::start_server,
             commands::stop_server,
             commands::server_status,
+            product_bridge::desktop_bridge_info,
+            product_bridge::account_status,
+            product_bridge::request_account_code,
+            product_bridge::verify_account_code,
+            product_bridge::logout_account,
+            product_bridge::billing_offer,
+            product_bridge::protection_status,
+            product_bridge::create_protection_intent,
+            product_bridge::bind_protection_intent,
+            product_bridge::cancel_protection_intent,
+            product_bridge::enable_protection,
+            product_bridge::disable_protection,
+            product_bridge::backup_now,
+            product_bridge::verify_now,
+            product_bridge::operation_status,
+            product_bridge::open_checkout,
+            product_bridge::open_billing_portal,
         ])
         .setup(|app| {
             // Linux: refuse to start a second instance so we never spawn a

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -17,7 +17,10 @@ use crate::commands::base_url;
 
 const BRIDGE_VERSION: u16 = 1;
 const LOCAL_ADMIN_HEADER: &str = "X-Ormah-Local-Token";
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+// Synchronous intent routes may wait for the canonical store lock for up to
+// 30 seconds. Keep the native request alive long enough to receive their
+// typed store_busy outcome instead of abandoning a request that may proceed.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(35);
 const MAX_HOSTED_URL_CHARS: usize = 2048;
 const CHECKOUT_HOST: &str = "checkout.stripe.com";
 const PORTAL_HOST: &str = "billing.stripe.com";

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -1,0 +1,681 @@
+//! Narrow desktop bridge for sensitive local account and protection operations.
+//!
+//! The product UI is served from the loopback Python service. It must not receive
+//! the owner-only local API capability, cloud bearer tokens, presigned URLs, or
+//! Stripe-hosted URLs. Each command below maps to one fixed local endpoint; there
+//! is deliberately no generic HTTP proxy.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tauri::{AppHandle, Runtime, WebviewWindow};
+use tauri_plugin_shell::ShellExt;
+use url::Url;
+
+use crate::commands::base_url;
+
+const BRIDGE_VERSION: u16 = 1;
+const LOCAL_ADMIN_HEADER: &str = "X-Ormah-Local-Token";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+const MAX_HOSTED_URL_CHARS: usize = 2048;
+const CHECKOUT_HOST: &str = "checkout.stripe.com";
+const PORTAL_HOST: &str = "billing.stripe.com";
+
+#[derive(Debug, Serialize)]
+pub struct DesktopBridgeInfo {
+    version: u16,
+    platform: &'static str,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AccountStatus {
+    signed_in: bool,
+    email: Option<String>,
+    device_name: Option<String>,
+    entitlement: Option<String>,
+    plan_status: Option<String>,
+    cache_age_seconds: Option<i64>,
+    entitlement_available: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RequestCodeResult {
+    status: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LogoutResult {
+    signed_in: bool,
+    revoked_remotely: bool,
+    warning: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BillingOffer {
+    name: String,
+    unit_amount: u64,
+    currency: String,
+    interval: String,
+    interval_count: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct CheckoutHandoff {
+    status: String,
+    url: Option<String>,
+    expires_at: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CheckoutResult {
+    status: String,
+    expires_at: Option<i64>,
+    opened: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct PortalHandoff {
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OpenedResult {
+    opened: bool,
+}
+
+#[tauri::command]
+pub fn desktop_bridge_info() -> DesktopBridgeInfo {
+    DesktopBridgeInfo {
+        version: BRIDGE_VERSION,
+        platform: std::env::consts::OS,
+    }
+}
+
+#[tauri::command]
+pub async fn account_status(window: WebviewWindow) -> Result<AccountStatus, String> {
+    require_product_origin(&window)?;
+    request_json("GET", "/admin/account/status", None).await
+}
+
+#[tauri::command]
+pub async fn request_account_code(
+    window: WebviewWindow,
+    email: String,
+) -> Result<RequestCodeResult, String> {
+    require_product_origin(&window)?;
+    let email = validate_email_input(&email)?;
+    request_json(
+        "POST",
+        "/admin/account/request-code",
+        Some(json!({ "email": email })),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn verify_account_code(
+    window: WebviewWindow,
+    email: String,
+    code: String,
+) -> Result<AccountStatus, String> {
+    require_product_origin(&window)?;
+    let email = validate_email_input(&email)?;
+    let code = validate_otp_input(&code)?;
+    request_json(
+        "POST",
+        "/admin/account/verify",
+        Some(json!({ "email": email, "code": code })),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn logout_account(window: WebviewWindow) -> Result<LogoutResult, String> {
+    require_product_origin(&window)?;
+    request_json("POST", "/admin/account/logout", Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn billing_offer(window: WebviewWindow) -> Result<BillingOffer, String> {
+    require_product_origin(&window)?;
+    request_json("GET", "/admin/account/offer", None).await
+}
+
+#[tauri::command]
+pub async fn protection_status(window: WebviewWindow) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    request_sanitized("GET", "/admin/cloud/protection", None).await
+}
+
+#[tauri::command]
+pub async fn create_protection_intent(window: WebviewWindow) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    request_sanitized("POST", "/admin/cloud/protection/intents", Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn bind_protection_intent(
+    window: WebviewWindow,
+    intent_id: String,
+) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    let intent_id = validate_uuid4(&intent_id, "protection intent")?;
+    let path = format!("/admin/cloud/protection/intents/{intent_id}/bind");
+    request_sanitized("POST", &path, Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn cancel_protection_intent(
+    window: WebviewWindow,
+    intent_id: String,
+) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    let intent_id = validate_uuid4(&intent_id, "protection intent")?;
+    let path = format!("/admin/cloud/protection/intents/{intent_id}/cancel");
+    request_sanitized("POST", &path, Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn enable_protection(window: WebviewWindow, intent_id: String) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    let intent_id = validate_uuid4(&intent_id, "protection intent")?;
+    let path = format!("/admin/cloud/protection/intents/{intent_id}/enable");
+    request_sanitized("POST", &path, Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn disable_protection(window: WebviewWindow) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    request_sanitized("POST", "/admin/cloud/protection/disable", Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn backup_now(window: WebviewWindow) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    request_sanitized("POST", "/admin/cloud/protection/backup", Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn verify_now(window: WebviewWindow) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    request_sanitized("POST", "/admin/cloud/protection/verify", Some(json!({}))).await
+}
+
+#[tauri::command]
+pub async fn operation_status(
+    window: WebviewWindow,
+    operation_id: String,
+) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    let operation_id = validate_uuid4(&operation_id, "operation")?;
+    let path = format!("/admin/cloud/protection/operations/{operation_id}");
+    request_sanitized("GET", &path, None).await
+}
+
+#[tauri::command]
+pub async fn open_checkout<R: Runtime>(
+    app: AppHandle<R>,
+    window: WebviewWindow<R>,
+    intent_id: String,
+) -> Result<CheckoutResult, String> {
+    require_product_origin(&window)?;
+    let intent_id = validate_uuid4(&intent_id, "protection intent")?;
+    let handoff: CheckoutHandoff = request_json(
+        "POST",
+        "/admin/account/checkout",
+        Some(json!({ "protection_intent_id": intent_id })),
+    )
+    .await?;
+
+    let hosted_url = validated_checkout_handoff(&handoff)?;
+    let opened = if let Some(hosted_url) = hosted_url {
+        open_external(&app, hosted_url.as_str())?;
+        true
+    } else {
+        false
+    };
+
+    Ok(CheckoutResult {
+        status: handoff.status,
+        expires_at: handoff.expires_at,
+        opened,
+    })
+}
+
+fn validated_checkout_handoff(handoff: &CheckoutHandoff) -> Result<Option<Url>, String> {
+    match handoff.status.as_str() {
+        "checkout_required" => {
+            if handoff.expires_at.is_none() {
+                return Err("Ormah Cloud returned an incomplete Checkout handoff.".to_string());
+            }
+            let raw_url = handoff.url.as_deref().ok_or_else(|| {
+                "Ormah Cloud returned an incomplete Checkout handoff.".to_string()
+            })?;
+            validate_hosted_url(raw_url, CHECKOUT_HOST).map(Some)
+        }
+        "already_subscribed" | "subscription_pending" => {
+            if handoff.url.is_some() || handoff.expires_at.is_some() {
+                return Err("Ormah Cloud returned an unexpected Checkout handoff.".to_string());
+            }
+            Ok(None)
+        }
+        _ => Err("Ormah Cloud returned an invalid Checkout handoff.".to_string()),
+    }
+}
+
+#[tauri::command]
+pub async fn open_billing_portal<R: Runtime>(
+    app: AppHandle<R>,
+    window: WebviewWindow<R>,
+) -> Result<OpenedResult, String> {
+    require_product_origin(&window)?;
+    let handoff: PortalHandoff =
+        request_json("POST", "/admin/account/portal", Some(json!({}))).await?;
+    let hosted_url = validate_hosted_url(&handoff.url, PORTAL_HOST)?;
+    open_external(&app, hosted_url.as_str())?;
+    Ok(OpenedResult { opened: true })
+}
+
+fn open_external<R: Runtime>(app: &AppHandle<R>, url: &str) -> Result<(), String> {
+    // This Rust-side API is not exposed to the frontend. The remote graph
+    // capability intentionally has no generic `shell:allow-open` permission.
+    #[allow(deprecated)]
+    app.shell()
+        .open(url, None)
+        .map_err(|_| "Could not open the system browser.".to_string())
+}
+
+fn require_product_origin<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
+    if window.label() != "main" {
+        return Err("Desktop product commands are unavailable in this window.".to_string());
+    }
+    let current = window
+        .url()
+        .map_err(|_| "Could not verify the desktop product origin.".to_string())?;
+    validate_product_origin(&current, &base_url())
+}
+
+fn validate_product_origin(current: &Url, expected_base: &str) -> Result<(), String> {
+    let expected = Url::parse(expected_base)
+        .map_err(|_| "The local Ormah service address is invalid.".to_string())?;
+    let matches = current.scheme() == "http"
+        && current.username().is_empty()
+        && current.password().is_none()
+        && current.host_str() == expected.host_str()
+        && current.port_or_known_default() == expected.port_or_known_default();
+    if !matches {
+        return Err("Desktop product commands require the local Ormah UI.".to_string());
+    }
+    Ok(())
+}
+
+async fn request_sanitized(method: &str, path: &str, body: Option<Value>) -> Result<Value, String> {
+    let value: Value = request_json(method, path, body).await?;
+    reject_forbidden_response_fields(&value)?;
+    Ok(value)
+}
+
+async fn request_json<T: for<'de> Deserialize<'de>>(
+    method: &str,
+    path: &str,
+    body: Option<Value>,
+) -> Result<T, String> {
+    let token = load_local_admin_token(&local_admin_token_path()?)?;
+    let url = format!("{}{path}", base_url());
+    let client = reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|_| "Could not initialize the local Ormah connection.".to_string())?;
+    let mut request = match method {
+        "GET" => client.get(url),
+        "POST" => client.post(url),
+        _ => return Err("Unsupported local operation.".to_string()),
+    }
+    .header(LOCAL_ADMIN_HEADER, token);
+    if let Some(body) = body {
+        request = request.json(&body);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|_| "Could not reach the local Ormah service.".to_string())?;
+    if !response.status().is_success() {
+        let message = match response.status().as_u16() {
+            401 if path == "/admin/account/verify" => {
+                "That code is wrong, expired, or already used."
+            }
+            401 => "Sign in to Ormah before continuing.",
+            403 => "This local Ormah operation is not allowed.",
+            404 => "This Ormah Desktop feature requires a newer Ormah runtime.",
+            409 => "The protection state changed; refresh and try again.",
+            429 => "Too many requests; wait briefly and try again.",
+            _ => "The local Ormah operation could not be completed.",
+        };
+        return Err(message.to_string());
+    }
+    response
+        .json::<T>()
+        .await
+        .map_err(|_| "The local Ormah service returned an invalid response.".to_string())
+}
+
+fn local_admin_token_path() -> Result<PathBuf, String> {
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "The local Ormah capability is unavailable.".to_string())?;
+    Ok(home.join(".local/share/ormah/local_api_token"))
+}
+
+fn load_local_admin_token(path: &Path) -> Result<String, String> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|_| "The local Ormah capability is unavailable.".to_string())?;
+    if metadata.file_type().is_symlink() || !metadata.file_type().is_file() {
+        return Err("The local Ormah capability is unavailable.".to_string());
+    }
+    if metadata.len() > 128 {
+        return Err("The local Ormah capability is invalid.".to_string());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o777 != 0o600 {
+            return Err("The local Ormah capability is not secured.".to_string());
+        }
+    }
+    let token = std::fs::read_to_string(path)
+        .map_err(|_| "The local Ormah capability is unavailable.".to_string())?;
+    let token = token.trim();
+    if token.len() != 64
+        || !token
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("The local Ormah capability is invalid.".to_string());
+    }
+    Ok(token.to_owned())
+}
+
+fn validate_hosted_url(raw: &str, expected_host: &str) -> Result<Url, String> {
+    if raw.len() > MAX_HOSTED_URL_CHARS {
+        return Err("Ormah Cloud returned an invalid hosted billing URL.".to_string());
+    }
+    // `url::Url` normalizes an explicit `:443` away. Check the raw authority
+    // first so userinfo and every explicit port remain rejected.
+    let authority = raw
+        .strip_prefix("https://")
+        .and_then(|rest| rest.split(['/', '?', '#']).next());
+    if authority != Some(expected_host) {
+        return Err("Ormah Cloud returned an invalid hosted billing URL.".to_string());
+    }
+    let url = Url::parse(raw)
+        .map_err(|_| "Ormah Cloud returned an invalid hosted billing URL.".to_string())?;
+    if url.scheme() != "https"
+        || url.host_str() != Some(expected_host)
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.port().is_some()
+    {
+        return Err("Ormah Cloud returned an invalid hosted billing URL.".to_string());
+    }
+    Ok(url)
+}
+
+fn validate_email_input(value: &str) -> Result<&str, String> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 254 || value.contains(['\r', '\n']) {
+        return Err("Enter a valid email address.".to_string());
+    }
+    Ok(value)
+}
+
+fn validate_otp_input(value: &str) -> Result<&str, String> {
+    let value = value.trim();
+    if value.len() != 6 || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err("Enter the six-digit code from your email.".to_string());
+    }
+    Ok(value)
+}
+
+fn validate_uuid4(value: &str, label: &str) -> Result<String, String> {
+    let parsed = uuid::Uuid::parse_str(value).map_err(|_| format!("Invalid {label} ID."))?;
+    if parsed.get_version_num() != 4 || parsed.to_string() != value {
+        return Err(format!("Invalid {label} ID."));
+    }
+    Ok(value.to_owned())
+}
+
+fn reject_forbidden_response_fields(value: &Value) -> Result<(), String> {
+    const FORBIDDEN: &[&str] = &[
+        "token",
+        "accounttoken",
+        "accountid",
+        "accesstoken",
+        "puturl",
+        "geturl",
+        "presignedurl",
+        "url",
+        "key",
+        "privatekey",
+        "remotekey",
+        "path",
+        "filepath",
+        "identity",
+        "identities",
+        "recoverykit",
+    ];
+    match value {
+        Value::Object(values) => {
+            for (key, nested) in values {
+                let normalized = key
+                    .chars()
+                    .filter(|character| character.is_ascii_alphanumeric())
+                    .flat_map(char::to_lowercase)
+                    .collect::<String>();
+                if FORBIDDEN.contains(&normalized.as_str()) {
+                    return Err("The local Ormah service returned forbidden data.".to_string());
+                }
+                reject_forbidden_response_fields(nested)?;
+            }
+        }
+        Value::Array(values) => {
+            for nested in values {
+                reject_forbidden_response_fields(nested)?;
+            }
+        }
+        Value::String(value) => {
+            let lower = value.to_ascii_lowercase();
+            if lower.contains("age-secret-key-")
+                || lower.contains("bearer ")
+                || lower.contains("x-amz-signature=")
+                || lower.contains("x-amz-credential=")
+                || lower.contains("x-amz-security-token=")
+            {
+                return Err("The local Ormah service returned forbidden data.".to_string());
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn product_origin_requires_exact_loopback_host_and_port() {
+        let expected = "http://127.0.0.1:8787";
+        assert!(validate_product_origin(
+            &Url::parse("http://127.0.0.1:8787/graph?x=1").unwrap(),
+            expected
+        )
+        .is_ok());
+        for raw in [
+            "http://localhost:8787/",
+            "http://127.0.0.1:8788/",
+            "https://127.0.0.1:8787/",
+            "http://127.0.0.1.evil.example:8787/",
+            "http://user@127.0.0.1:8787/",
+        ] {
+            assert!(validate_product_origin(&Url::parse(raw).unwrap(), expected).is_err());
+        }
+    }
+
+    #[test]
+    fn hosted_urls_require_exact_stripe_origin() {
+        assert!(validate_hosted_url(
+            "https://checkout.stripe.com/c/pay/cs_test_123?x=1",
+            CHECKOUT_HOST
+        )
+        .is_ok());
+        for raw in [
+            "http://checkout.stripe.com/c/pay/x",
+            "https://checkout.stripe.com.evil.example/c/pay/x",
+            "https://evil-checkout.stripe.com/c/pay/x",
+            "https://user@checkout.stripe.com/c/pay/x",
+            "https://checkout.stripe.com:443/c/pay/x",
+            "javascript:alert(1)",
+        ] {
+            assert!(validate_hosted_url(raw, CHECKOUT_HOST).is_err(), "{raw}");
+        }
+        assert!(
+            validate_hosted_url("https://billing.stripe.com/p/session-123", PORTAL_HOST).is_ok()
+        );
+    }
+
+    #[test]
+    fn hosted_url_length_is_bounded() {
+        let raw = format!(
+            "https://checkout.stripe.com/{}",
+            "a".repeat(MAX_HOSTED_URL_CHARS)
+        );
+        assert!(validate_hosted_url(&raw, CHECKOUT_HOST).is_err());
+    }
+
+    #[test]
+    fn checkout_handoff_is_purpose_bound() {
+        let required = CheckoutHandoff {
+            status: "checkout_required".to_string(),
+            url: Some("https://checkout.stripe.com/c/pay/cs_test_123".to_string()),
+            expires_at: Some(4_000_000_000),
+        };
+        assert!(validated_checkout_handoff(&required).unwrap().is_some());
+
+        let subscribed = CheckoutHandoff {
+            status: "already_subscribed".to_string(),
+            url: None,
+            expires_at: None,
+        };
+        assert!(validated_checkout_handoff(&subscribed).unwrap().is_none());
+
+        for invalid in [
+            CheckoutHandoff {
+                status: "checkout_required".to_string(),
+                url: None,
+                expires_at: Some(4_000_000_000),
+            },
+            CheckoutHandoff {
+                status: "already_subscribed".to_string(),
+                url: Some("https://checkout.stripe.com/c/pay/x".to_string()),
+                expires_at: None,
+            },
+            CheckoutHandoff {
+                status: "future_status".to_string(),
+                url: None,
+                expires_at: None,
+            },
+        ] {
+            assert!(validated_checkout_handoff(&invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn local_capability_is_validated_without_returning_file_details() {
+        let root = std::env::temp_dir().join(format!("ormah-bridge-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("capability");
+        fs::write(&path, format!("{}\n", "a".repeat(64))).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        assert_eq!(load_local_admin_token(&path).unwrap(), "a".repeat(64));
+
+        fs::write(&path, format!("{}\n", "A".repeat(64))).unwrap();
+        assert!(load_local_admin_token(&path).is_err());
+        fs::write(&path, "not-a-capability\n").unwrap();
+        assert_eq!(
+            load_local_admin_token(&path).unwrap_err(),
+            "The local Ormah capability is invalid."
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_capability_rejects_broad_permissions_and_symlinks() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let root = std::env::temp_dir().join(format!("ormah-bridge-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("capability");
+        fs::write(&path, "a".repeat(64)).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(load_local_admin_token(&path).is_err());
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        let link = root.join("link");
+        symlink(&path, &link).unwrap();
+        assert!(load_local_admin_token(&link).is_err());
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn identifiers_and_otp_are_canonical() {
+        let id = uuid::Uuid::new_v4().to_string();
+        assert_eq!(validate_uuid4(&id, "operation").unwrap(), id);
+        assert!(validate_uuid4(&id.to_ascii_uppercase(), "operation").is_err());
+        assert!(validate_uuid4(&uuid::Uuid::new_v4().simple().to_string(), "operation").is_err());
+        assert!(validate_otp_input("123456").is_ok());
+        assert!(validate_otp_input("12345x").is_err());
+    }
+
+    #[test]
+    fn protection_payload_rejects_secret_bearing_fields() {
+        assert!(reject_forbidden_response_fields(&json!({
+            "state": "protected",
+            "operation": { "id": "safe" }
+        }))
+        .is_ok());
+        for key in [
+            "token",
+            "accountToken",
+            "account_id",
+            "put_url",
+            "remote_key",
+            "path",
+            "recovery-kit",
+            "identity",
+        ] {
+            let mut nested = serde_json::Map::new();
+            nested.insert(key.to_string(), Value::String("secret".to_string()));
+            assert!(reject_forbidden_response_fields(&Value::Object(nested)).is_err());
+        }
+        for value in [
+            "Bearer opaque-cloud-token",
+            "AGE-SECRET-KEY-1EXAMPLE",
+            "https://r2.example/object?X-Amz-Signature=secret",
+            "https://r2.example/object?X-Amz-Credential=secret",
+            "https://r2.example/object?X-Amz-Security-Token=secret",
+        ] {
+            assert!(reject_forbidden_response_fields(&json!({
+                "message": value
+            }))
+            .is_err());
+        }
+    }
+}

--- a/docs/local-admin-auth.md
+++ b/docs/local-admin-auth.md
@@ -5,11 +5,24 @@ Sensitive desktop-only routes require an installation-local capability in the
 `~/.local/share/ormah/local_api_token` with mode `0600`. It is independent of the Ormah Cloud
 account token.
 
-The desktop integration must keep this boundary native: Tauri reads the owner-only capability and
-adds the header to requests it makes to the local Python server. React asks a narrow Tauri command
-to perform the request; React never receives either the local capability or
-`ORMAH_ACCOUNT_TOKEN`. Browser-only callers cannot use these billing routes.
+The desktop integration keeps this boundary native: Tauri reads the owner-only capability and adds
+the header to requests it makes to the local Python server. React asks a narrow Tauri command to
+perform a fixed account, billing, or protection operation; there is deliberately no generic HTTP
+proxy. React never receives the local capability, `ORMAH_ACCOUNT_TOKEN`, a presigned object-store
+URL, an age identity, recovery-kit material, or a Stripe-hosted URL. Browser-only callers cannot
+use these routes.
 
-`POST /admin/account/portal` requires an explicit empty JSON object (`{}`). The body carries no
-customer or redirect input; requiring JSON ensures browser requests are preflighted before the
-owner-only capability is checked.
+The remote graph WebView receives only the `desktop-product-bridge` capability. Every bridge command
+also verifies that it was invoked by the `main` window at the configured
+`http://127.0.0.1:<port>` origin. Checkout and Customer Portal handoffs are exact-host validated and
+opened by Rust in the system browser; the URL is not returned to React. Account responses use typed
+DTOs, while protection responses pass a recursive forbidden-field and secret-pattern check.
+
+Long backup and verification calls are submitted to a bounded Python coordinator and return `202`
+with a process-local polling ID. Durable truth remains in the per-store cloud state. If the Python
+process restarts during initial protection, startup finds a durable `running` intent and retries it
+through the existing upload journal and exact-snapshot verification path.
+
+Mutation routes with no product input require an explicit empty JSON object (`{}`). The body carries
+no token, customer, price, redirect, or object-store input; requiring JSON ensures browser requests
+are preflighted before the owner-only capability is checked.

--- a/src/ormah/api/routes_account.py
+++ b/src/ormah/api/routes_account.py
@@ -1,10 +1,8 @@
-"""Local admin routes for account-linked hosted billing handoffs.
+"""Owner-only local account authentication and hosted billing handoffs.
 
-Handlers here are thin wrappers over ``ormah.cloud.billing``: they authenticate
-the local request against the signed-in account, validate input, delegate, and
-translate stable billing reason codes into HTTP status codes. No remote request
-is constructed in this module, and each route only creates a short-lived hosted
-handoff — never a backup or verification run.
+Handlers are thin wrappers over ``ormah.cloud.account`` and ``ormah.cloud.billing``.
+They validate local input, delegate, and translate stable application errors.
+No remote request is constructed here, and no response includes an account token.
 """
 
 from __future__ import annotations
@@ -13,6 +11,16 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, field_validator
 
 from ormah.api.local_auth import require_local_admin
+from ormah.cloud.account import (
+    AccountError,
+    AccountErrorCode,
+    get_account_status,
+    logout_account,
+    normalize_email,
+    request_login_code,
+    validate_code,
+    verify_login_code,
+)
 from ormah.cloud.billing import (
     BillingError,
     BillingErrorCode,
@@ -40,6 +48,40 @@ _ERROR_STATUS: dict[BillingErrorCode, int] = {
     BillingErrorCode.STATE_UNAVAILABLE: 503,
 }
 
+_ACCOUNT_ERROR_STATUS: dict[AccountErrorCode, int] = {
+    AccountErrorCode.INVALID_REQUEST: 400,
+    AccountErrorCode.INVALID_CODE: 401,
+    AccountErrorCode.CLOUD_UNREACHABLE: 503,
+    AccountErrorCode.ACCOUNT_UNAVAILABLE: 502,
+    AccountErrorCode.STATE_UNAVAILABLE: 503,
+}
+
+
+class RequestCodeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    email: str
+
+    @field_validator("email")
+    @classmethod
+    def _email(cls, value: str) -> str:
+        try:
+            return normalize_email(value)
+        except AccountError as exc:
+            raise ValueError(str(exc)) from exc
+
+
+class VerifyCodeRequest(RequestCodeRequest):
+    code: str
+
+    @field_validator("code")
+    @classmethod
+    def _code(cls, value: str) -> str:
+        try:
+            return validate_code(value)
+        except AccountError as exc:
+            raise ValueError(str(exc)) from exc
+
 
 class CheckoutRequest(BaseModel):
     """The only accepted Checkout input: which protection intent to pay for."""
@@ -56,6 +98,12 @@ class CheckoutRequest(BaseModel):
 
 class PortalRequest(BaseModel):
     """Portal sessions take no client input: no customer, no return URL."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class LogoutRequest(BaseModel):
+    """Logout accepts no token or device identity from the caller."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -84,6 +132,54 @@ def _http_error(exc: BillingError) -> HTTPException:
         status_code=_ERROR_STATUS.get(exc.code, 502),
         detail={"error": exc.code.value, "message": str(exc)},
     )
+
+
+def _account_http_error(exc: AccountError) -> HTTPException:
+    return HTTPException(
+        status_code=_ACCOUNT_ERROR_STATUS.get(exc.code, 502),
+        detail={"error": exc.code.value, "message": str(exc)},
+    )
+
+
+@router.post("/request-code", status_code=202)
+def account_request_code(body: RequestCodeRequest, request: Request):
+    try:
+        result = request_login_code(
+            _settings(request), body.email, client=_cloud_client(request)
+        )
+    except AccountError as exc:
+        raise _account_http_error(exc) from exc
+    return result.to_payload()
+
+
+@router.post("/verify")
+def account_verify_code(body: VerifyCodeRequest, request: Request):
+    try:
+        status = verify_login_code(
+            _settings(request),
+            body.email,
+            body.code,
+            client=_cloud_client(request),
+        )
+    except AccountError as exc:
+        raise _account_http_error(exc) from exc
+    return status.to_payload()
+
+
+@router.get("/status")
+def account_status(request: Request):
+    return get_account_status(_settings(request)).to_payload()
+
+
+@router.post("/logout")
+def account_logout(body: LogoutRequest, request: Request):
+    try:
+        result = logout_account(
+            _settings(request), client=_cloud_client(request)
+        )
+    except AccountError as exc:
+        raise _account_http_error(exc) from exc
+    return result.to_payload()
 
 
 @router.get("/offer")

--- a/src/ormah/api/routes_protection.py
+++ b/src/ormah/api/routes_protection.py
@@ -1,0 +1,197 @@
+"""Authenticated local API adapters for cloud protection operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from ormah.api.local_auth import require_local_admin
+from ormah.cloud.billing import validate_protection_intent_id
+from ormah.cloud.entitlements import load_entitlement_cache, status_from_cache
+from ormah.cloud.operations import ProtectionOperationCoordinator
+from ormah.cloud.protection import CloudProtectionService
+from ormah.cloud.state import (
+    ProtectionOperation,
+    ProtectionOperationKind,
+    cloud_status_payload,
+)
+
+router = APIRouter(
+    prefix="/admin/cloud/protection",
+    tags=["cloud-protection"],
+    dependencies=[Depends(require_local_admin)],
+)
+
+
+class EmptyRequest(BaseModel):
+    """Explicit empty body that rejects accidental protocol inputs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VerifyRequest(BaseModel):
+    """Optional exact recovery point to verify."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_id: str | None = Field(
+        default=None,
+        pattern=r"^[0-7][0-9A-HJKMNP-TV-Z]{25}$",
+    )
+
+
+def _service(request: Request) -> CloudProtectionService:
+    injected = getattr(request.app.state, "protection_service", None)
+    return injected or CloudProtectionService.from_engine(request.app.state.engine)
+
+
+def _coordinator(request: Request) -> ProtectionOperationCoordinator:
+    coordinator = getattr(request.app.state, "protection_operations", None)
+    if not isinstance(coordinator, ProtectionOperationCoordinator):
+        raise HTTPException(status_code=503, detail="Protection operations are unavailable.")
+    return coordinator
+
+
+def _store_key(request: Request, operation: str) -> tuple[str, ...]:
+    memory_dir = Path(request.app.state.engine.settings.memory_dir).expanduser().resolve()
+    return str(memory_dir), operation
+
+
+def _intent_id(value: str) -> str:
+    try:
+        return validate_protection_intent_id(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="Invalid protection intent ID.") from exc
+
+
+def _operation_payload(operation: ProtectionOperation) -> dict[str, object]:
+    return {
+        "operation_id": operation.operation_id,
+        "kind": operation.kind.value,
+        "phase": operation.phase.value,
+        "protection_state": operation.state.value,
+        "reason_code": operation.reason_code.value if operation.reason_code else None,
+        "message": operation.message,
+        "snapshot_id": operation.snapshot_id,
+        "protection_intent_id": operation.protection_intent_id,
+    }
+
+
+def _cached_entitlement(settings) -> str:
+    """Classify local entitlement state without network access during polling."""
+    if not getattr(settings, "account_token", None):
+        return "none"
+    cache = load_entitlement_cache()
+    return status_from_cache(cache).value if cache is not None else "none"
+
+
+def _submit(
+    request: Request,
+    *,
+    operation: str,
+    kind: ProtectionOperationKind,
+    action,
+) -> dict[str, object]:
+    try:
+        record, deduplicated = _coordinator(request).submit(
+            key=_store_key(request, operation),
+            kind=kind,
+            action=action,
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail="Protection operations are unavailable.") from exc
+    payload = record.to_payload()
+    payload["deduplicated"] = deduplicated
+    return payload
+
+
+@router.get("")
+def protection_status(request: Request):
+    """Return durable, token-free protection state for this memory."""
+    settings = request.app.state.engine.settings
+    return cloud_status_payload(settings, entitlement=_cached_entitlement(settings))
+
+
+@router.post("/intents")
+def create_intent(body: EmptyRequest, request: Request):
+    """Record explicit upload consent and create or resume a protection intent."""
+    del body
+    return _operation_payload(_service(request).create_intent())
+
+
+@router.post("/intents/{intent_id}/bind")
+def bind_intent(intent_id: str, body: EmptyRequest, request: Request):
+    """Bind an existing protection intent to the currently authenticated account."""
+    del body
+    return _operation_payload(_service(request).bind_intent(_intent_id(intent_id)))
+
+
+@router.post("/intents/{intent_id}/cancel")
+def cancel_intent(intent_id: str, body: EmptyRequest, request: Request):
+    """Cancel a protection intent that has not crossed the upload boundary."""
+    del body
+    return _operation_payload(_service(request).cancel_intent(_intent_id(intent_id)))
+
+
+@router.post("/intents/{intent_id}/enable", status_code=status.HTTP_202_ACCEPTED)
+def enable_protection(intent_id: str, body: EmptyRequest, request: Request):
+    """Start immediate upload and verification without holding the request open."""
+    del body
+    intent_id = _intent_id(intent_id)
+    service = _service(request)
+    return _submit(
+        request,
+        operation=f"enable:{intent_id}",
+        kind=ProtectionOperationKind.ENABLE,
+        action=lambda: service.enable(intent_id),
+    )
+
+
+@router.post("/disable", status_code=status.HTTP_202_ACCEPTED)
+def disable_protection(body: EmptyRequest, request: Request):
+    """Stop future uploads while preserving retained recovery points."""
+    del body
+    service = _service(request)
+    return _submit(
+        request,
+        operation="disable",
+        kind=ProtectionOperationKind.DISABLE,
+        action=service.disable,
+    )
+
+
+@router.post("/backup", status_code=status.HTTP_202_ACCEPTED)
+def backup_now(body: EmptyRequest, request: Request):
+    """Start one user-requested encrypted backup."""
+    del body
+    service = _service(request)
+    return _submit(
+        request,
+        operation="backup",
+        kind=ProtectionOperationKind.BACKUP,
+        action=lambda: service.backup_now(reason="manual-ui"),
+    )
+
+
+@router.post("/verify", status_code=status.HTTP_202_ACCEPTED)
+def verify_now(body: VerifyRequest, request: Request):
+    """Start a full scratch restore verification for one recovery point."""
+    service = _service(request)
+    suffix = body.snapshot_id or "latest"
+    return _submit(
+        request,
+        operation=f"verify:{suffix}",
+        kind=ProtectionOperationKind.VERIFY,
+        action=lambda: service.verify_now(body.snapshot_id),
+    )
+
+
+@router.get("/operations/{operation_id}")
+def operation_status(operation_id: str, request: Request):
+    """Poll one process-local invocation; durable protection status is separate."""
+    record = _coordinator(request).get(operation_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail="Protection operation not found.")
+    return record.to_payload()

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -279,13 +279,11 @@ def _format_iso_time(value: str | None) -> str:
 
 
 def _cmd_account_login(args):
-    from ormah.cloud.client import (
-        CloudError,
-        get_device_name,
-        get_or_create_device_id,
-        persist_account_credentials,
+    from ormah.cloud.account import (
+        AccountError,
+        request_login_code,
+        verify_login_code,
     )
-    from ormah.cloud.entitlements import refresh_entitlements, status_from_cache
     from ormah.config import settings
     from ormah.console import info, ok, warn
 
@@ -296,18 +294,11 @@ def _cmd_account_login(args):
     client = None
     try:
         client = _cloud_client()
-        client.request_code(email)
+        request_login_code(settings, email, client=client)
         info(f"Sign-in code requested for {email}")
         code = (args.code or input("Sign-in code: ")).strip()
-        device_id = get_or_create_device_id()
-        device_name = get_device_name()
-        token = client.verify_code(email, code, device_id, device_name)
-        persist_account_credentials(token, email)
-        try:
-            cache = refresh_entitlements(settings, client=client)
-        except Exception:
-            cache = None
-    except (CloudError, OSError) as exc:
+        status = verify_login_code(settings, email, code, client=client)
+    except (AccountError, OSError) as exc:
         _print_account_error(str(exc))
     finally:
         close = getattr(client, "close", None) if client is not None else None
@@ -315,42 +306,32 @@ def _cmd_account_login(args):
             close()
 
     ok(f"Signed in as {email}")
-    if cache is None:
+    if not status.entitlement_available:
         warn("Entitlement status is unavailable while offline; it will refresh later.")
         return
-    print(f"Plan status: {cache.plan_status or 'unknown'}")
-    print(f"Cloud backup entitlement: {status_from_cache(cache).value}")
+    print(f"Plan status: {status.plan_status or 'unknown'}")
+    print(f"Cloud backup entitlement: {status.entitlement.value}")
 
 
 def _cmd_account_status(args):
-    from ormah.cloud.client import get_device_name
-    from ormah.cloud.entitlements import check_entitlement, load_entitlement_cache
+    from ormah.cloud.account import get_account_status
     from ormah.config import settings
 
-    state = check_entitlement(settings)
-    cache = load_entitlement_cache()
-    age_seconds = int(cache.age().total_seconds()) if cache is not None else None
-    result = {
-        "cache_age_seconds": age_seconds,
-        "device_name": get_device_name(),
-        "email": settings.account_email,
-        "entitlement": state.value,
-        "plan_status": cache.plan_status if cache is not None else None,
-    }
+    status = get_account_status(settings)
+    result = status.to_payload()
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
         return
 
-    print(f"Account: {settings.account_email or 'not signed in'}")
-    print(f"Entitlement: {state.value}")
+    print(f"Account: {status.email or 'not signed in'}")
+    print(f"Entitlement: {status.entitlement.value}")
     print(f"Plan status: {result['plan_status'] or 'unknown'}")
-    print(f"Cache age: {_format_cache_age(age_seconds)}")
+    print(f"Cache age: {_format_cache_age(status.cache_age_seconds)}")
     print(f"Device: {result['device_name']}")
 
 
 def _cmd_account_logout(args):
-    from ormah.cloud.client import remove_account_credentials
-    from ormah.cloud.entitlements import clear_entitlement_cache
+    from ormah.cloud.account import AccountError, logout_account
     from ormah.config import settings
     from ormah.console import info, ok, warn
 
@@ -362,20 +343,12 @@ def _cmd_account_logout(args):
             info("Logout cancelled")
             return
 
-    if settings.account_token:
-        client = None
-        try:
-            client = _cloud_client()
-            client.revoke_token()
-        except Exception as exc:
-            warn(f"Could not revoke the server token while offline: {exc}")
-        finally:
-            close = getattr(client, "close", None) if client is not None else None
-            if close:
-                close()
-
-    remove_account_credentials()
-    clear_entitlement_cache()
+    try:
+        result = logout_account(settings, client_factory=_cloud_client)
+    except AccountError as exc:
+        _print_account_error(str(exc))
+    if result.warning:
+        warn(result.warning)
     ok("Signed out locally")
 
 

--- a/src/ormah/cloud/account.py
+++ b/src/ormah/cloud/account.py
@@ -1,0 +1,287 @@
+"""Shared local account application service for CLI and desktop adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+import re
+from typing import Any
+
+from filelock import Timeout as FileLockTimeout
+
+from ormah.cloud.client import (
+    CloudClient,
+    CloudError,
+    client_from_settings,
+    get_device_name,
+    get_or_create_device_id,
+    persist_account_credentials,
+    remove_account_credentials,
+)
+from ormah.cloud.entitlements import (
+    EntitlementCache,
+    EntitlementStatus,
+    check_entitlement,
+    clear_entitlement_cache,
+    load_entitlement_cache,
+    refresh_entitlements,
+    status_from_cache,
+)
+
+
+_OTP_RE = re.compile(r"\d{6}")
+
+
+class AccountErrorCode(StrEnum):
+    """Stable failures shared by local account adapters."""
+
+    INVALID_REQUEST = "invalid_request"
+    INVALID_CODE = "invalid_or_expired_code"
+    CLOUD_UNREACHABLE = "cloud_unreachable"
+    ACCOUNT_UNAVAILABLE = "account_unavailable"
+    STATE_UNAVAILABLE = "state_unavailable"
+
+
+_ERROR_MESSAGES = {
+    AccountErrorCode.INVALID_REQUEST: "Enter a valid email address and six-digit code.",
+    AccountErrorCode.INVALID_CODE: "The sign-in code is invalid or expired.",
+    AccountErrorCode.CLOUD_UNREACHABLE: "Could not reach Ormah Cloud.",
+    AccountErrorCode.ACCOUNT_UNAVAILABLE: "Ormah Cloud account service is unavailable.",
+    AccountErrorCode.STATE_UNAVAILABLE: "Local account settings could not be updated.",
+}
+
+
+class AccountError(RuntimeError):
+    def __init__(self, code: AccountErrorCode) -> None:
+        super().__init__(_ERROR_MESSAGES[code])
+        self.code = code
+
+
+@dataclass(frozen=True)
+class CodeRequestResult:
+    status: str = "code_sent"
+
+    def to_payload(self) -> dict[str, str]:
+        return {"status": self.status}
+
+
+@dataclass(frozen=True)
+class AccountStatus:
+    signed_in: bool
+    email: str | None
+    device_name: str
+    entitlement: EntitlementStatus
+    plan_status: str | None
+    cache_age_seconds: int | None
+    entitlement_available: bool
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "signed_in": self.signed_in,
+            "email": self.email,
+            "device_name": self.device_name,
+            "entitlement": self.entitlement.value,
+            "plan_status": self.plan_status,
+            "cache_age_seconds": self.cache_age_seconds,
+            "entitlement_available": self.entitlement_available,
+        }
+
+
+@dataclass(frozen=True)
+class LogoutResult:
+    revoked_remotely: bool
+    warning: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "signed_in": False,
+            "revoked_remotely": self.revoked_remotely,
+            "warning": self.warning,
+        }
+
+
+def normalize_email(value: str) -> str:
+    email = value.strip().lower()
+    if (
+        not email
+        or len(email) > 320
+        or "@" not in email
+        or any(ord(char) < 0x20 or ord(char) == 0x7F for char in email)
+    ):
+        raise AccountError(AccountErrorCode.INVALID_REQUEST)
+    return email
+
+
+def validate_code(value: str) -> str:
+    code = value.strip()
+    if _OTP_RE.fullmatch(code) is None:
+        raise AccountError(AccountErrorCode.INVALID_REQUEST)
+    return code
+
+
+def _map_cloud_error(exc: CloudError, *, verifying: bool = False) -> AccountError:
+    if verifying and exc.status_code == 401:
+        return AccountError(AccountErrorCode.INVALID_CODE)
+    if exc.status_code in {400, 422}:
+        return AccountError(AccountErrorCode.INVALID_REQUEST)
+    if exc.status_code is None:
+        return AccountError(AccountErrorCode.CLOUD_UNREACHABLE)
+    return AccountError(AccountErrorCode.ACCOUNT_UNAVAILABLE)
+
+
+def _close_owned(client: CloudClient | None, owned: bool) -> None:
+    if owned and client is not None:
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+def request_login_code(
+    settings,
+    email: str,
+    *,
+    client: CloudClient | None = None,
+) -> CodeRequestResult:
+    """Request a generic email OTP without exposing account existence."""
+
+    email = normalize_email(email)
+    owned = client is None
+    try:
+        client = client or client_from_settings(settings)
+        client.request_code(email)
+    except CloudError as exc:
+        raise _map_cloud_error(exc) from exc
+    except (OSError, ValueError) as exc:
+        raise AccountError(AccountErrorCode.ACCOUNT_UNAVAILABLE) from exc
+    finally:
+        _close_owned(client, owned)
+    return CodeRequestResult()
+
+
+def _status_from_cache(settings, cache: EntitlementCache | None) -> AccountStatus:
+    signed_in = bool(
+        isinstance(getattr(settings, "account_token", None), str)
+        and settings.account_token.strip()
+    )
+    if not signed_in:
+        cache = None
+    entitlement = (
+        status_from_cache(cache)
+        if signed_in and cache is not None
+        else EntitlementStatus.NONE
+    )
+    return AccountStatus(
+        signed_in=signed_in,
+        email=getattr(settings, "account_email", None) if signed_in else None,
+        device_name=get_device_name(),
+        entitlement=entitlement,
+        plan_status=cache.plan_status if cache is not None else None,
+        cache_age_seconds=(
+            int(cache.age().total_seconds()) if cache is not None else None
+        ),
+        entitlement_available=cache is not None,
+    )
+
+
+def verify_login_code(
+    settings,
+    email: str,
+    code: str,
+    *,
+    client: CloudClient | None = None,
+) -> AccountStatus:
+    """Verify one OTP, persist the token privately, and update live settings."""
+
+    email = normalize_email(email)
+    code = validate_code(code)
+    owned = client is None
+    try:
+        client = client or client_from_settings(settings)
+        token = client.verify_code(
+            email,
+            code,
+            get_or_create_device_id(),
+            get_device_name(),
+        )
+        try:
+            clear_entitlement_cache()
+            persist_account_credentials(token, email)
+        except (OSError, FileLockTimeout) as exc:
+            try:
+                client.revoke_token()
+            except Exception:
+                pass
+            raise AccountError(AccountErrorCode.STATE_UNAVAILABLE) from exc
+
+        settings.account_token = token
+        settings.account_email = email
+        try:
+            cache = refresh_entitlements(settings, client=client)
+        except Exception:
+            cache = load_entitlement_cache()
+        return _status_from_cache(settings, cache)
+    except AccountError:
+        raise
+    except CloudError as exc:
+        raise _map_cloud_error(exc, verifying=True) from exc
+    except OSError as exc:
+        raise AccountError(AccountErrorCode.STATE_UNAVAILABLE) from exc
+    except ValueError as exc:
+        raise AccountError(AccountErrorCode.ACCOUNT_UNAVAILABLE) from exc
+    finally:
+        _close_owned(client, owned)
+
+
+def get_account_status(settings) -> AccountStatus:
+    """Return token-free account status using the canonical entitlement policy."""
+
+    entitlement = check_entitlement(settings)
+    cache = load_entitlement_cache()
+    status = _status_from_cache(settings, cache)
+    return AccountStatus(
+        signed_in=status.signed_in,
+        email=status.email,
+        device_name=status.device_name,
+        entitlement=entitlement,
+        plan_status=status.plan_status,
+        cache_age_seconds=status.cache_age_seconds,
+        entitlement_available=status.entitlement_available,
+    )
+
+
+def logout_account(
+    settings,
+    *,
+    client: CloudClient | None = None,
+    client_factory: Callable[[], CloudClient] | None = None,
+) -> LogoutResult:
+    """Revoke first when possible, then always remove local account state."""
+
+    revoked = False
+    warning = None
+    owned = False
+    if getattr(settings, "account_token", None):
+        try:
+            if client is None:
+                client = client_factory() if client_factory else client_from_settings(settings)
+                owned = True
+            client.revoke_token()
+            revoked = True
+        except Exception:
+            warning = "Could not revoke this device while offline."
+        finally:
+            _close_owned(client, owned)
+
+    try:
+        remove_account_credentials()
+    except (OSError, FileLockTimeout) as exc:
+        raise AccountError(AccountErrorCode.STATE_UNAVAILABLE) from exc
+    settings.account_token = None
+    settings.account_email = None
+    try:
+        clear_entitlement_cache()
+    except OSError as exc:
+        raise AccountError(AccountErrorCode.STATE_UNAVAILABLE) from exc
+    return LogoutResult(revoked_remotely=revoked, warning=warning)

--- a/src/ormah/cloud/operations.py
+++ b/src/ormah/cloud/operations.py
@@ -240,14 +240,21 @@ def resume_interrupted_enable(
     ):
         return None
 
-    from ormah.cloud.protection import CloudProtectionService
+    try:
+        from ormah.cloud.protection import CloudProtectionService
 
-    service = CloudProtectionService.from_engine(engine)
-    operation, deduplicated = coordinator.submit(
-        key=(str(memory_dir), f"enable:{intent_id}"),
-        kind=ProtectionOperationKind.ENABLE,
-        action=lambda: service.enable(intent_id),
-    )
+        service = CloudProtectionService.from_engine(engine)
+        operation, deduplicated = coordinator.submit(
+            key=(str(memory_dir), f"enable:{intent_id}"),
+            kind=ProtectionOperationKind.ENABLE,
+            action=lambda: service.enable(intent_id),
+        )
+    except Exception as exc:
+        logger.warning(
+            "Interrupted cloud protection could not be resumed at startup; error_type=%s",
+            type(exc).__name__,
+        )
+        return None
     logger.info(
         "%s interrupted cloud protection intent %s",
         "Reused" if deduplicated else "Resuming",

--- a/src/ormah/cloud/operations.py
+++ b/src/ormah/cloud/operations.py
@@ -1,0 +1,256 @@
+"""Small in-process coordinator for long-running cloud protection operations."""
+
+from __future__ import annotations
+
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from enum import StrEnum
+import logging
+from pathlib import Path
+import threading
+from typing import TYPE_CHECKING, Callable
+import uuid
+
+from ormah.cloud.keys import STORE_ID_NAME, get_or_create_store_id
+from ormah.cloud.state import (
+    CURRENT_CLOUD_STATE_SCHEMA_VERSION,
+    ProtectionIntentStatus,
+    ProtectionOperation,
+    ProtectionOperationKind,
+    load_state,
+)
+
+if TYPE_CHECKING:
+    from ormah.engine.memory_engine import MemoryEngine
+
+logger = logging.getLogger(__name__)
+
+
+class LocalOperationStatus(StrEnum):
+    """Lifecycle of work submitted by a local desktop/API caller."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class LocalOperation:
+    """Token-free polling record for one local background invocation."""
+
+    operation_id: str
+    kind: ProtectionOperationKind
+    status: LocalOperationStatus
+    submitted_at: datetime
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    result: ProtectionOperation | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        result = self.result
+        return {
+            "operation_id": self.operation_id,
+            "kind": self.kind.value,
+            "status": self.status.value,
+            "submitted_at": self.submitted_at.isoformat(),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "durable_operation_id": result.operation_id if result else None,
+            "phase": result.phase.value if result else None,
+            "protection_state": result.state.value if result else None,
+            "reason_code": result.reason_code.value if result and result.reason_code else None,
+            "message": result.message if result else self.error_message,
+            "snapshot_id": result.snapshot_id if result else None,
+            "protection_intent_id": result.protection_intent_id if result else None,
+            "error_code": self.error_code,
+        }
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ProtectionOperationCoordinator:
+    """Run blocking protection services without holding an HTTP request open.
+
+    The coordinator intentionally stores only a bounded, process-local polling
+    history. Durable recovery and product truth remain in ``CloudState`` and
+    ``CloudProtectionService``; callers must refresh the protection status if a
+    server restart makes a local operation ID unavailable.
+    """
+
+    def __init__(self, *, max_workers: int = 4, max_history: int = 128) -> None:
+        if max_workers < 1 or max_history < 1:
+            raise ValueError("operation coordinator limits must be positive")
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_workers,
+            thread_name_prefix="ormah-protection",
+        )
+        self._max_history = max_history
+        self._lock = threading.Lock()
+        self._operations: dict[str, LocalOperation] = {}
+        self._active_by_key: dict[tuple[str, ...], str] = {}
+        self._finished: deque[str] = deque()
+        self._closed = False
+
+    def submit(
+        self,
+        *,
+        key: tuple[str, ...],
+        kind: ProtectionOperationKind,
+        action: Callable[[], ProtectionOperation],
+    ) -> tuple[LocalOperation, bool]:
+        """Submit work or return the matching operation already in progress."""
+        if not key:
+            raise ValueError("operation deduplication key must not be empty")
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("operation coordinator is shutting down")
+            active_id = self._active_by_key.get(key)
+            if active_id is not None:
+                return self._operations[active_id], True
+
+            operation = LocalOperation(
+                operation_id=str(uuid.uuid4()),
+                kind=kind,
+                status=LocalOperationStatus.QUEUED,
+                submitted_at=_utc_now(),
+            )
+            self._operations[operation.operation_id] = operation
+            self._active_by_key[key] = operation.operation_id
+            self._executor.submit(self._run, operation.operation_id, key, action)
+            return operation, False
+
+    def get(self, operation_id: str) -> LocalOperation | None:
+        with self._lock:
+            operation = self._operations.get(operation_id)
+            return replace(operation) if operation is not None else None
+
+    def shutdown(self, *, wait: bool = True) -> None:
+        with self._lock:
+            self._closed = True
+        self._executor.shutdown(wait=wait, cancel_futures=False)
+
+    def _run(
+        self,
+        operation_id: str,
+        key: tuple[str, ...],
+        action: Callable[[], ProtectionOperation],
+    ) -> None:
+        self._update(
+            operation_id,
+            status=LocalOperationStatus.RUNNING,
+            started_at=_utc_now(),
+        )
+        try:
+            result = action()
+            if not isinstance(result, ProtectionOperation):
+                raise TypeError("protection operation returned an invalid result")
+        except Exception as exc:
+            # Exception strings can contain local paths, tokens, or provider URLs.
+            # Keep the API generic; durable service failures use safe typed results.
+            logger.warning(
+                "Local protection operation failed; kind=%s error_type=%s",
+                self._operations[operation_id].kind.value,
+                type(exc).__name__,
+            )
+            self._finish(
+                operation_id,
+                key,
+                status=LocalOperationStatus.FAILED,
+                error_code="operation_failed",
+                error_message="The protection operation could not be completed.",
+            )
+            return
+        self._finish(
+            operation_id,
+            key,
+            status=LocalOperationStatus.COMPLETED,
+            result=result,
+        )
+
+    def _update(self, operation_id: str, **changes: object) -> None:
+        with self._lock:
+            self._operations[operation_id] = replace(
+                self._operations[operation_id],
+                **changes,
+            )
+
+    def _finish(
+        self,
+        operation_id: str,
+        key: tuple[str, ...],
+        **changes: object,
+    ) -> None:
+        with self._lock:
+            self._operations[operation_id] = replace(
+                self._operations[operation_id],
+                finished_at=_utc_now(),
+                **changes,
+            )
+            if self._active_by_key.get(key) == operation_id:
+                del self._active_by_key[key]
+            self._finished.append(operation_id)
+            while len(self._finished) > self._max_history:
+                expired_id = self._finished.popleft()
+                self._operations.pop(expired_id, None)
+
+
+def resume_interrupted_enable(
+    engine: MemoryEngine,
+    coordinator: ProtectionOperationCoordinator,
+) -> LocalOperation | None:
+    """Queue the one durable Protect operation that may survive a process crash.
+
+    Upload reservation/finalize recovery and exact-snapshot verification are
+    already idempotent inside ``CloudProtectionService.enable``. Startup only
+    needs to rediscover a ``running`` intent and hand it back to that service.
+    """
+
+    memory_dir = Path(engine.settings.memory_dir).expanduser().resolve()
+    if not (memory_dir / STORE_ID_NAME).is_file():
+        return None
+
+    try:
+        store_id = get_or_create_store_id(memory_dir)
+        state = load_state(store_id)
+        if state.schema_version > CURRENT_CLOUD_STATE_SCHEMA_VERSION:
+            logger.warning(
+                "Interrupted cloud protection was not resumed because its state "
+                "requires a newer Ormah version."
+            )
+            return None
+    except Exception as exc:
+        logger.warning(
+            "Interrupted cloud protection could not be inspected at startup; error_type=%s",
+            type(exc).__name__,
+        )
+        return None
+
+    intent_id = state.pending_protection_intent_id
+    if (
+        state.pending_protection_status is not ProtectionIntentStatus.RUNNING
+        or not isinstance(intent_id, str)
+        or not intent_id
+    ):
+        return None
+
+    from ormah.cloud.protection import CloudProtectionService
+
+    service = CloudProtectionService.from_engine(engine)
+    operation, deduplicated = coordinator.submit(
+        key=(str(memory_dir), f"enable:{intent_id}"),
+        kind=ProtectionOperationKind.ENABLE,
+        action=lambda: service.enable(intent_id),
+    )
+    logger.info(
+        "%s interrupted cloud protection intent %s",
+        "Reused" if deduplicated else "Resuming",
+        intent_id,
+    )
+    return operation

--- a/src/ormah/main.py
+++ b/src/ormah/main.py
@@ -18,6 +18,7 @@ from ormah.api.routes_account import router as account_router
 from ormah.api.routes_admin import router as admin_router
 from ormah.api.routes_agent import router as agent_router
 from ormah.api.routes_ingest import router as ingest_router
+from ormah.api.routes_protection import router as protection_router
 from ormah.api.routes_stats import router as stats_router
 from ormah.api.routes_ui import router as ui_router
 from ormah.background.maintenance_manager import MaintenanceManager
@@ -68,6 +69,13 @@ async def lifespan(app: FastAPI):
     engine = MemoryEngine(settings)
     engine.startup()
     app.state.engine = engine
+    from ormah.cloud.operations import (
+        ProtectionOperationCoordinator,
+        resume_interrupted_enable,
+    )
+
+    app.state.protection_operations = ProtectionOperationCoordinator()
+    resume_interrupted_enable(engine, app.state.protection_operations)
     logger.info("Memory engine ready.")
 
     # Start background scheduler if available
@@ -135,6 +143,8 @@ async def lifespan(app: FastAPI):
     # Shutdown — wait for running jobs to finish
     if hasattr(app.state, "scheduler"):
         app.state.scheduler.shutdown(wait=True)
+    if hasattr(app.state, "protection_operations"):
+        app.state.protection_operations.shutdown(wait=True)
     engine.shutdown()
     logger.info("Ormah stopped")
 
@@ -159,6 +169,7 @@ app.add_middleware(AgentMiddleware)
 app.include_router(agent_router)
 app.include_router(admin_router)
 app.include_router(account_router)
+app.include_router(protection_router)
 app.include_router(stats_router)
 app.include_router(ui_router)
 app.include_router(ingest_router)

--- a/tests/test_api/test_account_auth_routes.py
+++ b/tests/test_api/test_account_auth_routes.py
@@ -1,0 +1,268 @@
+"""Tests for token-free local account authentication adapters."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from ormah import setup
+from ormah.api.local_auth import LOCAL_ADMIN_HEADER, require_loopback
+from ormah.api.routes_account import router as account_router
+from ormah.cloud import client as cloud_client
+from ormah.cloud import entitlements
+from ormah.cloud.client import CloudError
+from ormah.config import Settings
+
+
+LOCAL_TOKEN = "a" * 64
+HEADERS = {LOCAL_ADMIN_HEADER: LOCAL_TOKEN}
+BEARER_TOKEN = "account-bearer-token-must-never-leak"
+
+
+class FakeCloudClient:
+    def __init__(self, *, verify_error=None, entitlement_error=None, revoke_error=None):
+        self.verify_error = verify_error
+        self.entitlement_error = entitlement_error
+        self.revoke_error = revoke_error
+        self.calls: list[tuple] = []
+        self.before_revoke = None
+
+    def request_code(self, email):
+        self.calls.append(("request_code", email))
+        return {"message": "generic"}
+
+    def verify_code(self, email, code, device_id, device_name):
+        self.calls.append(("verify_code", email, code, device_id, device_name))
+        if self.verify_error:
+            raise self.verify_error
+        return BEARER_TOKEN
+
+    def get_entitlements(self):
+        self.calls.append(("get_entitlements",))
+        if self.entitlement_error:
+            raise self.entitlement_error
+        return {"backup": True, "plan_status": "active", "account_id": "ignored"}
+
+    def revoke_token(self):
+        self.calls.append(("revoke_token",))
+        if self.before_revoke:
+            self.before_revoke()
+        if self.revoke_error:
+            raise self.revoke_error
+        return {"revoked": True}
+
+
+@pytest.fixture
+def account_paths(tmp_path, monkeypatch):
+    env_path = tmp_path / "config" / ".env"
+    device_path = tmp_path / "data" / "device_id"
+    cache_path = tmp_path / "data" / "entitlements.json"
+    monkeypatch.setattr(setup, "ENV_PATH", env_path)
+    monkeypatch.setattr(setup, "ENV_DIR", env_path.parent)
+    monkeypatch.setattr(cloud_client, "DEVICE_ID_PATH", device_path)
+    monkeypatch.setattr(entitlements, "ENTITLEMENT_CACHE_PATH", cache_path)
+    return env_path, device_path, cache_path
+
+
+def build_client(tmp_path, fake, *, token=None, email=None):
+    async def allow_test_client():
+        return None
+
+    settings = Settings(
+        memory_dir=tmp_path / "memory",
+        cloud_api_url="https://cloud.test",
+        account_token=token,
+        account_email=email,
+    )
+    app = FastAPI()
+    app.include_router(account_router)
+    app.dependency_overrides[require_loopback] = allow_test_client
+    app.state.engine = SimpleNamespace(settings=settings)
+    app.state.local_admin_token = LOCAL_TOKEN
+    app.state.cloud_client = fake
+    return settings, app
+
+
+def test_otp_routes_require_local_capability(tmp_path, account_paths):
+    fake = FakeCloudClient()
+    _, app = build_client(tmp_path, fake)
+
+    with TestClient(app) as http:
+        assert http.post(
+            "/admin/account/request-code", json={"email": "person@example.com"}
+        ).status_code == 401
+        assert http.post(
+            "/admin/account/verify",
+            json={"email": "person@example.com", "code": "123456"},
+        ).status_code == 401
+
+    assert fake.calls == []
+
+
+def test_request_code_is_generic_normalized_and_rejects_extra_fields(
+    tmp_path, account_paths
+):
+    fake = FakeCloudClient()
+    _, app = build_client(tmp_path, fake)
+
+    with TestClient(app, headers=HEADERS) as http:
+        response = http.post(
+            "/admin/account/request-code", json={"email": " Person@Example.com "}
+        )
+        rejected = http.post(
+            "/admin/account/request-code",
+            json={"email": "person@example.com", "device_id": "caller-controlled"},
+        )
+
+    assert response.status_code == 202
+    assert response.json() == {"status": "code_sent"}
+    assert rejected.status_code == 422
+    assert fake.calls == [("request_code", "person@example.com")]
+
+
+def test_verify_persists_privately_updates_live_settings_and_returns_no_token(
+    tmp_path, account_paths
+):
+    env_path, device_path, cache_path = account_paths
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text("KEEP=exact\n", encoding="utf-8")
+    fake = FakeCloudClient()
+    settings, app = build_client(tmp_path, fake)
+
+    with TestClient(app, headers=HEADERS) as http:
+        response = http.post(
+            "/admin/account/verify",
+            json={"email": "Person@Example.com", "code": "123456"},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "signed_in": True,
+        "email": "person@example.com",
+        "device_name": payload["device_name"],
+        "entitlement": "active",
+        "plan_status": "active",
+        "cache_age_seconds": payload["cache_age_seconds"],
+        "entitlement_available": True,
+    }
+    assert BEARER_TOKEN not in response.text
+    assert "token" not in payload
+    assert settings.account_token == BEARER_TOKEN
+    assert settings.account_email == "person@example.com"
+    assert f"ORMAH_ACCOUNT_TOKEN={BEARER_TOKEN}\n" in env_path.read_text()
+    assert "ORMAH_ACCOUNT_EMAIL=person@example.com\n" in env_path.read_text()
+    assert device_path.is_file()
+    assert cache_path.is_file()
+    assert [call[0] for call in fake.calls] == ["verify_code", "get_entitlements"]
+
+
+def test_verify_error_is_static_and_cannot_echo_remote_token(tmp_path, account_paths):
+    fake = FakeCloudClient(
+        verify_error=CloudError(
+            f"invalid {BEARER_TOKEN}",
+            status_code=401,
+            payload={"token": BEARER_TOKEN},
+        )
+    )
+    _, app = build_client(tmp_path, fake)
+
+    with TestClient(app, headers=HEADERS) as http:
+        response = http.post(
+            "/admin/account/verify",
+            json={"email": "person@example.com", "code": "123456"},
+        )
+
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "invalid_or_expired_code"
+    assert BEARER_TOKEN not in response.text
+
+
+def test_verify_keeps_login_when_entitlement_refresh_is_offline(
+    tmp_path, account_paths
+):
+    fake = FakeCloudClient(entitlement_error=CloudError("offline"))
+    settings, app = build_client(tmp_path, fake)
+
+    with TestClient(app, headers=HEADERS) as http:
+        response = http.post(
+            "/admin/account/verify",
+            json={"email": "person@example.com", "code": "123456"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["signed_in"] is True
+    assert response.json()["entitlement_available"] is False
+    assert response.json()["entitlement"] == "none"
+    assert settings.account_token == BEARER_TOKEN
+
+
+def test_logout_revokes_first_then_clears_locally_even_offline(
+    tmp_path, account_paths
+):
+    env_path, _, cache_path = account_paths
+    env_path.parent.mkdir(parents=True)
+    env_path.write_text(
+        "KEEP=exact\n"
+        f"ORMAH_ACCOUNT_TOKEN={BEARER_TOKEN}\n"
+        "ORMAH_ACCOUNT_EMAIL=person@example.com\n",
+        encoding="utf-8",
+    )
+    entitlements.cache_entitlements({"backup": True, "plan_status": "active"})
+    fake = FakeCloudClient(revoke_error=CloudError("offline"))
+    settings, app = build_client(
+        tmp_path,
+        fake,
+        token=BEARER_TOKEN,
+        email="person@example.com",
+    )
+
+    def assert_local_state_exists():
+        assert "ORMAH_ACCOUNT_TOKEN" in env_path.read_text()
+        assert cache_path.is_file()
+
+    fake.before_revoke = assert_local_state_exists
+    with TestClient(app, headers=HEADERS) as http:
+        response = http.post("/admin/account/logout", json={})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "signed_in": False,
+        "revoked_remotely": False,
+        "warning": "Could not revoke this device while offline.",
+    }
+    assert fake.calls == [("revoke_token",)]
+    assert env_path.read_text() == "KEEP=exact\n"
+    assert not cache_path.exists()
+    assert settings.account_token is None
+    assert settings.account_email is None
+
+
+def test_status_is_token_free_and_logout_requires_explicit_json(
+    tmp_path, account_paths
+):
+    entitlements.cache_entitlements({"backup": True, "plan_status": "trialing"})
+    fake = FakeCloudClient()
+    _, app = build_client(
+        tmp_path,
+        fake,
+        token=BEARER_TOKEN,
+        email="person@example.com",
+    )
+
+    with TestClient(app, headers=HEADERS) as http:
+        status = http.get("/admin/account/status")
+        no_body = http.post("/admin/account/logout")
+        extra = http.post("/admin/account/logout", json={"token": BEARER_TOKEN})
+
+    assert status.status_code == 200
+    assert status.json()["email"] == "person@example.com"
+    assert status.json()["entitlement"] == "active"
+    assert BEARER_TOKEN not in status.text
+    assert "token" not in status.text.lower()
+    assert no_body.status_code == 422
+    assert extra.status_code == 422
+    assert fake.calls == []

--- a/tests/test_api/test_protection_routes.py
+++ b/tests/test_api/test_protection_routes.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+import threading
+import time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api import routes_protection
+from ormah.api.local_auth import LOCAL_ADMIN_HEADER, require_loopback
+from ormah.cloud.operations import ProtectionOperationCoordinator
+from ormah.cloud.state import (
+    ProtectionOperation,
+    ProtectionOperationKind,
+    ProtectionOperationPhase,
+    ProtectionState,
+)
+
+LOCAL_TOKEN = "a" * 64
+HEADERS = {LOCAL_ADMIN_HEADER: LOCAL_TOKEN}
+INTENT_ID = "3f1a6c4e-4b0a-4d5f-9a2b-8c7d6e5f4a3b"
+SNAPSHOT_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+
+
+def _operation(
+    kind: ProtectionOperationKind,
+    *,
+    operation_id: str = "durable-operation",
+    intent_id: str | None = None,
+) -> ProtectionOperation:
+    return ProtectionOperation(
+        operation_id=operation_id,
+        kind=kind,
+        phase=ProtectionOperationPhase.COMPLETED,
+        state=ProtectionState.PROTECTED,
+        reason_code=None,
+        snapshot_id=SNAPSHOT_ID,
+        protection_intent_id=intent_id,
+    )
+
+
+@dataclass
+class FakeProtectionService:
+    release_backup: threading.Event | None = None
+
+    def __post_init__(self):
+        self.calls: list[tuple] = []
+
+    def create_intent(self):
+        self.calls.append(("create_intent",))
+        return _operation(ProtectionOperationKind.ENABLE, intent_id=INTENT_ID)
+
+    def bind_intent(self, intent_id):
+        self.calls.append(("bind_intent", intent_id))
+        return _operation(ProtectionOperationKind.ENABLE, intent_id=intent_id)
+
+    def cancel_intent(self, intent_id):
+        self.calls.append(("cancel_intent", intent_id))
+        return _operation(ProtectionOperationKind.ENABLE, intent_id=intent_id)
+
+    def enable(self, intent_id):
+        self.calls.append(("enable", intent_id))
+        return _operation(ProtectionOperationKind.ENABLE, intent_id=intent_id)
+
+    def disable(self):
+        self.calls.append(("disable",))
+        return _operation(ProtectionOperationKind.DISABLE)
+
+    def backup_now(self, *, reason):
+        self.calls.append(("backup_now", reason))
+        if self.release_backup is not None:
+            assert self.release_backup.wait(timeout=2)
+        return _operation(ProtectionOperationKind.BACKUP)
+
+    def verify_now(self, snapshot_id=None):
+        self.calls.append(("verify_now", snapshot_id))
+        return _operation(ProtectionOperationKind.VERIFY)
+
+
+@pytest.fixture
+def protection_app(tmp_path: Path, monkeypatch):
+    async def allow_test_client():
+        return None
+
+    service = FakeProtectionService()
+    coordinator = ProtectionOperationCoordinator(max_workers=4)
+    app = FastAPI()
+    app.dependency_overrides[require_loopback] = allow_test_client
+    app.state.local_admin_token = LOCAL_TOKEN
+    app.state.engine = SimpleNamespace(
+        settings=SimpleNamespace(memory_dir=tmp_path, account_token="never-return-this-token")
+    )
+    app.state.protection_service = service
+    app.state.protection_operations = coordinator
+    app.include_router(routes_protection.router)
+    monkeypatch.setattr(
+        routes_protection,
+        "cloud_status_payload",
+        lambda settings, **kwargs: {
+            "protection_state": "local_only",
+            "last_operation_id": None,
+            "warnings": [],
+        },
+    )
+    try:
+        with TestClient(app) as client:
+            yield client, service, coordinator
+    finally:
+        if service.release_backup is not None:
+            service.release_backup.set()
+        coordinator.shutdown()
+
+
+def _poll(client: TestClient, operation_id: str) -> dict:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        response = client.get(
+            f"/admin/cloud/protection/operations/{operation_id}",
+            headers=HEADERS,
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        if payload["status"] in {"completed", "failed"}:
+            return payload
+        time.sleep(0.005)
+    raise AssertionError("operation did not finish")
+
+
+def test_all_protection_routes_require_local_capability(protection_app):
+    client, _, _ = protection_app
+    requests = [
+        ("GET", "/admin/cloud/protection", None),
+        ("POST", "/admin/cloud/protection/intents", {}),
+        ("POST", f"/admin/cloud/protection/intents/{INTENT_ID}/bind", {}),
+        ("POST", f"/admin/cloud/protection/intents/{INTENT_ID}/cancel", {}),
+        ("POST", f"/admin/cloud/protection/intents/{INTENT_ID}/enable", {}),
+        ("POST", "/admin/cloud/protection/disable", {}),
+        ("POST", "/admin/cloud/protection/backup", {}),
+        ("POST", "/admin/cloud/protection/verify", {}),
+        ("GET", f"/admin/cloud/protection/operations/{INTENT_ID}", None),
+    ]
+
+    for method, path, body in requests:
+        response = client.request(method, path, json=body)
+        assert response.status_code == 401, path
+
+
+def test_status_and_intent_adapters_are_thin_and_token_free(protection_app):
+    client, service, _ = protection_app
+
+    status_response = client.get("/admin/cloud/protection", headers=HEADERS)
+    create_response = client.post(
+        "/admin/cloud/protection/intents", headers=HEADERS, json={}
+    )
+    bind_response = client.post(
+        f"/admin/cloud/protection/intents/{INTENT_ID}/bind", headers=HEADERS, json={}
+    )
+    cancel_response = client.post(
+        f"/admin/cloud/protection/intents/{INTENT_ID}/cancel", headers=HEADERS, json={}
+    )
+
+    assert status_response.json()["protection_state"] == "local_only"
+    assert create_response.json()["protection_intent_id"] == INTENT_ID
+    assert bind_response.json()["protection_intent_id"] == INTENT_ID
+    assert cancel_response.json()["protection_intent_id"] == INTENT_ID
+    assert service.calls == [
+        ("create_intent",),
+        ("bind_intent", INTENT_ID),
+        ("cancel_intent", INTENT_ID),
+    ]
+    assert "never-return-this-token" not in str(
+        [
+            status_response.json(),
+            create_response.json(),
+            bind_response.json(),
+            cancel_response.json(),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "body"),
+    [
+        ("/admin/cloud/protection/intents", {"email": "person@example.com"}),
+        (f"/admin/cloud/protection/intents/{INTENT_ID}/bind", {"account_id": "secret"}),
+        (f"/admin/cloud/protection/intents/{INTENT_ID}/cancel", {"force": True}),
+        (f"/admin/cloud/protection/intents/{INTENT_ID}/enable", {"price_id": "price_x"}),
+        ("/admin/cloud/protection/disable", {"delete_remote": True}),
+        ("/admin/cloud/protection/backup", {"advance_head": True}),
+        ("/admin/cloud/protection/verify", {"presigned_url": "https://example.test"}),
+    ],
+)
+def test_mutation_routes_forbid_extra_fields(protection_app, path, body):
+    client, _, _ = protection_app
+    response = client.post(path, headers=HEADERS, json=body)
+    assert response.status_code == 422
+
+
+def test_long_operations_return_202_and_poll_safe_results(protection_app):
+    client, service, _ = protection_app
+    requests = [
+        (
+            f"/admin/cloud/protection/intents/{INTENT_ID}/enable",
+            {},
+            ("enable", INTENT_ID),
+        ),
+        ("/admin/cloud/protection/disable", {}, ("disable",)),
+        ("/admin/cloud/protection/backup", {}, ("backup_now", "manual-ui")),
+        (
+            "/admin/cloud/protection/verify",
+            {"snapshot_id": SNAPSHOT_ID},
+            ("verify_now", SNAPSHOT_ID),
+        ),
+    ]
+
+    for path, body, expected_call in requests:
+        response = client.post(path, headers=HEADERS, json=body)
+        assert response.status_code == 202
+        payload = _poll(client, response.json()["operation_id"])
+        assert payload["status"] == "completed"
+        assert payload["durable_operation_id"] == "durable-operation"
+        assert payload["protection_state"] == "protected"
+        assert "never-return-this-token" not in str(payload)
+        assert expected_call in service.calls
+
+
+def test_repeated_active_backup_joins_one_operation(protection_app):
+    client, service, _ = protection_app
+    service.release_backup = threading.Event()
+
+    first = client.post("/admin/cloud/protection/backup", headers=HEADERS, json={})
+    second = client.post("/admin/cloud/protection/backup", headers=HEADERS, json={})
+
+    assert first.status_code == second.status_code == 202
+    assert first.json()["operation_id"] == second.json()["operation_id"]
+    assert first.json()["deduplicated"] is False
+    assert second.json()["deduplicated"] is True
+    service.release_backup.set()
+    assert _poll(client, first.json()["operation_id"])["status"] == "completed"
+    assert service.calls.count(("backup_now", "manual-ui")) == 1
+
+
+def test_unknown_operation_returns_404(protection_app):
+    client, _, _ = protection_app
+    response = client.get(
+        "/admin/cloud/protection/operations/unknown",
+        headers=HEADERS,
+    )
+    assert response.status_code == 404
+
+
+def test_polling_entitlement_is_cache_only(monkeypatch):
+    settings = SimpleNamespace(account_token="private-token")
+    cached = object()
+    calls = []
+    monkeypatch.setattr(routes_protection, "load_entitlement_cache", lambda: cached)
+    monkeypatch.setattr(
+        routes_protection,
+        "status_from_cache",
+        lambda value: calls.append(value) or SimpleNamespace(value="grace"),
+    )
+
+    assert routes_protection._cached_entitlement(settings) == "grace"
+    assert calls == [cached]
+
+    settings.account_token = None
+    assert routes_protection._cached_entitlement(settings) == "none"
+    assert calls == [cached]
+
+
+def test_invalid_intent_and_snapshot_ids_fail_before_service_work(protection_app):
+    client, service, _ = protection_app
+
+    invalid_intent = client.post(
+        "/admin/cloud/protection/intents/not-a-uuid/enable",
+        headers=HEADERS,
+        json={},
+    )
+    invalid_snapshot = client.post(
+        "/admin/cloud/protection/verify",
+        headers=HEADERS,
+        json={"snapshot_id": "not-a-snapshot"},
+    )
+
+    assert invalid_intent.status_code == 422
+    assert invalid_snapshot.status_code == 422
+    assert service.calls == []

--- a/tests/test_cloud_operations.py
+++ b/tests/test_cloud_operations.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+import uuid
+
+from ormah.cloud import protection, state
+from ormah.cloud.keys import get_or_create_store_id
+from ormah.cloud.operations import (
+    LocalOperationStatus,
+    ProtectionOperationCoordinator,
+    resume_interrupted_enable,
+)
+from ormah.cloud.state import (
+    ProtectionIntentStatus,
+    ProtectionOperation,
+    ProtectionOperationKind,
+    ProtectionOperationPhase,
+    ProtectionState,
+)
+
+
+def _result(operation_id: str = "durable-operation") -> ProtectionOperation:
+    return ProtectionOperation(
+        operation_id=operation_id,
+        kind=ProtectionOperationKind.BACKUP,
+        phase=ProtectionOperationPhase.COMPLETED,
+        state=ProtectionState.VERIFICATION_PENDING,
+        snapshot_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+    )
+
+
+def _wait_for_terminal(
+    coordinator: ProtectionOperationCoordinator,
+    operation_id: str,
+):
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        operation = coordinator.get(operation_id)
+        assert operation is not None
+        if operation.status in {
+            LocalOperationStatus.COMPLETED,
+            LocalOperationStatus.FAILED,
+        }:
+            return operation
+        time.sleep(0.005)
+    raise AssertionError("operation did not finish")
+
+
+def test_coordinator_returns_immediately_and_deduplicates_active_work():
+    coordinator = ProtectionOperationCoordinator(max_workers=1)
+    release = threading.Event()
+    calls = 0
+
+    def action():
+        nonlocal calls
+        calls += 1
+        assert release.wait(timeout=2)
+        return _result()
+
+    try:
+        first, first_deduplicated = coordinator.submit(
+            key=("store", "backup"),
+            kind=ProtectionOperationKind.BACKUP,
+            action=action,
+        )
+        second, second_deduplicated = coordinator.submit(
+            key=("store", "backup"),
+            kind=ProtectionOperationKind.BACKUP,
+            action=action,
+        )
+
+        assert first.operation_id == second.operation_id
+        assert first_deduplicated is False
+        assert second_deduplicated is True
+        release.set()
+        completed = _wait_for_terminal(coordinator, first.operation_id)
+        assert completed.status is LocalOperationStatus.COMPLETED
+        assert completed.result == _result()
+        assert calls == 1
+    finally:
+        release.set()
+        coordinator.shutdown()
+
+
+def test_coordinator_redacts_unexpected_exception_details():
+    coordinator = ProtectionOperationCoordinator(max_workers=1)
+
+    def action():
+        raise RuntimeError("bearer-secret https://signed.example.test/private")
+
+    try:
+        operation, _ = coordinator.submit(
+            key=("store", "verify"),
+            kind=ProtectionOperationKind.VERIFY,
+            action=action,
+        )
+        failed = _wait_for_terminal(coordinator, operation.operation_id)
+        payload = failed.to_payload()
+        serialized = str(payload)
+        assert failed.status is LocalOperationStatus.FAILED
+        assert payload["error_code"] == "operation_failed"
+        assert payload["message"] == "The protection operation could not be completed."
+        assert "bearer-secret" not in serialized
+        assert "signed.example" not in serialized
+    finally:
+        coordinator.shutdown()
+
+
+def test_coordinator_bounds_finished_history():
+    coordinator = ProtectionOperationCoordinator(max_workers=1, max_history=1)
+    try:
+        first, _ = coordinator.submit(
+            key=("store", "backup"),
+            kind=ProtectionOperationKind.BACKUP,
+            action=_result,
+        )
+        _wait_for_terminal(coordinator, first.operation_id)
+        second, _ = coordinator.submit(
+            key=("store", "verify"),
+            kind=ProtectionOperationKind.VERIFY,
+            action=_result,
+        )
+        _wait_for_terminal(coordinator, second.operation_id)
+
+        assert coordinator.get(first.operation_id) is None
+        assert coordinator.get(second.operation_id) is not None
+    finally:
+        coordinator.shutdown()
+
+
+def test_startup_resumes_and_deduplicates_running_enable(tmp_path, monkeypatch):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    monkeypatch.setattr(state, "CLOUD_STATE_DIR", tmp_path / "cloud-state")
+    store_id = get_or_create_store_id(memory_dir)
+    intent_id = str(uuid.uuid4())
+    state.update_state(
+        store_id,
+        memory_dir=memory_dir,
+        protection_state=ProtectionState.UPLOADING_FIRST_BACKUP,
+        pending_protection_intent_id=intent_id,
+        pending_protection_store_id=store_id,
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+    )
+    release = threading.Event()
+    calls: list[str] = []
+
+    class FakeService:
+        def enable(self, resumed_intent_id: str):
+            calls.append(resumed_intent_id)
+            assert release.wait(timeout=2)
+            return _result(resumed_intent_id)
+
+    monkeypatch.setattr(
+        protection.CloudProtectionService,
+        "from_engine",
+        lambda engine: FakeService(),
+    )
+    engine = SimpleNamespace(settings=SimpleNamespace(memory_dir=memory_dir))
+    coordinator = ProtectionOperationCoordinator(max_workers=1)
+    try:
+        first = resume_interrupted_enable(engine, coordinator)
+        second = resume_interrupted_enable(engine, coordinator)
+
+        assert first is not None
+        assert second is not None
+        assert first.operation_id == second.operation_id
+        release.set()
+        completed = _wait_for_terminal(coordinator, first.operation_id)
+        assert completed.status is LocalOperationStatus.COMPLETED
+        assert calls == [intent_id]
+    finally:
+        release.set()
+        coordinator.shutdown()
+
+
+def test_startup_ignores_non_running_or_uninitialized_stores(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "CLOUD_STATE_DIR", tmp_path / "cloud-state")
+    coordinator = ProtectionOperationCoordinator(max_workers=1)
+    try:
+        empty_engine = SimpleNamespace(
+            settings=SimpleNamespace(memory_dir=tmp_path / "empty-memory")
+        )
+        assert resume_interrupted_enable(empty_engine, coordinator) is None
+
+        memory_dir = tmp_path / "initialized-memory"
+        memory_dir.mkdir()
+        store_id = get_or_create_store_id(memory_dir)
+        state.update_state(
+            store_id,
+            memory_dir=memory_dir,
+            protection_state=ProtectionState.SUBSCRIPTION_REQUIRED,
+            pending_protection_intent_id=str(uuid.uuid4()),
+            pending_protection_store_id=store_id,
+            pending_protection_status=ProtectionIntentStatus.ACCOUNT_BOUND,
+        )
+        initialized_engine = SimpleNamespace(
+            settings=SimpleNamespace(memory_dir=memory_dir)
+        )
+        assert resume_interrupted_enable(initialized_engine, coordinator) is None
+    finally:
+        coordinator.shutdown()

--- a/tests/test_cloud_operations.py
+++ b/tests/test_cloud_operations.py
@@ -202,3 +202,30 @@ def test_startup_ignores_non_running_or_uninitialized_stores(tmp_path, monkeypat
         assert resume_interrupted_enable(initialized_engine, coordinator) is None
     finally:
         coordinator.shutdown()
+
+
+def test_startup_resume_failure_never_blocks_server_start(tmp_path, monkeypatch):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    monkeypatch.setattr(state, "CLOUD_STATE_DIR", tmp_path / "cloud-state")
+    store_id = get_or_create_store_id(memory_dir)
+    intent_id = str(uuid.uuid4())
+    state.update_state(
+        store_id,
+        memory_dir=memory_dir,
+        protection_state=ProtectionState.INITIALIZING,
+        pending_protection_intent_id=intent_id,
+        pending_protection_store_id=store_id,
+        pending_protection_status=ProtectionIntentStatus.RUNNING,
+    )
+    monkeypatch.setattr(
+        protection.CloudProtectionService,
+        "from_engine",
+        lambda engine: (_ for _ in ()).throw(RuntimeError("startup failure")),
+    )
+    engine = SimpleNamespace(settings=SimpleNamespace(memory_dir=memory_dir))
+    coordinator = ProtectionOperationCoordinator(max_workers=1)
+    try:
+        assert resume_interrupted_enable(engine, coordinator) is None
+    finally:
+        coordinator.shutdown()

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,9 +8,11 @@
       "name": "ormah-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@tauri-apps/api": "^2.8.0",
         "cytoscape": "^3.30.4",
         "cytoscape-cola": "^2.5.1",
         "cytoscape-fcose": "^2.2.0",
+        "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -20,7 +22,8 @@
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5.6.3",
-        "vite": "^6.0.5"
+        "vite": "^6.0.5",
+        "vitest": "^2.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1154,6 +1157,16 @@
         "win32"
       ]
     },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1262,6 +1275,102 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -1309,6 +1418,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001770",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
@@ -1329,6 +1448,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1447,12 +1593,29 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1504,6 +1667,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1599,6 +1782,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1607,6 +1797,25 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.468.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/ms": {
@@ -1641,6 +1850,23 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1790,6 +2016,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1799,6 +2032,34 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -1815,6 +2076,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1937,6 +2228,1102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webcola": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/webcola/-/webcola-3.4.0.tgz",
@@ -1947,6 +3334,23 @@
         "d3-drag": "^1.0.4",
         "d3-shape": "^1.3.5",
         "d3-timer": "^1.0.5"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@tauri-apps/api": "^2.8.0",
     "cytoscape": "^3.30.4",
     "cytoscape-cola": "^2.5.1",
     "cytoscape-fcose": "^2.2.0",
+    "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -21,6 +24,7 @@
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.6.3",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vitest": "^2.1.8"
   }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,6 +8,7 @@ import FilterDrawer from "./components/FilterDrawer";
 import InsightsPanel from "./components/InsightsPanel";
 import AdminPanel from "./components/AdminPanel";
 import AgentsPanel from "./components/AgentsPanel";
+import ProtectionPanel from "./components/ProtectionPanel";
 import ToastContainer from "./components/Toast";
 import type { ToastData } from "./components/Toast";
 import {
@@ -19,6 +20,7 @@ import {
   type GraphTheme,
 } from "./graphAppearance";
 import useKeyboardShortcuts from "./hooks/useKeyboardShortcuts";
+import { isDesktopApp, productBridge, type ProtectionState } from "./productBridge";
 
 export interface Filters {
   tiers: Set<Tier>;
@@ -40,7 +42,7 @@ const ALL_EDGE_TYPES: EdgeType[] = [
 ];
 const DEFAULT_EDGE_TYPES = new Set<EdgeType>(ALL_EDGE_TYPES);
 
-type PanelId = "settings" | "insights" | "admin" | "agents" | null;
+type PanelId = "protection" | "settings" | "insights" | "admin" | "agents" | null;
 type ThemeTransitionState = {
   theme: GraphTheme;
   id: number;
@@ -65,6 +67,7 @@ export default function App() {
   const [allSpaces, setAllSpaces] = useState<string[]>([]);
   const [userNodeId, setUserNodeId] = useState<string | null>(null);
   const [toasts, setToasts] = useState<ToastData[]>([]);
+  const [protectionState, setProtectionState] = useState<ProtectionState | null>(null);
   const [graphAppearance, setGraphAppearance] =
     useState<GraphAppearance>(loadGraphAppearance);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -108,6 +111,13 @@ export default function App() {
       setAllSpaces(spaceList);
       setFilters((f) => ({ ...f, spaces: new Set(spaceList) }));
     });
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktopApp()) return;
+    productBridge.status()
+      .then((cloud) => setProtectionState(cloud.protection_state))
+      .catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -240,12 +250,13 @@ export default function App() {
     <>
       <TopBar
         nodeCount={filteredNodes.length}
-        activePanel={activePanel as "settings" | "insights" | "admin" | "agents" | null}
-        onTogglePanel={togglePanel as (id: "settings" | "insights" | "admin" | "agents") => void}
+        activePanel={activePanel}
+        onTogglePanel={togglePanel}
         onSearchSelect={handleSearchSelect}
         onSearchHover={(id) => graphViewRef.current?.highlightNode(id)}
         onSearchHoverEnd={() => graphViewRef.current?.clearHighlight()}
         searchInputRef={searchInputRef}
+        protectionState={protectionState}
       />
       <div className="graph-container">
         {graph && (
@@ -294,6 +305,12 @@ export default function App() {
       <AgentsPanel
         open={activePanel === "agents"}
         onClose={() => setActivePanel(null)}
+      />
+      <ProtectionPanel
+        open={activePanel === "protection"}
+        onClose={() => setActivePanel(null)}
+        onToast={addToast}
+        onStatusChange={(cloud) => setProtectionState(cloud.protection_state)}
       />
       {themeTransition && (
         <div

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -90,6 +90,13 @@ export default function App() {
     setActivePanel((p) => (p === id ? null : id));
   }, []);
 
+  const handleProtectionStatusChange = useCallback(
+    (cloud: { protection_state: ProtectionState }) => {
+      setProtectionState(cloud.protection_state);
+    },
+    [],
+  );
+
   useKeyboardShortcuts({
     onTogglePanel: togglePanel as (id: "settings" | "insights" | "admin" | "agents") => void,
     onClosePanel: useCallback(() => setActivePanel(null), []),
@@ -310,7 +317,7 @@ export default function App() {
         open={activePanel === "protection"}
         onClose={() => setActivePanel(null)}
         onToast={addToast}
-        onStatusChange={(cloud) => setProtectionState(cloud.protection_state)}
+        onStatusChange={handleProtectionStatusChange}
       />
       {themeTransition && (
         <div

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -114,6 +114,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
   const [confirmStop, setConfirmStop] = useState(false);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const checkoutCheckInFlight = useRef(false);
+  const offerRequested = useRef(false);
   const desktop = isDesktopApp();
 
   const refresh = useCallback(async () => {
@@ -126,23 +127,27 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
       } catch {
         throw new Error("Update Ormah Desktop to use cloud protection.");
       }
-      const [nextAccount, nextStatus] = await Promise.all([
-        productBridge.accountStatus(),
-        productBridge.status(),
-      ]);
+      // Account status refreshes a stale entitlement cache. Read protection
+      // after it so an active subscriber is never painted as paused from an
+      // expired cache entry on first open.
+      const nextAccount = await productBridge.accountStatus();
+      const nextStatus = await productBridge.status();
       setAccount(nextAccount);
       setStatus(nextStatus);
       onStatusChange?.(nextStatus);
       setError(null);
-      if (nextAccount.signed_in && !offer) {
-        productBridge.offer().then(setOffer).catch(() => undefined);
+      if (nextAccount.signed_in && !offerRequested.current) {
+        offerRequested.current = true;
+        productBridge.offer().then(setOffer).catch(() => {
+          offerRequested.current = false;
+        });
       }
     } catch (err) {
       setError(errorMessage(err, "Protection status is unavailable."));
     } finally {
       setLoading(false);
     }
-  }, [desktop, offer, onStatusChange]);
+  }, [desktop, onStatusChange]);
 
   useEffect(() => {
     if (!open) return;
@@ -231,11 +236,16 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     setError(null);
     try {
       const intent = await productBridge.createIntent();
+      if (intent.reason_code && intent.reason_code !== "sign_in_required") {
+        throw new Error(intent.message || "Protection could not start.");
+      }
+      const intentId = intent.protection_intent_id;
+      if (!intentId) throw new Error("Protection could not create a durable request.");
       setOperation(intent);
       if (!account?.signed_in || intent.protection_state === "sign_in_required") {
         setView("email");
       } else {
-        await bindAndContinue(intent.protection_intent_id || intent.operation_id);
+        await bindAndContinue(intentId);
       }
     } catch (err) {
       setError(errorMessage(err, "Protection could not start."));
@@ -266,7 +276,11 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
       const nextAccount = await productBridge.verifyCode(email.trim().toLowerCase(), code);
       setAccount(nextAccount);
       const intentId = operation?.protection_intent_id || status?.protection_intent_id;
-      if (!intentId) throw new Error("The protection request expired. Start again.");
+      if (!intentId) {
+        setOperation(null);
+        setView("summary");
+        throw new Error("The protection request expired. Start again.");
+      }
       await bindAndContinue(intentId);
       await refresh();
     } catch (err) {

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -1,0 +1,629 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  CloudOff,
+  CreditCard,
+  ExternalLink,
+  LoaderCircle,
+  LockKeyhole,
+  LogOut,
+  RefreshCw,
+  ShieldCheck,
+  X,
+} from "lucide-react";
+import {
+  isDesktopApp,
+  operationPhaseIsActive,
+  productBridge,
+  protectionPresentation,
+  protectionRepairAction,
+  type AccountStatus,
+  type BillingOffer,
+  type ProtectionOperation,
+  type ProtectionStatus,
+} from "../productBridge";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onToast: (message: string, type?: "success" | "error" | "info") => void;
+  onStatusChange?: (status: ProtectionStatus) => void;
+}
+
+type View = "summary" | "email" | "code" | "checkout";
+
+function operationIsActive(operation: ProtectionOperation | null): boolean {
+  return Boolean(
+    operation && (
+      operation.status === "queued"
+      || operation.status === "running"
+    )
+  );
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "not yet";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "unavailable";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(parsed);
+}
+
+function formatPrice(offer: BillingOffer | null): string | null {
+  if (!offer) return null;
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: offer.currency.toUpperCase(),
+    }).format(offer.unit_amount / 100);
+  } catch {
+    return null;
+  }
+}
+
+function operationLabel(
+  operation: ProtectionOperation | null,
+  status: ProtectionStatus | null,
+): string | null {
+  if (!operation) return null;
+  if (operation.status === "queued") return "Queued";
+  if (operation.status !== "running") return null;
+  const phase = status?.last_operation_phase || operation.phase;
+  switch (phase) {
+    case "pending": return "Queued";
+    case "running": return "Preparing encryption";
+    case "uploading": return "Uploading encrypted recovery point";
+    case "finalizing": return "Committing recovery point";
+    case "verifying": return "Checking recovery";
+    default: return null;
+  }
+}
+
+function operationSuccessMessage(operation: ProtectionOperation): string {
+  switch (operation.kind) {
+    case "enable": return "Memory protected and verified.";
+    case "backup": return "Encrypted recovery point uploaded.";
+    case "verify": return "Recovery point verified.";
+    case "disable": return "Future cloud backups stopped.";
+    default: return "Operation completed.";
+  }
+}
+
+function errorMessage(value: unknown, fallback: string): string {
+  if (value instanceof Error && value.message.trim()) return value.message;
+  if (typeof value === "string" && value.trim()) return value;
+  return fallback;
+}
+
+export default function ProtectionPanel({ open, onClose, onToast, onStatusChange }: Props) {
+  const [account, setAccount] = useState<AccountStatus | null>(null);
+  const [status, setStatus] = useState<ProtectionStatus | null>(null);
+  const [offer, setOffer] = useState<BillingOffer | null>(null);
+  const [operation, setOperation] = useState<ProtectionOperation | null>(null);
+  const [view, setView] = useState<View>("summary");
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [checkoutPolling, setCheckoutPolling] = useState(false);
+  const [confirmStop, setConfirmStop] = useState(false);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const checkoutCheckInFlight = useRef(false);
+  const desktop = isDesktopApp();
+
+  const refresh = useCallback(async () => {
+    if (!desktop) return;
+    setLoading(true);
+    try {
+      try {
+        const bridge = await productBridge.info();
+        if (bridge.version < 1) throw new Error("unsupported bridge");
+      } catch {
+        throw new Error("Update Ormah Desktop to use cloud protection.");
+      }
+      const [nextAccount, nextStatus] = await Promise.all([
+        productBridge.accountStatus(),
+        productBridge.status(),
+      ]);
+      setAccount(nextAccount);
+      setStatus(nextStatus);
+      onStatusChange?.(nextStatus);
+      setError(null);
+      if (nextAccount.signed_in && !offer) {
+        productBridge.offer().then(setOffer).catch(() => undefined);
+      }
+    } catch (err) {
+      setError(errorMessage(err, "Protection status is unavailable."));
+    } finally {
+      setLoading(false);
+    }
+  }, [desktop, offer, onStatusChange]);
+
+  useEffect(() => {
+    if (!open) return;
+    void refresh();
+    requestAnimationFrame(() => headingRef.current?.focus());
+  }, [open, refresh]);
+
+  useEffect(() => {
+    if (!open || !operationIsActive(operation)) return;
+    const operationId = operation?.operation_id;
+    if (!operationId) return;
+    const timer = window.setInterval(async () => {
+      try {
+        const next = await productBridge.operation(operationId);
+        setOperation(next);
+        const nextStatus = await productBridge.status();
+        setStatus(nextStatus);
+        onStatusChange?.(nextStatus);
+        if (!operationIsActive(next)) {
+          window.clearInterval(timer);
+          await refresh();
+          if (next.phase === "completed") onToast(operationSuccessMessage(next), "success");
+          else if (next.message) setError(next.message);
+        }
+      } catch (err) {
+        // Polling IDs are process-local. After a Python restart, discard the
+        // stale ID and continue from the durable per-store status.
+        setOperation(null);
+        try {
+          const nextStatus = await productBridge.status();
+          setStatus(nextStatus);
+          onStatusChange?.(nextStatus);
+          setError(null);
+        } catch {
+          setError(errorMessage(err, "Could not read operation status."));
+        }
+      }
+    }, 1500);
+    return () => window.clearInterval(timer);
+  }, [open, operation?.operation_id, operation?.phase, operation?.status, onStatusChange, onToast, refresh]);
+
+  useEffect(() => {
+    if (
+      !open
+      || operationIsActive(operation)
+      || status?.protection_intent_status !== "running"
+      || !operationPhaseIsActive(status?.last_operation_phase)
+    ) return;
+    const timer = window.setInterval(async () => {
+      try {
+        const nextStatus = await productBridge.status();
+        setStatus(nextStatus);
+        onStatusChange?.(nextStatus);
+      } catch (err) {
+        setError(errorMessage(err, "Could not refresh protection progress."));
+      }
+    }, 1500);
+    return () => window.clearInterval(timer);
+  }, [
+    open,
+    operation,
+    onStatusChange,
+    status?.last_operation_phase,
+    status?.protection_intent_status,
+  ]);
+
+  const bindAndContinue = useCallback(async (intentId: string) => {
+    const bound = await productBridge.bindIntent(intentId);
+    setOperation(bound);
+    if (bound.protection_state === "subscription_required" || bound.reason_code === "subscription_required") {
+      setView("checkout");
+      const nextOffer = await productBridge.offer();
+      setOffer(nextOffer);
+      return;
+    }
+    if (bound.reason_code) {
+      throw new Error(bound.message || "Protection could not continue.");
+    }
+    const started = await productBridge.enable(intentId);
+    setOperation(started);
+    setView("summary");
+  }, []);
+
+  const beginProtection = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const intent = await productBridge.createIntent();
+      setOperation(intent);
+      if (!account?.signed_in || intent.protection_state === "sign_in_required") {
+        setView("email");
+      } else {
+        await bindAndContinue(intent.protection_intent_id || intent.operation_id);
+      }
+    } catch (err) {
+      setError(errorMessage(err, "Protection could not start."));
+    } finally {
+      setBusy(false);
+    }
+  }, [account?.signed_in, bindAndContinue]);
+
+  const requestCode = useCallback(async () => {
+    if (!email.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await productBridge.requestCode(email.trim().toLowerCase());
+      setView("code");
+    } catch (err) {
+      setError(errorMessage(err, "Could not request a sign-in code."));
+    } finally {
+      setBusy(false);
+    }
+  }, [email]);
+
+  const verifyCode = useCallback(async () => {
+    if (!/^\d{6}$/.test(code)) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const nextAccount = await productBridge.verifyCode(email.trim().toLowerCase(), code);
+      setAccount(nextAccount);
+      const intentId = operation?.protection_intent_id || status?.protection_intent_id;
+      if (!intentId) throw new Error("The protection request expired. Start again.");
+      await bindAndContinue(intentId);
+      await refresh();
+    } catch (err) {
+      setError(errorMessage(err, "That code could not be verified."));
+    } finally {
+      setBusy(false);
+    }
+  }, [bindAndContinue, code, email, operation?.protection_intent_id, refresh, status?.protection_intent_id]);
+
+  const openCheckout = useCallback(async () => {
+    const intentId = operation?.protection_intent_id || status?.protection_intent_id;
+    if (!intentId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const handoff = await productBridge.openCheckout(intentId);
+      if (handoff.status === "already_subscribed") {
+        await bindAndContinue(intentId);
+      } else {
+        if (!handoff.opened) {
+          setError("Your subscription is still being processed. Check again shortly or manage it in Stripe.");
+        }
+        setCheckoutPolling(true);
+      }
+    } catch (err) {
+      setError(errorMessage(err, "Checkout could not open."));
+    } finally {
+      setBusy(false);
+    }
+  }, [bindAndContinue, operation?.protection_intent_id, status?.protection_intent_id]);
+
+  const checkPayment = useCallback(async (silent = false) => {
+    if (checkoutCheckInFlight.current) return;
+    const intentId = operation?.protection_intent_id || status?.protection_intent_id;
+    if (!intentId) return;
+    checkoutCheckInFlight.current = true;
+    setBusy(true);
+    setError(null);
+    try {
+      const bound = await productBridge.bindIntent(intentId);
+      setOperation(bound);
+      if (bound.protection_state === "subscription_required" || bound.reason_code === "subscription_required") {
+        if (!silent) setError("Payment is not active yet. Stripe may still be processing it.");
+        return;
+      }
+      setCheckoutPolling(false);
+      await bindAndContinue(intentId);
+    } catch (err) {
+      setError(errorMessage(err, "Payment status is unavailable."));
+    } finally {
+      checkoutCheckInFlight.current = false;
+      setBusy(false);
+    }
+  }, [bindAndContinue, operation?.protection_intent_id, status?.protection_intent_id]);
+
+  useEffect(() => {
+    if (!checkoutPolling) return;
+    let checks = 0;
+    const poll = window.setInterval(() => {
+      checks += 1;
+      if (checks >= 20) {
+        window.clearInterval(poll);
+        setCheckoutPolling(false);
+        return;
+      }
+      void checkPayment(true);
+    }, 3000);
+    const onFocus = () => void checkPayment(false);
+    window.addEventListener("focus", onFocus);
+    return () => {
+      window.clearInterval(poll);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [checkoutPolling, checkPayment]);
+
+  const runOperation = useCallback(async (action: "backup" | "verify" | "disable") => {
+    setBusy(true);
+    setError(null);
+    try {
+      const next = action === "backup"
+        ? await productBridge.backupNow()
+        : action === "verify"
+          ? await productBridge.verifyNow()
+          : await productBridge.disable();
+      setOperation(next);
+      await refresh();
+    } catch (err) {
+      setError(errorMessage(err, "The operation could not start."));
+    } finally {
+      setBusy(false);
+    }
+  }, [refresh]);
+
+  const presentation = useMemo(
+    () => protectionPresentation(operation?.protection_state || status?.protection_state || "local_only"),
+    [operation?.protection_state, status?.protection_state],
+  );
+  const price = formatPrice(offer);
+  const activeLabel = operationLabel(operation, status);
+  const repairAction = status ? protectionRepairAction(status) : "none";
+
+  const runRepairAction = useCallback(async () => {
+    if (!status) return;
+    if (repairAction === "signin") {
+      await beginProtection();
+      return;
+    }
+    if (repairAction === "subscribe") {
+      setView("checkout");
+      if (!offer) productBridge.offer().then(setOffer).catch(() => undefined);
+      return;
+    }
+    if (repairAction === "resume") {
+      const intentId = status.protection_intent_id;
+      if (!intentId) return;
+      setBusy(true);
+      setError(null);
+      try {
+        setOperation(await productBridge.enable(intentId));
+      } catch (err) {
+        setError(errorMessage(err, "Protection could not resume."));
+      } finally {
+        setBusy(false);
+      }
+      return;
+    }
+    if (repairAction === "backup" || repairAction === "verify") {
+      await runOperation(repairAction);
+      return;
+    }
+    await refresh();
+  }, [beginProtection, offer, refresh, repairAction, runOperation, status]);
+
+  return (
+    <aside className={`side-panel protection-panel ${open ? "open" : ""}`} aria-hidden={!open}>
+      <div className="side-panel-header">
+        <div>
+          <div className="protection-eyebrow">Ormah Cloud</div>
+          <h2 className="review-title" ref={headingRef} tabIndex={-1}>Protection</h2>
+        </div>
+        <button className="icon-button" onClick={onClose} aria-label="Close protection">
+          <X size={16} />
+        </button>
+      </div>
+
+      {!desktop ? (
+        <div className="protection-empty">
+          <ShieldCheck size={24} />
+          <strong>Open Ormah Desktop to protect this memory</strong>
+          <p>The desktop app keeps account credentials and encryption material out of this page.</p>
+        </div>
+      ) : loading && !status ? (
+        <div className="protection-empty"><LoaderCircle className="spin" size={22} />Loading protection status</div>
+      ) : (
+        <>
+          <section className={`protection-summary tone-${presentation.tone}`}>
+            <div className="protection-status-icon" aria-hidden="true">
+              {presentation.tone === "success" ? <ShieldCheck size={22} />
+                : presentation.tone === "danger" ? <AlertTriangle size={22} />
+                  : presentation.tone === "warning" ? <CloudOff size={22} />
+                    : presentation.tone === "working" ? <LoaderCircle className="spin" size={22} />
+                      : <LockKeyhole size={22} />}
+            </div>
+            <div>
+              <h3>{activeLabel || presentation.title}</h3>
+              <p>{presentation.detail}</p>
+            </div>
+          </section>
+
+          {error && (
+            <div className="protection-error" role="alert">
+              <AlertTriangle size={15} />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <div className="sr-status" aria-live="polite">{activeLabel || presentation.title}</div>
+
+          {view === "email" && (
+            <section className="protection-step">
+              <button className="step-back" onClick={() => setView("summary")}>Back</button>
+              <h3>Sign in or create an account</h3>
+              <p>Enter your email. Ormah will send a one-time code; there is no password.</p>
+              <label className="protection-field">
+                <span>Email</span>
+                <input
+                  type="email"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  onKeyDown={(event) => { if (event.key === "Enter") void requestCode(); }}
+                  autoFocus
+                />
+              </label>
+              <button className="protection-primary" disabled={busy || !email.trim()} onClick={() => void requestCode()}>
+                {busy ? <LoaderCircle className="spin" size={15} /> : <ChevronRight size={15} />}
+                Send code
+              </button>
+            </section>
+          )}
+
+          {view === "code" && (
+            <section className="protection-step">
+              <button className="step-back" onClick={() => setView("email")}>Change email</button>
+              <h3>Check your email</h3>
+              <p>Enter the six-digit code sent to <strong>{email}</strong>.</p>
+              <label className="protection-field">
+                <span>One-time code</span>
+                <input
+                  className="otp-input"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  maxLength={6}
+                  value={code}
+                  onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
+                  onKeyDown={(event) => { if (event.key === "Enter") void verifyCode(); }}
+                  autoFocus
+                />
+              </label>
+              <button className="protection-primary" disabled={busy || code.length !== 6} onClick={() => void verifyCode()}>
+                {busy ? <LoaderCircle className="spin" size={15} /> : <Check size={15} />}
+                Verify and continue
+              </button>
+              <button className="protection-secondary" disabled={busy} onClick={() => void requestCode()}>
+                Send another code
+              </button>
+            </section>
+          )}
+
+          {view === "checkout" && (
+            <section className="protection-step">
+              <h3>Start cloud protection</h3>
+              <p>Card details are handled by Stripe in your browser. Ormah never receives them.</p>
+              {offer && (
+                <div className="protection-offer">
+                  <span>{offer.name}</span>
+                  <strong>{price || `${offer.unit_amount} ${offer.currency}`} / {offer.interval}</strong>
+                </div>
+              )}
+              <button className="protection-primary" disabled={busy} onClick={() => void openCheckout()}>
+                {busy ? <LoaderCircle className="spin" size={15} /> : <ExternalLink size={15} />}
+                Subscribe with Stripe
+              </button>
+              {checkoutPolling && (
+                <div className="checkout-waiting">
+                  <LoaderCircle className="spin" size={15} /> Waiting for Stripe to confirm payment
+                </div>
+              )}
+                <button className="protection-secondary" disabled={busy} onClick={() => void checkPayment(false)}>
+                <RefreshCw size={14} /> I've paid, check again
+              </button>
+            </section>
+          )}
+
+          {view === "summary" && !activeLabel && (
+            <section className="protection-actions">
+              {["local_only", "sign_in_required", "stopped"].includes(status?.protection_state || "local_only") && (
+                <button className="protection-primary" disabled={busy} onClick={() => void beginProtection()}>
+                  <ShieldCheck size={16} /> Protect this memory
+                </button>
+              )}
+              {["protected", "changes_pending"].includes(status?.protection_state || "") && (
+                <button className="protection-primary" disabled={busy} onClick={() => void runOperation("backup")}>
+                  <RefreshCw size={15} /> Back up now
+                </button>
+              )}
+              {["attention_required", "offline"].includes(status?.protection_state || "") && repairAction !== "none" && (
+                <button className="protection-primary" disabled={busy} onClick={() => void runRepairAction()}>
+                  <RefreshCw size={15} />
+                  {repairAction === "verify" ? "Retry recovery check"
+                    : repairAction === "signin" ? "Sign in again"
+                      : repairAction === "subscribe" ? "Reactivate subscription"
+                        : repairAction === "refresh" ? "Check connection"
+                          : repairAction === "resume" ? "Resume protection"
+                            : "Retry encrypted backup"}
+                </button>
+              )}
+              {["subscription_required", "paused"].includes(status?.protection_state || "") && (
+                <button className="protection-primary" disabled={busy} onClick={() => {
+                  setView("checkout");
+                  if (!offer) productBridge.offer().then(setOffer).catch(() => undefined);
+                }}>
+                  <CreditCard size={15} /> Reactivate protection
+                </button>
+              )}
+            </section>
+          )}
+
+          {(status?.last_successful_verify_at || status?.last_successful_upload_at) && (
+            <section className="protection-facts" aria-label="Protection details">
+              <div><span>Last verified restorable</span><strong>{formatDate(status.last_successful_verify_at)}</strong></div>
+              <div><span>Last encrypted upload</span><strong>{formatDate(status.last_successful_upload_at)}</strong></div>
+              <div><span>Cloud can read</span><strong>metadata only</strong></div>
+            </section>
+          )}
+
+          {status?.warnings?.length ? (
+            <section className="protection-warnings">
+              {status.warnings.map((warning) => <p key={warning}>{warning}</p>)}
+            </section>
+          ) : null}
+
+          {account?.signed_in && view === "summary" && (
+            <section className="protection-account">
+              <div>
+                <span>Account</span>
+                <strong>{account.email}</strong>
+              </div>
+              <div className="protection-account-actions">
+                <button className="icon-text-button" onClick={async () => {
+                  try {
+                    await productBridge.openPortal();
+                  } catch (err) {
+                    setError(errorMessage(err, "Subscription management could not open."));
+                  }
+                }}>
+                  <CreditCard size={14} /> Manage subscription
+                </button>
+                <button className="icon-text-button" onClick={async () => {
+                  setBusy(true);
+                  try {
+                    const result = await productBridge.logout();
+                    if (result.warning) onToast(result.warning, "info");
+                    await refresh();
+                  } catch (err) {
+                    setError(errorMessage(err, "Could not sign out locally."));
+                  } finally {
+                    setBusy(false);
+                  }
+                }}>
+                  <LogOut size={14} /> Sign out
+                </button>
+              </div>
+            </section>
+          )}
+
+          {status?.enabled && view === "summary" && (
+            confirmStop ? (
+              <section className="protection-stop-confirm">
+                <strong>Stop cloud protection?</strong>
+                <p>Future uploads will stop. Existing recovery points remain available, and your subscription is managed separately.</p>
+                <div>
+                  <button className="protection-secondary" onClick={() => setConfirmStop(false)}>Keep protection on</button>
+                  <button className="protection-danger" disabled={busy} onClick={async () => {
+                    await runOperation("disable");
+                    setConfirmStop(false);
+                  }}>Stop protection</button>
+                </div>
+              </section>
+            ) : (
+              <button className="protection-stop" disabled={busy} onClick={() => setConfirmStop(true)}>
+                Stop future cloud backups
+              </button>
+            )
+          )}
+        </>
+      )}
+    </aside>
+  );
+}

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useRef, useState } from "react";
+import { ShieldCheck } from "lucide-react";
 import { searchNodes } from "../api";
 import SearchResults from "./SearchResults";
 import type { MemoryNode } from "../types";
+import type { ProtectionState } from "../productBridge";
 
-type PanelId = "settings" | "insights" | "admin" | "agents";
+type PanelId = "protection" | "settings" | "insights" | "admin" | "agents";
 
 interface Props {
   nodeCount: number;
@@ -13,6 +15,7 @@ interface Props {
   onSearchHover: (nodeId: string) => void;
   onSearchHoverEnd: () => void;
   searchInputRef: React.RefObject<HTMLInputElement>;
+  protectionState: ProtectionState | null;
 }
 
 export default function TopBar({
@@ -23,6 +26,7 @@ export default function TopBar({
   onSearchHover,
   onSearchHoverEnd,
   searchInputRef,
+  protectionState,
 }: Props) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<MemoryNode[] | null>(null);
@@ -57,6 +61,14 @@ export default function TopBar({
 
   const actionButtons = (
     <>
+      <button
+        className={`top-bar-btn protection-entry ${activePanel === "protection" ? "active" : ""} ${protectionState === "protected" ? "protected" : ""}`}
+        onClick={() => onTogglePanel("protection")}
+        title="Cloud protection"
+      >
+        <ShieldCheck size={14} aria-hidden="true" />
+        {protectionState === "protected" ? "protected" : "protect"}
+      </button>
       <button
         className={`top-bar-btn ${activePanel === "settings" ? "active" : ""}`}
         onClick={() => onTogglePanel("settings")}

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  operationPhaseIsActive,
+  protectionRepairAction,
+  protectionPresentation,
+  type ProtectionStatus,
+  type ProtectionState,
+} from "./productBridge";
+
+describe("protectionPresentation", () => {
+  it.each<ProtectionState>([
+    "initializing",
+    "uploading_first_backup",
+    "verifying_first_backup",
+    "verification_pending",
+  ])("never calls incomplete state %s protected", (state) => {
+    const result = protectionPresentation(state);
+
+    expect(result.title.toLowerCase()).not.toContain("protected");
+    expect(result.action).toBe("wait");
+  });
+
+  it("uses the verified claim only for the protected state", () => {
+    const result = protectionPresentation("protected");
+
+    expect(result.title).toBe("Protected and verified");
+    expect(result.tone).toBe("success");
+  });
+
+  it("keeps retained recovery points explicit when uploads stop", () => {
+    const result = protectionPresentation("stopped");
+
+    expect(result.detail).toContain("recovery points remain available");
+    expect(result.action).toBe("resume");
+  });
+
+  it("does not imply local data loss while offline", () => {
+    const result = protectionPresentation("offline");
+
+    expect(result.detail).toContain("safe here");
+    expect(result.tone).toBe("warning");
+  });
+});
+
+describe("operationPhaseIsActive", () => {
+  it("distinguishes durable progress from terminal and absent phases", () => {
+    for (const phase of ["pending", "running", "uploading", "finalizing", "verifying"] as const) {
+      expect(operationPhaseIsActive(phase)).toBe(true);
+    }
+    for (const phase of ["completed", "failed", "canceled", null, undefined] as const) {
+      expect(operationPhaseIsActive(phase)).toBe(false);
+    }
+  });
+});
+
+function status(overrides: Partial<ProtectionStatus>): ProtectionStatus {
+  return {
+    enabled: true,
+    store_id: "store",
+    entitlement: "active",
+    protection_state: "attention_required",
+    protection_intent_id: null,
+    protection_intent_status: null,
+    protection_intent_expires_at: null,
+    last_operation_id: null,
+    last_operation_kind: null,
+    last_operation_phase: "failed",
+    last_successful_upload_at: null,
+    last_successful_backup_snapshot_id: null,
+    last_successful_verify_at: null,
+    last_verified_snapshot_id: null,
+    last_error_code: null,
+    last_error_message: null,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("protectionRepairAction", () => {
+  it("routes failures only to operations that can repair them", () => {
+    expect(protectionRepairAction(status({ last_error_code: "decrypt_failed" }))).toBe("verify");
+    expect(protectionRepairAction(status({ last_error_code: "upload_failed" }))).toBe("backup");
+    expect(protectionRepairAction(status({ last_error_code: "sign_in_required" }))).toBe("signin");
+    expect(protectionRepairAction(status({ last_error_code: "entitlement_expired" }))).toBe("subscribe");
+    expect(protectionRepairAction(status({ last_error_code: "key_missing" }))).toBe("none");
+    expect(protectionRepairAction(status({ last_error_code: "quota_exceeded" }))).toBe("none");
+  });
+
+  it("resumes an interrupted initial protection intent", () => {
+    expect(protectionRepairAction(status({
+      last_error_code: "operation_interrupted",
+      protection_intent_status: "running",
+    }))).toBe("resume");
+  });
+});

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -1,0 +1,295 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type EntitlementState = "active" | "grace" | "expired" | "none";
+
+export type ProtectionState =
+  | "local_only"
+  | "sign_in_required"
+  | "subscription_required"
+  | "initializing"
+  | "uploading_first_backup"
+  | "verifying_first_backup"
+  | "verification_pending"
+  | "protected"
+  | "changes_pending"
+  | "offline"
+  | "paused"
+  | "stopped"
+  | "attention_required";
+
+export type OperationPhase =
+  | "pending"
+  | "running"
+  | "uploading"
+  | "finalizing"
+  | "verifying"
+  | "completed"
+  | "failed"
+  | "canceled";
+
+const ACTIVE_OPERATION_PHASES = new Set<OperationPhase>([
+  "pending",
+  "running",
+  "uploading",
+  "finalizing",
+  "verifying",
+]);
+
+export function operationPhaseIsActive(phase: OperationPhase | null | undefined): boolean {
+  return phase !== null && phase !== undefined && ACTIVE_OPERATION_PHASES.has(phase);
+}
+
+export interface BridgeInfo {
+  version: number;
+  platform: string;
+}
+
+export interface AccountStatus {
+  signed_in: boolean;
+  email: string | null;
+  device_name: string;
+  entitlement: EntitlementState;
+  plan_status: string | null;
+  cache_age_seconds: number | null;
+  warning?: string | null;
+}
+
+export interface BillingOffer {
+  name: string;
+  unit_amount: number;
+  currency: string;
+  interval: string;
+}
+
+export interface ProtectionStatus {
+  enabled: boolean;
+  store_id: string | null;
+  entitlement: EntitlementState;
+  protection_state: ProtectionState;
+  protection_intent_id: string | null;
+  protection_intent_status: string | null;
+  protection_intent_expires_at: string | null;
+  last_operation_id: string | null;
+  last_operation_kind: string | null;
+  last_operation_phase: OperationPhase | null;
+  last_successful_upload_at: string | null;
+  last_successful_backup_snapshot_id: string | null;
+  last_successful_verify_at: string | null;
+  last_verified_snapshot_id: string | null;
+  last_error_code: string | null;
+  last_error_message: string | null;
+  warnings: string[];
+}
+
+export interface ProtectionOperation {
+  operation_id: string;
+  kind: "enable" | "disable" | "backup" | "verify" | "restore";
+  status?: "queued" | "running" | "completed" | "failed";
+  phase: OperationPhase | null;
+  protection_state: ProtectionState | null;
+  reason_code: string | null;
+  message: string | null;
+  snapshot_id: string | null;
+  protection_intent_id: string | null;
+}
+
+export interface BillingHandoff {
+  status: "checkout_required" | "already_subscribed" | "subscription_pending";
+  expires_at: number | null;
+  opened: boolean;
+}
+
+export interface LogoutResult {
+  signed_in: false;
+  revoked_remotely: boolean;
+  warning: string | null;
+}
+
+export function isDesktopApp(): boolean {
+  if (typeof window === "undefined") return false;
+  const marker = window as unknown as {
+    __ORMAH_DESKTOP__?: boolean;
+    __TAURI_INTERNALS__?: unknown;
+  };
+  return Boolean(marker.__ORMAH_DESKTOP__ || marker.__TAURI_INTERNALS__);
+}
+
+async function native<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  if (!isDesktopApp()) {
+    throw new Error("Cloud protection is available in Ormah Desktop.");
+  }
+  return invoke<T>(command, args);
+}
+
+export const productBridge = {
+  info: () => native<BridgeInfo>("desktop_bridge_info"),
+  accountStatus: () => native<AccountStatus>("account_status"),
+  requestCode: (email: string) => native<{ status: string }>("request_account_code", { email }),
+  verifyCode: (email: string, code: string) =>
+    native<AccountStatus>("verify_account_code", { email, code }),
+  logout: () => native<LogoutResult>("logout_account"),
+  offer: () => native<BillingOffer>("billing_offer"),
+  status: () => native<ProtectionStatus>("protection_status"),
+  createIntent: () => native<ProtectionOperation>("create_protection_intent"),
+  bindIntent: (intentId: string) =>
+    native<ProtectionOperation>("bind_protection_intent", { intentId }),
+  cancelIntent: (intentId: string) =>
+    native<ProtectionOperation>("cancel_protection_intent", { intentId }),
+  enable: (intentId: string) =>
+    native<ProtectionOperation>("enable_protection", { intentId }),
+  disable: () => native<ProtectionOperation>("disable_protection"),
+  backupNow: () => native<ProtectionOperation>("backup_now"),
+  verifyNow: () => native<ProtectionOperation>("verify_now"),
+  operation: (operationId: string) =>
+    native<ProtectionOperation>("operation_status", { operationId }),
+  openCheckout: (intentId: string) =>
+    native<BillingHandoff>("open_checkout", { intentId }),
+  openPortal: () => native<{ opened: boolean }>("open_billing_portal"),
+};
+
+export interface ProtectionPresentation {
+  tone: "neutral" | "working" | "success" | "warning" | "danger";
+  title: string;
+  detail: string;
+  action: "protect" | "signin" | "subscribe" | "wait" | "backup" | "retry" | "resume";
+}
+
+export type ProtectionRepairAction =
+  | "backup"
+  | "verify"
+  | "resume"
+  | "signin"
+  | "subscribe"
+  | "refresh"
+  | "none";
+
+const VERIFY_FAILURES = new Set([
+  "verification_failed",
+  "download_failed",
+  "ciphertext_hash_unavailable",
+  "ciphertext_hash_mismatch",
+  "decrypt_failed",
+  "manifest_verification_failed",
+  "node_parse_failed",
+  "bundle_corrupt",
+  "index_environment_unavailable",
+  "index_rebuild_failed",
+  "search_probe_failed",
+  "self_pointer_invalid",
+]);
+
+const BACKUP_FAILURES = new Set([
+  "upload_failed",
+  "upload_status_unknown",
+  "operation_interrupted",
+  "store_busy",
+]);
+
+export function protectionRepairAction(status: ProtectionStatus): ProtectionRepairAction {
+  const reason = status.last_error_code;
+  if (reason === "sign_in_required") return "signin";
+  if (reason === "subscription_required" || reason === "entitlement_expired") {
+    return "subscribe";
+  }
+  if (VERIFY_FAILURES.has(reason || "")) return "verify";
+  if (BACKUP_FAILURES.has(reason || "")) {
+    return status.protection_intent_status === "running" ? "resume" : "backup";
+  }
+  if (status.protection_state === "offline") {
+    if (status.protection_intent_status === "running") return "resume";
+    return status.enabled ? "backup" : "refresh";
+  }
+  // Key, quota, disk, and version failures need a dedicated repair path;
+  // retrying verification would be misleading and cannot repair them.
+  return "none";
+}
+
+export function protectionPresentation(state: ProtectionState): ProtectionPresentation {
+  switch (state) {
+    case "sign_in_required":
+      return {
+        tone: "neutral",
+        title: "Sign in to protect this memory",
+        detail: "Your memory stays on this machine until you explicitly continue.",
+        action: "signin",
+      };
+    case "subscription_required":
+      return {
+        tone: "neutral",
+        title: "Subscription required",
+        detail: "Subscribe to create encrypted, verified recovery points.",
+        action: "subscribe",
+      };
+    case "initializing":
+      return {
+        tone: "working",
+        title: "Preparing encryption",
+        detail: "Setting up this memory's protected recovery path.",
+        action: "wait",
+      };
+    case "uploading_first_backup":
+      return {
+        tone: "working",
+        title: "Uploading encrypted recovery point",
+        detail: "Only ciphertext is leaving this machine.",
+        action: "wait",
+      };
+    case "verifying_first_backup":
+    case "verification_pending":
+      return {
+        tone: "working",
+        title: "Checking recovery",
+        detail: "Downloading, decrypting, rebuilding, and probing a temporary copy.",
+        action: "wait",
+      };
+    case "protected":
+      return {
+        tone: "success",
+        title: "Protected and verified",
+        detail: "The latest recovery point was restored and checked on this device.",
+        action: "backup",
+      };
+    case "changes_pending":
+      return {
+        tone: "warning",
+        title: "Changes waiting for protection",
+        detail: "Your last verified recovery point remains available.",
+        action: "backup",
+      };
+    case "offline":
+      return {
+        tone: "warning",
+        title: "Cloud protection is offline",
+        detail: "Changes are safe here and will resume when the service is reachable.",
+        action: "retry",
+      };
+    case "paused":
+      return {
+        tone: "warning",
+        title: "Cloud uploads are paused",
+        detail: "Local memory and retained recovery points remain available.",
+        action: "subscribe",
+      };
+    case "stopped":
+      return {
+        tone: "neutral",
+        title: "Cloud protection stopped",
+        detail: "Existing recovery points remain available. Billing is managed separately.",
+        action: "resume",
+      };
+    case "attention_required":
+      return {
+        tone: "danger",
+        title: "Protection needs attention",
+        detail: "Review the problem below, then retry the failed step.",
+        action: "retry",
+      };
+    default:
+      return {
+        tone: "neutral",
+        title: "Protect this memory",
+        detail: "Keep an encrypted, verified recovery copy that Ormah Cloud cannot read.",
+        action: "protect",
+      };
+  }
+}

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -830,6 +830,379 @@ body.in-app .node-detail.tier-core {
   padding: 24px 0;
 }
 
+/* ---- Cloud protection ---------------------------------------------------- */
+.top-bar-btn.protection-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-bright);
+}
+
+.top-bar-btn.protection-entry svg {
+  color: var(--node-self);
+}
+
+.top-bar-btn.protection-entry.protected {
+  color: var(--edge-supports);
+}
+
+.protection-panel {
+  width: min(430px, 100vw);
+  z-index: 90;
+  padding: 22px;
+}
+
+.protection-eyebrow {
+  margin-bottom: 3px;
+  color: var(--node-self);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.icon-button {
+  width: 30px;
+  height: 30px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  border-color: var(--border-light);
+  color: var(--text-bright);
+}
+
+.protection-summary {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px 0 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.protection-status-icon {
+  width: 34px;
+  height: 34px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-surface);
+}
+
+.tone-success .protection-status-icon { color: var(--edge-supports); }
+.tone-warning .protection-status-icon { color: var(--accent); }
+.tone-danger .protection-status-icon { color: var(--edge-contradicts); }
+.tone-working .protection-status-icon { color: var(--node-self); }
+
+.protection-summary h3,
+.protection-step h3 {
+  margin: 0 0 5px;
+  color: var(--text-bright);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.protection-summary p,
+.protection-step p,
+.protection-empty p {
+  color: var(--text);
+  line-height: 1.55;
+}
+
+.protection-error {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+  margin-top: 14px;
+  padding: 10px;
+  border-left: 2px solid var(--edge-contradicts);
+  background: var(--danger-bg);
+  color: var(--text-bright);
+  line-height: 1.45;
+}
+
+.protection-step,
+.protection-actions,
+.protection-account,
+.protection-facts,
+.protection-warnings {
+  padding: 18px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.step-back {
+  margin-bottom: 13px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.step-back:hover { color: var(--text-bright); }
+
+.protection-field {
+  display: grid;
+  gap: 6px;
+  margin: 16px 0 12px;
+}
+
+.protection-field span {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.protection-field input {
+  width: 100%;
+  min-width: 0;
+  height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  outline: none;
+  background: var(--bg-surface);
+  color: var(--text-bright);
+  font: inherit;
+}
+
+.protection-field input:focus {
+  border-color: var(--node-self);
+  box-shadow: 0 0 0 2px rgba(116, 179, 165, 0.14);
+}
+
+.protection-field .otp-input {
+  font-family: var(--font-mono);
+  font-size: 20px;
+  letter-spacing: 0;
+  text-align: center;
+}
+
+.protection-primary,
+.protection-secondary,
+.icon-text-button,
+.protection-stop {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.protection-primary {
+  width: 100%;
+  border: 1px solid var(--node-self);
+  background: rgba(116, 179, 165, 0.12);
+  color: var(--text-bright);
+}
+
+.protection-primary:hover:not(:disabled) { background: rgba(116, 179, 165, 0.2); }
+
+.protection-secondary {
+  width: 100%;
+  margin-top: 8px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+}
+
+.protection-primary:disabled,
+.protection-secondary:disabled,
+.protection-stop:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.protection-offer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 16px 0 12px;
+  padding: 12px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.protection-offer span { color: var(--text); }
+.protection-offer strong { color: var(--text-bright); white-space: nowrap; }
+
+.checkout-waiting {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  color: var(--node-self);
+  font-size: 11px;
+}
+
+.protection-facts {
+  display: grid;
+  gap: 11px;
+}
+
+.protection-facts > div,
+.protection-account > div:first-child {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.protection-facts span,
+.protection-account span {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.protection-facts strong,
+.protection-account strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-bright);
+  font-size: 11px;
+  font-weight: 500;
+  text-align: right;
+}
+
+.protection-warnings p {
+  padding-left: 10px;
+  border-left: 2px solid var(--accent);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.protection-warnings p + p { margin-top: 10px; }
+
+.protection-account-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.icon-text-button {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+}
+
+.icon-text-button:hover { border-color: var(--border-light); color: var(--text-bright); }
+
+.protection-stop {
+  width: 100%;
+  margin-top: 18px;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.protection-stop:hover { color: var(--edge-contradicts); }
+
+.protection-stop-confirm {
+  margin-top: 18px;
+  padding: 12px;
+  border: 1px solid var(--edge-contradicts);
+  border-radius: var(--radius);
+  background: var(--danger-bg);
+}
+
+.protection-stop-confirm strong { color: var(--text-bright); }
+
+.protection-stop-confirm p {
+  margin: 6px 0 12px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.protection-stop-confirm > div {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.protection-stop-confirm .protection-secondary { margin-top: 0; }
+
+.protection-danger {
+  min-height: 36px;
+  border: 1px solid var(--edge-contradicts);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--edge-contradicts);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.protection-danger:hover:not(:disabled) { background: var(--danger-bg); }
+.protection-danger:disabled { opacity: 0.5; cursor: default; }
+
+.protection-empty {
+  min-height: 180px;
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 9px;
+  padding: 30px 12px;
+  color: var(--node-self);
+  text-align: center;
+}
+
+.protection-empty strong { color: var(--text-bright); }
+
+.spin { animation: protection-spin 900ms linear infinite; }
+
+.sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes protection-spin { to { transform: rotate(360deg); } }
+
+@media (prefers-reduced-motion: reduce) {
+  .spin { animation: none; }
+}
+
+@media (max-width: 720px) {
+  .protection-panel {
+    top: 40px;
+    width: 100vw;
+    padding: 18px;
+  }
+
+  .top-bar-btn.protection-entry {
+    width: 32px;
+    padding-inline: 0;
+    justify-content: center;
+    font-size: 0;
+  }
+}
+
 .review-card-nodes {
   display: none; /* replaced by review-source-nodes */
 }


### PR DESCRIPTION
## Problem

C02's backend could enable, upload, and verify paid protection, but Ormah Desktop had no safe customer-facing path for account login, hosted billing, progress, or recovery after a runtime restart. Sensitive local credentials and hosted URLs also needed to remain outside React.

## Solution

- add shared account application services and owner-only local account routes
- add token-free protection routes plus a bounded background-operation coordinator
- resume durable RUNNING protection intents on Python startup through the existing upload journal
- add a narrow Tauri product bridge with exact local-origin checks and fixed endpoints only
- keep local capabilities, account tokens, presigned URLs, age identities, and Stripe URLs out of React
- exact-host validate Checkout and Customer Portal URLs and open them only from Rust
- add a first-class Protection panel for OTP login, offer display, hosted Checkout, entitlement refresh, immediate protection, status, backup, verification, stop, logout, and portal management
- distinguish process-local polling IDs from durable operation phases so restart recovery remains observable
- serialize Checkout entitlement checks and map repair actions to stable failure reasons
- document the bridge and desktop protection flow

## Security

- no generic Tauri HTTP proxy
- remote graph WebView receives only the narrow product-bridge capability
- each command requires the real `main` WebView at the configured `127.0.0.1` origin
- local capability must be a regular non-symlink `0600` lowercase-hex file
- hosted billing URLs require exact Stripe HTTPS authorities and never cross into React
- protection responses reject secret-bearing fields and secret-shaped string values recursively
- card data remains entirely in Stripe Checkout

## Verification

- `1761 passed, 1 deselected` full Python suite
- `ruff check src/ tests/` clean
- 29 focused account/protection API and CLI tests pass
- 49 protection/journal/coordinator tests pass
- 15 Rust tests pass; `cargo check` passes
- 10 UI policy tests pass; TypeScript/Vite production build passes
- visual Playwright check at 860x600 passed for local-only and protected states
- `npm audit --omit=dev` reported 0 production vulnerabilities before final source-only edits
- independent adversarial review found no remaining security or correctness blocker

## Follow-up

This PR deliberately does not claim device-loss recovery readiness. The next C02 slice will add native recovery-kit Save/Print plus read-back validation and expose that as a separate state from **Protected and verified**. It will also add a fuller component harness around restart polling.