### PR TITLE
chore(release): prepare 0.14.5 and desktop 0.3.18

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.17"
+version = "0.3.18"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.4"
+version = "0.14.5"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Prepare the coordinated patch release for the desktop protection UX fixes merged in #178.

- Python package and Claude plugin: `0.14.5`
- Desktop application: `0.3.18`
- The desktop build reads `0.14.5` from `pyproject.toml`, ensuring its uv sidecar installs the matching backend/API version.

## Release order

1. Merge this version-only PR.
2. Run the Python Release workflow for `0.14.5` and wait for PyPI publication.
3. Push `desktop-v0.3.18`; desktop CI verifies PyPI already exposes `0.14.5` before building, signing, notarizing, and publishing.

## Verification

- Release-version verifier accepts `0.14.5`.
- Both JSON manifests parse successfully.
- Cargo metadata resolves `ormah-desktop 0.3.18`.
- Product changes already passed test, lint, desktop CI, native/UI suites, and visual verification in #178.
