### PR TITLE
feat(desktop): add recovery-kit readiness UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ them. Keep it offline and separate from the machine and cloud account it
 protects. Anyone with the kit can read the backups; without it, nobody can,
 including Ormah.
 
+Snapshot protection and device-loss recovery are reported separately in Ormah
+Desktop. **Protected and verified** means the encrypted snapshot was restored
+and checked on this device. **Device-loss recovery ready** appears only after
+Desktop saves the current recovery kit through the native file picker, reopens
+the saved file, and verifies it against this memory's active store and complete
+identity set. Canceling the picker does not affect cloud protection; the
+recovery action remains incomplete. **Open printable copy** opens the kit in the
+system viewer but does not claim that a durable copy was saved. Key rotation
+clears readiness until the new kit is saved and checked again.
+
 `ormah uninstall` removes local data and account configuration, but it always
 preserves `~/.config/ormah/cloud.key` and
 `~/.config/ormah/ormah-recovery-kit.md`. Before deleting anything, uninstall

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -12,6 +12,8 @@ product:
    count, with a dropdown for stats and actions.
 4. **In-app graph** — the existing web UI loads inside the window.
 5. **Auto-update** — Tauri updater (appcast).
+6. **Trusted recovery handoff** — fixed native commands save or open the
+   canonical recovery kit without exposing its bytes or location to React.
 
 ## Architecture
 
