### PR TITLE
fix(desktop): make protection progress truthful

### DIFF
--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -30,6 +30,7 @@ const CHECKOUT_HOST: &str = "checkout.stripe.com";
 const PORTAL_HOST: &str = "billing.stripe.com";
 const RECOVERY_KIT_FILENAME: &str = "ormah-recovery-kit.md";
 const MAX_RECOVERY_KIT_BYTES: u64 = 256 * 1024;
+const RECOVERY_PREPARE_PATH: &str = "/admin/cloud/protection/recovery-kit/prepare";
 const RECOVERY_CONFIRM_PATH: &str = "/admin/cloud/protection/recovery-kit/confirm";
 
 #[derive(Debug, Serialize)]
@@ -254,6 +255,7 @@ pub async fn save_recovery_kit<R: Runtime>(
     window: WebviewWindow<R>,
 ) -> Result<RecoveryKitActionResult, String> {
     require_product_origin(&window)?;
+    let _: Value = request_json("POST", RECOVERY_PREPARE_PATH, Some(json!({}))).await?;
     let selected = app
         .dialog()
         .file()

--- a/src/ormah/api/routes_protection.py
+++ b/src/ormah/api/routes_protection.py
@@ -62,6 +62,15 @@ class RecoveryReadinessResponse(BaseModel):
     recovery_kit_verified_at: str
 
 
+class RecoveryKitPrepareResponse(BaseModel):
+    """Secret-free readiness result for the native save dialog."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    regenerated: bool
+
+
 def _service(request: Request) -> CloudProtectionService:
     injected = getattr(request.app.state, "protection_service", None)
     return injected or CloudProtectionService.from_engine(request.app.state.engine)
@@ -206,14 +215,14 @@ def disable_protection(body: EmptyRequest, request: Request):
 
 @router.post("/backup", status_code=status.HTTP_202_ACCEPTED)
 def backup_now(body: EmptyRequest, request: Request):
-    """Start one user-requested encrypted backup."""
+    """Create a recovery point and restore-test that exact snapshot."""
     del body
     service = _service(request)
     return _submit(
         request,
         operation="backup",
         kind=ProtectionOperationKind.BACKUP,
-        action=lambda: service.backup_now(reason="manual-ui"),
+        action=lambda: service.backup_and_verify(reason="manual-ui"),
     )
 
 
@@ -228,6 +237,24 @@ def verify_now(body: VerifyRequest, request: Request):
         kind=ProtectionOperationKind.VERIFY,
         action=lambda: service.verify_now(body.snapshot_id),
     )
+
+
+@router.post(
+    "/recovery-kit/prepare",
+    response_model=RecoveryKitPrepareResponse,
+)
+def prepare_recovery_kit(body: EmptyRequest, request: Request):
+    """Ensure the canonical kit matches current keys before native save."""
+
+    del body
+    try:
+        regenerated = _recovery_service(request).ensure_current_kit()
+    except (RecoveryKitError, CloudStateError, StoreLockTimeout, OSError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="The recovery kit could not be prepared for saving.",
+        ) from exc
+    return {"status": "ready_to_save", "regenerated": regenerated}
 
 
 @router.post(

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -1314,6 +1314,45 @@ class CloudProtectionService:
         except Exception as exc:
             return self._backup_failure(operation_id, exc)
 
+    def backup_and_verify(self, reason: str = "manual-ui") -> ProtectionOperation:
+        """Upload one recovery point and restore-test that exact snapshot.
+
+        This is the product-facing manual action. Scheduled backups continue to
+        use :meth:`backup_now` so they do not download every uploaded snapshot.
+        """
+
+        operation_id = str(uuid.uuid4())
+        try:
+            with StoreLock(self.settings.memory_dir):
+                backup = self._backup_now(
+                    operation_id,
+                    reason=reason,
+                    only_if_due=False,
+                    entitlement_verified=False,
+                )
+                if backup.phase is not ProtectionOperationPhase.COMPLETED:
+                    return backup
+                verification = self._verify_now(
+                    operation_id,
+                    requested_snapshot_id=backup.snapshot_id,
+                )
+                return ProtectionOperation(
+                    operation_id,
+                    ProtectionOperationKind.BACKUP,
+                    verification.phase,
+                    verification.state,
+                    verification.reason_code,
+                    verification.message,
+                    verification.snapshot_id,
+                )
+        except StoreLockTimeout:
+            return self._store_busy_operation(
+                operation_id,
+                ProtectionOperationKind.BACKUP,
+            )
+        except Exception as exc:
+            return self._verification_failure(operation_id, exc)
+
     def _record_upload_success(
         self,
         *,
@@ -1545,9 +1584,28 @@ class CloudProtectionService:
                     snapshot_id=state.last_upload_snapshot_id,
                 )
 
+            operation_kind = (
+                ProtectionOperationKind.ENABLE
+                if protection_intent_id is not None
+                else ProtectionOperationKind.BACKUP
+            )
+            update_state(
+                store_id,
+                memory_dir=settings.memory_dir,
+                last_operation_id=operation_id,
+                last_operation_kind=operation_kind,
+                last_operation_phase=ProtectionOperationPhase.PREPARING,
+            )
             backup = _backup_for_upload(backup_service, reason=reason)
             with tempfile.TemporaryDirectory(prefix="ormah-cloud-upload-") as tmp:
                 bundle = Path(tmp) / f"{backup.name}.age"
+                update_state(
+                    store_id,
+                    memory_dir=settings.memory_dir,
+                    last_operation_id=operation_id,
+                    last_operation_kind=operation_kind,
+                    last_operation_phase=ProtectionOperationPhase.ENCRYPTING,
+                )
                 build_bundle(
                     backup.path,
                     bundle,
@@ -1582,6 +1640,9 @@ class CloudProtectionService:
                 update_state(
                     store_id,
                     memory_dir=settings.memory_dir,
+                    last_operation_id=operation_id,
+                    last_operation_kind=operation_kind,
+                    last_operation_phase=ProtectionOperationPhase.UPLOADING,
                     pending_upload_id=upload_id,
                     pending_upload_snapshot_id=snapshot_id,
                     pending_upload_operation_id=operation_id,
@@ -1593,6 +1654,9 @@ class CloudProtectionService:
                 update_state(
                     store_id,
                     memory_dir=settings.memory_dir,
+                    last_operation_id=operation_id,
+                    last_operation_kind=operation_kind,
+                    last_operation_phase=ProtectionOperationPhase.FINALIZING,
                     pending_upload_phase=UploadJournalPhase.FINALIZING,
                 )
                 finalize_attempted = True
@@ -1771,6 +1835,13 @@ class CloudProtectionService:
                     ProtectionReasonCode.SIGN_IN_REQUIRED,
                 )
 
+            update_state(
+                store_id,
+                memory_dir=settings.memory_dir,
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.VERIFY,
+                last_operation_phase=ProtectionOperationPhase.DOWNLOADING,
+            )
             client = client_from_settings(settings)
             listing = client.list_blobs(store_id)
             blobs = listing.get("blobs")
@@ -1845,6 +1916,13 @@ class CloudProtectionService:
                     "The downloaded ciphertext hash did not match cloud metadata.",
                     ProtectionReasonCode.CIPHERTEXT_HASH_MISMATCH,
                 )
+            update_state(
+                store_id,
+                memory_dir=settings.memory_dir,
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.VERIFY,
+                last_operation_phase=ProtectionOperationPhase.VERIFYING,
+            )
             try:
                 info = open_bundle(bundle, extracted, load_identities())
             except CloudCryptoError as exc:
@@ -1862,6 +1940,13 @@ class CloudProtectionService:
                     "The decrypted snapshot failed manifest and file-integrity verification.",
                     ProtectionReasonCode.MANIFEST_VERIFICATION_FAILED,
                 ) from exc
+            update_state(
+                store_id,
+                memory_dir=settings.memory_dir,
+                last_operation_id=operation_id,
+                last_operation_kind=ProtectionOperationKind.VERIFY,
+                last_operation_phase=ProtectionOperationPhase.REBUILDING,
+            )
             _verify_extracted_bundle(extracted, store_id, info)
 
             verified_at = _utc_now()

--- a/src/ormah/cloud/recovery.py
+++ b/src/ormah/cloud/recovery.py
@@ -102,6 +102,35 @@ class RecoveryKitService:
         with StoreLock(self.settings.memory_dir):
             self._validate_canonical_kit_locked()
 
+    def ensure_current_kit(self) -> bool:
+        """Repair a stale canonical kit before a native save operation.
+
+        Returns ``True`` only when the canonical file had to be regenerated.
+        A regenerated file invalidates the proof for any previously saved copy;
+        the native save-and-reopen flow establishes a new proof immediately.
+        """
+
+        with StoreLock(self.settings.memory_dir):
+            try:
+                self._validate_canonical_kit_locked()
+                return False
+            except RecoveryKitError:
+                store_id = self._active_store_id()
+                update_state(
+                    store_id,
+                    memory_dir=self.settings.memory_dir,
+                    state_dir=self.state_dir,
+                    recovery_kit_verified_at=None,
+                )
+                cloud_keys.write_recovery_kit(
+                    store_id,
+                    key_path=self.key_path,
+                    kit_path=self.kit_path,
+                    account_email=getattr(self.settings, "account_email", None),
+                )
+                self._validate_canonical_kit_locked()
+                return True
+
     def confirm_saved_digest(self, digest: str) -> RecoveryReadiness:
         """Record a saved-copy proof only when its bytes equal the current valid kit."""
 

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -80,9 +80,13 @@ class ProtectionOperationKind(StrEnum):
 class ProtectionOperationPhase(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
+    PREPARING = "preparing"
+    ENCRYPTING = "encrypting"
     UPLOADING = "uploading"
     FINALIZING = "finalizing"
+    DOWNLOADING = "downloading"
     VERIFYING = "verifying"
+    REBUILDING = "rebuilding"
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELED = "canceled"

--- a/tests/test_api/test_protection_routes.py
+++ b/tests/test_api/test_protection_routes.py
@@ -72,8 +72,8 @@ class FakeProtectionService:
         self.calls.append(("disable",))
         return _operation(ProtectionOperationKind.DISABLE)
 
-    def backup_now(self, *, reason):
-        self.calls.append(("backup_now", reason))
+    def backup_and_verify(self, *, reason):
+        self.calls.append(("backup_and_verify", reason))
         if self.release_backup is not None:
             assert self.release_backup.wait(timeout=2)
         return _operation(ProtectionOperationKind.BACKUP)
@@ -88,6 +88,12 @@ class FakeRecoveryKitService:
         self.calls: list[str] = []
         self.fail = False
         self.ready = True
+
+    def ensure_current_kit(self):
+        self.calls.append("prepare")
+        if self.fail:
+            raise RecoveryKitError("secret path and AGE-SECRET-KEY-private")
+        return True
 
     def confirm_saved_digest(self, digest):
         self.calls.append(digest)
@@ -161,6 +167,7 @@ def test_all_protection_routes_require_local_capability(protection_app):
         ("POST", "/admin/cloud/protection/disable", {}),
         ("POST", "/admin/cloud/protection/backup", {}),
         ("POST", "/admin/cloud/protection/verify", {}),
+        ("POST", "/admin/cloud/protection/recovery-kit/prepare", {}),
         (
             "POST",
             "/admin/cloud/protection/recovery-kit/confirm",
@@ -251,6 +258,10 @@ def test_product_status_redacts_paths_credentials_and_secret_material(
         ("/admin/cloud/protection/backup", {"advance_head": True}),
         ("/admin/cloud/protection/verify", {"presigned_url": "https://example.test"}),
         (
+            "/admin/cloud/protection/recovery-kit/prepare",
+            {"path": "/secret"},
+        ),
+        (
             "/admin/cloud/protection/recovery-kit/confirm",
             {"sha256_digest": "a" * 64, "path": "/secret"},
         ),
@@ -271,7 +282,7 @@ def test_long_operations_return_202_and_poll_safe_results(protection_app):
             ("enable", INTENT_ID),
         ),
         ("/admin/cloud/protection/disable", {}, ("disable",)),
-        ("/admin/cloud/protection/backup", {}, ("backup_now", "manual-ui")),
+        ("/admin/cloud/protection/backup", {}, ("backup_and_verify", "manual-ui")),
         (
             "/admin/cloud/protection/verify",
             {"snapshot_id": SNAPSHOT_ID},
@@ -303,7 +314,7 @@ def test_repeated_active_backup_joins_one_operation(protection_app):
     assert second.json()["deduplicated"] is True
     service.release_backup.set()
     assert _poll(client, first.json()["operation_id"])["status"] == "completed"
-    assert service.calls.count(("backup_now", "manual-ui")) == 1
+    assert service.calls.count(("backup_and_verify", "manual-ui")) == 1
 
 
 def test_unknown_operation_returns_404(protection_app):
@@ -371,6 +382,40 @@ def test_recovery_confirmation_is_typed_and_secret_free(protection_app):
     serialized = str(response.json()).lower()
     for forbidden in ["age-secret-key", "path", "token", "digest", "identity"]:
         assert forbidden not in serialized
+
+
+def test_recovery_kit_prepare_repairs_server_side_without_returning_material(
+    protection_app,
+):
+    client, _, _, recovery_service = protection_app
+
+    response = client.post(
+        "/admin/cloud/protection/recovery-kit/prepare",
+        headers=HEADERS,
+        json={},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready_to_save", "regenerated": True}
+    assert recovery_service.calls == ["prepare"]
+    serialized = str(response.json()).lower()
+    for forbidden in ["age-secret-key", "path", "token", "identity", "store_id"]:
+        assert forbidden not in serialized
+
+
+def test_recovery_kit_prepare_failure_is_generic(protection_app):
+    client, _, _, recovery_service = protection_app
+    recovery_service.fail = True
+
+    response = client.post(
+        "/admin/cloud/protection/recovery-kit/prepare",
+        headers=HEADERS,
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "The recovery kit could not be prepared for saving."}
+    assert "secret" not in response.text.lower()
 
 
 def test_recovery_confirmation_does_not_invent_readiness(protection_app):

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -65,6 +65,81 @@ def test_backup_now_returns_typed_completed_operation(tmp_path, monkeypatch, clo
     assert durable.pending_upload_phase is None
 
 
+def test_backup_records_truthful_processing_phases(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, _store_id = _settings(tmp_path)
+    client = FakeCloudClient()
+    _patch_upload_prerequisites(monkeypatch, client)
+    observed = []
+    real_update = state.update_state
+
+    def capture_update(*args, **kwargs):
+        phase = kwargs.get("last_operation_phase")
+        if phase is not None:
+            observed.append(phase)
+        return real_update(*args, **kwargs)
+
+    monkeypatch.setattr(protection, "update_state", capture_update)
+
+    result = CloudProtectionService(settings).backup_now()
+
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert observed == [
+        ProtectionOperationPhase.PREPARING,
+        ProtectionOperationPhase.ENCRYPTING,
+        ProtectionOperationPhase.UPLOADING,
+        ProtectionOperationPhase.FINALIZING,
+        ProtectionOperationPhase.COMPLETED,
+    ]
+
+
+def test_backup_and_verify_checks_the_exact_uploaded_snapshot(
+    tmp_path, monkeypatch, cloud_state_dir
+):
+    settings, _store_id = _settings(tmp_path)
+    service = CloudProtectionService(settings)
+    calls = []
+    backup = ProtectionOperation(
+        "backup-op",
+        ProtectionOperationKind.BACKUP,
+        ProtectionOperationPhase.COMPLETED,
+        ProtectionState.VERIFICATION_PENDING,
+        snapshot_id=SNAPSHOT_ID,
+    )
+    verified = ProtectionOperation(
+        "backup-op",
+        ProtectionOperationKind.VERIFY,
+        ProtectionOperationPhase.COMPLETED,
+        ProtectionState.PROTECTED,
+        snapshot_id=SNAPSHOT_ID,
+    )
+
+    monkeypatch.setattr(
+        service,
+        "_backup_now",
+        lambda operation_id, **kwargs: calls.append(("backup", operation_id, kwargs)) or backup,
+    )
+    monkeypatch.setattr(
+        service,
+        "_verify_now",
+        lambda operation_id, **kwargs: calls.append(("verify", operation_id, kwargs)) or verified,
+    )
+
+    result = service.backup_and_verify()
+
+    assert result.kind is ProtectionOperationKind.BACKUP
+    assert result.phase is ProtectionOperationPhase.COMPLETED
+    assert result.state is ProtectionState.PROTECTED
+    assert result.snapshot_id == SNAPSHOT_ID
+    assert calls[0][0] == "backup"
+    assert calls[1] == (
+        "verify",
+        calls[0][1],
+        {"requested_snapshot_id": SNAPSHOT_ID},
+    )
+
+
 def test_legacy_opted_in_store_reaches_protected_after_first_backup_and_verification(
     tmp_path, monkeypatch, cloud_state_dir
 ):
@@ -689,6 +764,16 @@ def test_verify_now_accepts_snapshot_id_after_entitlement_lapse(
             AssertionError("downloads must not check upload entitlement")
         ),
     )
+    observed = []
+    real_update = state.update_state
+
+    def capture_update(*args, **kwargs):
+        phase = kwargs.get("last_operation_phase")
+        if phase is not None:
+            observed.append(phase)
+        return real_update(*args, **kwargs)
+
+    monkeypatch.setattr(protection, "update_state", capture_update)
 
     result = CloudProtectionService(settings).verify_now(SNAPSHOT_ID)
 
@@ -698,6 +783,12 @@ def test_verify_now_accepts_snapshot_id_after_entitlement_lapse(
     assert result.state is ProtectionState.PROTECTED
     assert result.snapshot_id == SNAPSHOT_ID
     assert load_state(store_id).last_verified_snapshot_id == SNAPSHOT_ID
+    assert observed == [
+        ProtectionOperationPhase.DOWNLOADING,
+        ProtectionOperationPhase.VERIFYING,
+        ProtectionOperationPhase.REBUILDING,
+        ProtectionOperationPhase.COMPLETED,
+    ]
 
 
 def test_verifying_an_older_snapshot_does_not_claim_latest_backup_is_protected(

--- a/tests/test_cloud_recovery.py
+++ b/tests/test_cloud_recovery.py
@@ -74,6 +74,32 @@ def test_wrong_digest_fails_without_updating_state(recovery_store):
     assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
 
 
+def test_ensure_current_kit_keeps_valid_material_and_existing_readiness(recovery_store):
+    _, store_id, _, kit_path, state_dir, service = recovery_store
+    original = kit_path.read_bytes()
+    service.confirm_saved_digest(hashlib.sha256(original).hexdigest())
+
+    assert service.ensure_current_kit() is False
+
+    assert kit_path.read_bytes() == original
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at == NOW
+
+
+def test_ensure_current_kit_repairs_stale_material_before_native_save(recovery_store):
+    settings, store_id, key_path, kit_path, state_dir, service = recovery_store
+    service.confirm_saved_digest(hashlib.sha256(kit_path.read_bytes()).hexdigest())
+    replacement_key = key_path.with_suffix(".replacement")
+    init_key(replacement_key)
+    key_path.write_bytes(replacement_key.read_bytes())
+    settings.account_email = "person@example.com"
+
+    assert service.ensure_current_kit() is True
+
+    service.validate_canonical_kit()
+    assert "person@example.com" in kit_path.read_text(encoding="utf-8")
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
+
+
 def test_saved_copy_proof_does_not_claim_ready_without_current_protection(
     recovery_store,
 ):

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -3,11 +3,13 @@ import {
   AlertTriangle,
   Check,
   ChevronRight,
+  Circle,
   CloudOff,
   CreditCard,
   ExternalLink,
   LoaderCircle,
   LockKeyhole,
+  LogIn,
   LogOut,
   RefreshCw,
   ShieldCheck,
@@ -15,6 +17,7 @@ import {
 } from "lucide-react";
 import {
   isDesktopApp,
+  effectiveProtectionState,
   operationPhaseIsActive,
   productBridge,
   protectionPresentation,
@@ -22,6 +25,7 @@ import {
   recoveryKitSectionVisible,
   type AccountStatus,
   type BillingOffer,
+  type OperationPhase,
   type ProtectionOperation,
   type ProtectionStatus,
 } from "../productBridge";
@@ -35,6 +39,7 @@ interface Props {
 }
 
 type View = "summary" | "email" | "code" | "checkout";
+type LoginPurpose = "account" | "protect";
 
 function operationIsActive(operation: ProtectionOperation | null): boolean {
   return Boolean(
@@ -77,18 +82,37 @@ function operationLabel(
   const phase = status?.last_operation_phase || operation.phase;
   switch (phase) {
     case "pending": return "Queued";
-    case "running": return "Preparing encryption";
-    case "uploading": return "Uploading encrypted recovery point";
-    case "finalizing": return "Committing recovery point";
-    case "verifying": return "Checking recovery";
-    default: return null;
+    case "running":
+    case "preparing": return "Creating a local recovery point";
+    case "encrypting": return "Encrypting on this device";
+    case "uploading": return "Uploading encrypted data";
+    case "finalizing": return "Securing the cloud recovery point";
+    case "downloading": return "Downloading a temporary recovery test";
+    case "verifying": return "Decrypting and checking every file";
+    case "rebuilding": return "Rebuilding memory and testing search";
+    default: return "Finishing protection check";
   }
+}
+
+const PROTECTION_STAGES = [
+  { phase: "preparing", label: "Create local recovery point" },
+  { phase: "encrypting", label: "Encrypt on this device" },
+  { phase: "uploading", label: "Upload encrypted data" },
+  { phase: "finalizing", label: "Secure cloud recovery point" },
+  { phase: "downloading", label: "Download a temporary test copy" },
+  { phase: "verifying", label: "Decrypt and check every file" },
+  { phase: "rebuilding", label: "Rebuild memory and test search" },
+] as const;
+
+function phaseIndex(phase: OperationPhase | null | undefined): number {
+  if (phase === "pending" || phase === "running") return 0;
+  return PROTECTION_STAGES.findIndex((stage) => stage.phase === phase);
 }
 
 function operationSuccessMessage(operation: ProtectionOperation): string {
   switch (operation.kind) {
     case "enable": return "Memory protected and verified.";
-    case "backup": return "Encrypted recovery point uploaded.";
+    case "backup": return "Encrypted recovery point uploaded and restore-tested.";
     case "verify": return "Recovery point verified.";
     case "disable": return "Future cloud backups stopped.";
     default: return "Operation completed.";
@@ -107,6 +131,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
   const [offer, setOffer] = useState<BillingOffer | null>(null);
   const [operation, setOperation] = useState<ProtectionOperation | null>(null);
   const [view, setView] = useState<View>("summary");
+  const [loginPurpose, setLoginPurpose] = useState<LoginPurpose>("account");
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [busy, setBusy] = useState(false);
@@ -173,6 +198,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
         if (!operationIsActive(next)) {
           window.clearInterval(timer);
           await refresh();
+          setOperation(null);
           if (next.phase === "completed") onToast(operationSuccessMessage(next), "success");
           else if (next.message) setError(next.message);
         }
@@ -239,6 +265,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     setBusy(true);
     setError(null);
     try {
+      setLoginPurpose("protect");
       const intent = await productBridge.createIntent();
       if (intent.reason_code && intent.reason_code !== "sign_in_required") {
         throw new Error(intent.message || "Protection could not start.");
@@ -279,6 +306,13 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     try {
       const nextAccount = await productBridge.verifyCode(email.trim().toLowerCase(), code);
       setAccount(nextAccount);
+      if (loginPurpose === "account") {
+        setOperation(null);
+        setView("summary");
+        await refresh();
+        onToast("Signed in to Ormah Cloud.", "success");
+        return;
+      }
       const intentId = operation?.protection_intent_id || status?.protection_intent_id;
       if (!intentId) {
         setOperation(null);
@@ -292,7 +326,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     } finally {
       setBusy(false);
     }
-  }, [bindAndContinue, code, email, operation?.protection_intent_id, refresh, status?.protection_intent_id]);
+  }, [bindAndContinue, code, email, loginPurpose, onToast, operation?.protection_intent_id, refresh, status?.protection_intent_id]);
 
   const openCheckout = useCallback(async () => {
     const intentId = operation?.protection_intent_id || status?.protection_intent_id;
@@ -415,12 +449,18 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     }
   }, [onToast]);
 
+  const activeOperation = operationIsActive(operation);
   const presentation = useMemo(
-    () => protectionPresentation(operation?.protection_state || status?.protection_state || "local_only"),
-    [operation?.protection_state, status?.protection_state],
+    () => protectionPresentation(effectiveProtectionState(operation, status)),
+    [operation, status],
   );
   const price = formatPrice(offer);
   const activeLabel = operationLabel(operation, status);
+  const activePhase = activeOperation
+    ? (status?.last_operation_phase || operation?.phase)
+    : null;
+  const activeStageIndex = phaseIndex(activePhase);
+  const summaryTone = activeOperation ? "working" : presentation.tone;
   const repairAction = status ? protectionRepairAction(status) : "none";
 
   const runRepairAction = useCallback(async () => {
@@ -477,19 +517,50 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
         <div className="protection-empty"><LoaderCircle className="spin" size={22} />Loading protection status</div>
       ) : (
         <>
-          <section className={`protection-summary tone-${presentation.tone}`}>
+          <section className={`protection-summary tone-${summaryTone}`}>
             <div className="protection-status-icon" aria-hidden="true">
-              {presentation.tone === "success" ? <ShieldCheck size={22} />
-                : presentation.tone === "danger" ? <AlertTriangle size={22} />
-                  : presentation.tone === "warning" ? <CloudOff size={22} />
-                    : presentation.tone === "working" ? <LoaderCircle className="spin" size={22} />
+              {summaryTone === "success" ? <ShieldCheck size={22} />
+                : summaryTone === "danger" ? <AlertTriangle size={22} />
+                  : summaryTone === "warning" ? <CloudOff size={22} />
+                    : summaryTone === "working" ? <LoaderCircle className="spin" size={22} />
                       : <LockKeyhole size={22} />}
             </div>
             <div>
               <h3>{activeLabel || presentation.title}</h3>
-              <p>{presentation.detail}</p>
+              <p>{activeOperation
+                ? "Ormah is creating and restore-testing an encrypted recovery point."
+                : presentation.detail}</p>
             </div>
           </section>
+
+          {activeOperation && activeStageIndex >= 0 && (
+            <section className="protection-progress" aria-label="Protection progress">
+              <div className="protection-progress-heading">
+                <span>Recovery check</span>
+                <strong>In progress</strong>
+              </div>
+              <ol>
+                {PROTECTION_STAGES.map((stage, index) => {
+                  const stageState = index < activeStageIndex
+                    ? "complete"
+                    : index === activeStageIndex
+                      ? "current"
+                      : "upcoming";
+                  return (
+                    <li className={stageState} key={stage.phase}>
+                      <span aria-hidden="true">
+                        {stageState === "complete" ? <Check size={13} />
+                          : stageState === "current" ? <LoaderCircle className="spin" size={13} />
+                            : <Circle size={10} />}
+                      </span>
+                      <span>{stage.label}</span>
+                    </li>
+                  );
+                })}
+              </ol>
+              <p>Verification uses a temporary copy. Your live memory is never replaced.</p>
+            </section>
+          )}
 
           {error && (
             <div className="protection-error" role="alert">
@@ -503,7 +574,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
           {view === "email" && (
             <section className="protection-step">
               <button className="step-back" onClick={() => setView("summary")}>Back</button>
-              <h3>Sign in or create an account</h3>
+              <h3>{loginPurpose === "protect" ? "Sign in to continue" : "Sign in to Ormah Cloud"}</h3>
               <p>Enter your email. Ormah will send a one-time code; there is no password.</p>
               <label className="protection-field">
                 <span>Email</span>
@@ -543,7 +614,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
               </label>
               <button className="protection-primary" disabled={busy || code.length !== 6} onClick={() => void verifyCode()}>
                 {busy ? <LoaderCircle className="spin" size={15} /> : <Check size={15} />}
-                Verify and continue
+                {loginPurpose === "protect" ? "Verify and continue" : "Sign in"}
               </button>
               <button className="protection-secondary" disabled={busy} onClick={() => void requestCode()}>
                 Send another code
@@ -578,14 +649,28 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
 
           {view === "summary" && !activeLabel && (
             <section className="protection-actions">
-              {["local_only", "sign_in_required", "stopped"].includes(status?.protection_state || "local_only") && (
+              {!account?.signed_in && (
+                <button className="protection-primary" disabled={busy} onClick={() => {
+                  setLoginPurpose("account");
+                  setError(null);
+                  setView("email");
+                }}>
+                  <LogIn size={16} /> Sign in to Ormah Cloud
+                </button>
+              )}
+              {account?.signed_in && ["local_only", "sign_in_required", "stopped"].includes(status?.protection_state || "local_only") && (
                 <button className="protection-primary" disabled={busy} onClick={() => void beginProtection()}>
                   <ShieldCheck size={16} /> Protect this memory
                 </button>
               )}
-              {["protected", "changes_pending"].includes(status?.protection_state || "") && (
+              {account?.signed_in && ["protected", "changes_pending"].includes(status?.protection_state || "") && (
                 <button className="protection-primary" disabled={busy} onClick={() => void runOperation("backup")}>
                   <RefreshCw size={15} /> Back up now
+                </button>
+              )}
+              {account?.signed_in && status?.protection_state === "verification_pending" && (
+                <button className="protection-primary" disabled={busy} onClick={() => void runOperation("verify")}>
+                  <ShieldCheck size={15} /> Verify this recovery point
                 </button>
               )}
               {["attention_required", "offline"].includes(status?.protection_state || "") && repairAction !== "none" && (
@@ -656,6 +741,8 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
                   try {
                     const result = await productBridge.logout();
                     if (result.warning) onToast(result.warning, "info");
+                    setOperation(null);
+                    setView("summary");
                     await refresh();
                   } catch (err) {
                     setError(errorMessage(err, "Could not sign out locally."));
@@ -684,7 +771,7 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
               </section>
             ) : (
               <button className="protection-stop" disabled={busy} onClick={() => setConfirmStop(true)}>
-                Stop future cloud backups
+                <CloudOff size={15} /> Stop future cloud backups
               </button>
             )
           )}

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  effectiveProtectionState,
   operationPhaseIsActive,
   protectionRepairAction,
   protectionPresentation,
@@ -14,12 +15,19 @@ describe("protectionPresentation", () => {
     "initializing",
     "uploading_first_backup",
     "verifying_first_backup",
-    "verification_pending",
   ])("never calls incomplete state %s protected", (state) => {
     const result = protectionPresentation(state);
 
     expect(result.title.toLowerCase()).not.toContain("protected");
     expect(result.action).toBe("wait");
+  });
+
+  it("makes an uploaded but unchecked backup an explicit recovery action", () => {
+    const result = protectionPresentation("verification_pending");
+
+    expect(result.title).toBe("Recovery check needed");
+    expect(result.tone).toBe("warning");
+    expect(result.action).toBe("retry");
   });
 
   it("uses the verified claim only for the protected state", () => {
@@ -46,7 +54,17 @@ describe("protectionPresentation", () => {
 
 describe("operationPhaseIsActive", () => {
   it("distinguishes durable progress from terminal and absent phases", () => {
-    for (const phase of ["pending", "running", "uploading", "finalizing", "verifying"] as const) {
+    for (const phase of [
+      "pending",
+      "running",
+      "preparing",
+      "encrypting",
+      "uploading",
+      "finalizing",
+      "downloading",
+      "verifying",
+      "rebuilding",
+    ] as const) {
       expect(operationPhaseIsActive(phase)).toBe(true);
     }
     for (const phase of ["completed", "failed", "canceled", null, undefined] as const) {
@@ -88,6 +106,10 @@ describe("protectionRepairAction", () => {
     expect(protectionRepairAction(status({ last_error_code: "entitlement_expired" }))).toBe("subscribe");
     expect(protectionRepairAction(status({ last_error_code: "key_missing" }))).toBe("none");
     expect(protectionRepairAction(status({ last_error_code: "quota_exceeded" }))).toBe("none");
+    expect(protectionRepairAction(status({
+      protection_state: "verification_pending",
+      last_error_code: null,
+    }))).toBe("verify");
   });
 
   it("resumes an interrupted initial protection intent", () => {
@@ -95,6 +117,42 @@ describe("protectionRepairAction", () => {
       last_error_code: "operation_interrupted",
       protection_intent_status: "running",
     }))).toBe("resume");
+  });
+});
+
+describe("effectiveProtectionState", () => {
+  it("does not let a completed operation hide newer durable status", () => {
+    const durable = status({ protection_state: "protected" });
+    const completed = {
+      operation_id: "operation",
+      kind: "backup" as const,
+      status: "completed" as const,
+      phase: "completed" as const,
+      protection_state: "verification_pending" as const,
+      reason_code: null,
+      message: null,
+      snapshot_id: "snapshot",
+      protection_intent_id: null,
+    };
+
+    expect(effectiveProtectionState(completed, durable)).toBe("protected");
+  });
+
+  it("uses live operation state while work is active", () => {
+    const durable = status({ protection_state: "protected" });
+    const running = {
+      operation_id: "operation",
+      kind: "backup" as const,
+      status: "running" as const,
+      phase: null,
+      protection_state: "verifying_first_backup" as const,
+      reason_code: null,
+      message: null,
+      snapshot_id: null,
+      protection_intent_id: null,
+    };
+
+    expect(effectiveProtectionState(running, durable)).toBe("verifying_first_backup");
   });
 });
 

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -20,9 +20,13 @@ export type ProtectionState =
 export type OperationPhase =
   | "pending"
   | "running"
+  | "preparing"
+  | "encrypting"
   | "uploading"
   | "finalizing"
+  | "downloading"
   | "verifying"
+  | "rebuilding"
   | "completed"
   | "failed"
   | "canceled";
@@ -30,9 +34,13 @@ export type OperationPhase =
 const ACTIVE_OPERATION_PHASES = new Set<OperationPhase>([
   "pending",
   "running",
+  "preparing",
+  "encrypting",
   "uploading",
   "finalizing",
+  "downloading",
   "verifying",
+  "rebuilding",
 ]);
 
 export function operationPhaseIsActive(phase: OperationPhase | null | undefined): boolean {
@@ -111,6 +119,16 @@ export interface ProtectionOperation {
   message: string | null;
   snapshot_id: string | null;
   protection_intent_id: string | null;
+}
+
+export function effectiveProtectionState(
+  operation: ProtectionOperation | null | undefined,
+  status: ProtectionStatus | null | undefined,
+): ProtectionState {
+  const operationActive = operation?.status === "queued" || operation?.status === "running";
+  return (operationActive ? operation.protection_state : null)
+    || status?.protection_state
+    || "local_only";
 }
 
 export interface BillingHandoff {
@@ -209,6 +227,7 @@ const BACKUP_FAILURES = new Set([
 ]);
 
 export function protectionRepairAction(status: ProtectionStatus): ProtectionRepairAction {
+  if (status.protection_state === "verification_pending") return "verify";
   const reason = status.last_error_code;
   if (reason === "sign_in_required") return "signin";
   if (reason === "subscription_required" || reason === "entitlement_expired") {
@@ -258,12 +277,18 @@ export function protectionPresentation(state: ProtectionState): ProtectionPresen
         action: "wait",
       };
     case "verifying_first_backup":
-    case "verification_pending":
       return {
         tone: "working",
         title: "Checking recovery",
         detail: "Downloading, decrypting, rebuilding, and probing a temporary copy.",
         action: "wait",
+      };
+    case "verification_pending":
+      return {
+        tone: "warning",
+        title: "Recovery check needed",
+        detail: "The encrypted backup is uploaded but has not yet passed a restore test.",
+        action: "retry",
       };
     case "protected":
       return {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -847,9 +847,9 @@ body.in-app .node-detail.tier-core {
 }
 
 .protection-panel {
-  width: min(430px, 100vw);
+  width: min(450px, 100vw);
   z-index: 90;
-  padding: 22px;
+  padding: 22px 24px 26px;
 }
 
 .protection-eyebrow {
@@ -883,7 +883,7 @@ body.in-app .node-detail.tier-core {
   display: grid;
   grid-template-columns: 34px minmax(0, 1fr);
   gap: 12px;
-  padding: 14px 0 18px;
+  padding: 16px 0 20px;
   border-bottom: 1px solid var(--border);
 }
 
@@ -935,9 +935,84 @@ body.in-app .node-detail.tier-core {
 .protection-account,
 .protection-facts,
 .protection-warnings,
+.protection-progress,
 .recovery-kit-section {
   padding: 18px 0;
   border-bottom: 1px solid var(--border);
+}
+
+.protection-progress-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.protection-progress-heading span {
+  color: var(--text-bright);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.protection-progress-heading strong {
+  color: var(--node-self);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.protection-progress ol {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.protection-progress li {
+  position: relative;
+  min-height: 31px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: start;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 18px;
+}
+
+.protection-progress li:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  top: 18px;
+  bottom: 0;
+  left: 7px;
+  width: 1px;
+  background: var(--border);
+}
+
+.protection-progress li > span:first-child {
+  width: 15px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+}
+
+.protection-progress li.complete,
+.protection-progress li.current {
+  color: var(--text-bright);
+}
+
+.protection-progress li.complete > span:first-child { color: var(--edge-supports); }
+.protection-progress li.current > span:first-child { color: var(--node-self); }
+
+.protection-progress > p {
+  margin: 6px 0 0 24px;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.5;
 }
 
 .recovery-kit-heading {
@@ -1186,13 +1261,16 @@ body.in-app .node-detail.tier-core {
 
 .protection-stop {
   width: 100%;
-  margin-top: 18px;
-  border: 0;
-  background: transparent;
-  color: var(--text-muted);
+  margin-top: 22px;
+  border: 1px solid rgba(209, 94, 94, 0.42);
+  background: rgba(209, 94, 94, 0.08);
+  color: var(--edge-contradicts);
 }
 
-.protection-stop:hover { color: var(--edge-contradicts); }
+.protection-stop:hover:not(:disabled) {
+  border-color: rgba(209, 94, 94, 0.68);
+  background: rgba(209, 94, 94, 0.14);
+}
 
 .protection-stop-confirm {
   margin-top: 18px;


### PR DESCRIPTION
## Problem

Desktop acceptance testing found that the cloud protection panel could remain on **Checking recovery** indefinitely after a successful upload. The manual action did not actually run restore verification, a terminal React operation could mask newer durable state, sign-out had no in-app recovery path, and a stale canonical recovery kit required a CLI repair step.

Closes #176.

## Solution

- Make the desktop **Back up now** action upload and restore-test the exact committed snapshot. Scheduled backups remain upload-only.
- Persist truthful operation boundaries: preparing, encrypting, uploading, finalizing, downloading, verifying, and rebuilding.
- Show those boundaries as an accessible staged progress timeline with clear completed/current/upcoming states.
- Clear terminal process-local operations and prefer durable protection state afterward.
- Treat `verification_pending` as an actionable warning rather than an endless spinner.
- Add standalone in-app email/OTP sign-in, including recovery after signing out, without restarting Ormah.
- Prepare and repair the canonical recovery kit locally before the native Save dialog. The webview receives no kit bytes, identities, paths, tokens, or digests.
- Polish the normal protection layout and make **Stop future cloud backups** a restrained translucent-red destructive action.

Desktop restore browsing remains deliberately deferred.

## Verification

- `pytest tests/test_cloud_protection.py tests/test_cloud_recovery.py -q` — 64 passed
- `pytest tests/test_api/test_protection_routes.py -q` — 26 passed
- `npm test -- --run` — 17 passed
- `npm run build` — passed
- `cargo test product_bridge --lib` — 17 passed
- `ruff check src tests` — passed
- Headless Chrome visual verification at 1440x900 for protected and active-rebuild states — no clipping or overlap after panel transition
- Full suite — 1811 passed, 1 failed, 1 deselected. The sole failure is `test_cloud_setting_preserves_unrelated_env_lines_and_updates_runtime`; it reproduces on untouched `origin/main` and is tracked separately in #177.

## Security

- Cloud uploads still never advance the sync head.
- Scheduled backup behavior is unchanged.
- Verification operates on a temporary copy and never replaces live memory.
- Recovery-kit preparation is owner-only, loopback-only, secret-free at the API boundary, and preserves the native save/reopen/digest confirmation flow.
