### PR TITLE
fix(cloud): repair fresh-install sign-in and prepare 0.14.6

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.18"
+version = "0.3.19"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -652,6 +652,7 @@ fn local_error_message(status: u16, path: &str) -> &'static str {
         }
         409 => "The protection state changed; refresh and try again.",
         429 => "Too many requests; wait briefly and try again.",
+        502 | 503 => "Ormah Cloud is temporarily unavailable. Check your connection and try again.",
         _ => "The local Ormah operation could not be completed.",
     }
 }
@@ -1139,5 +1140,15 @@ mod tests {
             generic,
             "The protection state changed; refresh and try again."
         );
+    }
+
+    #[test]
+    fn cloud_availability_errors_have_an_actionable_message() {
+        for status in [502, 503] {
+            assert_eq!(
+                local_error_message(status, "/admin/account/request-code"),
+                "Ormah Cloud is temporarily unavailable. Check your connection and try again."
+            );
+        }
     }
 }

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.5"
+version = "0.14.6"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     # ever leaves the machine. Off by default until an account is configured.
     cloud_backup_enabled: bool = False
     cloud_backup_interval_hours: int = 24
-    cloud_api_url: str = "https://api.ormah.dev"
+    cloud_api_url: str = "https://api.ormah.me"
     account_token: str | None = None
     account_email: str | None = None
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -119,6 +119,10 @@ def test_cloud_backup_interval_zero():
         _settings(cloud_backup_interval_hours=0)
 
 
+def test_cloud_api_url_default_uses_the_owned_production_domain():
+    assert Settings.model_fields["cloud_api_url"].default == "https://api.ormah.me"
+
+
 def test_backup_retention_zero():
     with pytest.raises(ValidationError, match="backup_retention_count must be >= 1"):
         _settings(backup_retention_count=0)


### PR DESCRIPTION
## Release

Prepare the coordinated releases after the post-acceptance protection reliability fixes:

- Python/CLI: `0.14.6`
- Desktop: `0.3.19`
- Claude plugin manifest: `0.14.6`

The desktop build remains pinned to the exact Python package version injected from `pyproject.toml`.

## Fresh-install fix

- Default new installations to the owned and deployed `https://api.ormah.me` cloud endpoint.
- Preserve `ORMAH_CLOUD_API_URL` overrides for development.
- Give desktop users an actionable cloud-connectivity message for upstream 502/503 responses.
- Add regression coverage for the production default and native error mapping.

DNS, Fly TLS, `/healthz`, `/readyz`, and protocol v2 have been verified through `api.ormah.me`.

Closes #195.

## Verification

- `PYTHONPATH=src ORMAH_LLM_PROVIDER=none pytest tests/test_config.py -q` (`53 passed`)
- `ruff check src/ormah/config.py tests/test_config.py`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib` (`26 passed`)
- `.github/release/verify_release_versions.py 0.14.6`
- PR #187 CI: Python tests, Ruff, and desktop gate all passed

After merge, publish Python `0.14.6` first, wait for PyPI visibility, then tag/build Desktop `0.3.19`.