@@ -28,6 +30,16 @@ binaries/uv-<triple>        ← bundled uv binary (downloaded at CI build time)
        ↓ serves
 http://127.0.0.1:8787        ← existing FastAPI app + web UI
 ```
+
+The product webview receives only the purpose-built `desktop-product-bridge`
+commands. Recovery-kit Save uses `tauri-plugin-dialog` only inside Rust; the
+remote graph capability is not granted generic dialog, filesystem, or shell
+access. Rust bounded-reads the fixed canonical kit, writes the selected file
+with owner-only permissions on Unix, reopens it without following symlinks,
+and sends only its SHA-256 digest to a fixed capability-authenticated local
+endpoint. Python independently validates the canonical store and full active
+identity set before recording readiness under the store lock. The direct
+`sha2` and `libc` dependencies provide digesting and Unix `O_NOFOLLOW` support.
 
 ## Build & run (dev)
 

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2511,14 +2511,17 @@ dependencies = [
 name = "ormah-desktop"
 version = "0.3.16"
 dependencies = [
+ "libc",
  "once_cell",
  "reqwest 0.12.28",
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",
+ "tauri-plugin-dialog",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
@@ -3129,6 +3132,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4030,6 +4057,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-notification = "2"
@@ -27,6 +28,8 @@ once_cell = "1"
 semver = "1"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
+sha2 = "0.10"
+libc = "0.2"
 
 # Single-instance guard: macOS uses this plugin (Unix socket). On Linux the
 # plugin relies on claiming a D-Bus name, which fails silently and lets

--- a/desktop/src-tauri/permissions/desktop.toml
+++ b/desktop/src-tauri/permissions/desktop.toml
@@ -36,4 +36,6 @@ commands.allow = [
   "operation_status",
   "open_checkout",
   "open_billing_portal",
+  "save_recovery_kit",
+  "open_printable_recovery_kit",
 ]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -150,6 +150,7 @@ pub fn run() {
 
     builder
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_autostart::init(
@@ -184,6 +185,8 @@ pub fn run() {
             product_bridge::operation_status,
             product_bridge::open_checkout,
             product_bridge::open_billing_portal,
+            product_bridge::save_recovery_kit,
+            product_bridge::open_printable_recovery_kit,
         ])
         .setup(|app| {
             // Linux: refuse to start a second instance so we never spawn a

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -7,9 +7,13 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::fs::{Metadata, OpenOptions};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tauri::{AppHandle, Runtime, WebviewWindow};
+use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_shell::ShellExt;
 use url::Url;
 
@@ -24,6 +28,8 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(35);
 const MAX_HOSTED_URL_CHARS: usize = 2048;
 const CHECKOUT_HOST: &str = "checkout.stripe.com";
 const PORTAL_HOST: &str = "billing.stripe.com";
+const RECOVERY_KIT_FILENAME: &str = "ormah-recovery-kit.md";
+const MAX_RECOVERY_KIT_BYTES: u64 = 256 * 1024;
 
 #[derive(Debug, Serialize)]
 pub struct DesktopBridgeInfo {
@@ -85,6 +91,31 @@ struct PortalHandoff {
 #[derive(Debug, Serialize)]
 pub struct OpenedResult {
     opened: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecoveryKitReadiness {
+    device_loss_recovery_ready: bool,
+    recovery_kit_verified_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RecoveryKitActionResult {
+    status: &'static str,
+    device_loss_recovery_ready: Option<bool>,
+    recovery_kit_verified_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PrintableRecoveryKitResult {
+    opened: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RecoveryKitSaveOutcome {
+    Canceled,
+    Saved { digest: String },
 }
 
 #[tauri::command]
@@ -217,6 +248,65 @@ pub async fn operation_status(
 }
 
 #[tauri::command]
+pub async fn save_recovery_kit<R: Runtime>(
+    app: AppHandle<R>,
+    window: WebviewWindow<R>,
+) -> Result<RecoveryKitActionResult, String> {
+    require_product_origin(&window)?;
+    let selected = app
+        .dialog()
+        .file()
+        .set_title("Save sensitive Ormah recovery kit")
+        .set_file_name(RECOVERY_KIT_FILENAME)
+        .add_filter("Markdown document", &["md"])
+        .blocking_save_file();
+    let destination = selected.and_then(|selection| selection.into_path().ok());
+    let canonical = recovery_kit_path()?;
+    let digest = match save_selected_recovery_kit(&canonical, destination.as_deref())? {
+        RecoveryKitSaveOutcome::Canceled => {
+            return Ok(RecoveryKitActionResult {
+                status: "canceled",
+                device_loss_recovery_ready: None,
+                recovery_kit_verified_at: None,
+            });
+        }
+        RecoveryKitSaveOutcome::Saved { digest } => digest,
+    };
+    let readiness: RecoveryKitReadiness = request_json(
+        "POST",
+        "/admin/cloud/protection/recovery-kit/confirm",
+        Some(json!({ "sha256_digest": digest })),
+    )
+    .await?;
+    if readiness.recovery_kit_verified_at.is_empty()
+        || readiness.recovery_kit_verified_at.len() > 64
+    {
+        return Err("The saved recovery kit could not be verified.".to_string());
+    }
+    Ok(RecoveryKitActionResult {
+        status: "saved",
+        device_loss_recovery_ready: Some(readiness.device_loss_recovery_ready),
+        recovery_kit_verified_at: Some(readiness.recovery_kit_verified_at),
+    })
+}
+
+#[tauri::command]
+pub async fn open_printable_recovery_kit<R: Runtime>(
+    app: AppHandle<R>,
+    window: WebviewWindow<R>,
+) -> Result<PrintableRecoveryKitResult, String> {
+    require_product_origin(&window)?;
+    let canonical = recovery_kit_path()?;
+    read_bounded_recovery_kit(&canonical)?;
+    let printable = canonical
+        .to_str()
+        .ok_or_else(|| "The printable recovery kit is unavailable.".to_string())?;
+    open_external(&app, printable)
+        .map_err(|_| "Could not open the printable recovery kit.".to_string())?;
+    Ok(PrintableRecoveryKitResult { opened: true })
+}
+
+#[tauri::command]
 pub async fn open_checkout<R: Runtime>(
     app: AppHandle<R>,
     window: WebviewWindow<R>,
@@ -287,6 +377,176 @@ fn open_external<R: Runtime>(app: &AppHandle<R>, url: &str) -> Result<(), String
     app.shell()
         .open(url, None)
         .map_err(|_| "Could not open the system browser.".to_string())
+}
+
+fn recovery_kit_path() -> Result<PathBuf, String> {
+    Ok(user_home()?
+        .join(".config/ormah")
+        .join(RECOVERY_KIT_FILENAME))
+}
+
+fn user_home() -> Result<PathBuf, String> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .ok_or_else(|| "The local Ormah configuration is unavailable.".to_string())
+}
+
+fn read_bounded_recovery_kit(path: &Path) -> Result<Vec<u8>, String> {
+    read_bounded_recovery_kit_with_metadata(path).map(|(bytes, _)| bytes)
+}
+
+fn read_bounded_recovery_kit_with_metadata(path: &Path) -> Result<(Vec<u8>, Metadata), String> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|_| "The recovery kit is unavailable.".to_string())?;
+    let metadata = file
+        .metadata()
+        .map_err(|_| "The recovery kit is unavailable.".to_string())?;
+    if !metadata.is_file() || metadata.len() > MAX_RECOVERY_KIT_BYTES {
+        return Err("The recovery kit is invalid.".to_string());
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    Read::by_ref(&mut file)
+        .take(MAX_RECOVERY_KIT_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| "The recovery kit is unavailable.".to_string())?;
+    if bytes.len() as u64 > MAX_RECOVERY_KIT_BYTES {
+        return Err("The recovery kit is invalid.".to_string());
+    }
+    Ok((bytes, metadata))
+}
+
+fn save_selected_recovery_kit(
+    canonical: &Path,
+    destination: Option<&Path>,
+) -> Result<RecoveryKitSaveOutcome, String> {
+    let Some(destination) = destination else {
+        return Ok(RecoveryKitSaveOutcome::Canceled);
+    };
+    let (canonical_bytes, canonical_metadata) = read_bounded_recovery_kit_with_metadata(canonical)?;
+    if paths_resolve_to_same_file(canonical, destination)? {
+        return Err("Choose a separate location for the recovery kit.".to_string());
+    }
+
+    let mut options = OpenOptions::new();
+    options.create(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+    }
+    let mut output = options
+        .open(destination)
+        .map_err(|_| "Could not save the recovery kit.".to_string())?;
+    let metadata = output
+        .metadata()
+        .map_err(|_| "Could not save the recovery kit.".to_string())?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err("Could not save the recovery kit.".to_string());
+    }
+    if metadata_is_same_file(&canonical_metadata, &metadata) {
+        return Err("Choose a separate location for the recovery kit.".to_string());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        output
+            .set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|_| "Could not secure the saved recovery kit.".to_string())?;
+    }
+    output
+        .set_len(0)
+        .and_then(|_| output.write_all(&canonical_bytes))
+        .and_then(|_| output.sync_all())
+        .map_err(|_| "Could not save the recovery kit.".to_string())?;
+    drop(output);
+
+    let reopened = read_bounded_recovery_kit(destination)
+        .map_err(|_| "The saved recovery kit could not be reopened.".to_string())?;
+    if reopened != canonical_bytes {
+        return Err("The saved recovery kit did not match the current kit.".to_string());
+    }
+    let digest = format!("{:x}", Sha256::digest(&reopened));
+    Ok(RecoveryKitSaveOutcome::Saved { digest })
+}
+
+#[cfg(unix)]
+fn metadata_is_same_file(left: &Metadata, right: &Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(windows)]
+fn metadata_is_same_file(left: &Metadata, right: &Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt;
+    match (
+        (left.volume_serial_number(), left.file_index()),
+        (right.volume_serial_number(), right.file_index()),
+    ) {
+        ((Some(left_volume), Some(left_index)), (Some(right_volume), Some(right_index))) => {
+            left_volume == right_volume && left_index == right_index
+        }
+        _ => false,
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn metadata_is_same_file(_left: &Metadata, _right: &Metadata) -> bool {
+    false
+}
+
+fn paths_resolve_to_same_file(canonical: &Path, destination: &Path) -> Result<bool, String> {
+    let source = std::fs::canonicalize(canonical)
+        .map_err(|_| "The recovery kit is unavailable.".to_string())?;
+    if destination.exists() {
+        let resolved_destination = std::fs::canonicalize(destination)
+            .map_err(|_| "Could not inspect the save location.".to_string())?;
+        if resolved_destination == source {
+            return Ok(true);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let source_metadata = std::fs::metadata(&source)
+                .map_err(|_| "The recovery kit is unavailable.".to_string())?;
+            let destination_metadata = std::fs::metadata(&resolved_destination)
+                .map_err(|_| "Could not inspect the save location.".to_string())?;
+            return Ok(source_metadata.dev() == destination_metadata.dev()
+                && source_metadata.ino() == destination_metadata.ino());
+        }
+        #[cfg(not(unix))]
+        return Ok(false);
+    }
+    let parent = destination
+        .parent()
+        .ok_or_else(|| "Could not inspect the save location.".to_string())?;
+    let filename = destination
+        .file_name()
+        .ok_or_else(|| "Could not inspect the save location.".to_string())?;
+    let resolved_parent = std::fs::canonicalize(parent)
+        .map_err(|_| "Could not inspect the save location.".to_string())?;
+    Ok(resolved_parent.join(filename) == source)
 }
 
 fn require_product_origin<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
@@ -364,12 +624,7 @@ async fn request_json<T: for<'de> Deserialize<'de>>(
 }
 
 fn local_admin_token_path() -> Result<PathBuf, String> {
-    let home = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .ok_or_else(|| "The local Ormah capability is unavailable.".to_string())?;
-    Ok(home.join(".local/share/ormah/local_api_token"))
+    Ok(user_home()?.join(".local/share/ormah/local_api_token"))
 }
 
 fn load_local_admin_token(path: &Path) -> Result<String, String> {
@@ -529,6 +784,21 @@ mod tests {
     }
 
     #[test]
+    fn remote_graph_has_no_generic_dialog_file_or_shell_permission() {
+        let capability: Value =
+            serde_json::from_str(include_str!("../capabilities/graph.json")).unwrap();
+        let permissions = capability["permissions"].as_array().unwrap();
+        assert!(permissions
+            .iter()
+            .any(|permission| permission == "desktop-product-bridge"));
+        for permission in permissions.iter().filter_map(Value::as_str) {
+            assert!(!permission.starts_with("dialog:"), "{permission}");
+            assert!(!permission.starts_with("fs:"), "{permission}");
+            assert!(!permission.starts_with("shell:"), "{permission}");
+        }
+    }
+
+    #[test]
     fn hosted_urls_require_exact_stripe_origin() {
         assert!(validate_hosted_url(
             "https://checkout.stripe.com/c/pay/cs_test_123?x=1",
@@ -679,6 +949,149 @@ mod tests {
                 "message": value
             }))
             .is_err());
+        }
+    }
+
+    #[test]
+    fn recovery_kit_save_reopens_exact_bytes_and_hashes_them() {
+        let root = std::env::temp_dir().join(format!("ormah-recovery-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let canonical = root.join("canonical.md");
+        let destination = root.join("saved.md");
+        let contents = b"# Ormah Recovery Kit\nAGE-SECRET-KEY-TEST-MATERIAL\n";
+        fs::write(&canonical, contents).unwrap();
+
+        let outcome = save_selected_recovery_kit(&canonical, Some(&destination)).unwrap();
+
+        let expected = format!("{:x}", Sha256::digest(contents));
+        assert_eq!(outcome, RecoveryKitSaveOutcome::Saved { digest: expected });
+        assert_eq!(fs::read(&destination).unwrap(), contents);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&destination).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn canceled_recovery_kit_save_does_no_file_work() {
+        let missing = PathBuf::from("/definitely/not/a/recovery-kit");
+        assert_eq!(
+            save_selected_recovery_kit(&missing, None).unwrap(),
+            RecoveryKitSaveOutcome::Canceled
+        );
+    }
+
+    #[test]
+    fn recovery_kit_reads_are_bounded_and_save_must_be_separate() {
+        let root = std::env::temp_dir().join(format!("ormah-recovery-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let canonical = root.join("canonical.md");
+        fs::write(&canonical, vec![b'x'; MAX_RECOVERY_KIT_BYTES as usize + 1]).unwrap();
+        assert!(read_bounded_recovery_kit(&canonical).is_err());
+
+        fs::write(&canonical, b"current kit").unwrap();
+        assert!(save_selected_recovery_kit(&canonical, Some(&canonical)).is_err());
+        assert_eq!(fs::read(&canonical).unwrap(), b"current kit");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_kit_save_refuses_symlink_destinations() {
+        use std::os::unix::fs::symlink;
+
+        let root = std::env::temp_dir().join(format!("ormah-recovery-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let canonical = root.join("canonical.md");
+        let target = root.join("target.md");
+        let destination = root.join("destination.md");
+        fs::write(&canonical, b"current kit").unwrap();
+        fs::write(&target, b"do not overwrite").unwrap();
+        symlink(&target, &destination).unwrap();
+
+        assert!(save_selected_recovery_kit(&canonical, Some(&destination)).is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"do not overwrite");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_kit_save_refuses_hard_links_to_the_canonical_file() {
+        let root = std::env::temp_dir().join(format!("ormah-recovery-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let canonical = root.join("canonical.md");
+        let destination = root.join("destination.md");
+        fs::write(&canonical, b"current kit").unwrap();
+        fs::hard_link(&canonical, &destination).unwrap();
+
+        assert!(save_selected_recovery_kit(&canonical, Some(&destination)).is_err());
+        assert_eq!(fs::read(&canonical).unwrap(), b"current kit");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recovery_kit_file_identity_is_checked_from_open_handles() {
+        let root = std::env::temp_dir().join(format!("ormah-recovery-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        let canonical = root.join("canonical.md");
+        let alias = root.join("alias.md");
+        fs::write(&canonical, b"current kit").unwrap();
+        fs::hard_link(&canonical, &alias).unwrap();
+
+        assert!(metadata_is_same_file(
+            &fs::File::open(&canonical).unwrap().metadata().unwrap(),
+            &fs::File::open(&alias).unwrap().metadata().unwrap(),
+        ));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn recovery_action_results_are_purpose_bound_and_secret_free() {
+        let canceled = serde_json::to_value(RecoveryKitActionResult {
+            status: "canceled",
+            device_loss_recovery_ready: None,
+            recovery_kit_verified_at: None,
+        })
+        .unwrap();
+        let saved = serde_json::to_value(RecoveryKitActionResult {
+            status: "saved",
+            device_loss_recovery_ready: Some(false),
+            recovery_kit_verified_at: Some("2026-07-31T12:00:00+00:00".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(
+            canceled,
+            json!({
+                "status": "canceled",
+                "device_loss_recovery_ready": null,
+                "recovery_kit_verified_at": null
+            })
+        );
+        assert_eq!(
+            saved,
+            json!({
+                "status": "saved",
+                "device_loss_recovery_ready": false,
+                "recovery_kit_verified_at": "2026-07-31T12:00:00+00:00"
+            })
+        );
+        let serialized = serde_json::to_string(&saved).unwrap().to_ascii_lowercase();
+        for forbidden in [
+            "age-secret-key",
+            "sha256",
+            "digest",
+            "filepath",
+            "presigned",
+            "accounttoken",
+        ] {
+            assert!(!serialized.contains(forbidden));
         }
     }
 }

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -30,6 +30,7 @@ const CHECKOUT_HOST: &str = "checkout.stripe.com";
 const PORTAL_HOST: &str = "billing.stripe.com";
 const RECOVERY_KIT_FILENAME: &str = "ormah-recovery-kit.md";
 const MAX_RECOVERY_KIT_BYTES: u64 = 256 * 1024;
+const RECOVERY_CONFIRM_PATH: &str = "/admin/cloud/protection/recovery-kit/confirm";
 
 #[derive(Debug, Serialize)]
 pub struct DesktopBridgeInfo {
@@ -260,7 +261,14 @@ pub async fn save_recovery_kit<R: Runtime>(
         .set_file_name(RECOVERY_KIT_FILENAME)
         .add_filter("Markdown document", &["md"])
         .blocking_save_file();
-    let destination = selected.and_then(|selection| selection.into_path().ok());
+    let destination = match selected {
+        Some(selection) => Some(
+            selection
+                .into_path()
+                .map_err(|_| "Could not use the selected save location.".to_string())?,
+        ),
+        None => None,
+    };
     let canonical = recovery_kit_path()?;
     let digest = match save_selected_recovery_kit(&canonical, destination.as_deref())? {
         RecoveryKitSaveOutcome::Canceled => {
@@ -274,7 +282,7 @@ pub async fn save_recovery_kit<R: Runtime>(
     };
     let readiness: RecoveryKitReadiness = request_json(
         "POST",
-        "/admin/cloud/protection/recovery-kit/confirm",
+        RECOVERY_CONFIRM_PATH,
         Some(json!({ "sha256_digest": digest })),
     )
     .await?;
@@ -481,6 +489,7 @@ fn save_selected_recovery_kit(
         .and_then(|_| output.sync_all())
         .map_err(|_| "Could not save the recovery kit.".to_string())?;
     drop(output);
+    sync_parent_directory(destination)?;
 
     let reopened = read_bounded_recovery_kit(destination)
         .map_err(|_| "The saved recovery kit could not be reopened.".to_string())?;
@@ -489,6 +498,21 @@ fn save_selected_recovery_kit(
     }
     let digest = format!("{:x}", Sha256::digest(&reopened));
     Ok(RecoveryKitSaveOutcome::Saved { digest })
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(path: &Path) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Could not secure the saved recovery kit.".to_string())?;
+    std::fs::File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| "Could not secure the saved recovery kit.".to_string())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_path: &Path) -> Result<(), String> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -604,23 +628,30 @@ async fn request_json<T: for<'de> Deserialize<'de>>(
         .await
         .map_err(|_| "Could not reach the local Ormah service.".to_string())?;
     if !response.status().is_success() {
-        let message = match response.status().as_u16() {
-            401 if path == "/admin/account/verify" => {
-                "That code is wrong, expired, or already used."
-            }
-            401 => "Sign in to Ormah before continuing.",
-            403 => "This local Ormah operation is not allowed.",
-            404 => "This Ormah Desktop feature requires a newer Ormah runtime.",
-            409 => "The protection state changed; refresh and try again.",
-            429 => "Too many requests; wait briefly and try again.",
-            _ => "The local Ormah operation could not be completed.",
-        };
+        let message = local_error_message(response.status().as_u16(), path);
         return Err(message.to_string());
     }
     response
         .json::<T>()
         .await
         .map_err(|_| "The local Ormah service returned an invalid response.".to_string())
+}
+
+fn local_error_message(status: u16, path: &str) -> &'static str {
+    match status {
+        401 if path == "/admin/account/verify" => {
+            "That code is wrong, expired, or already used."
+        }
+        401 => "Sign in to Ormah before continuing.",
+        403 => "This local Ormah operation is not allowed.",
+        404 => "This Ormah Desktop feature requires a newer Ormah runtime.",
+        409 if path == RECOVERY_CONFIRM_PATH => {
+            "The saved recovery kit no longer matches current recovery material. Run `ormah cloud kit`, then save it again."
+        }
+        409 => "The protection state changed; refresh and try again.",
+        429 => "Too many requests; wait briefly and try again.",
+        _ => "The local Ormah operation could not be completed.",
+    }
 }
 
 fn local_admin_token_path() -> Result<PathBuf, String> {
@@ -1093,5 +1124,18 @@ mod tests {
         ] {
             assert!(!serialized.contains(forbidden));
         }
+    }
+
+    #[test]
+    fn recovery_confirmation_conflict_has_a_specific_repair_message() {
+        let recovery = local_error_message(409, RECOVERY_CONFIRM_PATH);
+        let generic = local_error_message(409, "/admin/cloud/protection/backup");
+
+        assert!(recovery.contains("ormah cloud kit"));
+        assert!(recovery.contains("saved recovery kit"));
+        assert_eq!(
+            generic,
+            "The protection state changed; refresh and try again."
+        );
     }
 }

--- a/src/ormah/api/routes_protection.py
+++ b/src/ormah/api/routes_protection.py
@@ -11,12 +11,15 @@ from ormah.api.local_auth import require_local_admin
 from ormah.cloud.billing import validate_protection_intent_id
 from ormah.cloud.entitlements import load_entitlement_cache, status_from_cache
 from ormah.cloud.operations import ProtectionOperationCoordinator
-from ormah.cloud.protection import CloudProtectionService
+from ormah.cloud.protection import CloudProtectionService, safe_error_message
+from ormah.cloud.recovery import RecoveryKitError, RecoveryKitService
 from ormah.cloud.state import (
+    CloudStateError,
     ProtectionOperation,
     ProtectionOperationKind,
     cloud_status_payload,
 )
+from ormah.cloud.store_lock import StoreLockTimeout
 
 router = APIRouter(
     prefix="/admin/cloud/protection",
@@ -42,6 +45,23 @@ class VerifyRequest(BaseModel):
     )
 
 
+class ConfirmRecoveryKitRequest(BaseModel):
+    """Proof from the trusted native save/reopen flow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sha256_digest: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class RecoveryReadinessResponse(BaseModel):
+    """Purpose-bound response containing no recovery material or locations."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    device_loss_recovery_ready: bool
+    recovery_kit_verified_at: str
+
+
 def _service(request: Request) -> CloudProtectionService:
     injected = getattr(request.app.state, "protection_service", None)
     return injected or CloudProtectionService.from_engine(request.app.state.engine)
@@ -52,6 +72,11 @@ def _coordinator(request: Request) -> ProtectionOperationCoordinator:
     if not isinstance(coordinator, ProtectionOperationCoordinator):
         raise HTTPException(status_code=503, detail="Protection operations are unavailable.")
     return coordinator
+
+
+def _recovery_service(request: Request) -> RecoveryKitService:
+    injected = getattr(request.app.state, "recovery_kit_service", None)
+    return injected or RecoveryKitService(request.app.state.engine.settings)
 
 
 def _store_key(request: Request, operation: str) -> tuple[str, ...]:
@@ -111,7 +136,24 @@ def _submit(
 def protection_status(request: Request):
     """Return durable, token-free protection state for this memory."""
     settings = request.app.state.engine.settings
-    return cloud_status_payload(settings, entitlement=_cached_entitlement(settings))
+    payload = cloud_status_payload(settings, entitlement=_cached_entitlement(settings))
+    # The shared payload also serves the local CLI, where detailed state paths
+    # are useful. The product webview receives only redacted diagnostics.
+    payload.pop("state_error", None)
+    for field in (
+        "last_upload_error",
+        "last_verify_error",
+        "last_error_message",
+    ):
+        if payload.get(field) is not None:
+            payload[field] = safe_error_message(
+                payload[field], getattr(settings, "account_token", None)
+            )
+    payload["warnings"] = [
+        safe_error_message(warning, getattr(settings, "account_token", None))
+        for warning in payload.get("warnings", [])
+    ]
+    return payload
 
 
 @router.post("/intents")
@@ -186,6 +228,26 @@ def verify_now(body: VerifyRequest, request: Request):
         kind=ProtectionOperationKind.VERIFY,
         action=lambda: service.verify_now(body.snapshot_id),
     )
+
+
+@router.post(
+    "/recovery-kit/confirm",
+    response_model=RecoveryReadinessResponse,
+)
+def confirm_recovery_kit(body: ConfirmRecoveryKitRequest, request: Request):
+    """Confirm only the digest produced after the native destination was reopened."""
+
+    try:
+        result = _recovery_service(request).confirm_saved_digest(body.sha256_digest)
+    except (RecoveryKitError, CloudStateError, StoreLockTimeout, OSError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The saved recovery kit could not be verified.",
+        ) from exc
+    return {
+        "device_loss_recovery_ready": result.device_loss_recovery_ready,
+        "recovery_kit_verified_at": result.recovery_kit_verified_at.isoformat(),
+    }
 
 
 @router.get("/operations/{operation_id}")

--- a/src/ormah/api/routes_protection.py
+++ b/src/ormah/api/routes_protection.py
@@ -11,7 +11,7 @@ from ormah.api.local_auth import require_local_admin
 from ormah.cloud.billing import validate_protection_intent_id
 from ormah.cloud.entitlements import load_entitlement_cache, status_from_cache
 from ormah.cloud.operations import ProtectionOperationCoordinator
-from ormah.cloud.protection import CloudProtectionService, safe_error_message
+from ormah.cloud.protection import CloudProtectionService, safe_product_error_message
 from ormah.cloud.recovery import RecoveryKitError, RecoveryKitService
 from ormah.cloud.state import (
     CloudStateError,
@@ -146,11 +146,11 @@ def protection_status(request: Request):
         "last_error_message",
     ):
         if payload.get(field) is not None:
-            payload[field] = safe_error_message(
+            payload[field] = safe_product_error_message(
                 payload[field], getattr(settings, "account_token", None)
             )
     payload["warnings"] = [
-        safe_error_message(warning, getattr(settings, "account_token", None))
+        safe_product_error_message(warning, getattr(settings, "account_token", None))
         for warning in payload.get("warnings", [])
     ]
     return payload

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -609,11 +609,11 @@ def _cmd_cloud_rotate_key(args):
     from ormah.cloud.crypto import CloudCryptoError
     from ormah.cloud.keys import (
         CloudKeyError,
-        get_or_create_store_id,
         load_identity_strings,
-        rotate_key,
-        write_recovery_kit,
     )
+    from ormah.cloud.recovery import RecoveryKitError, RecoveryKitService
+    from ormah.cloud.state import CloudStateError
+    from ormah.cloud.store_lock import StoreLockTimeout
     from ormah.config import settings
     from ormah.console import info, ok, warn
 
@@ -627,18 +627,21 @@ def _cmd_cloud_rotate_key(args):
             return
 
     try:
-        rotate_key()
-    except (CloudKeyError, CloudCryptoError, OSError) as exc:
-        _print_backup_error(str(exc))
-
-    try:
-        store_id = get_or_create_store_id(settings.memory_dir)
-        kit_path = write_recovery_kit(store_id)
+        kit_path = RecoveryKitService(settings).rotate_current_key(
+            account_email=getattr(settings, "account_email", None),
+        )
         identity_count = len(load_identity_strings())
-    except (CloudKeyError, CloudCryptoError, OSError) as exc:
+    except (
+        RecoveryKitError,
+        CloudKeyError,
+        CloudCryptoError,
+        CloudStateError,
+        StoreLockTimeout,
+        OSError,
+    ) as exc:
         _print_backup_error(
-            f"Key was rotated, but recovery-kit regeneration failed: {exc}\n"
-            "Your stored kit is now MISSING the new key — run `ormah cloud kit` immediately."
+            f"Key rotation could not be completed safely: {exc}\n"
+            "Check `ormah cloud kit` before relying on a previously saved recovery kit."
         )
 
     if args.json:

--- a/src/ormah/cloud/account.py
+++ b/src/ormah/cloud/account.py
@@ -108,6 +108,7 @@ def normalize_email(value: str) -> str:
         or len(email) > 320
         or "@" not in email
         or any(ord(char) < 0x20 or ord(char) == 0x7F for char in email)
+        or any(char in "\x85\u2028\u2029" for char in email)
     ):
         raise AccountError(AccountErrorCode.INVALID_REQUEST)
     return email

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -173,19 +173,14 @@ def get_or_create_store_id(memory_dir: Path) -> str:
     return store_id
 
 
-def extract_store_id(source: str) -> str | None:
-    """Pull the store id out of recovery-kit material (path or raw text).
+def extract_store_id_from_text(text: str) -> str | None:
+    """Pull the store id out of already-loaded recovery-kit material.
 
     Fails closed: an explicit ``store_id:`` line that does not carry a valid
     UUIDv4 raises — a damaged kit must abort the import, not silently mint a
     new namespace. Returns None only when the material genuinely contains no
     store identifier (e.g. a bare key file).
     """
-    source_path = Path(source).expanduser()
-    try:
-        text = source_path.read_text(encoding="utf-8") if source_path.is_file() else source
-    except OSError:
-        text = source
     for line in text.splitlines():
         stripped = line.strip()
         if stripped.startswith("store_id:"):
@@ -208,6 +203,17 @@ def extract_store_id(source: str) -> str | None:
             except CloudKeyError:
                 continue  # arbitrary 36-char line, not a store id claim
     return None
+
+
+def extract_store_id(source: str) -> str | None:
+    """Pull the store id out of recovery-kit material (path or raw text)."""
+
+    source_path = Path(source).expanduser()
+    try:
+        text = source_path.read_text(encoding="utf-8") if source_path.is_file() else source
+    except OSError:
+        text = source
+    return extract_store_id_from_text(text)
 
 
 def install_store_id(memory_dir: Path, store_id: str) -> str:

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -24,6 +24,8 @@ CONFIG_DIR = Path.home() / ".config" / "ormah"
 KEY_PATH = CONFIG_DIR / "cloud.key"
 RECOVERY_KIT_PATH = CONFIG_DIR / "ormah-recovery-kit.md"
 STORE_ID_NAME = ".store_id"
+RECOVERY_KIT_FORMAT_VERSION = 1
+MAX_RECOVERY_KIT_BYTES = 256 * 1024
 
 
 class CloudKeyError(RuntimeError):
@@ -141,6 +143,40 @@ def rotate_key(key_path: Path | None = None) -> str:
     return new_identity
 
 
+def rotate_key_and_recovery_kit(
+    store_id: str,
+    *,
+    key_path: Path | None = None,
+    kit_path: Path | None = None,
+    account_email: str | None = None,
+) -> tuple[str, Path]:
+    """Rotate the active identity without leaving recovery material behind.
+
+    The recovery kit is installed first and contains both the prospective new
+    identity and every existing identity. If the process stops before the key
+    file is replaced, the old active identity is still present in that kit. A
+    failure can therefore make the files temporarily disagree, but cannot make
+    a successfully used encryption identity unrecoverable.
+    """
+
+    key_path = (KEY_PATH if key_path is None else key_path).expanduser()
+    kit_path = (RECOVERY_KIT_PATH if kit_path is None else kit_path).expanduser()
+    _ensure_recovery_kit_can_be_rewritten(kit_path)
+    existing = load_identity_strings(key_path)
+    new_identity = identity_to_str(generate_identity())
+    identity_strings = [new_identity, *existing]
+
+    _atomic_write_0600(
+        kit_path,
+        _serialize_recovery_kit(store_id, identity_strings, account_email),
+    )
+    _atomic_write_0600(
+        key_path,
+        _serialize_key_file(identity_strings, rotated=True),
+    )
+    return new_identity, kit_path
+
+
 # --- store_id (E08 §1) ---
 
 
@@ -244,23 +280,55 @@ def install_store_id(memory_dir: Path, store_id: str) -> str:
 # --- Recovery kit ---
 
 
-def write_recovery_kit(
-    store_id: str,
-    key_path: Path | None = None,
-    kit_path: Path | None = None,
-    account_email: str | None = None,
-) -> Path:
-    """(Re)generate the recovery kit with ALL identities.
+def extract_recovery_kit_format_version(text: str) -> int | None:
+    """Return one declared kit format version, or None for a legacy kit."""
 
-    The kit is the entire recovery story: anyone with this file can read the
-    backups; without it, nobody can — including us.
-    """
-    kit_path = RECOVERY_KIT_PATH if kit_path is None else kit_path
-    identity_strings = load_identity_strings(key_path)
+    claims = [
+        line.strip().split(":", 1)[1].strip()
+        for line in text.splitlines()
+        if line.strip().startswith("format_version:")
+    ]
+    if not claims:
+        return None
+    if len(claims) != 1:
+        raise CloudKeyError("Recovery kit contains multiple format versions.")
+    try:
+        version = int(claims[0])
+    except ValueError as exc:
+        raise CloudKeyError("Recovery kit format version is invalid.") from exc
+    if version < 1:
+        raise CloudKeyError("Recovery kit format version is invalid.")
+    return version
+
+
+def _ensure_recovery_kit_can_be_rewritten(kit_path: Path) -> None:
+    """Prevent an older client from discarding a newer kit envelope."""
+
+    if not kit_path.exists():
+        return
+    try:
+        if not kit_path.is_file() or kit_path.stat().st_size > MAX_RECOVERY_KIT_BYTES:
+            raise CloudKeyError("The existing recovery kit is invalid.")
+        version = extract_recovery_kit_format_version(kit_path.read_text(encoding="utf-8"))
+    except UnicodeDecodeError as exc:
+        raise CloudKeyError("The existing recovery kit is invalid.") from exc
+    if version is not None and version > RECOVERY_KIT_FORMAT_VERSION:
+        raise CloudKeyError(
+            "The recovery kit was created by a newer Ormah version; update Ormah before "
+            "regenerating or rotating recovery material."
+        )
+
+
+def _serialize_recovery_kit(
+    store_id: str,
+    identity_strings: list[str],
+    account_email: str | None,
+) -> str:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     identities_block = "\n".join(identity_strings)
-    kit = f"""# Ormah Recovery Kit
+    return f"""# Ormah Recovery Kit
 
+format_version: {RECOVERY_KIT_FORMAT_VERSION}
 Generated: {now}
 
 > **Anyone with this file can read your backups; without it, nobody can —
@@ -292,6 +360,19 @@ Email: {account_email or "<your ormah account email>"}
 That's the whole procedure. Every identity listed above is needed to read
 backups made before key rotations — never trim this list.
 """
-    kit_path = kit_path.expanduser()
+
+
+def write_recovery_kit(
+    store_id: str,
+    key_path: Path | None = None,
+    kit_path: Path | None = None,
+    account_email: str | None = None,
+) -> Path:
+    """(Re)generate the versioned recovery kit with every identity."""
+
+    kit_path = (RECOVERY_KIT_PATH if kit_path is None else kit_path).expanduser()
+    _ensure_recovery_kit_can_be_rewritten(kit_path)
+    identity_strings = load_identity_strings(key_path)
+    kit = _serialize_recovery_kit(store_id, identity_strings, account_email)
     _atomic_write_0600(kit_path, kit)
     return kit_path

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -131,8 +131,8 @@ def import_key(source: str, key_path: Path | None = None) -> list[str]:
     return strings
 
 
-def rotate_key(key_path: Path | None = None) -> str:
-    """Generate a new current identity, retaining all previous ones."""
+def _rotate_key_without_recovery_kit(key_path: Path | None = None) -> str:
+    """Test/migration helper; product rotation must update the recovery kit first."""
     key_path = KEY_PATH if key_path is None else key_path
     existing = load_identity_strings(key_path)
     new_identity = identity_to_str(generate_identity())
@@ -324,6 +324,8 @@ def _serialize_recovery_kit(
     identity_strings: list[str],
     account_email: str | None,
 ) -> str:
+    if account_email is not None and account_email.splitlines() != [account_email]:
+        raise CloudKeyError("The account email cannot be represented safely in the recovery kit.")
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     identities_block = "\n".join(identity_strings)
     return f"""# Ormah Recovery Kit

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -43,6 +43,7 @@ from ormah.cloud.keys import (
     load_identities,
     write_recovery_kit,
 )
+from ormah.cloud.recovery import RecoveryKitService
 from ormah.cloud.settings import set_cloud_backup_enabled
 from ormah.cloud.state import (
     CURRENT_CLOUD_STATE_SCHEMA_VERSION,
@@ -81,6 +82,10 @@ _QUERY_SECRET_RE = re.compile(
 _SNAPSHOT_ID_RE = re.compile(r"[0-7][0-9A-HJKMNP-TV-Z]{25}")
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
 _NODE_PATH_RE = re.compile(r"\b(nodes|deleted)[/\\][^\s'\",)\]]+\.md\b")
+_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9])(?:/[A-Za-z0-9._~+@%=-]+)+|"
+    r"(?<![A-Za-z0-9])[A-Za-z]:\\(?:[^\\\s:;,]+\\)*[^\\\s:;,]+"
+)
 _DISK_FULL_ERRNOS = {errno.ENOSPC, getattr(errno, "EDQUOT", errno.ENOSPC)}
 
 
@@ -97,6 +102,7 @@ def safe_error_message(value: object, *sensitive_values: str | None) -> str:
     message = _BEARER_RE.sub("Bearer <redacted>", message)
     message = _AGE_SECRET_RE.sub("<redacted-age-key>", message)
     message = _NODE_PATH_RE.sub(r"\1/<redacted>.md", message)
+    message = _ABSOLUTE_PATH_RE.sub("<redacted-path>", message)
     for sensitive in sensitive_values:
         if sensitive:
             message = message.replace(sensitive, "<redacted>")
@@ -823,6 +829,7 @@ class CloudProtectionService:
                         store_id,
                         account_email=getattr(self.settings, "account_email", None),
                     )
+                    RecoveryKitService(self.settings).validate_canonical_kit()
                 except _EnablePrerequisiteError:
                     raise
                 except CloudKeyError as exc:

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -102,11 +102,17 @@ def safe_error_message(value: object, *sensitive_values: str | None) -> str:
     message = _BEARER_RE.sub("Bearer <redacted>", message)
     message = _AGE_SECRET_RE.sub("<redacted-age-key>", message)
     message = _NODE_PATH_RE.sub(r"\1/<redacted>.md", message)
-    message = _ABSOLUTE_PATH_RE.sub("<redacted-path>", message)
     for sensitive in sensitive_values:
         if sensitive:
             message = message.replace(sensitive, "<redacted>")
     return message[:1000]
+
+
+def safe_product_error_message(value: object, *sensitive_values: str | None) -> str:
+    """Redact local paths in addition to secrets before crossing into the webview."""
+
+    message = safe_error_message(value, *sensitive_values)
+    return _ABSOLUTE_PATH_RE.sub("<redacted-path>", message)
 
 
 def _existing_store_id(memory_dir: Path) -> str | None:

--- a/src/ormah/cloud/recovery.py
+++ b/src/ormah/cloud/recovery.py
@@ -20,18 +20,19 @@ from typing import Callable
 from ormah.cloud import keys as cloud_keys
 from ormah.cloud.crypto import identity_from_str
 from ormah.cloud.keys import (
+    MAX_RECOVERY_KIT_BYTES,
+    RECOVERY_KIT_FORMAT_VERSION,
     STORE_ID_NAME,
     CloudKeyError,
+    extract_recovery_kit_format_version,
     extract_store_id_from_text,
     load_identity_strings,
-    rotate_key,
-    write_recovery_kit,
+    rotate_key_and_recovery_kit,
 )
 from ormah.cloud.state import is_device_loss_recovery_ready, update_state
 from ormah.cloud.store_lock import StoreLock
 
 
-MAX_RECOVERY_KIT_BYTES = 256 * 1024
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -126,12 +127,12 @@ class RecoveryKitService:
             )
 
     def rotate_current_key(self, *, account_email: str | None = None) -> Path:
-        """Clear readiness before rotating and atomically rewriting the current files.
+        """Clear readiness before installing a recovery-first key rotation.
 
         The ordering is deliberately fail-safe: if cloud state cannot be made
-        writable, neither key nor kit is touched. Once readiness is cleared,
-        any later failure remains conservative and atomic file writers prevent a
-        partially written key or kit from replacing the prior file.
+        writable, neither key nor kit is touched. The prospective kit is then
+        installed before the key becomes active, so every identity that could
+        encrypt a bundle is recoverable even if the process stops between files.
         """
 
         with StoreLock(self.settings.memory_dir):
@@ -142,8 +143,7 @@ class RecoveryKitService:
                 state_dir=self.state_dir,
                 recovery_kit_verified_at=None,
             )
-            rotate_key(self.key_path)
-            kit_path = write_recovery_kit(
+            _, kit_path = rotate_key_and_recovery_kit(
                 store_id,
                 key_path=self.key_path,
                 kit_path=self.kit_path,
@@ -181,6 +181,7 @@ class RecoveryKitService:
                 for line in kit_text.splitlines()
                 if line.strip().startswith("store_id:")
             ]
+            kit_format_version = extract_recovery_kit_format_version(kit_text)
             active_identity_strings = load_identity_strings(self.key_path)
             for identity in active_identity_strings:
                 identity_from_str(identity)
@@ -197,6 +198,7 @@ class RecoveryKitService:
         if (
             kit_store_id != store_id
             or len(store_claims) != 1
+            or kit_format_version != RECOVERY_KIT_FORMAT_VERSION
             or kit_identity_strings != active_identity_strings
         ):
             raise RecoveryKitError("The recovery kit is not current for this memory.")

--- a/src/ormah/cloud/recovery.py
+++ b/src/ormah/cloud/recovery.py
@@ -1,0 +1,203 @@
+"""Recovery-kit validation and device-loss readiness confirmation.
+
+This is the only product service that turns a native saved-copy proof into
+durable recovery readiness. It never returns kit bytes, identities, digests,
+or filesystem locations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import hmac
+import os
+from pathlib import Path
+import re
+import stat
+from typing import Callable
+
+from ormah.cloud import keys as cloud_keys
+from ormah.cloud.crypto import identity_from_str
+from ormah.cloud.keys import (
+    STORE_ID_NAME,
+    CloudKeyError,
+    extract_store_id_from_text,
+    load_identity_strings,
+    rotate_key,
+    write_recovery_kit,
+)
+from ormah.cloud.state import is_device_loss_recovery_ready, update_state
+from ormah.cloud.store_lock import StoreLock
+
+
+MAX_RECOVERY_KIT_BYTES = 256 * 1024
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class RecoveryKitError(RuntimeError):
+    """Raised when recovery material cannot be proven current and complete."""
+
+
+@dataclass(frozen=True)
+class RecoveryReadiness:
+    """Token-free result safe for the local API and product webview."""
+
+    device_loss_recovery_ready: bool
+    recovery_kit_verified_at: datetime
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _read_bounded_regular_file(path: Path) -> bytes:
+    """Read one fixed sensitive file without following symlinks where supported."""
+
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+        with os.fdopen(descriptor, "rb") as handle:
+            metadata = os.fstat(handle.fileno())
+            if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > MAX_RECOVERY_KIT_BYTES:
+                raise RecoveryKitError("The recovery kit is invalid.")
+            data = handle.read(MAX_RECOVERY_KIT_BYTES + 1)
+    except RecoveryKitError:
+        raise
+    except OSError as exc:
+        raise RecoveryKitError("The recovery kit is unavailable.") from exc
+    if len(data) > MAX_RECOVERY_KIT_BYTES:
+        raise RecoveryKitError("The recovery kit is invalid.")
+    return data
+
+
+class RecoveryKitService:
+    """Validate the canonical kit and confirm a reopened native saved copy."""
+
+    def __init__(
+        self,
+        settings,
+        *,
+        key_path: Path | None = None,
+        kit_path: Path | None = None,
+        state_dir: Path | None = None,
+        now: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self.settings = settings
+        self.key_path = cloud_keys.KEY_PATH if key_path is None else key_path
+        self.kit_path = cloud_keys.RECOVERY_KIT_PATH if kit_path is None else kit_path
+        self.state_dir = state_dir
+        self.now = now
+
+    def validate_canonical_kit(self) -> None:
+        """Validate the fixed canonical kit without changing readiness."""
+
+        with StoreLock(self.settings.memory_dir):
+            self._validate_canonical_kit_locked()
+
+    def confirm_saved_digest(self, digest: str) -> RecoveryReadiness:
+        """Record a saved-copy proof only when its bytes equal the current valid kit."""
+
+        if not isinstance(digest, str) or SHA256_PATTERN.fullmatch(digest) is None:
+            raise ValueError("digest must be a lowercase SHA-256 value")
+
+        with StoreLock(self.settings.memory_dir):
+            store_id, kit_bytes = self._validate_canonical_kit_locked()
+            canonical_digest = hashlib.sha256(kit_bytes).hexdigest()
+            if not hmac.compare_digest(digest, canonical_digest):
+                raise RecoveryKitError("The saved recovery kit could not be verified.")
+            verified_at = self.now().astimezone(timezone.utc)
+            state = update_state(
+                store_id,
+                memory_dir=self.settings.memory_dir,
+                state_dir=self.state_dir,
+                recovery_kit_verified_at=verified_at,
+            )
+            return RecoveryReadiness(
+                is_device_loss_recovery_ready(
+                    state,
+                    enabled=bool(getattr(self.settings, "cloud_backup_enabled", False)),
+                ),
+                verified_at,
+            )
+
+    def rotate_current_key(self, *, account_email: str | None = None) -> Path:
+        """Clear readiness before rotating and atomically rewriting the current files.
+
+        The ordering is deliberately fail-safe: if cloud state cannot be made
+        writable, neither key nor kit is touched. Once readiness is cleared,
+        any later failure remains conservative and atomic file writers prevent a
+        partially written key or kit from replacing the prior file.
+        """
+
+        with StoreLock(self.settings.memory_dir):
+            store_id = self._active_store_id()
+            update_state(
+                store_id,
+                memory_dir=self.settings.memory_dir,
+                state_dir=self.state_dir,
+                recovery_kit_verified_at=None,
+            )
+            rotate_key(self.key_path)
+            kit_path = write_recovery_kit(
+                store_id,
+                key_path=self.key_path,
+                kit_path=self.kit_path,
+                account_email=account_email,
+            )
+            self._validate_canonical_kit_locked()
+            return kit_path
+
+    def _active_store_id(self) -> str:
+        store_marker = Path(self.settings.memory_dir).expanduser() / STORE_ID_NAME
+        if not store_marker.exists():
+            raise RecoveryKitError(
+                "Cloud recovery is not initialized; run `ormah cloud init` first."
+            )
+        try:
+            marker_bytes = _read_bounded_regular_file(store_marker)
+            if len(marker_bytes) > 128:
+                raise RecoveryKitError("The active memory store is invalid.")
+            marker_value = marker_bytes.decode("utf-8").strip()
+            store_id = extract_store_id_from_text(f"store_id: {marker_value}")
+        except (RecoveryKitError, UnicodeDecodeError, CloudKeyError, OSError) as exc:
+            raise RecoveryKitError("The active memory store is invalid.") from exc
+        if store_id is None or marker_value != store_id:
+            raise RecoveryKitError("The active memory store is invalid.")
+        return store_id
+
+    def _validate_canonical_kit_locked(self) -> tuple[str, bytes]:
+        store_id = self._active_store_id()
+        kit_bytes = _read_bounded_regular_file(self.kit_path.expanduser())
+        try:
+            kit_text = kit_bytes.decode("utf-8")
+            kit_store_id = extract_store_id_from_text(kit_text)
+            store_claims = [
+                line.strip()
+                for line in kit_text.splitlines()
+                if line.strip().startswith("store_id:")
+            ]
+            active_identity_strings = load_identity_strings(self.key_path)
+            for identity in active_identity_strings:
+                identity_from_str(identity)
+            kit_identity_strings = [
+                line.strip()
+                for line in kit_text.splitlines()
+                if line.strip().startswith("AGE-SECRET-KEY-")
+            ]
+            for identity in kit_identity_strings:
+                identity_from_str(identity)
+        except (UnicodeDecodeError, CloudKeyError, ValueError, OSError) as exc:
+            raise RecoveryKitError("The recovery kit is invalid.") from exc
+
+        if (
+            kit_store_id != store_id
+            or len(store_claims) != 1
+            or kit_identity_strings != active_identity_strings
+        ):
+            raise RecoveryKitError("The recovery kit is not current for this memory.")
+        return store_id, kit_bytes

--- a/src/ormah/cloud/recovery.py
+++ b/src/ormah/cloud/recovery.py
@@ -60,6 +60,8 @@ def _read_bounded_regular_file(path: Path) -> bytes:
         flags |= os.O_CLOEXEC
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
     try:
         descriptor = os.open(path, flags)
         with os.fdopen(descriptor, "rb") as handle:

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -544,6 +544,15 @@ def is_protected_and_verified(state: CloudState, *, enabled: bool) -> bool:
     )
 
 
+def is_device_loss_recovery_ready(state: CloudState, *, enabled: bool) -> bool:
+    """Require both a saved-kit proof and the current verified snapshot invariant."""
+
+    return state.recovery_kit_verified_at is not None and is_protected_and_verified(
+        state,
+        enabled=enabled,
+    )
+
+
 def cloud_status_payload(
     settings,
     *,
@@ -674,6 +683,11 @@ def cloud_status_payload(
         "last_successful_backup_snapshot_id": state.last_successful_backup_snapshot_id,
         "last_successful_verify_at": _serialize_time(state.last_successful_verify_at),
         "last_verified_snapshot_id": state.last_verified_snapshot_id,
+        "recovery_kit_verified_at": _serialize_time(state.recovery_kit_verified_at),
+        "device_loss_recovery_ready": is_device_loss_recovery_ready(
+            state,
+            enabled=settings.cloud_backup_enabled,
+        ),
         "last_error_code": _serialize_enum(state.last_error_code),
         "last_error_message": state.last_error_message,
         "warnings": warnings,

--- a/tests/test_api/test_account_auth_routes.py
+++ b/tests/test_api/test_account_auth_routes.py
@@ -123,6 +123,25 @@ def test_request_code_is_generic_normalized_and_rejects_extra_fields(
     assert fake.calls == [("request_code", "person@example.com")]
 
 
+@pytest.mark.parametrize("separator", ["\x85", "\u2028", "\u2029"])
+def test_account_email_rejects_unicode_line_separators(
+    tmp_path,
+    account_paths,
+    separator,
+):
+    fake = FakeCloudClient()
+    _, app = build_client(tmp_path, fake)
+
+    with TestClient(app, headers=HEADERS) as http:
+        response = http.post(
+            "/admin/account/request-code",
+            json={"email": f"person@example.com{separator}format_version: 99"},
+        )
+
+    assert response.status_code == 422
+    assert fake.calls == []
+
+
 def test_verify_persists_privately_updates_live_settings_and_returns_no_token(
     tmp_path, account_paths
 ):

--- a/tests/test_api/test_protection_routes.py
+++ b/tests/test_api/test_protection_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 import threading
@@ -13,6 +14,7 @@ from fastapi.testclient import TestClient
 from ormah.api import routes_protection
 from ormah.api.local_auth import LOCAL_ADMIN_HEADER, require_loopback
 from ormah.cloud.operations import ProtectionOperationCoordinator
+from ormah.cloud.recovery import RecoveryKitError, RecoveryReadiness
 from ormah.cloud.state import (
     ProtectionOperation,
     ProtectionOperationKind,
@@ -81,12 +83,29 @@ class FakeProtectionService:
         return _operation(ProtectionOperationKind.VERIFY)
 
 
+class FakeRecoveryKitService:
+    def __init__(self):
+        self.calls: list[str] = []
+        self.fail = False
+        self.ready = True
+
+    def confirm_saved_digest(self, digest):
+        self.calls.append(digest)
+        if self.fail:
+            raise RecoveryKitError("secret path and AGE-SECRET-KEY-private")
+        return RecoveryReadiness(
+            self.ready,
+            datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc),
+        )
+
+
 @pytest.fixture
 def protection_app(tmp_path: Path, monkeypatch):
     async def allow_test_client():
         return None
 
     service = FakeProtectionService()
+    recovery_service = FakeRecoveryKitService()
     coordinator = ProtectionOperationCoordinator(max_workers=4)
     app = FastAPI()
     app.dependency_overrides[require_loopback] = allow_test_client
@@ -96,6 +115,7 @@ def protection_app(tmp_path: Path, monkeypatch):
     )
     app.state.protection_service = service
     app.state.protection_operations = coordinator
+    app.state.recovery_kit_service = recovery_service
     app.include_router(routes_protection.router)
     monkeypatch.setattr(
         routes_protection,
@@ -108,7 +128,7 @@ def protection_app(tmp_path: Path, monkeypatch):
     )
     try:
         with TestClient(app) as client:
-            yield client, service, coordinator
+            yield client, service, coordinator, recovery_service
     finally:
         if service.release_backup is not None:
             service.release_backup.set()
@@ -131,7 +151,7 @@ def _poll(client: TestClient, operation_id: str) -> dict:
 
 
 def test_all_protection_routes_require_local_capability(protection_app):
-    client, _, _ = protection_app
+    client, _, _, _ = protection_app
     requests = [
         ("GET", "/admin/cloud/protection", None),
         ("POST", "/admin/cloud/protection/intents", {}),
@@ -141,6 +161,11 @@ def test_all_protection_routes_require_local_capability(protection_app):
         ("POST", "/admin/cloud/protection/disable", {}),
         ("POST", "/admin/cloud/protection/backup", {}),
         ("POST", "/admin/cloud/protection/verify", {}),
+        (
+            "POST",
+            "/admin/cloud/protection/recovery-kit/confirm",
+            {"sha256_digest": "a" * 64},
+        ),
         ("GET", f"/admin/cloud/protection/operations/{INTENT_ID}", None),
     ]
 
@@ -150,7 +175,7 @@ def test_all_protection_routes_require_local_capability(protection_app):
 
 
 def test_status_and_intent_adapters_are_thin_and_token_free(protection_app):
-    client, service, _ = protection_app
+    client, service, _, _ = protection_app
 
     status_response = client.get("/admin/cloud/protection", headers=HEADERS)
     create_response = client.post(
@@ -182,6 +207,39 @@ def test_status_and_intent_adapters_are_thin_and_token_free(protection_app):
     )
 
 
+def test_product_status_redacts_paths_credentials_and_secret_material(
+    protection_app,
+    monkeypatch,
+):
+    client, _, _, _ = protection_app
+    monkeypatch.setattr(
+        routes_protection,
+        "cloud_status_payload",
+        lambda settings, **kwargs: {
+            "protection_state": "attention_required",
+            "state_error": "failed at /home/person/cloud-state.json",
+            "last_upload_error": "token never-return-this-token",
+            "last_verify_error": "AGE-SECRET-KEY-private",
+            "last_error_message": "https://example.test/private",
+            "warnings": ["bad file /tmp/recovery/kit.md"],
+        },
+    )
+
+    response = client.get("/admin/cloud/protection", headers=HEADERS)
+
+    assert response.status_code == 200
+    serialized = str(response.json()).lower()
+    assert "state_error" not in response.json()
+    for forbidden in [
+        "/home/person",
+        "/tmp/recovery",
+        "never-return-this-token",
+        "age-secret-key",
+        "https://",
+    ]:
+        assert forbidden not in serialized
+
+
 @pytest.mark.parametrize(
     ("path", "body"),
     [
@@ -192,16 +250,20 @@ def test_status_and_intent_adapters_are_thin_and_token_free(protection_app):
         ("/admin/cloud/protection/disable", {"delete_remote": True}),
         ("/admin/cloud/protection/backup", {"advance_head": True}),
         ("/admin/cloud/protection/verify", {"presigned_url": "https://example.test"}),
+        (
+            "/admin/cloud/protection/recovery-kit/confirm",
+            {"sha256_digest": "a" * 64, "path": "/secret"},
+        ),
     ],
 )
 def test_mutation_routes_forbid_extra_fields(protection_app, path, body):
-    client, _, _ = protection_app
+    client, _, _, _ = protection_app
     response = client.post(path, headers=HEADERS, json=body)
     assert response.status_code == 422
 
 
 def test_long_operations_return_202_and_poll_safe_results(protection_app):
-    client, service, _ = protection_app
+    client, service, _, _ = protection_app
     requests = [
         (
             f"/admin/cloud/protection/intents/{INTENT_ID}/enable",
@@ -229,7 +291,7 @@ def test_long_operations_return_202_and_poll_safe_results(protection_app):
 
 
 def test_repeated_active_backup_joins_one_operation(protection_app):
-    client, service, _ = protection_app
+    client, service, _, _ = protection_app
     service.release_backup = threading.Event()
 
     first = client.post("/admin/cloud/protection/backup", headers=HEADERS, json={})
@@ -245,7 +307,7 @@ def test_repeated_active_backup_joins_one_operation(protection_app):
 
 
 def test_unknown_operation_returns_404(protection_app):
-    client, _, _ = protection_app
+    client, _, _, _ = protection_app
     response = client.get(
         "/admin/cloud/protection/operations/unknown",
         headers=HEADERS,
@@ -273,7 +335,7 @@ def test_polling_entitlement_is_cache_only(monkeypatch):
 
 
 def test_invalid_intent_and_snapshot_ids_fail_before_service_work(protection_app):
-    client, service, _ = protection_app
+    client, service, _, _ = protection_app
 
     invalid_intent = client.post(
         "/admin/cloud/protection/intents/not-a-uuid/enable",
@@ -289,3 +351,69 @@ def test_invalid_intent_and_snapshot_ids_fail_before_service_work(protection_app
     assert invalid_intent.status_code == 422
     assert invalid_snapshot.status_code == 422
     assert service.calls == []
+
+
+def test_recovery_confirmation_is_typed_and_secret_free(protection_app):
+    client, _, _, recovery_service = protection_app
+
+    response = client.post(
+        "/admin/cloud/protection/recovery-kit/confirm",
+        headers=HEADERS,
+        json={"sha256_digest": "a" * 64},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "device_loss_recovery_ready": True,
+        "recovery_kit_verified_at": "2026-07-31T12:00:00+00:00",
+    }
+    assert recovery_service.calls == ["a" * 64]
+    serialized = str(response.json()).lower()
+    for forbidden in ["age-secret-key", "path", "token", "digest", "identity"]:
+        assert forbidden not in serialized
+
+
+def test_recovery_confirmation_does_not_invent_readiness(protection_app):
+    client, _, _, recovery_service = protection_app
+    recovery_service.ready = False
+
+    response = client.post(
+        "/admin/cloud/protection/recovery-kit/confirm",
+        headers=HEADERS,
+        json={"sha256_digest": "a" * 64},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["device_loss_recovery_ready"] is False
+
+
+@pytest.mark.parametrize("digest", ["ABC", "A" * 64, "a" * 63, "a" * 65])
+def test_malformed_recovery_digest_is_rejected_before_service_work(
+    protection_app,
+    digest,
+):
+    client, _, _, recovery_service = protection_app
+
+    response = client.post(
+        "/admin/cloud/protection/recovery-kit/confirm",
+        headers=HEADERS,
+        json={"sha256_digest": digest},
+    )
+
+    assert response.status_code == 422
+    assert recovery_service.calls == []
+
+
+def test_recovery_confirmation_failure_does_not_leak_service_error(protection_app):
+    client, _, _, recovery_service = protection_app
+    recovery_service.fail = True
+
+    response = client.post(
+        "/admin/cloud/protection/recovery-kit/confirm",
+        headers=HEADERS,
+        json={"sha256_digest": "a" * 64},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "The saved recovery kit could not be verified."}
+    assert "secret" not in response.text.lower()

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 from unittest.mock import patch
 
@@ -9,6 +10,8 @@ import pytest
 
 from ormah import cli
 from ormah.cloud import keys as cloud_keys
+from ormah.cloud import state as cloud_state
+from ormah.cloud.state import CloudState, load_state, save_state
 
 
 @pytest.fixture
@@ -19,6 +22,7 @@ def cloud_paths(tmp_path, monkeypatch):
     memory_dir = tmp_path / "memory"
     monkeypatch.setattr(cloud_keys, "KEY_PATH", key_path)
     monkeypatch.setattr(cloud_keys, "RECOVERY_KIT_PATH", kit_path)
+    monkeypatch.setattr(cloud_state, "CLOUD_STATE_DIR", tmp_path / "cloud-state")
     from ormah.config import settings
 
     monkeypatch.setattr(settings, "memory_dir", memory_dir)
@@ -84,6 +88,22 @@ def test_cloud_rotate_key_json(cloud_paths, capsys):
     strings = cloud_keys.load_identity_strings(key_path)
     assert strings[1:] == first  # old identity retained
     assert strings[0] in kit_path.read_text()  # kit regenerated with new key
+
+
+def test_cloud_rotate_key_clears_recovery_readiness(cloud_paths, capsys):
+    _, _, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    store_id = (memory_dir / ".store_id").read_text(encoding="utf-8").strip()
+    save_state(
+        store_id,
+        CloudState(recovery_kit_verified_at=datetime.now(timezone.utc)),
+        memory_dir=memory_dir,
+    )
+    capsys.readouterr()
+
+    _run(["cloud", "rotate-key", "--yes", "--json"])
+
+    assert load_state(store_id).recovery_kit_verified_at is None
 
 
 def test_cloud_rotate_key_requires_confirmation_non_tty(cloud_paths, capsys, monkeypatch):

--- a/tests/test_cloud_enablement.py
+++ b/tests/test_cloud_enablement.py
@@ -11,6 +11,7 @@ import pytest
 from ormah.cloud import protection, state
 from ormah.cloud.client import CloudError
 from ormah.cloud.protection import CloudProtectionService
+from ormah.cloud.recovery import RecoveryKitError
 from ormah.cloud.state import (
     ProtectionIntentStatus,
     ProtectionOperation,
@@ -55,6 +56,11 @@ def cloud_state_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(protection, "_utc_now", lambda: NOW)
     monkeypatch.setattr(protection, "cache_entitlements", lambda *args, **kwargs: None)
     monkeypatch.setattr(protection, "RECOVERY_KIT_PATH", tmp_path / "recovery-kit.md")
+    monkeypatch.setattr(
+        protection,
+        "RecoveryKitService",
+        lambda settings: SimpleNamespace(validate_canonical_kit=lambda: None),
+    )
 
 
 def _settings(tmp_path: Path, *, token: str | None = "token"):
@@ -466,6 +472,13 @@ def test_enable_only_claims_protected_after_exact_snapshot_verification(
         return Path("kit")
 
     monkeypatch.setattr(protection, "write_recovery_kit", write_kit)
+    monkeypatch.setattr(
+        protection,
+        "RecoveryKitService",
+        lambda settings: SimpleNamespace(
+            validate_canonical_kit=lambda: order.append("kit")
+        ),
+    )
 
     def enable_setting(settings, enabled):
         assert load_state(store_id).protection_state is ProtectionState.INITIALIZING
@@ -533,7 +546,7 @@ def test_enable_only_claims_protected_after_exact_snapshot_verification(
 
     result = service.enable(intent)
 
-    assert order == ["settings", "upload", "verify"]
+    assert order == ["kit", "settings", "upload", "verify"]
     assert result.phase is ProtectionOperationPhase.COMPLETED
     assert result.operation_id == intent
     assert result.snapshot_id == SNAPSHOT_ID
@@ -542,6 +555,37 @@ def test_enable_only_claims_protected_after_exact_snapshot_verification(
     assert durable.protection_state is ProtectionState.PROTECTED
     assert durable.pending_protection_status is ProtectionIntentStatus.COMPLETED
     assert durable.recovery_kit_verified_at is None
+
+
+def test_enable_fails_closed_when_generated_kit_does_not_validate(tmp_path, monkeypatch):
+    settings, service, intent, _ = _ready_intent(tmp_path, monkeypatch)
+    monkeypatch.setattr(protection, "key_file_exists", lambda: True)
+    monkeypatch.setattr(protection, "load_identities", lambda: [object()])
+    monkeypatch.setattr(
+        protection,
+        "write_recovery_kit",
+        lambda store_id, **kwargs: Path("kit"),
+    )
+    monkeypatch.setattr(
+        protection,
+        "RecoveryKitService",
+        lambda settings: SimpleNamespace(
+            validate_canonical_kit=lambda: (_ for _ in ()).throw(
+                RecoveryKitError("invalid kit")
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        protection,
+        "set_cloud_backup_enabled",
+        lambda *args: (_ for _ in ()).throw(AssertionError("must not enable")),
+    )
+
+    result = service.enable(intent)
+
+    assert result.phase is ProtectionOperationPhase.FAILED
+    assert result.reason_code is ProtectionReasonCode.KEY_INVALID
+    assert settings.cloud_backup_enabled is False
 
 
 def test_running_intent_retries_verification_without_reupload(tmp_path, monkeypatch):

--- a/tests/test_cloud_keys.py
+++ b/tests/test_cloud_keys.py
@@ -12,6 +12,7 @@ from ormah.cloud.bundle import build_bundle, open_bundle
 from ormah.cloud.crypto import encrypt_bytes, decrypt_bytes
 from ormah.cloud.keys import (
     CloudKeyError,
+    _rotate_key_without_recovery_kit,
     current_recipient,
     get_or_create_store_id,
     import_key,
@@ -19,7 +20,6 @@ from ormah.cloud.keys import (
     key_file_exists,
     load_identities,
     load_identity_strings,
-    rotate_key,
     rotate_key_and_recovery_kit,
     write_recovery_kit,
 )
@@ -55,7 +55,7 @@ def test_rotate_retains_old_identities_and_old_bundles_decrypt(key_path):
     old_recipient = current_recipient(key_path)
     old_bundle = encrypt_bytes(b"pre-rotation", [old_recipient])
 
-    new_str = rotate_key(key_path)
+    new_str = _rotate_key_without_recovery_kit(key_path)
 
     strings = load_identity_strings(key_path)
     assert strings[0] == new_str
@@ -71,14 +71,14 @@ def test_rotate_retains_old_identities_and_old_bundles_decrypt(key_path):
 
 def test_double_rotation_keeps_all_three(key_path):
     first = init_key(key_path)
-    second = rotate_key(key_path)
-    third = rotate_key(key_path)
+    second = _rotate_key_without_recovery_kit(key_path)
+    third = _rotate_key_without_recovery_kit(key_path)
     assert load_identity_strings(key_path) == [third, second, first]
 
 
 def test_rotate_without_key_fails(key_path):
     with pytest.raises(CloudKeyError, match="cloud init"):
-        rotate_key(key_path)
+        _rotate_key_without_recovery_kit(key_path)
 
 
 def test_recovery_first_rotation_leaves_key_untouched_when_kit_write_fails(
@@ -165,12 +165,77 @@ def test_older_client_never_overwrites_newer_recovery_kit(tmp_path, key_path):
     assert load_identity_strings(key_path) == [original_identity]
 
 
+@pytest.mark.parametrize(
+    "format_text",
+    [
+        "format_version: invalid",
+        "format_version: 0",
+        "format_version: 1\nformat_version: 1",
+    ],
+)
+def test_malformed_existing_kit_is_never_overwritten(
+    tmp_path,
+    key_path,
+    format_text,
+):
+    init_key(key_path)
+    kit_path = tmp_path / "kit.md"
+    damaged = f"# Ormah Recovery Kit\n{format_text}\nfuture_field: preserve-me\n"
+    kit_path.write_text(damaged, encoding="utf-8")
+
+    with pytest.raises(CloudKeyError, match="format version"):
+        write_recovery_kit(
+            "22222222-3333-4444-9555-666666666666",
+            key_path,
+            kit_path,
+        )
+
+    assert kit_path.read_text(encoding="utf-8") == damaged
+
+
+def test_non_utf8_oversized_or_non_file_kit_is_never_overwritten(tmp_path, key_path):
+    init_key(key_path)
+    store_id = "22222222-3333-4444-9555-666666666666"
+
+    non_utf8 = tmp_path / "non-utf8.md"
+    non_utf8.write_bytes(b"format_version: 1\n\xff")
+    with pytest.raises(CloudKeyError, match="invalid"):
+        write_recovery_kit(store_id, key_path, non_utf8)
+
+    oversized = tmp_path / "oversized.md"
+    oversized.write_bytes(b"x" * (keys.MAX_RECOVERY_KIT_BYTES + 1))
+    with pytest.raises(CloudKeyError, match="invalid"):
+        write_recovery_kit(store_id, key_path, oversized)
+
+    directory = tmp_path / "directory.md"
+    directory.mkdir()
+    with pytest.raises(CloudKeyError, match="invalid"):
+        write_recovery_kit(store_id, key_path, directory)
+
+
+@pytest.mark.parametrize("separator", ["\n", "\x85", "\u2028", "\u2029"])
+def test_recovery_kit_refuses_multiline_account_email(
+    tmp_path,
+    key_path,
+    separator,
+):
+    init_key(key_path)
+
+    with pytest.raises(CloudKeyError, match="account email"):
+        write_recovery_kit(
+            "22222222-3333-4444-9555-666666666666",
+            key_path,
+            tmp_path / "kit.md",
+            account_email=f"person@example.com{separator}format_version: 99",
+        )
+
+
 # --- import ---
 
 
 def test_import_key_roundtrip_from_kit(tmp_path, key_path):
     init_key(key_path)
-    rotate_key(key_path)
+    _rotate_key_without_recovery_kit(key_path)
     originals = load_identity_strings(key_path)
     kit = write_recovery_kit("store-1", key_path, tmp_path / "kit.md")
 
@@ -230,7 +295,7 @@ def test_store_id_corrupt_raises(tmp_path):
 
 def test_recovery_kit_contains_everything_and_no_passphrase(tmp_path, key_path):
     init_key(key_path)
-    rotate_key(key_path)
+    _rotate_key_without_recovery_kit(key_path)
     strings = load_identity_strings(key_path)
 
     kit_path = write_recovery_kit(

--- a/tests/test_cloud_keys.py
+++ b/tests/test_cloud_keys.py
@@ -7,6 +7,7 @@ import uuid
 
 import pytest
 
+from ormah.cloud import keys
 from ormah.cloud.bundle import build_bundle, open_bundle
 from ormah.cloud.crypto import encrypt_bytes, decrypt_bytes
 from ormah.cloud.keys import (
@@ -19,6 +20,7 @@ from ormah.cloud.keys import (
     load_identities,
     load_identity_strings,
     rotate_key,
+    rotate_key_and_recovery_kit,
     write_recovery_kit,
 )
 
@@ -77,6 +79,90 @@ def test_double_rotation_keeps_all_three(key_path):
 def test_rotate_without_key_fails(key_path):
     with pytest.raises(CloudKeyError, match="cloud init"):
         rotate_key(key_path)
+
+
+def test_recovery_first_rotation_leaves_key_untouched_when_kit_write_fails(
+    tmp_path, key_path, monkeypatch
+):
+    original_identity = init_key(key_path)
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-9555-666666666666",
+        key_path,
+        tmp_path / "kit.md",
+    )
+    key_before = key_path.read_bytes()
+    kit_before = kit_path.read_bytes()
+    atomic_write = keys._atomic_write_0600
+
+    def fail_kit(path, text):
+        if path == kit_path:
+            raise OSError("kit unavailable")
+        atomic_write(path, text)
+
+    monkeypatch.setattr(keys, "_atomic_write_0600", fail_kit)
+
+    with pytest.raises(OSError, match="kit unavailable"):
+        rotate_key_and_recovery_kit(
+            "22222222-3333-4444-9555-666666666666",
+            key_path=key_path,
+            kit_path=kit_path,
+        )
+
+    assert key_path.read_bytes() == key_before
+    assert kit_path.read_bytes() == kit_before
+    assert load_identity_strings(key_path) == [original_identity]
+
+
+def test_recovery_first_rotation_keeps_active_key_recoverable_when_key_write_fails(
+    tmp_path, key_path, monkeypatch
+):
+    original_identity = init_key(key_path)
+    kit_path = tmp_path / "kit.md"
+    key_before = key_path.read_bytes()
+    atomic_write = keys._atomic_write_0600
+
+    def fail_key(path, text):
+        if path == key_path:
+            raise OSError("key unavailable")
+        atomic_write(path, text)
+
+    monkeypatch.setattr(keys, "_atomic_write_0600", fail_key)
+
+    with pytest.raises(OSError, match="key unavailable"):
+        rotate_key_and_recovery_kit(
+            "22222222-3333-4444-9555-666666666666",
+            key_path=key_path,
+            kit_path=kit_path,
+        )
+
+    assert key_path.read_bytes() == key_before
+    kit_identities = [
+        line.strip()
+        for line in kit_path.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith("AGE-SECRET-KEY-")
+    ]
+    assert kit_identities[1:] == [original_identity]
+
+
+def test_older_client_never_overwrites_newer_recovery_kit(tmp_path, key_path):
+    original_identity = init_key(key_path)
+    store_id = "22222222-3333-4444-9555-666666666666"
+    kit_path = write_recovery_kit(store_id, key_path, tmp_path / "kit.md")
+    newer_kit = kit_path.read_text(encoding="utf-8").replace(
+        "format_version: 1",
+        "format_version: 2\nfuture_recovery_token: opaque",
+    )
+    kit_path.write_text(newer_kit, encoding="utf-8")
+    key_before = key_path.read_bytes()
+
+    with pytest.raises(CloudKeyError, match="newer Ormah version"):
+        write_recovery_kit(store_id, key_path, kit_path)
+    with pytest.raises(CloudKeyError, match="newer Ormah version"):
+        rotate_key_and_recovery_kit(store_id, key_path=key_path, kit_path=kit_path)
+
+    assert kit_path.read_text(encoding="utf-8") == newer_kit
+    assert key_path.read_bytes() == key_before
+    assert load_identity_strings(key_path) == [original_identity]
 
 
 # --- import ---
@@ -157,6 +243,7 @@ def test_recovery_kit_contains_everything_and_no_passphrase(tmp_path, key_path):
         assert s in text
     assert "22222222-3333-4444-5555-666666666666" in text
     assert "rishi@example.com" in text
+    assert "format_version: 1" in text
     assert "ormah cloud init --import-key" in text
     assert "ormah backup restore --cloud" in text
     assert "including us" in text

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -549,6 +549,22 @@ def test_safe_error_message_redacts_windows_node_paths():
     assert message == "Hash mismatch for nodes/<redacted>.md"
 
 
+def test_persisted_error_keeps_nonsecret_path_for_cli_diagnostics():
+    message = protection.safe_error_message(
+        "Could not write /home/person/.local/share/ormah/cloud/state.json"
+    )
+
+    assert "/home/person/.local/share/ormah/cloud/state.json" in message
+
+
+def test_product_error_redacts_nonsecret_local_path():
+    message = protection.safe_product_error_message(
+        "Could not write /home/person/.local/share/ormah/cloud/state.json"
+    )
+
+    assert message == "Could not write <redacted-path>"
+
+
 def test_offline_upload_preserves_verification_health_and_redacts_persisted_error(
     tmp_path, monkeypatch, cloud_state_dir
 ):

--- a/tests/test_cloud_recovery.py
+++ b/tests/test_cloud_recovery.py
@@ -192,6 +192,31 @@ def test_rotation_state_failure_leaves_key_and_kit_untouched(
     assert kit_path.read_bytes() == kit_before
 
 
+def test_partially_applied_rotation_is_not_confirmable(
+    recovery_store,
+    monkeypatch,
+):
+    _, store_id, key_path, kit_path, state_dir, service = recovery_store
+    service.confirm_saved_digest(hashlib.sha256(kit_path.read_bytes()).hexdigest())
+    active_identity = load_identity_strings(key_path)[0]
+    atomic_write = recovery.cloud_keys._atomic_write_0600
+
+    def fail_key(path, text):
+        if path == key_path:
+            raise OSError("key unavailable")
+        atomic_write(path, text)
+
+    monkeypatch.setattr(recovery.cloud_keys, "_atomic_write_0600", fail_key)
+
+    with pytest.raises(OSError, match="key unavailable"):
+        service.rotate_current_key()
+
+    assert active_identity in kit_path.read_text(encoding="utf-8")
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
+    with pytest.raises(RecoveryKitError, match="not current"):
+        service.validate_canonical_kit()
+
+
 def test_canonical_read_is_bounded(recovery_store):
     _, _, _, kit_path, _, service = recovery_store
     kit_path.write_bytes(b"x" * (recovery.MAX_RECOVERY_KIT_BYTES + 1))

--- a/tests/test_cloud_recovery.py
+++ b/tests/test_cloud_recovery.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+import uuid
+
+import pytest
+
+from ormah.cloud import recovery
+from ormah.cloud.keys import (
+    get_or_create_store_id,
+    init_key,
+    load_identity_strings,
+    write_recovery_kit,
+)
+from ormah.cloud.recovery import RecoveryKitError, RecoveryKitService
+from ormah.cloud.state import CloudState, ProtectionState, load_state, save_state
+
+
+NOW = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def recovery_store(tmp_path: Path):
+    memory_dir = tmp_path / "memory"
+    key_path = tmp_path / "config" / "cloud.key"
+    kit_path = tmp_path / "config" / "ormah-recovery-kit.md"
+    state_dir = tmp_path / "state"
+    settings = SimpleNamespace(memory_dir=memory_dir, cloud_backup_enabled=True)
+    store_id = get_or_create_store_id(memory_dir)
+    init_key(key_path)
+    write_recovery_kit(store_id, key_path=key_path, kit_path=kit_path)
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.PROTECTED,
+            last_successful_backup_snapshot_id="snapshot-a",
+            last_verified_snapshot_id="snapshot-a",
+            last_verify_ok=True,
+        ),
+        memory_dir=memory_dir,
+        state_dir=state_dir,
+    )
+    service = RecoveryKitService(
+        settings,
+        key_path=key_path,
+        kit_path=kit_path,
+        state_dir=state_dir,
+        now=lambda: NOW,
+    )
+    return settings, store_id, key_path, kit_path, state_dir, service
+
+
+def test_current_reopened_digest_updates_state_only_after_success(recovery_store):
+    settings, store_id, _, kit_path, state_dir, service = recovery_store
+    digest = hashlib.sha256(kit_path.read_bytes()).hexdigest()
+
+    result = service.confirm_saved_digest(digest)
+
+    assert result.device_loss_recovery_ready is True
+    assert result.recovery_kit_verified_at == NOW
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at == NOW
+    assert settings.memory_dir.is_dir()
+
+
+def test_wrong_digest_fails_without_updating_state(recovery_store):
+    _, store_id, _, _, state_dir, service = recovery_store
+
+    with pytest.raises(RecoveryKitError, match="could not be verified"):
+        service.confirm_saved_digest("0" * 64)
+
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
+
+
+def test_saved_copy_proof_does_not_claim_ready_without_current_protection(
+    recovery_store,
+):
+    settings, store_id, _, kit_path, state_dir, service = recovery_store
+    settings.cloud_backup_enabled = False
+
+    result = service.confirm_saved_digest(hashlib.sha256(kit_path.read_bytes()).hexdigest())
+
+    assert result.device_loss_recovery_ready is False
+    assert result.recovery_kit_verified_at == NOW
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at == NOW
+
+
+@pytest.mark.parametrize("damage", ["store", "key", "kit"])
+def test_wrong_store_key_or_kit_fails_closed(recovery_store, damage):
+    _, store_id, key_path, kit_path, state_dir, service = recovery_store
+    if damage == "store":
+        text = kit_path.read_text(encoding="utf-8")
+        kit_path.write_text(
+            text.replace(store_id, str(uuid.uuid4())),
+            encoding="utf-8",
+        )
+    elif damage == "key":
+        init_key(key_path.with_suffix(".new"))
+        key_path.write_bytes(key_path.with_suffix(".new").read_bytes())
+    else:
+        kit_path.write_text("not a recovery kit\n", encoding="utf-8")
+    digest = hashlib.sha256(kit_path.read_bytes()).hexdigest()
+
+    with pytest.raises(RecoveryKitError):
+        service.confirm_saved_digest(digest)
+
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
+
+
+def test_malformed_digest_is_rejected_before_kit_work(recovery_store, monkeypatch):
+    *_, service = recovery_store
+    calls = []
+    monkeypatch.setattr(
+        service,
+        "_validate_canonical_kit_locked",
+        lambda: calls.append(True),
+    )
+
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        service.confirm_saved_digest("ABC")
+
+    assert calls == []
+
+
+def test_confirmation_never_mints_a_missing_store_identity(recovery_store):
+    settings, _, _, kit_path, _, service = recovery_store
+    store_marker = settings.memory_dir / ".store_id"
+    store_marker.unlink()
+
+    with pytest.raises(RecoveryKitError):
+        service.confirm_saved_digest(hashlib.sha256(kit_path.read_bytes()).hexdigest())
+
+    assert not store_marker.exists()
+
+
+def test_rotation_clears_readiness_and_regenerates_current_kit(recovery_store):
+    _, store_id, key_path, kit_path, state_dir, service = recovery_store
+    digest = hashlib.sha256(kit_path.read_bytes()).hexdigest()
+    service.confirm_saved_digest(digest)
+    identities_before = load_identity_strings(key_path)
+
+    service.rotate_current_key()
+
+    state = load_state(store_id, state_dir=state_dir)
+    identities_after = load_identity_strings(key_path)
+    assert state.recovery_kit_verified_at is None
+    assert identities_after[1:] == identities_before
+    assert identities_after[0] in kit_path.read_text(encoding="utf-8")
+
+
+def test_rotation_state_failure_leaves_key_and_kit_untouched(
+    recovery_store,
+    monkeypatch,
+):
+    _, _, key_path, kit_path, _, service = recovery_store
+    key_before = key_path.read_bytes()
+    kit_before = kit_path.read_bytes()
+
+    def fail_state(*args, **kwargs):
+        raise RuntimeError("state unavailable")
+
+    monkeypatch.setattr(recovery, "update_state", fail_state)
+
+    with pytest.raises(RuntimeError, match="state unavailable"):
+        service.rotate_current_key()
+
+    assert key_path.read_bytes() == key_before
+    assert kit_path.read_bytes() == kit_before
+
+
+def test_canonical_read_is_bounded(recovery_store):
+    _, _, _, kit_path, _, service = recovery_store
+    kit_path.write_bytes(b"x" * (recovery.MAX_RECOVERY_KIT_BYTES + 1))
+
+    with pytest.raises(RecoveryKitError, match="invalid"):
+        service.validate_canonical_kit()

--- a/tests/test_cloud_recovery.py
+++ b/tests/test_cloud_recovery.py
@@ -109,6 +109,28 @@ def test_wrong_store_key_or_kit_fails_closed(recovery_store, damage):
     assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
 
 
+@pytest.mark.parametrize(
+    "replacement",
+    ["", "format_version: 2"],
+    ids=["missing", "unsupported"],
+)
+def test_unversioned_or_unsupported_kit_cannot_be_confirmed(
+    recovery_store,
+    replacement,
+):
+    _, store_id, _, kit_path, state_dir, service = recovery_store
+    kit_text = kit_path.read_text(encoding="utf-8")
+    kit_path.write_text(
+        kit_text.replace("format_version: 1", replacement),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RecoveryKitError, match="not current"):
+        service.confirm_saved_digest(hashlib.sha256(kit_path.read_bytes()).hexdigest())
+
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
+
+
 def test_malformed_digest_is_rejected_before_kit_work(recovery_store, monkeypatch):
     *_, service = recovery_store
     calls = []

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -21,6 +21,7 @@ from ormah.cloud.state import (
     ProtectionState,
     UploadJournalPhase,
     cloud_status_payload,
+    is_device_loss_recovery_ready,
     is_protected_and_verified,
     load_state,
     save_state,
@@ -82,6 +83,68 @@ def test_reserved_upload_does_not_hide_last_verified_protection():
         CloudState(**values, pending_upload_phase=UploadJournalPhase.FINALIZING),
         enabled=True,
     )
+
+
+def test_device_loss_readiness_requires_saved_kit_and_current_verified_snapshot():
+    verified_at = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+    current = CloudState(
+        last_successful_backup_snapshot_id="snapshot-a",
+        last_verified_snapshot_id="snapshot-a",
+        last_verify_ok=True,
+        recovery_kit_verified_at=verified_at,
+    )
+
+    assert is_device_loss_recovery_ready(current, enabled=True)
+    assert not is_device_loss_recovery_ready(
+        CloudState(
+            last_successful_backup_snapshot_id="snapshot-a",
+            last_verified_snapshot_id="snapshot-a",
+            last_verify_ok=True,
+        ),
+        enabled=True,
+    )
+    assert not is_device_loss_recovery_ready(
+        CloudState(
+            last_successful_backup_snapshot_id="snapshot-b",
+            last_verified_snapshot_id="snapshot-a",
+            last_verify_ok=True,
+            recovery_kit_verified_at=verified_at,
+        ),
+        enabled=True,
+    )
+    assert not is_device_loss_recovery_ready(current, enabled=False)
+
+
+def test_cloud_status_exposes_only_derived_recovery_readiness(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    verified_at = datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.PROTECTED,
+            last_successful_backup_snapshot_id="snapshot-a",
+            last_verified_snapshot_id="snapshot-a",
+            last_verify_ok=True,
+            recovery_kit_verified_at=verified_at,
+        ),
+        memory_dir=memory_dir,
+        state_dir=tmp_path / "state",
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=True),
+        entitlement="active",
+        state_dir=tmp_path / "state",
+    )
+
+    assert payload["device_loss_recovery_ready"] is True
+    assert payload["recovery_kit_verified_at"] == verified_at.isoformat()
+    serialized = json.dumps(payload).lower()
+    assert "age-secret-key" not in serialized
+    assert "ormah-recovery-kit.md" not in serialized
 
 
 def test_update_preserves_unmodified_fields(tmp_path):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3074,10 +3074,10 @@ class TestRunUninstall:
 
     def test_recovery_preflight_refreshes_stale_kit_after_rotation(self, tmp_path):
         from ormah.cloud.keys import (
+            _rotate_key_without_recovery_kit,
             get_or_create_store_id,
             init_key,
             load_identity_strings,
-            rotate_key,
             write_recovery_kit,
         )
 
@@ -3088,7 +3088,7 @@ class TestRunUninstall:
         init_key(key_path)
         store_id = get_or_create_store_id(memory_dir)
         write_recovery_kit(store_id, key_path=key_path, kit_path=kit_path)
-        rotate_key(key_path)
+        _rotate_key_without_recovery_kit(key_path)
 
         result = _prepare_cloud_recovery(config_dir, [memory_dir])
 

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -19,6 +19,7 @@ import {
   productBridge,
   protectionPresentation,
   protectionRepairAction,
+  recoveryKitSectionVisible,
   type AccountStatus,
   type BillingOffer,
   type ProtectionOperation,
@@ -406,7 +407,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     try {
       const result = await productBridge.openPrintableRecoveryKit();
       if (!result.opened) throw new Error("The printable copy could not be opened.");
-      onToast("Printable recovery kit opened in your system viewer.", "info");
+      onToast("Recovery kit sent to your system viewer.", "info");
     } catch (err) {
       setRecoveryError(errorMessage(err, "The printable copy could not be opened."));
     } finally {
@@ -617,10 +618,10 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
             </section>
           )}
 
-          {status?.enabled && status.last_successful_verify_at && view === "summary" && (
+          {recoveryKitSectionVisible(status) && view === "summary" && (
             <RecoveryKitSection
-              ready={status.device_loss_recovery_ready}
-              verifiedAt={formatDate(status.recovery_kit_verified_at)}
+              ready={Boolean(status?.device_loss_recovery_ready)}
+              verifiedAt={formatDate(status?.recovery_kit_verified_at ?? null)}
               busy={recoveryBusy}
               error={recoveryError}
               onSave={() => void saveRecoveryKit()}

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -24,6 +24,7 @@ import {
   type ProtectionOperation,
   type ProtectionStatus,
 } from "../productBridge";
+import RecoveryKitSection from "./RecoveryKitSection";
 
 interface Props {
   open: boolean;
@@ -112,6 +113,8 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
   const [error, setError] = useState<string | null>(null);
   const [checkoutPolling, setCheckoutPolling] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
+  const [recoveryBusy, setRecoveryBusy] = useState<"save" | "print" | null>(null);
+  const [recoveryError, setRecoveryError] = useState<string | null>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const checkoutCheckInFlight = useRef(false);
   const offerRequested = useRef(false);
@@ -374,6 +377,43 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     }
   }, [refresh]);
 
+  const saveRecoveryKit = useCallback(async () => {
+    setRecoveryBusy("save");
+    setRecoveryError(null);
+    try {
+      const result = await productBridge.saveRecoveryKit();
+      if (result.status === "canceled") return;
+      if (!result.recovery_kit_verified_at) {
+        throw new Error("The saved recovery kit could not be verified.");
+      }
+      await refresh();
+      onToast(
+        result.device_loss_recovery_ready
+          ? "Recovery kit saved and verified."
+          : "Recovery kit saved and verified; recovery readiness is waiting for current protection verification.",
+        "success",
+      );
+    } catch (err) {
+      setRecoveryError(errorMessage(err, "The recovery kit could not be saved."));
+    } finally {
+      setRecoveryBusy(null);
+    }
+  }, [onToast, refresh]);
+
+  const openPrintableRecoveryKit = useCallback(async () => {
+    setRecoveryBusy("print");
+    setRecoveryError(null);
+    try {
+      const result = await productBridge.openPrintableRecoveryKit();
+      if (!result.opened) throw new Error("The printable copy could not be opened.");
+      onToast("Printable recovery kit opened in your system viewer.", "info");
+    } catch (err) {
+      setRecoveryError(errorMessage(err, "The printable copy could not be opened."));
+    } finally {
+      setRecoveryBusy(null);
+    }
+  }, [onToast]);
+
   const presentation = useMemo(
     () => protectionPresentation(operation?.protection_state || status?.protection_state || "local_only"),
     [operation?.protection_state, status?.protection_state],
@@ -575,6 +615,17 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
               <div><span>Last encrypted upload</span><strong>{formatDate(status.last_successful_upload_at)}</strong></div>
               <div><span>Cloud can read</span><strong>metadata only</strong></div>
             </section>
+          )}
+
+          {status?.enabled && status.last_successful_verify_at && view === "summary" && (
+            <RecoveryKitSection
+              ready={status.device_loss_recovery_ready}
+              verifiedAt={formatDate(status.recovery_kit_verified_at)}
+              busy={recoveryBusy}
+              error={recoveryError}
+              onSave={() => void saveRecoveryKit()}
+              onOpenPrintable={() => void openPrintableRecoveryKit()}
+            />
           )}
 
           {status?.warnings?.length ? (

--- a/ui/src/components/RecoveryKitSection.test.tsx
+++ b/ui/src/components/RecoveryKitSection.test.tsx
@@ -1,0 +1,64 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import RecoveryKitSection from "./RecoveryKitSection";
+
+function render(
+  overrides: Partial<Parameters<typeof RecoveryKitSection>[0]> = {},
+): string {
+  return renderToStaticMarkup(
+    <RecoveryKitSection
+      ready={false}
+      verifiedAt="not yet"
+      busy={null}
+      error={null}
+      onSave={() => undefined}
+      onOpenPrintable={() => undefined}
+      {...overrides}
+    />,
+  );
+}
+
+describe("RecoveryKitSection", () => {
+  it("renders a distinct truthful action-required state", () => {
+    const markup = render();
+
+    expect(markup).toContain("Device-loss recovery");
+    expect(markup).toContain("Action required");
+    expect(markup).toContain("Save recovery kit");
+    expect(markup).toContain("Open printable copy");
+    expect(markup).toContain("Anyone with this file can read your backups");
+    expect(markup).toContain("Opening it does not verify a saved copy");
+  });
+
+  it("shows readiness only with the supplied verification time", () => {
+    const markup = render({
+      ready: true,
+      verifiedAt: "Jul 31, 2026 at 12:00 PM",
+    });
+
+    expect(markup).toContain("Ready");
+    expect(markup).toContain("reopened and verified Jul 31, 2026 at 12:00 PM");
+    expect(markup).toContain("Save another copy");
+  });
+
+  it("does not claim readiness from a saved-copy timestamp alone", () => {
+    const markup = render({
+      ready: false,
+      verifiedAt: "Jul 31, 2026 at 12:00 PM",
+    });
+
+    expect(markup).toContain("Action required");
+    expect(markup).not.toContain("reopened and verified Jul 31, 2026");
+  });
+
+  it("exposes deterministic accessible busy and error states", () => {
+    const markup = render({ busy: "save", error: "Verification failed." });
+
+    expect(markup).toContain('aria-busy="true"');
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Verification failed.");
+    expect(markup).toContain("Saving and checking");
+    expect(markup.match(/disabled=""/g)).toHaveLength(2);
+  });
+});

--- a/ui/src/components/RecoveryKitSection.tsx
+++ b/ui/src/components/RecoveryKitSection.tsx
@@ -1,0 +1,85 @@
+import {
+  AlertTriangle,
+  Check,
+  Download,
+  LoaderCircle,
+  Printer,
+} from "lucide-react";
+
+interface Props {
+  ready: boolean;
+  verifiedAt: string;
+  busy: "save" | "print" | null;
+  error: string | null;
+  onSave: () => void;
+  onOpenPrintable: () => void;
+}
+
+export default function RecoveryKitSection({
+  ready,
+  verifiedAt,
+  busy,
+  error,
+  onSave,
+  onOpenPrintable,
+}: Props) {
+  return (
+    <section
+      className={`recovery-kit-section ${ready ? "is-ready" : "action-required"}`}
+      aria-label="Device-loss recovery"
+      aria-busy={busy !== null}
+    >
+      <div className="recovery-kit-heading">
+        <span aria-hidden="true">
+          {ready ? <Check size={16} /> : <AlertTriangle size={16} />}
+        </span>
+        <div>
+          <h3>Device-loss recovery</h3>
+          <strong>{ready ? "Ready" : "Action required"}</strong>
+        </div>
+      </div>
+      {ready ? (
+        <p>Your saved recovery kit was reopened and verified {verifiedAt}.</p>
+      ) : (
+        <p>
+          This file is the only way to restore if all trusted devices are lost.
+          Save a separate copy now.
+        </p>
+      )}
+      <div className="recovery-kit-warning">
+        Anyone with this file can read your backups. Ormah cannot recover it for you.
+      </div>
+      {error && (
+        <div className="recovery-kit-error" role="alert">
+          <AlertTriangle size={14} />
+          <span>{error}</span>
+        </div>
+      )}
+      <button
+        className="protection-primary"
+        disabled={busy !== null}
+        onClick={onSave}
+      >
+        {busy === "save" ? <LoaderCircle className="spin" size={15} /> : <Download size={15} />}
+        {busy === "save" ? "Saving and checking…" : ready ? "Save another copy" : "Save recovery kit"}
+      </button>
+      <button
+        className="protection-secondary"
+        disabled={busy !== null}
+        onClick={onOpenPrintable}
+      >
+        {busy === "print" ? <LoaderCircle className="spin" size={14} /> : <Printer size={14} />}
+        {busy === "print" ? "Opening…" : "Open printable copy"}
+      </button>
+      <p className="recovery-print-note">
+        Opens in your system viewer so you can print it. Opening it does not verify a saved copy.
+      </p>
+      <div className="sr-status" aria-live="polite">
+        {busy === "save" ? "Saving and checking recovery kit"
+          : busy === "print" ? "Opening printable recovery kit"
+            : ready ? "Device-loss recovery ready"
+              : "Device-loss recovery action required"}
+      </div>
+    </section>
+  );
+}

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -70,6 +70,8 @@ function status(overrides: Partial<ProtectionStatus>): ProtectionStatus {
     last_successful_backup_snapshot_id: null,
     last_successful_verify_at: null,
     last_verified_snapshot_id: null,
+    recovery_kit_verified_at: null,
+    device_loss_recovery_ready: false,
     last_error_code: null,
     last_error_message: null,
     warnings: [],

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -4,6 +4,7 @@ import {
   operationPhaseIsActive,
   protectionRepairAction,
   protectionPresentation,
+  recoveryKitSectionVisible,
   type ProtectionStatus,
   type ProtectionState,
 } from "./productBridge";
@@ -94,5 +95,17 @@ describe("protectionRepairAction", () => {
       last_error_code: "operation_interrupted",
       protection_intent_status: "running",
     }))).toBe("resume");
+  });
+});
+
+describe("recoveryKitSectionVisible", () => {
+  it("keeps recovery export available while protection needs attention", () => {
+    expect(recoveryKitSectionVisible(status({
+      enabled: true,
+      protection_state: "attention_required",
+      last_successful_verify_at: null,
+    }))).toBe(true);
+    expect(recoveryKitSectionVisible(status({ enabled: false }))).toBe(false);
+    expect(recoveryKitSectionVisible(null)).toBe(false);
   });
 });

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -76,10 +76,24 @@ export interface ProtectionStatus {
   last_successful_backup_snapshot_id: string | null;
   last_successful_verify_at: string | null;
   last_verified_snapshot_id: string | null;
+  recovery_kit_verified_at: string | null;
+  device_loss_recovery_ready: boolean;
   last_error_code: string | null;
   last_error_message: string | null;
   warnings: string[];
 }
+
+export type RecoveryKitActionResult =
+  | {
+    status: "saved";
+    device_loss_recovery_ready: boolean;
+    recovery_kit_verified_at: string;
+  }
+  | {
+    status: "canceled";
+    device_loss_recovery_ready: null;
+    recovery_kit_verified_at: null;
+  };
 
 export interface ProtectionOperation {
   operation_id: string;
@@ -145,6 +159,9 @@ export const productBridge = {
   openCheckout: (intentId: string) =>
     native<BillingHandoff>("open_checkout", { intentId }),
   openPortal: () => native<{ opened: boolean }>("open_billing_portal"),
+  saveRecoveryKit: () => native<RecoveryKitActionResult>("save_recovery_kit"),
+  openPrintableRecoveryKit: () =>
+    native<{ opened: boolean }>("open_printable_recovery_kit"),
 };
 
 export interface ProtectionPresentation {

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -95,6 +95,12 @@ export type RecoveryKitActionResult =
     recovery_kit_verified_at: null;
   };
 
+export function recoveryKitSectionVisible(
+  status: ProtectionStatus | null | undefined,
+): boolean {
+  return Boolean(status?.enabled);
+}
+
 export interface ProtectionOperation {
   operation_id: string;
   kind: "enable" | "disable" | "backup" | "verify" | "restore";

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -934,9 +934,86 @@ body.in-app .node-detail.tier-core {
 .protection-actions,
 .protection-account,
 .protection-facts,
-.protection-warnings {
+.protection-warnings,
+.recovery-kit-section {
   padding: 18px 0;
   border-bottom: 1px solid var(--border);
+}
+
+.recovery-kit-heading {
+  display: flex;
+  gap: 9px;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+
+.recovery-kit-heading > span {
+  width: 26px;
+  height: 26px;
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-surface);
+}
+
+.recovery-kit-section.action-required .recovery-kit-heading > span {
+  color: var(--accent);
+}
+
+.recovery-kit-section.is-ready .recovery-kit-heading > span {
+  color: var(--edge-supports);
+}
+
+.recovery-kit-heading h3 {
+  margin: 0 0 2px;
+  color: var(--text-bright);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.recovery-kit-heading strong {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.recovery-kit-section > p {
+  margin: 0 0 12px;
+  color: var(--text);
+  line-height: 1.55;
+}
+
+.recovery-kit-warning {
+  margin: 12px 0;
+  padding: 9px 10px;
+  border-left: 2px solid var(--accent);
+  background: var(--bg-surface);
+  color: var(--text-bright);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.recovery-kit-error {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 7px;
+  align-items: start;
+  margin: 0 0 12px;
+  padding: 9px 10px;
+  background: var(--danger-bg);
+  color: var(--text-bright);
+  line-height: 1.45;
+}
+
+.recovery-kit-section .recovery-print-note {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.45;
 }
 
 .step-back {


### PR DESCRIPTION
## Problem

PR #173 can create and verify encrypted cloud recovery points, but the desktop app does not yet complete the separate device-loss recovery step. A protected snapshot is not enough if the user loses every trusted device without saving the local recovery kit.

## Solution

- add a focused Python recovery service that validates the canonical kit against the active store and complete identity set
- confirm a native saved-copy proof only after the destination is reopened and its SHA-256 matches the independently validated canonical kit
- persist `recovery_kit_verified_at` under the canonical store lock and derive `device_loss_recovery_ready` from both that proof and the existing protected-and-verified invariant
- clear recovery readiness before key rotation and regenerate/revalidate the current kit
- add a fixed local capability-authenticated confirmation route whose response contains no kit bytes, identities, paths, or digest
- add exact-origin Tauri commands for a native Save dialog and an honest "Open printable copy" handoff
- add a separate desktop recovery section that distinguishes **Protected and verified** from **Device-loss recovery ready**
- keep cancel non-destructive and ensure opening/printing alone never marks recovery ready

## Security boundary

Recovery-kit contents and private identities never enter React state or API responses. React invokes fixed, no-argument native commands and receives only purpose-bound status/timestamp fields. The Rust bridge bounds sensitive-file reads, rejects symlinks and hard links to the canonical kit, securely writes and reopens the selected copy, and sends only a lowercase SHA-256 proof to the fixed local endpoint.

No generic filesystem, dialog, HTTP, or shell bridge is added to the product webview.

## Dependencies

- `tauri-plugin-dialog` for the Rust-owned native Save dialog
- `sha2` for hashing the reopened saved copy
- direct `libc` use for secure Unix file operations

## Verification performed on ai-agents

- focused touched-area Python suites: 112 passed
- native recovery/bridge suite: 16 passed
- root product UI production build: passed
- Rust `cargo check`: passed
- full Python suite: 1,758 passed, 26 failed, 1 deselected; the failures were existing VM/environment issues in sqlite-vec-backed background tests and setup tests detecting the installed Claude/Codex binaries, not touched recovery paths

The Home PC maintainer review and independent Claude review will follow before merge.

## Deferred

- C05 trusted-device pairing, PAKE, and recovery-authorization tokens
- direct confirmation that a physical print completed; **Open printable copy** is intentionally not treated as a recovery-readiness proof
- release/version changes
