### PR TITLE
fix(cloud): harden desktop protection recovery

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -136,6 +136,12 @@ pub async fn server_status() -> bool {
     crate::sidecar::is_running().await
 }
 
+/// Retry a failed bundled-runtime setup without starting concurrent installers.
+#[tauri::command]
+pub fn retry_runtime_setup<R: Runtime>(app: AppHandle<R>) -> bool {
+    crate::sidecar::start(app)
+}
+
 // ---- onboarding marker -----------------------------------------------------
 
 fn marker_path<R: Runtime>(app: &AppHandle<R>) -> Option<std::path::PathBuf> {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -168,6 +168,7 @@ pub fn run() {
             commands::start_server,
             commands::stop_server,
             commands::server_status,
+            commands::retry_runtime_setup,
             product_bridge::desktop_bridge_info,
             product_bridge::account_status,
             product_bridge::request_account_code,

--- a/desktop/src-tauri/src/sidecar.rs
+++ b/desktop/src-tauri/src/sidecar.rs
@@ -10,26 +10,51 @@
 //! sidecar is absent (dev builds).
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use tauri::{AppHandle, Emitter, Runtime};
 use tauri_plugin_shell::ShellExt;
 
 // Injected by build.rs from the repo's pyproject.toml, so the pinned Python
 // package version can never drift from the released one.
 const ORMAH_VERSION: &str = env!("ORMAH_PY_VERSION");
+const INSTALL_ATTEMPTS: u8 = 3;
+static SETUP_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 /// Phase emitted on the "ormah://status" event so the UI can show progress.
 #[derive(Clone, serde::Serialize)]
 #[serde(tag = "phase", rename_all = "snake_case")]
 pub enum Phase {
-    Installing { version: &'static str },
+    Installing {
+        version: &'static str,
+        attempt: u8,
+        attempts: u8,
+    },
+    Retrying {
+        version: &'static str,
+        attempt: u8,
+        attempts: u8,
+        delay_seconds: u64,
+    },
     Starting,
-    Failed { reason: String },
+    Failed {
+        reason: String,
+        can_retry: bool,
+    },
 }
 
-pub fn start<R: Runtime>(app: AppHandle<R>) {
+/// Start runtime setup once. Returns false when another attempt is still active.
+pub fn start<R: Runtime>(app: AppHandle<R>) -> bool {
+    if SETUP_IN_PROGRESS
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return false;
+    }
     tauri::async_runtime::spawn(async move {
         ensure_running(app).await;
+        SETUP_IN_PROGRESS.store(false, Ordering::Release);
     });
+    true
 }
 
 async fn ensure_running<R: Runtime>(app: AppHandle<R>) {
@@ -37,17 +62,13 @@ async fn ensure_running<R: Runtime>(app: AppHandle<R>) {
     let runtime_action = choose_runtime_action(installed, installed && needs_upgrade());
     let runtime_changed = match runtime_action {
         RuntimeAction::Install | RuntimeAction::Upgrade => {
-            let _ = app.emit(
-                "ormah://status",
-                Phase::Installing {
-                    version: ORMAH_VERSION,
-                },
-            );
-            if !install_via_uv(&app).await {
+            if let Err(failure) = install_with_retry(&app).await {
+                eprintln!("uv install failed after retries:\n{}", failure.details);
                 let _ = app.emit(
                     "ormah://status",
                     Phase::Failed {
-                        reason: "Could not install ormah. Check your internet connection.".into(),
+                        reason: failure.public_reason(),
+                        can_retry: true,
                     },
                 );
                 return;
@@ -193,28 +214,111 @@ fn clean_python_env(mut cmd: std::process::Command) -> std::process::Command {
     cmd
 }
 
-async fn install_via_uv<R: Runtime>(app: &AppHandle<R>) -> bool {
+#[derive(Debug)]
+struct InstallFailure {
+    details: String,
+    transient: bool,
+}
+
+impl InstallFailure {
+    fn public_reason(&self) -> String {
+        if self.transient {
+            "Ormah could not reach the package service. Check your connection, then try again."
+                .into()
+        } else {
+            "Ormah could not install its runtime. Try again; if it keeps failing, reinstall the desktop app."
+                .into()
+        }
+    }
+}
+
+fn transient_install_error(details: &str) -> bool {
+    let details = details.to_ascii_lowercase();
+    [
+        "dns error",
+        "failed to lookup address",
+        "temporary failure in name resolution",
+        "timed out",
+        "timeout",
+        "connection reset",
+        "connection refused",
+        "network is unreachable",
+    ]
+    .iter()
+    .any(|pattern| details.contains(pattern))
+}
+
+async fn install_with_retry<R: Runtime>(app: &AppHandle<R>) -> Result<(), InstallFailure> {
+    for attempt in 1..=INSTALL_ATTEMPTS {
+        let _ = app.emit(
+            "ormah://status",
+            Phase::Installing {
+                version: ORMAH_VERSION,
+                attempt,
+                attempts: INSTALL_ATTEMPTS,
+            },
+        );
+        match install_via_uv(app).await {
+            Ok(()) => return Ok(()),
+            Err(failure) if failure.transient && attempt < INSTALL_ATTEMPTS => {
+                let delay_seconds = if attempt == 1 { 2 } else { 5 };
+                eprintln!(
+                    "transient uv install failure on attempt {attempt}/{INSTALL_ATTEMPTS}: {}",
+                    failure.details
+                );
+                let _ = app.emit(
+                    "ormah://status",
+                    Phase::Retrying {
+                        version: ORMAH_VERSION,
+                        attempt,
+                        attempts: INSTALL_ATTEMPTS,
+                        delay_seconds,
+                    },
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(delay_seconds)).await;
+            }
+            Err(failure) => return Err(failure),
+        }
+    }
+    unreachable!("the bounded install loop always returns")
+}
+
+async fn install_via_uv<R: Runtime>(app: &AppHandle<R>) -> Result<(), InstallFailure> {
     let uv = match app.shell().sidecar("uv") {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("uv sidecar not available ({e}); ormah must be on PATH");
-            return false;
+            return Err(InstallFailure {
+                details: format!("uv sidecar not available ({e})"),
+                transient: false,
+            });
         }
     };
     let spec = format!("ormah=={}", ORMAH_VERSION);
     match uv.args(["tool", "install", "--reinstall", &spec]).output().await {
-        Ok(out) if out.status.success() => { eprintln!("uv: installed {spec}"); true }
-        Ok(out) => {
-            eprintln!("uv install failed:\n{}", String::from_utf8_lossy(&out.stderr));
-            false
+        Ok(out) if out.status.success() => {
+            eprintln!("uv: installed {spec}");
+            Ok(())
         }
-        Err(e) => { eprintln!("uv sidecar error: {e}"); false }
+        Ok(out) => {
+            let details = String::from_utf8_lossy(&out.stderr).into_owned();
+            Err(InstallFailure {
+                transient: transient_install_error(&details),
+                details,
+            })
+        }
+        Err(e) => {
+            let details = e.to_string();
+            Err(InstallFailure {
+                transient: transient_install_error(&details),
+                details,
+            })
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{choose_runtime_action, should_upgrade, RuntimeAction};
+    use super::{choose_runtime_action, should_upgrade, transient_install_error, RuntimeAction};
 
     #[test]
     fn installs_when_runtime_is_missing() {
@@ -249,5 +353,15 @@ mod tests {
     #[test]
     fn repairs_unparseable_version_output() {
         assert!(should_upgrade(b"unknown\n", "0.14.0"));
+    }
+
+    #[test]
+    fn retries_only_transient_install_failures() {
+        assert!(transient_install_error(
+            "Temporary failure in name resolution while fetching pypi.org"
+        ));
+        assert!(transient_install_error("operation timed out"));
+        assert!(!transient_install_error("No solution found when resolving dependencies"));
+        assert!(!transient_install_error("permission denied"));
     }
 }

--- a/desktop/ui/src/App.tsx
+++ b/desktop/ui/src/App.tsx
@@ -35,23 +35,58 @@ export default function App() {
   const selfNodeReadyRef = useRef<{ x: number; y: number } | null>(null);
   const [phase, setPhase] = useState<Phase>("intro");
   const [statusMsg, setStatusMsg] = useState("");
+  const [canRetry, setCanRetry] = useState(false);
+  const [retryBusy, setRetryBusy] = useState(false);
   const started = useRef(false);
+  const navigating = useRef(false);
 
   useEffect(() => {
     return onServerStatus((s) => {
-      if (s.phase === "installing") setStatusMsg(`Installing ormah ${s.version}…`);
-      else if (s.phase === "starting") setStatusMsg("Starting up…");
-      else if (s.phase === "failed") setStatusMsg(`Setup failed: ${s.reason}`);
+      if (s.phase === "installing") {
+        setCanRetry(false);
+        setStatusMsg(`Installing Ormah ${s.version} (attempt ${s.attempt} of ${s.attempts})…`);
+      } else if (s.phase === "retrying") {
+        setCanRetry(false);
+        setStatusMsg(`Connection unavailable. Trying again in ${s.delay_seconds} seconds…`);
+      } else if (s.phase === "starting") {
+        setCanRetry(false);
+        setStatusMsg("Starting Ormah…");
+      } else if (s.phase === "failed") {
+        setCanRetry(s.can_retry);
+        setStatusMsg(s.reason);
+      }
     });
   }, []);
 
   async function goGraph() {
+    if (navigating.current) return;
+    navigating.current = true;
     const url = await graphUrl();
     document.getElementById("root")?.classList.add("to-graph");
     await sleep(620);
     // Navigate to the graph; its TopBar becomes the window title bar.
     // Cache-bust so a fresh UI build always loads in the webview.
     window.location.replace(url + (url.includes("?") ? "&" : "?") + "_=" + Date.now());
+  }
+
+  async function retrySetup() {
+    setRetryBusy(true);
+    setCanRetry(false);
+    try {
+      let onboarded = false;
+      try { onboarded = await invoke<boolean>("is_onboarded"); } catch { /* ignore */ }
+      const accepted = await invoke<boolean>("retry_runtime_setup");
+      if (!accepted) {
+        setCanRetry(true);
+        return;
+      }
+      const ready = await waitForServer();
+      if (!ready) return;
+      if (onboarded) await goGraph();
+      else setPhase("connect");
+    } finally {
+      setRetryBusy(false);
+    }
   }
 
   useEffect(() => {
@@ -83,7 +118,14 @@ export default function App() {
         <GraphCanvas progressRef={progressRef} selfNodeReadyRef={selfNodeReadyRef} />
         <Act1Void progressRef={progressRef} selfNodeReadyRef={selfNodeReadyRef} />
         {phase === "intro" && statusMsg && (
-          <div className="boot-status">{statusMsg}</div>
+          <div className="boot-status" role={canRetry ? "alert" : "status"}>
+            <span>{statusMsg}</span>
+            {canRetry && (
+              <button disabled={retryBusy} onClick={() => void retrySetup()}>
+                {retryBusy ? "Trying again…" : "Try again"}
+              </button>
+            )}
+          </div>
         )}
         {phase === "connect" && <InstallPanel onDone={goGraph} />}
       </div>

--- a/desktop/ui/src/lib/bridge.ts
+++ b/desktop/ui/src/lib/bridge.ts
@@ -29,9 +29,10 @@ export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 // Listen for server lifecycle events emitted by sidecar.rs.
 export type ServerStatus =
-  | { phase: "installing"; version: string }
+  | { phase: "installing"; version: string; attempt: number; attempts: number }
+  | { phase: "retrying"; version: string; attempt: number; attempts: number; delay_seconds: number }
   | { phase: "starting" }
-  | { phase: "failed"; reason: string };
+  | { phase: "failed"; reason: string; can_retry: boolean };
 
 type ListenFn = (event: string, cb: (e: { payload: unknown }) => void) => Promise<() => void>;
 

--- a/desktop/ui/src/styles/app.css
+++ b/desktop/ui/src/styles/app.css
@@ -109,9 +109,18 @@ h1, h2, h3, h4, .display {
 /* First-launch status shown during uv install / server start */
 .boot-status {
   position: fixed; bottom: 40px; left: 0; right: 0;
-  text-align: center; font-size: 12px; color: #555;
-  pointer-events: none; letter-spacing: 0.03em;
+  display: grid; justify-items: center; gap: 12px;
+  padding: 0 24px; text-align: center; font-size: 12px; color: #777;
+  letter-spacing: 0.03em;
 }
+.boot-status button {
+  min-width: 104px; height: 34px; padding: 0 16px;
+  border: 1px solid rgba(124, 194, 181, .55); border-radius: 5px;
+  background: rgba(124, 194, 181, .08); color: #9ed4ca;
+  font: inherit; cursor: pointer;
+}
+.boot-status button:hover { background: rgba(124, 194, 181, .14); }
+.boot-status button:disabled { cursor: default; opacity: .55; }
 
 @media (prefers-reduced-motion: reduce) {
   .install, .scrim, .tool { transition: none !important; animation: none !important; }

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -544,7 +544,10 @@ def _cmd_cloud_init(args):
 
     try:
         store_id = get_or_create_store_id(settings.memory_dir)
-        kit_path = write_recovery_kit(store_id)
+        kit_path = write_recovery_kit(
+            store_id,
+            account_email=getattr(settings, "account_email", None),
+        )
         identity_count = len(load_identity_strings())
     except (CloudKeyError, CloudCryptoError, OSError) as exc:
         _print_backup_error(
@@ -588,7 +591,10 @@ def _cmd_cloud_kit(args):
 
     try:
         store_id = get_or_create_store_id(settings.memory_dir)
-        kit_path = write_recovery_kit(store_id)
+        kit_path = write_recovery_kit(
+            store_id,
+            account_email=getattr(settings, "account_email", None),
+        )
         identity_count = len(load_identity_strings())
     except (CloudKeyError, CloudCryptoError, OSError) as exc:
         _print_backup_error(str(exc))

--- a/src/ormah/cloud/operations.py
+++ b/src/ormah/cloud/operations.py
@@ -67,6 +67,7 @@ class LocalOperation:
             "message": result.message if result else self.error_message,
             "snapshot_id": result.snapshot_id if result else None,
             "protection_intent_id": result.protection_intent_id if result else None,
+            "verified_node_count": result.verified_node_count if result else None,
             "error_code": self.error_code,
         }
 

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -931,6 +931,7 @@ class CloudProtectionService:
                     ProtectionState.PROTECTED,
                     snapshot_id=snapshot_id,
                     protection_intent_id=intent_id,
+                    verified_node_count=verification.verified_node_count,
                 )
         except StoreLockTimeout:
             return self._store_busy_operation(
@@ -1344,6 +1345,7 @@ class CloudProtectionService:
                     verification.reason_code,
                     verification.message,
                     verification.snapshot_id,
+                    verified_node_count=verification.verified_node_count,
                 )
         except StoreLockTimeout:
             return self._store_busy_operation(
@@ -1947,7 +1949,7 @@ class CloudProtectionService:
                 last_operation_kind=ProtectionOperationKind.VERIFY,
                 last_operation_phase=ProtectionOperationPhase.REBUILDING,
             )
-            _verify_extracted_bundle(extracted, store_id, info)
+            verified_node_count = _verify_extracted_bundle(extracted, store_id, info)
 
             verified_at = _utc_now()
             next_state = _state_after_verification(state, snapshot_id)
@@ -1984,6 +1986,7 @@ class CloudProtectionService:
                 ProtectionOperationPhase.COMPLETED,
                 next_state,
                 snapshot_id=snapshot_id,
+                verified_node_count=verified_node_count,
             )
         except Exception as exc:
             offline = _is_offline_error(exc)

--- a/src/ormah/cloud/recovery.py
+++ b/src/ormah/cloud/recovery.py
@@ -78,6 +78,26 @@ def _read_bounded_regular_file(path: Path) -> bytes:
     return data
 
 
+def _recovery_kit_account_email(kit_bytes: bytes) -> str | None:
+    """Read the descriptive email from the canonical Account section."""
+
+    try:
+        lines = kit_bytes.decode("utf-8").splitlines()
+    except UnicodeDecodeError:
+        return None
+    try:
+        account_index = lines.index("## Account")
+    except ValueError:
+        return None
+    for line in lines[account_index + 1 :]:
+        if line.startswith("## "):
+            break
+        if line.startswith("Email: "):
+            value = line.removeprefix("Email: ").strip()
+            return value if value and not value.startswith("<") else None
+    return None
+
+
 class RecoveryKitService:
     """Validate the canonical kit and confirm a reopened native saved copy."""
 
@@ -112,24 +132,30 @@ class RecoveryKitService:
 
         with StoreLock(self.settings.memory_dir):
             try:
-                self._validate_canonical_kit_locked()
-                return False
+                store_id, kit_bytes = self._validate_canonical_kit_locked()
             except RecoveryKitError:
                 store_id = self._active_store_id()
-                update_state(
-                    store_id,
-                    memory_dir=self.settings.memory_dir,
-                    state_dir=self.state_dir,
-                    recovery_kit_verified_at=None,
-                )
-                cloud_keys.write_recovery_kit(
-                    store_id,
-                    key_path=self.key_path,
-                    kit_path=self.kit_path,
-                    account_email=getattr(self.settings, "account_email", None),
-                )
-                self._validate_canonical_kit_locked()
-                return True
+            else:
+                account_email = getattr(self.settings, "account_email", None)
+                if not account_email or _recovery_kit_account_email(kit_bytes) == account_email:
+                    return False
+            return self._regenerate_current_kit_locked(store_id)
+
+    def _regenerate_current_kit_locked(self, store_id: str) -> bool:
+        update_state(
+            store_id,
+            memory_dir=self.settings.memory_dir,
+            state_dir=self.state_dir,
+            recovery_kit_verified_at=None,
+        )
+        cloud_keys.write_recovery_kit(
+            store_id,
+            key_path=self.key_path,
+            kit_path=self.kit_path,
+            account_email=getattr(self.settings, "account_email", None),
+        )
+        self._validate_canonical_kit_locked()
+        return True
 
     def confirm_saved_digest(self, digest: str) -> RecoveryReadiness:
         """Record a saved-copy proof only when its bytes equal the current valid kit."""

--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -150,6 +150,7 @@ class ProtectionOperation:
     message: str | None = None
     snapshot_id: str | None = None
     protection_intent_id: str | None = None
+    verified_node_count: int | None = None
 
 
 def _as_utc(value: datetime) -> datetime:

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -26,6 +26,7 @@ def cloud_paths(tmp_path, monkeypatch):
     from ormah.config import settings
 
     monkeypatch.setattr(settings, "memory_dir", memory_dir)
+    monkeypatch.setattr(settings, "account_email", None)
     return key_path, kit_path, memory_dir
 
 
@@ -48,6 +49,19 @@ def test_cloud_init_json(cloud_paths, capsys):
     assert kit_path.is_file()
     assert (memory_dir / ".store_id").is_file()
     assert out["store_id"] == (memory_dir / ".store_id").read_text().strip()
+
+
+def test_cloud_init_writes_signed_in_email_to_recovery_kit(
+    cloud_paths, capsys, monkeypatch
+):
+    _, kit_path, _ = cloud_paths
+    from ormah.config import settings
+
+    monkeypatch.setattr(settings, "account_email", "person@example.com")
+
+    _run(["cloud", "init", "--json"])
+
+    assert "Email: person@example.com" in kit_path.read_text(encoding="utf-8")
 
 
 def test_cloud_init_refuses_second_run(cloud_paths, capsys):
@@ -137,6 +151,19 @@ def test_cloud_kit_regenerates_after_loss(cloud_paths, capsys):
     assert kit_path.is_file()
     current = cloud_keys.load_identity_strings(key_path)[0]
     assert current in kit_path.read_text()
+
+
+def test_cloud_kit_writes_signed_in_email(cloud_paths, capsys, monkeypatch):
+    _, kit_path, _ = cloud_paths
+    from ormah.config import settings
+
+    _run(["cloud", "init", "--json"])
+    capsys.readouterr()
+    monkeypatch.setattr(settings, "account_email", "person@example.com")
+
+    _run(["cloud", "kit", "--json"])
+
+    assert "Email: person@example.com" in kit_path.read_text(encoding="utf-8")
 
 
 def test_cloud_kit_without_key_fails(cloud_paths, capsys):

--- a/tests/test_cloud_operations.py
+++ b/tests/test_cloud_operations.py
@@ -28,6 +28,7 @@ def _result(operation_id: str = "durable-operation") -> ProtectionOperation:
         phase=ProtectionOperationPhase.COMPLETED,
         state=ProtectionState.VERIFICATION_PENDING,
         snapshot_id="01ARZ3NDEKTSV4RRFFQ69G5FAV",
+        verified_node_count=42,
     )
 
 
@@ -78,6 +79,7 @@ def test_coordinator_returns_immediately_and_deduplicates_active_work():
         completed = _wait_for_terminal(coordinator, first.operation_id)
         assert completed.status is LocalOperationStatus.COMPLETED
         assert completed.result == _result()
+        assert completed.to_payload()["verified_node_count"] == 42
         assert calls == 1
     finally:
         release.set()

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -113,6 +113,7 @@ def test_backup_and_verify_checks_the_exact_uploaded_snapshot(
         ProtectionOperationPhase.COMPLETED,
         ProtectionState.PROTECTED,
         snapshot_id=SNAPSHOT_ID,
+        verified_node_count=7,
     )
 
     monkeypatch.setattr(
@@ -132,6 +133,7 @@ def test_backup_and_verify_checks_the_exact_uploaded_snapshot(
     assert result.phase is ProtectionOperationPhase.COMPLETED
     assert result.state is ProtectionState.PROTECTED
     assert result.snapshot_id == SNAPSHOT_ID
+    assert result.verified_node_count == 7
     assert calls[0][0] == "backup"
     assert calls[1] == (
         "verify",
@@ -782,6 +784,7 @@ def test_verify_now_accepts_snapshot_id_after_entitlement_lapse(
     assert result.phase is ProtectionOperationPhase.COMPLETED
     assert result.state is ProtectionState.PROTECTED
     assert result.snapshot_id == SNAPSHOT_ID
+    assert result.verified_node_count == 1
     assert load_state(store_id).last_verified_snapshot_id == SNAPSHOT_ID
     assert observed == [
         ProtectionOperationPhase.DOWNLOADING,

--- a/tests/test_cloud_recovery.py
+++ b/tests/test_cloud_recovery.py
@@ -28,7 +28,11 @@ def recovery_store(tmp_path: Path):
     key_path = tmp_path / "config" / "cloud.key"
     kit_path = tmp_path / "config" / "ormah-recovery-kit.md"
     state_dir = tmp_path / "state"
-    settings = SimpleNamespace(memory_dir=memory_dir, cloud_backup_enabled=True)
+    settings = SimpleNamespace(
+        memory_dir=memory_dir,
+        cloud_backup_enabled=True,
+        account_email=None,
+    )
     store_id = get_or_create_store_id(memory_dir)
     init_key(key_path)
     write_recovery_kit(store_id, key_path=key_path, kit_path=kit_path)
@@ -97,6 +101,18 @@ def test_ensure_current_kit_repairs_stale_material_before_native_save(recovery_s
 
     service.validate_canonical_kit()
     assert "person@example.com" in kit_path.read_text(encoding="utf-8")
+    assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
+
+
+def test_ensure_current_kit_repairs_placeholder_for_signed_in_account(recovery_store):
+    settings, store_id, _, kit_path, state_dir, service = recovery_store
+    service.confirm_saved_digest(hashlib.sha256(kit_path.read_bytes()).hexdigest())
+    assert "Email: <your ormah account email>" in kit_path.read_text(encoding="utf-8")
+    settings.account_email = "person@example.com"
+
+    assert service.ensure_current_kit() is True
+
+    assert "Email: person@example.com" in kit_path.read_text(encoding="utf-8")
     assert load_state(store_id, state_dir=state_dir).recovery_kit_verified_at is None
 
 

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -20,6 +20,7 @@ import {
   effectiveProtectionState,
   operationPhaseIsActive,
   productBridge,
+  protectionCompletionSummary,
   protectionPresentation,
   protectionRepairAction,
   recoveryKitSectionVisible,
@@ -198,9 +199,12 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
         if (!operationIsActive(next)) {
           window.clearInterval(timer);
           await refresh();
-          setOperation(null);
-          if (next.phase === "completed") onToast(operationSuccessMessage(next), "success");
-          else if (next.message) setError(next.message);
+          if (next.phase === "completed") {
+            onToast(operationSuccessMessage(next), "success");
+          } else {
+            setOperation(null);
+            if (next.message) setError(next.message);
+          }
         }
       } catch (err) {
         // Polling IDs are process-local. After a Python restart, discard the
@@ -460,6 +464,10 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
     ? (status?.last_operation_phase || operation?.phase)
     : null;
   const activeStageIndex = phaseIndex(activePhase);
+  const completionSummary = protectionCompletionSummary(operation);
+  const completedStages = operation?.kind === "verify"
+    ? PROTECTION_STAGES.slice(4)
+    : PROTECTION_STAGES;
   const summaryTone = activeOperation ? "working" : presentation.tone;
   const repairAction = status ? protectionRepairAction(status) : "none";
 
@@ -559,6 +567,24 @@ export default function ProtectionPanel({ open, onClose, onToast, onStatusChange
                 })}
               </ol>
               <p>Verification uses a temporary copy. Your live memory is never replaced.</p>
+            </section>
+          )}
+
+          {completionSummary && (
+            <section className="protection-progress protection-complete" aria-label="Protection completed">
+              <div className="protection-progress-heading">
+                <span>Recovery check</span>
+                <strong>Complete</strong>
+              </div>
+              <ol>
+                {completedStages.map((stage) => (
+                  <li className="complete" key={stage.phase}>
+                    <span aria-hidden="true"><Check size={13} /></span>
+                    <span>{stage.label}</span>
+                  </li>
+                ))}
+              </ol>
+              <p>{completionSummary}</p>
             </section>
           )}
 

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   effectiveProtectionState,
   operationPhaseIsActive,
+  protectionCompletionSummary,
   protectionRepairAction,
   protectionPresentation,
   recoveryKitSectionVisible,
@@ -70,6 +71,46 @@ describe("operationPhaseIsActive", () => {
     for (const phase of ["completed", "failed", "canceled", null, undefined] as const) {
       expect(operationPhaseIsActive(phase)).toBe(false);
     }
+  });
+});
+
+describe("protectionCompletionSummary", () => {
+  it("uses backend timing and verified counts for a backup receipt", () => {
+    const summary = protectionCompletionSummary({
+      operation_id: "operation",
+      kind: "backup",
+      status: "completed",
+      submitted_at: "2026-08-01T19:00:00Z",
+      started_at: "2026-08-01T19:00:01Z",
+      finished_at: "2026-08-01T19:00:07.4Z",
+      phase: "completed",
+      protection_state: "protected",
+      reason_code: null,
+      message: null,
+      snapshot_id: "snapshot",
+      protection_intent_id: null,
+      verified_node_count: 1839,
+    });
+
+    expect(summary).toContain("1,839 active memories");
+    expect(summary).toContain("encrypted, uploaded, and restore-tested in 6 seconds");
+  });
+
+  it("never invents a receipt without a verified count and valid server timing", () => {
+    expect(protectionCompletionSummary({
+      operation_id: "operation",
+      kind: "backup",
+      status: "completed",
+      started_at: null,
+      finished_at: null,
+      phase: "completed",
+      protection_state: "protected",
+      reason_code: null,
+      message: null,
+      snapshot_id: "snapshot",
+      protection_intent_id: null,
+      verified_node_count: null,
+    })).toBeNull();
   });
 });
 

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -113,12 +113,46 @@ export interface ProtectionOperation {
   operation_id: string;
   kind: "enable" | "disable" | "backup" | "verify" | "restore";
   status?: "queued" | "running" | "completed" | "failed";
+  submitted_at?: string;
+  started_at?: string | null;
+  finished_at?: string | null;
   phase: OperationPhase | null;
   protection_state: ProtectionState | null;
   reason_code: string | null;
   message: string | null;
   snapshot_id: string | null;
   protection_intent_id: string | null;
+  verified_node_count?: number | null;
+}
+
+export function protectionCompletionSummary(
+  operation: ProtectionOperation | null | undefined,
+): string | null {
+  if (
+    operation?.phase !== "completed"
+    || !Number.isInteger(operation.verified_node_count)
+    || (operation.verified_node_count ?? 0) < 1
+    || !operation.started_at
+    || !operation.finished_at
+  ) return null;
+
+  const started = new Date(operation.started_at).getTime();
+  const finished = new Date(operation.finished_at).getTime();
+  if (!Number.isFinite(started) || !Number.isFinite(finished) || finished < started) return null;
+
+  const count = operation.verified_node_count as number;
+  const memories = `${new Intl.NumberFormat().format(count)} active ${
+    count === 1 ? "memory" : "memories"
+  }`;
+  const seconds = Math.max(1, Math.round((finished - started) / 1000));
+  const elapsed = `${seconds} ${seconds === 1 ? "second" : "seconds"}`;
+  if (operation.kind === "enable" || operation.kind === "backup") {
+    return `${memories} encrypted, uploaded, and restore-tested in ${elapsed}.`;
+  }
+  if (operation.kind === "verify") {
+    return `${memories} restore-tested in ${elapsed}.`;
+  }
+  return null;
 }
 
 export function effectiveProtectionState(

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1015,6 +1015,14 @@ body.in-app .node-detail.tier-core {
   line-height: 1.5;
 }
 
+.protection-complete .protection-progress-heading strong {
+  color: var(--edge-supports);
+}
+
+.protection-complete > p {
+  color: var(--text-bright);
+}
+
 .recovery-kit-heading {
   display: flex;
   gap: 9px;


### PR DESCRIPTION
## Problem

The first released desktop protection flow exposed three post-acceptance gaps:

- a transient boot-time DNS failure could strand the pinned Python runtime upgrade with no retry action;
- fast backup and restore verification could finish before the user could understand the stages or retain proof of what completed;
- CLI kit regeneration omitted the signed-in account email, leaving the recovery kit's placeholder intact.

## Solution

- Retry only classified transient `uv` install failures with bounded delays, prevent concurrent installers, and expose a native **Try again** action after failure.
- Carry the verified active-node count through the shared protection result and local operation payload, retain completed operations in the panel, and show the completed stage list plus a receipt based on backend timestamps.
- Pass `settings.account_email` through both CLI recovery-kit writers and repair otherwise-valid placeholder/mismatched metadata before native Save. A rewritten kit clears the old saved-copy proof until the corrected file is saved and reopened.

No encryption identities, store IDs, entitlement policy, upload behavior, or restore semantics change.

Closes #182
Closes #185
Closes #186

## Verification

- `uv run pytest tests/test_cloud_recovery.py tests/test_cloud_cli.py tests/test_cloud_operations.py -q` - 37 passed
- `uv run pytest tests/test_cloud_protection.py -q` - 48 passed
- `uv run ruff check src/ tests/` - clean
- `npm test -- --run && npm run build` in `ui/` - 19 passed, build clean
- `npm exec tsc -- --noEmit && npm run build` in `desktop/ui/` - clean
- `cargo test` in `desktop/src-tauri/` - 25 passed

The full local Python run reaches the environment's existing `TestClient`/AnyIO stall; GitHub CI remains the authoritative full-suite run.
