### PR TITLE
chore(release): prepare 0.14.4 and desktop 0.3.17

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.16"
+version = "0.3.17"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.16"
+version = "0.3.17"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.3"
+version = "0.14.4"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump Ormah Python and Claude plugin versions from 0.14.3 to 0.14.4
- bump Ormah Desktop from 0.3.16 to 0.3.17
- ship the completed C02 paid protection flow and recovery-kit readiness UX from PRs #172, #173, and #174

## Verification

- release version verifier passed for 0.14.4
- Cargo metadata resolves Desktop 0.3.17
- both JSON manifests parse
- git diff --check passed
- product head already passed Python, lint, and desktop CI in PR #174

## Publishing order after merge

1. dispatch the Python Release workflow for 0.14.4 from main
2. wait for PyPI and GitHub release success
3. tag the same main commit as desktop-v0.3.17
4. wait for signed and notarized desktop artifacts and updater feed

Stripe remains configured in test mode for this acceptance release, so Checkout can be tested without real charges.