### PR TITLE
feat(desktop): add signed in-app update flow

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -217,6 +217,7 @@ jobs:
       - name: Attach artifacts to GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: |
             dist/**/*.dmg
             dist/**/*.AppImage*
@@ -232,6 +233,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#desktop-v}"
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}"
+          gh release view "$GITHUB_REF_NAME" --json body --jq .body > release-notes.txt
 
           APPIMAGE=$(find dist -name '*.AppImage' | head -1)
           DEB=$(find dist -name '*.deb' | head -1)
@@ -240,10 +242,10 @@ jobs:
             [ -s "$f" ] || { echo "missing updater artifact: $f" >&2; exit 1; }
           done
 
-          python3 - "$VERSION" "$BASE_URL" "$APPIMAGE" "$DEB" "$APPTAR" > latest.json <<'EOF'
+          python3 - "$VERSION" "$BASE_URL" "$APPIMAGE" "$DEB" "$APPTAR" release-notes.txt > latest.json <<'EOF'
           import json, pathlib, sys
           from datetime import datetime, timezone
-          version, base_url, appimage, deb, apptar = sys.argv[1:6]
+          version, base_url, appimage, deb, apptar, notes_path = sys.argv[1:7]
           def entry(path):
               p = pathlib.Path(path)
               return {
@@ -252,12 +254,11 @@ jobs:
               }
           print(json.dumps({
               "version": version,
+              "notes": pathlib.Path(notes_path).read_text().strip(),
               "pub_date": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
               "platforms": {
                   "linux-x86_64-deb": entry(deb),
-                  "linux-x86_64-appimage": entry(appimage),
                   "linux-x86_64": entry(appimage),
-                  "darwin-aarch64-app": entry(apptar),
                   "darwin-aarch64": entry(apptar),
               },
           }, indent=2))

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -170,6 +170,21 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: cargo tauri build --target ${{ matrix.target }}
 
+      # Tauri generates updater signatures for AppImage automatically, but a
+      # desktop installed from our .deb identifies itself as a Debian bundle
+      # and must receive a signed .deb from the update feed.
+      - name: Sign Debian updater artifact
+        if: runner.os == 'Linux'
+        working-directory: desktop
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          DEB=$(find "src-tauri/target/${{ matrix.target }}/release/bundle/deb" -name '*.deb' | head -1)
+          [ -s "$DEB" ] || { echo "missing Debian artifact" >&2; exit 1; }
+          cargo tauri signer sign "$DEB"
+          [ -s "$DEB.sig" ] || { echo "missing Debian updater signature" >&2; exit 1; }
+
       - name: Upload artifacts (macOS)
         if: runner.os == 'macOS'
         uses: actions/upload-artifact@v4
@@ -186,7 +201,7 @@ jobs:
           name: ormah-${{ matrix.target }}
           path: |
             desktop/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage*
-            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
+            desktop/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb*
 
   publish:
     needs: build
@@ -219,15 +234,16 @@ jobs:
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}"
 
           APPIMAGE=$(find dist -name '*.AppImage' | head -1)
+          DEB=$(find dist -name '*.deb' | head -1)
           APPTAR=$(find dist -name '*.app.tar.gz' | head -1)
-          for f in "$APPIMAGE" "$APPIMAGE.sig" "$APPTAR" "$APPTAR.sig"; do
+          for f in "$APPIMAGE" "$APPIMAGE.sig" "$DEB" "$DEB.sig" "$APPTAR" "$APPTAR.sig"; do
             [ -s "$f" ] || { echo "missing updater artifact: $f" >&2; exit 1; }
           done
 
-          python3 - "$VERSION" "$BASE_URL" "$APPIMAGE" "$APPTAR" > latest.json <<'EOF'
+          python3 - "$VERSION" "$BASE_URL" "$APPIMAGE" "$DEB" "$APPTAR" > latest.json <<'EOF'
           import json, pathlib, sys
           from datetime import datetime, timezone
-          version, base_url, appimage, apptar = sys.argv[1:5]
+          version, base_url, appimage, deb, apptar = sys.argv[1:6]
           def entry(path):
               p = pathlib.Path(path)
               return {
@@ -238,7 +254,10 @@ jobs:
               "version": version,
               "pub_date": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
               "platforms": {
+                  "linux-x86_64-deb": entry(deb),
+                  "linux-x86_64-appimage": entry(appimage),
                   "linux-x86_64": entry(appimage),
+                  "darwin-aarch64-app": entry(apptar),
                   "darwin-aarch64": entry(apptar),
               },
           }, indent=2))

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Silence is better than noise. Ormah should whisper, not shout.
 </p>
 
 No Python or terminal required. Download, open, and Ormah sets itself up.
+Desktop checks for signed releases at startup. When one is available, the main
+app shows its version and concise release notes with **Update now** and
+**Later**. Updates are never installed or restarted silently: installation
+starts only after an explicit click, verifies the configured release signature,
+and keeps the current version available if download or installation fails.
 
 ### Terminal
 

--- a/desktop/src-tauri/permissions/desktop.toml
+++ b/desktop/src-tauri/permissions/desktop.toml
@@ -38,4 +38,7 @@ commands.allow = [
   "open_billing_portal",
   "save_recovery_kit",
   "open_printable_recovery_kit",
+  "desktop_update_status",
+  "check_desktop_update",
+  "install_desktop_update",
 ]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -188,6 +188,9 @@ pub fn run() {
             product_bridge::open_billing_portal,
             product_bridge::save_recovery_kit,
             product_bridge::open_printable_recovery_kit,
+            updater::desktop_update_status,
+            updater::check_desktop_update,
+            updater::install_desktop_update,
         ])
         .setup(|app| {
             // Linux: refuse to start a second instance so we never spawn a

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -229,10 +229,6 @@ pub fn run() {
             // Always enable autostart — ormah should run at login by default.
             let _ = app.handle().autolaunch().enable();
 
-            // Check for a desktop app update in the background — user is
-            // notified and must explicitly click to install.
-            updater::check(app.handle().clone());
-
             // Main window: shows the install/boot flow, then navigates to the
             // graph. Built in Rust so we can attach the scrollbar-hiding init
             // script that also applies after navigating to the graph.
@@ -259,6 +255,10 @@ pub fn run() {
 
             // Build the tray; it owns the stats poller and server controls.
             tray::build(app)?;
+
+            // Check only after the tray has registered its event listeners.
+            // Discovery is background-only; installation still needs a click.
+            updater::check(app.handle().clone());
 
             Ok(())
         })

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -575,7 +575,7 @@ fn paths_resolve_to_same_file(canonical: &Path, destination: &Path) -> Result<bo
     Ok(resolved_parent.join(filename) == source)
 }
 
-fn require_product_origin<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
+pub(crate) fn require_product_origin<R: Runtime>(window: &WebviewWindow<R>) -> Result<(), String> {
     if window.label() != "main" {
         return Err("Desktop product commands are unavailable in this window.".to_string());
     }

--- a/desktop/src-tauri/src/updater.rs
+++ b/desktop/src-tauri/src/updater.rs
@@ -9,6 +9,7 @@ use tauri_plugin_updater::{Update, UpdaterExt};
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdatePhase {
+    Unknown,
     Checking,
     Current,
     Available,
@@ -34,6 +35,13 @@ impl UpdateStatus {
             notes: String::new(),
             progress_percent: None,
             message: None,
+        }
+    }
+
+    fn unknown() -> Self {
+        Self {
+            phase: UpdatePhase::Unknown,
+            ..Self::checking()
         }
     }
 
@@ -73,6 +81,7 @@ pub struct UpdateAvailable {
 }
 
 static STATUS: OnceLock<Mutex<UpdateStatus>> = OnceLock::new();
+static AVAILABLE_UPDATE: OnceLock<Mutex<Option<Update>>> = OnceLock::new();
 static INSTALL_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
 
 struct InstallGuard;
@@ -96,6 +105,23 @@ fn status_store() -> &'static Mutex<UpdateStatus> {
     STATUS.get_or_init(|| Mutex::new(UpdateStatus::checking()))
 }
 
+fn available_update_store() -> &'static Mutex<Option<Update>> {
+    AVAILABLE_UPDATE.get_or_init(|| Mutex::new(None))
+}
+
+fn set_available_update(update: Option<Update>) {
+    *available_update_store()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = update;
+}
+
+fn take_available_update() -> Option<Update> {
+    available_update_store()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .take()
+}
+
 fn current_status() -> UpdateStatus {
     status_store()
         .lock()
@@ -114,6 +140,7 @@ fn concise_notes(body: Option<&str>) -> String {
         .unwrap_or_default()
         .lines()
         .map(str::trim)
+        .map(|line| line.trim_start_matches(['#', '-', '*', ' ']))
         .filter(|line| !line.is_empty())
         .take(3)
         .collect::<Vec<_>>()
@@ -124,11 +151,18 @@ fn concise_notes(body: Option<&str>) -> String {
 /// Check once at startup. This only discovers updates; it never installs one.
 pub fn check<R: Runtime>(app: AppHandle<R>) {
     tauri::async_runtime::spawn(async move {
-        if let Err(error) = check_now(&app, true).await {
-            eprintln!("updater check failed: {error}");
-            // Startup checks are best-effort. Being offline is not an app
-            // failure and should not interrupt the user with a warning.
-            set_status(UpdateStatus::current());
+        loop {
+            match check_now(&app, true).await {
+                Ok(status) if status.phase == UpdatePhase::Available => break,
+                Ok(_) => tokio::time::sleep(std::time::Duration::from_secs(6 * 60 * 60)).await,
+                Err(error) => {
+                    eprintln!("updater check failed: {error}");
+                    // Stay quiet while offline, but do not mistake an unknown
+                    // result for proof that this installation is current.
+                    set_status(UpdateStatus::unknown());
+                    tokio::time::sleep(std::time::Duration::from_secs(15 * 60)).await;
+                }
+            }
         }
     });
 }
@@ -145,6 +179,7 @@ async fn check_now<R: Runtime>(
 ) -> tauri_plugin_updater::Result<UpdateStatus> {
     set_status(UpdateStatus::checking());
     let Some(update) = available_update(app).await? else {
+        set_available_update(None);
         let status = UpdateStatus::current();
         set_status(status.clone());
         return Ok(status);
@@ -154,6 +189,7 @@ async fn check_now<R: Runtime>(
         update.version.clone(),
         concise_notes(update.body.as_deref()),
     );
+    set_available_update(Some(update.clone()));
     set_status(status.clone());
     let _ = app.emit(
         "ormah://update-available",
@@ -235,7 +271,11 @@ pub fn install<R: Runtime>(app: AppHandle<R>) {
 }
 
 async fn install_now<R: Runtime>(app: AppHandle<R>) -> tauri_plugin_updater::Result<()> {
-    let Some(update) = available_update(&app).await? else {
+    let update = match take_available_update() {
+        Some(update) => Some(update),
+        None => available_update(&app).await?,
+    };
+    let Some(update) = update else {
         set_status(UpdateStatus::current());
         return Ok(());
     };

--- a/desktop/src-tauri/src/updater.rs
+++ b/desktop/src-tauri/src/updater.rs
@@ -1,92 +1,305 @@
-//! App update checker — runs once on launch, shows a tray/notification prompt.
-//!
-//! Never silently applies an update. If a new version is available the user
-//! sees a notification and a tray menu item; the download + relaunch only
-//! happens when they explicitly click "Install update".
+//! Signed desktop updates with explicit user-controlled installation.
 
-use tauri::{AppHandle, Emitter, Runtime};
-use tauri_plugin_updater::UpdaterExt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 
-/// Emitted to the webview so the UI can show an in-app banner if desired.
+use tauri::{AppHandle, Emitter, Runtime, WebviewWindow};
+use tauri_plugin_updater::{Update, UpdaterExt};
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdatePhase {
+    Checking,
+    Current,
+    Available,
+    Downloading,
+    Installing,
+    Failed,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct UpdateStatus {
+    pub phase: UpdatePhase,
+    pub version: Option<String>,
+    pub notes: String,
+    pub progress_percent: Option<u8>,
+    pub message: Option<String>,
+}
+
+impl UpdateStatus {
+    fn checking() -> Self {
+        Self {
+            phase: UpdatePhase::Checking,
+            version: None,
+            notes: String::new(),
+            progress_percent: None,
+            message: None,
+        }
+    }
+
+    fn current() -> Self {
+        Self {
+            phase: UpdatePhase::Current,
+            ..Self::checking()
+        }
+    }
+
+    fn available(version: String, notes: String) -> Self {
+        Self {
+            phase: UpdatePhase::Available,
+            version: Some(version),
+            notes,
+            progress_percent: None,
+            message: None,
+        }
+    }
+
+    fn failed(message: &str) -> Self {
+        Self {
+            phase: UpdatePhase::Failed,
+            version: None,
+            notes: String::new(),
+            progress_percent: None,
+            message: Some(message.to_string()),
+        }
+    }
+}
+
+/// Kept for the existing tray event contract.
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct UpdateAvailable {
     pub version: String,
     pub notes: String,
 }
 
-/// Check for an app update in the background. If one is found, notify the
-/// user via a system notification and emit `ormah://update-available` to
-/// the webview. Does NOT download or apply anything.
+static STATUS: OnceLock<Mutex<UpdateStatus>> = OnceLock::new();
+static INSTALL_IN_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+struct InstallGuard;
+
+impl InstallGuard {
+    fn acquire() -> Option<Self> {
+        INSTALL_IN_PROGRESS
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| Self)
+    }
+}
+
+impl Drop for InstallGuard {
+    fn drop(&mut self) {
+        INSTALL_IN_PROGRESS.store(false, Ordering::Release);
+    }
+}
+
+fn status_store() -> &'static Mutex<UpdateStatus> {
+    STATUS.get_or_init(|| Mutex::new(UpdateStatus::checking()))
+}
+
+fn current_status() -> UpdateStatus {
+    status_store()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+fn set_status(status: UpdateStatus) {
+    *status_store()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = status;
+}
+
+fn concise_notes(body: Option<&str>) -> String {
+    let notes = body
+        .unwrap_or_default()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(3)
+        .collect::<Vec<_>>()
+        .join(" ");
+    notes.chars().take(320).collect()
+}
+
+/// Check once at startup. This only discovers updates; it never installs one.
 pub fn check<R: Runtime>(app: AppHandle<R>) {
     tauri::async_runtime::spawn(async move {
-        if let Err(e) = do_check(app).await {
-            eprintln!("updater check failed: {e}");
+        if let Err(error) = check_now(&app, true).await {
+            eprintln!("updater check failed: {error}");
+            // Startup checks are best-effort. Being offline is not an app
+            // failure and should not interrupt the user with a warning.
+            set_status(UpdateStatus::current());
         }
     });
 }
 
-async fn do_check<R: Runtime>(app: AppHandle<R>) -> tauri_plugin_updater::Result<()> {
-    let updater = app.updater()?;
-    let Some(update) = updater.check().await? else {
+async fn available_update<R: Runtime>(
+    app: &AppHandle<R>,
+) -> tauri_plugin_updater::Result<Option<Update>> {
+    app.updater()?.check().await
+}
+
+async fn check_now<R: Runtime>(
+    app: &AppHandle<R>,
+    notify: bool,
+) -> tauri_plugin_updater::Result<UpdateStatus> {
+    set_status(UpdateStatus::checking());
+    let Some(update) = available_update(app).await? else {
+        let status = UpdateStatus::current();
+        set_status(status.clone());
+        return Ok(status);
+    };
+
+    let status = UpdateStatus::available(
+        update.version.clone(),
+        concise_notes(update.body.as_deref()),
+    );
+    set_status(status.clone());
+    let _ = app.emit(
+        "ormah://update-available",
+        UpdateAvailable {
+            version: update.version.clone(),
+            notes: status.notes.clone(),
+        },
+    );
+
+    if notify {
+        use tauri_plugin_notification::NotificationExt;
+        let body = format!(
+            "Ormah Desktop {} is ready. Open Ormah to review and install it.",
+            update.version
+        );
+        let _ = app
+            .notification()
+            .builder()
+            .title("Update available")
+            .body(body)
+            .show();
+    }
+    Ok(status)
+}
+
+#[tauri::command]
+pub fn desktop_update_status(window: WebviewWindow) -> Result<UpdateStatus, String> {
+    crate::product_bridge::require_product_origin(&window)?;
+    Ok(current_status())
+}
+
+#[tauri::command]
+pub async fn check_desktop_update<R: Runtime>(
+    app: AppHandle<R>,
+    window: WebviewWindow<R>,
+) -> Result<UpdateStatus, String> {
+    crate::product_bridge::require_product_origin(&window)?;
+    check_now(&app, false).await.map_err(|error| {
+        eprintln!("manual updater check failed: {error}");
+        let status = UpdateStatus::failed(
+            "Ormah could not check for updates. Check your connection and try again.",
+        );
+        set_status(status);
+        "Ormah could not check for updates. Check your connection and try again.".to_string()
+    })
+}
+
+#[tauri::command]
+pub async fn install_desktop_update<R: Runtime>(
+    app: AppHandle<R>,
+    window: WebviewWindow<R>,
+) -> Result<UpdateStatus, String> {
+    crate::product_bridge::require_product_origin(&window)?;
+    let _guard = InstallGuard::acquire()
+        .ok_or_else(|| "An Ormah update is already in progress.".to_string())?;
+    install_now(app).await.map_err(|error| {
+        eprintln!("update install failed: {error}");
+        let message = "The update could not be installed. Your current Ormah version is unchanged.";
+        set_status(UpdateStatus::failed(message));
+        message.to_string()
+    })?;
+    Ok(current_status())
+}
+
+/// Tray entry point. Installation still happens only after an explicit click.
+pub fn install<R: Runtime>(app: AppHandle<R>) {
+    let Some(guard) = InstallGuard::acquire() else {
+        return;
+    };
+    tauri::async_runtime::spawn(async move {
+        let _guard = guard;
+        if let Err(error) = install_now(app).await {
+            eprintln!("update install failed: {error}");
+            set_status(UpdateStatus::failed(
+                "The update could not be installed. Your current Ormah version is unchanged.",
+            ));
+        }
+    });
+}
+
+async fn install_now<R: Runtime>(app: AppHandle<R>) -> tauri_plugin_updater::Result<()> {
+    let Some(update) = available_update(&app).await? else {
+        set_status(UpdateStatus::current());
         return Ok(());
     };
 
     let version = update.version.clone();
-    let notes = update
-        .body
-        .clone()
-        .unwrap_or_default()
-        .lines()
-        .take(3)
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    // Emit to the webview so an in-app banner can appear.
-    let _ = app.emit(
-        "ormah://update-available",
-        UpdateAvailable {
-            version: version.clone(),
-            notes: notes.clone(),
-        },
-    );
-
-    // Surface a system notification — this reaches the user even if the
-    // window is hidden.
-    use tauri_plugin_notification::NotificationExt;
-    let body = format!("Ormah Desktop {version} is ready. Open the menu to install.");
-    let _ = app
-        .notification()
-        .builder()
-        .title("Update available")
-        .body(body)
-        .show();
-
-    Ok(())
-}
-
-/// Download and apply the update, then relaunch. Call this only after the
-/// user has explicitly consented (e.g. clicked "Install update" in the tray).
-pub fn install<R: Runtime>(app: AppHandle<R>) {
-    tauri::async_runtime::spawn(async move {
-        if let Err(e) = do_install(app).await {
-            eprintln!("update install failed: {e}");
-        }
+    let notes = concise_notes(update.body.as_deref());
+    let mut downloaded = 0_u64;
+    set_status(UpdateStatus {
+        phase: UpdatePhase::Downloading,
+        version: Some(version.clone()),
+        notes: notes.clone(),
+        progress_percent: Some(0),
+        message: None,
     });
-}
-
-async fn do_install<R: Runtime>(app: AppHandle<R>) -> tauri_plugin_updater::Result<()> {
-    let updater = app.updater()?;
-    let Some(update) = updater.check().await? else {
-        return Ok(());
-    };
-
     update
         .download_and_install(
-            |_chunk, _total| {},
+            move |chunk, total| {
+                downloaded = downloaded.saturating_add(chunk as u64);
+                let progress = total
+                    .filter(|total| *total > 0)
+                    .map(|total| ((downloaded.saturating_mul(100) / total).min(100)) as u8);
+                set_status(UpdateStatus {
+                    phase: UpdatePhase::Downloading,
+                    version: Some(version.clone()),
+                    notes: notes.clone(),
+                    progress_percent: progress,
+                    message: None,
+                });
+            },
             || {
-                // Relaunch after install. The new binary picks up from here.
-                app.restart();
+                let previous = current_status();
+                set_status(UpdateStatus {
+                    phase: UpdatePhase::Installing,
+                    progress_percent: Some(100),
+                    ..previous
+                });
             },
         )
-        .await
+        .await?;
+
+    // download_and_install verifies the configured signature before it returns.
+    // Restart only after the signed artifact has been installed successfully.
+    app.restart();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_notes_are_short_plain_text() {
+        let input = "\n First improvement \n\nSecond improvement\nThird improvement\nIgnored";
+        assert_eq!(
+            concise_notes(Some(input)),
+            "First improvement Second improvement Third improvement"
+        );
+        assert!(concise_notes(Some(&"x".repeat(400))).chars().count() <= 320);
+    }
+
+    #[test]
+    fn update_state_never_implies_automatic_installation() {
+        let available = UpdateStatus::available("0.4.0".into(), "Safer restore".into());
+        assert_eq!(available.phase, UpdatePhase::Available);
+        assert_eq!(available.progress_percent, None);
+        assert_eq!(UpdateStatus::current().phase, UpdatePhase::Current);
+    }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,6 +9,7 @@ import InsightsPanel from "./components/InsightsPanel";
 import AdminPanel from "./components/AdminPanel";
 import AgentsPanel from "./components/AgentsPanel";
 import ProtectionPanel from "./components/ProtectionPanel";
+import UpdateBanner from "./components/UpdateBanner";
 import ToastContainer from "./components/Toast";
 import type { ToastData } from "./components/Toast";
 import {
@@ -265,6 +266,7 @@ export default function App() {
         searchInputRef={searchInputRef}
         protectionState={protectionState}
       />
+      <UpdateBanner />
       <div className="graph-container">
         {graph && (
           <GraphView

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, Download, LoaderCircle, RefreshCw, X } from "lucide-react";
+
+import {
+  desktopUpdateProgress,
+  desktopUpdater,
+  type DesktopUpdateStatus,
+} from "../desktopUpdate";
+import { isDesktopApp } from "../productBridge";
+
+const POLL_MS = 750;
+
+export default function UpdateBanner() {
+  const [status, setStatus] = useState<DesktopUpdateStatus | null>(null);
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
+  const [installAttempted, setInstallAttempted] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await desktopUpdater.status());
+    } catch {
+      // An older desktop bridge cannot update in-app. Its existing tray
+      // updater remains available, so keep the product UI quiet.
+      setStatus(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isDesktopApp()) return;
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!status || !["checking", "downloading", "installing"].includes(status.phase)) return;
+    const timer = window.setInterval(() => void refresh(), POLL_MS);
+    return () => window.clearInterval(timer);
+  }, [refresh, status]);
+
+  const install = useCallback(() => {
+    setInstallAttempted(true);
+    setStatus((current) => current ? { ...current, phase: "downloading", progress_percent: 0 } : current);
+    void desktopUpdater.install().catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      setStatus((current) => ({
+        phase: "failed",
+        version: current?.version ?? null,
+        notes: current?.notes ?? "",
+        progress_percent: null,
+        message: message || "The update could not be installed. Your current version is unchanged.",
+      }));
+    });
+  }, []);
+
+  const retry = useCallback(async () => {
+    setInstallAttempted(false);
+    setStatus((current) => current ? { ...current, phase: "checking", message: null } : current);
+    try {
+      setStatus(await desktopUpdater.check());
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setStatus({
+        phase: "failed",
+        version: null,
+        notes: "",
+        progress_percent: null,
+        message: message || "Ormah could not check for updates.",
+      });
+    }
+  }, []);
+
+  if (!status || status.phase === "checking" || status.phase === "current") return null;
+  if (status.phase === "available" && dismissedVersion === status.version) return null;
+  if (status.phase === "failed" && dismissedVersion === "failed") return null;
+
+  const working = status.phase === "downloading" || status.phase === "installing";
+  const failed = status.phase === "failed";
+  const title = failed
+    ? installAttempted ? "Update interrupted" : "Update check unavailable"
+    : working
+      ? desktopUpdateProgress(status)
+      : `Ormah ${status.version} is available`;
+
+  return (
+    <section className={`update-banner ${failed ? "update-failed" : ""}`} aria-live="polite">
+      <div className="update-banner-icon" aria-hidden="true">
+        {failed ? <AlertTriangle size={17} />
+          : working ? <LoaderCircle className="spin" size={17} />
+            : <Download size={17} />}
+      </div>
+      <div className="update-banner-copy">
+        <strong>{title}</strong>
+        <span>{failed
+          ? status.message || "Your current version is unchanged."
+          : working
+            ? "Ormah will restart only after the signed update is installed."
+            : status.notes || "A new signed desktop version is ready."}</span>
+        {status.phase === "downloading" && status.progress_percent !== null && (
+          <div className="update-progress" aria-label={`${status.progress_percent}% downloaded`}>
+            <span style={{ width: `${status.progress_percent}%` }} />
+          </div>
+        )}
+      </div>
+      <div className="update-banner-actions">
+        {status.phase === "available" && (
+          <>
+            <button className="update-now" onClick={install}>
+              <Download size={13} /> Update now
+            </button>
+            <button
+              className="update-later"
+              onClick={() => setDismissedVersion(status.version)}
+            >Later</button>
+          </>
+        )}
+        {failed && (
+          <button className="update-now" onClick={() => void retry()}>
+            <RefreshCw size={13} /> Try again
+          </button>
+        )}
+      </div>
+      {!working && (
+        <button
+          className="update-dismiss"
+          aria-label="Dismiss update notice"
+          onClick={() => setDismissedVersion(status.version || "failed")}
+        ><X size={14} /></button>
+      )}
+    </section>
+  );
+}

--- a/ui/src/components/UpdateBanner.tsx
+++ b/ui/src/components/UpdateBanner.tsx
@@ -34,7 +34,7 @@ export default function UpdateBanner() {
     if (!status || !["checking", "downloading", "installing"].includes(status.phase)) return;
     const timer = window.setInterval(() => void refresh(), POLL_MS);
     return () => window.clearInterval(timer);
-  }, [refresh, status]);
+  }, [refresh, status?.phase]);
 
   const install = useCallback(() => {
     setInstallAttempted(true);
@@ -68,9 +68,10 @@ export default function UpdateBanner() {
     }
   }, []);
 
-  if (!status || status.phase === "checking" || status.phase === "current") return null;
+  if (!status || ["unknown", "checking", "current"].includes(status.phase)) return null;
   if (status.phase === "available" && dismissedVersion === status.version) return null;
-  if (status.phase === "failed" && dismissedVersion === "failed") return null;
+  const dismissalKey = status.phase === "failed" ? (status.version || "failed") : status.version;
+  if (status.phase === "failed" && dismissedVersion === dismissalKey) return null;
 
   const working = status.phase === "downloading" || status.phase === "installing";
   const failed = status.phase === "failed";
@@ -122,7 +123,7 @@ export default function UpdateBanner() {
         <button
           className="update-dismiss"
           aria-label="Dismiss update notice"
-          onClick={() => setDismissedVersion(status.version || "failed")}
+          onClick={() => setDismissedVersion(dismissalKey)}
         ><X size={14} /></button>
       )}
     </section>

--- a/ui/src/desktopUpdate.test.ts
+++ b/ui/src/desktopUpdate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { desktopUpdateProgress, type DesktopUpdateStatus } from "./desktopUpdate";
+
+function status(overrides: Partial<DesktopUpdateStatus>): DesktopUpdateStatus {
+  return {
+    phase: "downloading",
+    version: "0.4.0",
+    notes: "Safer recovery",
+    progress_percent: null,
+    message: null,
+    ...overrides,
+  };
+}
+
+describe("desktopUpdateProgress", () => {
+  it("shows determinate and indeterminate signed-download progress", () => {
+    expect(desktopUpdateProgress(status({ progress_percent: 42 }))).toContain("42%");
+    expect(desktopUpdateProgress(status({ progress_percent: null }))).toBe(
+      "Downloading signed update",
+    );
+  });
+
+  it("does not imply installation while only downloading", () => {
+    expect(desktopUpdateProgress(status({ phase: "installing" }))).toBe(
+      "Installing signed update",
+    );
+    expect(desktopUpdateProgress(status({ phase: "available" }))).toBe("");
+  });
+});

--- a/ui/src/desktopUpdate.ts
+++ b/ui/src/desktopUpdate.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type DesktopUpdatePhase =
+  | "checking"
+  | "current"
+  | "available"
+  | "downloading"
+  | "installing"
+  | "failed";
+
+export interface DesktopUpdateStatus {
+  phase: DesktopUpdatePhase;
+  version: string | null;
+  notes: string;
+  progress_percent: number | null;
+  message: string | null;
+}
+
+export function desktopUpdateProgress(status: DesktopUpdateStatus): string {
+  if (status.phase === "installing") return "Installing signed update";
+  if (status.phase === "downloading") {
+    return status.progress_percent === null
+      ? "Downloading signed update"
+      : `Downloading signed update · ${status.progress_percent}%`;
+  }
+  return "";
+}
+
+export const desktopUpdater = {
+  status: () => invoke<DesktopUpdateStatus>("desktop_update_status"),
+  check: () => invoke<DesktopUpdateStatus>("check_desktop_update"),
+  install: () => invoke<DesktopUpdateStatus>("install_desktop_update"),
+};

--- a/ui/src/desktopUpdate.ts
+++ b/ui/src/desktopUpdate.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 
 export type DesktopUpdatePhase =
+  | "unknown"
   | "checking"
   | "current"
   | "available"

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -275,6 +275,143 @@ body.in-app .node-detail.tier-core {
   bottom: 0;
 }
 
+/* ---- Signed desktop update ---- */
+.update-banner {
+  position: fixed;
+  top: 52px;
+  right: 18px;
+  width: min(420px, calc(100vw - 36px));
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto 24px;
+  gap: 10px;
+  align-items: start;
+  padding: 12px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  background: var(--toast-bg);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.28);
+  z-index: 190;
+}
+
+.update-banner-icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  color: var(--node-self);
+}
+
+.update-banner-copy {
+  min-width: 0;
+}
+
+.update-banner-copy strong,
+.update-banner-copy span {
+  display: block;
+}
+
+.update-banner-copy strong {
+  color: var(--text-bright);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.update-banner-copy span {
+  max-height: 34px;
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 10px;
+  line-height: 1.55;
+}
+
+.update-banner-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.update-now,
+.update-later,
+.update-dismiss {
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.update-now {
+  min-height: 30px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 9px;
+  border: 1px solid var(--node-self);
+  background: rgba(116, 179, 165, 0.12);
+  color: var(--text-bright);
+  white-space: nowrap;
+}
+
+.update-now:hover { background: rgba(116, 179, 165, 0.2); }
+
+.update-later,
+.update-dismiss {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.update-later {
+  min-height: 30px;
+  padding: 0 5px;
+}
+
+.update-dismiss {
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+}
+
+.update-later:hover,
+.update-dismiss:hover { color: var(--text-bright); }
+
+.update-progress {
+  height: 2px;
+  margin-top: 9px;
+  overflow: hidden;
+  background: var(--border);
+}
+
+.update-progress span {
+  height: 100%;
+  margin: 0;
+  background: var(--node-self);
+  transition: width 180ms ease;
+}
+
+.update-banner.update-failed .update-banner-icon { color: var(--edge-contradicts); }
+
+@media (max-width: 620px) {
+  .update-banner {
+    left: 12px;
+    right: 12px;
+    width: auto;
+    grid-template-columns: 24px minmax(0, 1fr) 24px;
+  }
+
+  .update-banner-actions {
+    grid-column: 2 / 3;
+    justify-content: flex-start;
+  }
+
+  .update-dismiss {
+    grid-column: 3;
+    grid-row: 1;
+  }
+}
+
 /* ---- Search Results ---- */
 .search-results {
   position: absolute;


### PR DESCRIPTION
## Problem

Desktop detects signed releases in the tray, but users cannot see or install them from the main product UI. The existing install callback also restarted when downloading finished, before Tauri completed signature verification and installation. Linux `.deb` installs were offered the generic AppImage feed entry and would reject it as the wrong package format.

## Solution

- Add a compact in-app update banner with release version, concise notes, **Update now**, **Later**, progress, retry, and explicit restart copy.
- Keep installation opt-in: no silent download, install, or restart.
- Expose a narrow origin-checked native update bridge; older desktop bridges quietly keep the existing tray updater.
- Serialize tray/UI installs so only one signed update can run.
- Await Tauri signature verification and successful installation before restarting.
- Keep startup update checks quiet when offline.
- Sign the Debian artifact and publish package-specific updater feed entries so `.deb`, AppImage, and macOS installations receive the correct signed artifact.

This delivers the explicit v1 portion of #183. Automatic installation remains deliberately deferred; every added behavior must justify its complexity.

## Security

- Uses the existing pinned Tauri updater public key and signed release artifacts.
- Native commands require the trusted local product origin.
- Release notes are bounded and rendered as React text.
- Installation errors leave the current app unchanged and show a retry path.

## Verification

- `npm run build`
- `npm test -- --run` (21 passed)
- `cargo test -q` (28 passed)
- `rustfmt --edition 2021 --check src/updater.rs src/product_bridge.rs`
- workflow YAML parse
- `ruff check src tests`
- `git diff --check`

Addresses #183