### PR TITLE
fix(desktop): recover cloud status after transient outages

### DIFF
--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -24,6 +24,7 @@ import {
   productBridge,
   protectionCompletionSummary,
   protectionPresentation,
+  protectionReconnectDelay,
   protectionRepairAction,
   recoveryKitSectionVisible,
   type AccountStatus,
@@ -201,6 +202,7 @@ export default function ProtectionPanel({
   const checkoutCheckInFlight = useRef(false);
   const offerRequested = useRef(false);
   const preparedRestoreRef = useRef<ProtectionOperation | null>(null);
+  const reconnectAttempt = useRef(0);
   const desktop = isDesktopApp();
 
   const refresh = useCallback(async () => {
@@ -241,6 +243,21 @@ export default function ProtectionPanel({
     void refresh();
     requestAnimationFrame(() => headingRef.current?.focus());
   }, [open, refresh]);
+
+  useEffect(() => {
+    if (!open || status?.protection_state !== "offline") {
+      reconnectAttempt.current = 0;
+      return;
+    }
+    if (loading || operationIsActive(operation)) return;
+    const delay = protectionReconnectDelay(reconnectAttempt.current);
+    if (delay === null) return;
+    const timer = window.setTimeout(() => {
+      reconnectAttempt.current += 1;
+      void refresh();
+    }, delay);
+    return () => window.clearTimeout(timer);
+  }, [loading, open, operation?.status, refresh, status?.protection_state]);
 
   useEffect(() => {
     if (!open || !operationIsActive(operation)) return;
@@ -714,6 +731,7 @@ export default function ProtectionPanel({
       await runOperation(repairAction);
       return;
     }
+    reconnectAttempt.current = 0;
     await refresh();
   }, [beginProtection, offer, refresh, repairAction, runOperation, status]);
 

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -192,6 +192,7 @@ export default function ProtectionPanel({
   const [code, setCode] = useState("");
   const [busy, setBusy] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [refreshFailed, setRefreshFailed] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [checkoutPolling, setCheckoutPolling] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
@@ -223,6 +224,7 @@ export default function ProtectionPanel({
       const nextStatus = await productBridge.status();
       setAccount(nextAccount);
       setStatus(nextStatus);
+      setRefreshFailed(false);
       onStatusChange?.(nextStatus);
       setError(null);
       if (nextAccount.signed_in && !offerRequested.current) {
@@ -232,6 +234,7 @@ export default function ProtectionPanel({
         });
       }
     } catch (err) {
+      setRefreshFailed(true);
       setError(errorMessage(err, "Protection status is unavailable."));
     } finally {
       setLoading(false);
@@ -245,19 +248,18 @@ export default function ProtectionPanel({
   }, [open, refresh]);
 
   useEffect(() => {
-    if (!open || status?.protection_state !== "offline") {
+    if (!open || (!refreshFailed && status?.protection_state !== "offline")) {
       reconnectAttempt.current = 0;
       return;
     }
     if (loading || operationIsActive(operation)) return;
     const delay = protectionReconnectDelay(reconnectAttempt.current);
-    if (delay === null) return;
     const timer = window.setTimeout(() => {
       reconnectAttempt.current += 1;
       void refresh();
     }, delay);
     return () => window.clearTimeout(timer);
-  }, [loading, open, operation?.status, refresh, status?.protection_state]);
+  }, [loading, open, operation?.status, refresh, refreshFailed, status?.protection_state]);
 
   useEffect(() => {
     if (!open || !operationIsActive(operation)) return;

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -56,13 +56,14 @@ describe("protectionPresentation", () => {
 });
 
 describe("protectionReconnectDelay", () => {
-  it("backs off and then stops retrying", () => {
-    expect([0, 1, 2, 3, 4].map(protectionReconnectDelay)).toEqual([
+  it("backs off to a capped reconnect interval", () => {
+    expect([0, 1, 2, 3, 4, 5].map(protectionReconnectDelay)).toEqual([
       5_000,
       15_000,
       30_000,
       60_000,
-      null,
+      60_000,
+      60_000,
     ]);
   });
 

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -4,6 +4,7 @@ import {
   effectiveProtectionState,
   operationPhaseIsActive,
   protectionCompletionSummary,
+  protectionReconnectDelay,
   protectionRepairAction,
   protectionPresentation,
   recoveryKitSectionVisible,
@@ -48,8 +49,26 @@ describe("protectionPresentation", () => {
   it("does not imply local data loss while offline", () => {
     const result = protectionPresentation("offline");
 
-    expect(result.detail).toContain("safe here");
+    expect(result.detail).toContain("safe on this device");
+    expect(result.detail).toContain("retry automatically");
     expect(result.tone).toBe("warning");
+  });
+});
+
+describe("protectionReconnectDelay", () => {
+  it("backs off and then stops retrying", () => {
+    expect([0, 1, 2, 3, 4].map(protectionReconnectDelay)).toEqual([
+      5_000,
+      15_000,
+      30_000,
+      60_000,
+      null,
+    ]);
+  });
+
+  it("treats an invalid attempt as the first retry", () => {
+    expect(protectionReconnectDelay(Number.NaN)).toBe(5_000);
+    expect(protectionReconnectDelay(-3)).toBe(5_000);
   });
 });
 

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -284,9 +284,11 @@ const BACKUP_FAILURES = new Set([
 
 const PROTECTION_RECONNECT_DELAYS_MS = [5_000, 15_000, 30_000, 60_000] as const;
 
-export function protectionReconnectDelay(attempt: number): number | null {
+export function protectionReconnectDelay(attempt: number): number {
   const index = Number.isFinite(attempt) ? Math.max(0, Math.floor(attempt)) : 0;
-  return PROTECTION_RECONNECT_DELAYS_MS[index] ?? null;
+  return PROTECTION_RECONNECT_DELAYS_MS[
+    Math.min(index, PROTECTION_RECONNECT_DELAYS_MS.length - 1)
+  ];
 }
 
 export function protectionRepairAction(status: ProtectionStatus): ProtectionRepairAction {

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -282,6 +282,13 @@ const BACKUP_FAILURES = new Set([
   "store_busy",
 ]);
 
+const PROTECTION_RECONNECT_DELAYS_MS = [5_000, 15_000, 30_000, 60_000] as const;
+
+export function protectionReconnectDelay(attempt: number): number | null {
+  const index = Number.isFinite(attempt) ? Math.max(0, Math.floor(attempt)) : 0;
+  return PROTECTION_RECONNECT_DELAYS_MS[index] ?? null;
+}
+
 export function protectionRepairAction(status: ProtectionStatus): ProtectionRepairAction {
   if (status.protection_state === "verification_pending") return "verify";
   const reason = status.last_error_code;
@@ -364,7 +371,7 @@ export function protectionPresentation(state: ProtectionState): ProtectionPresen
       return {
         tone: "warning",
         title: "Cloud protection is offline",
-        detail: "Changes are safe here and will resume when the service is reachable.",
+        detail: "Ormah will retry automatically. Your changes remain safe on this device.",
         action: "retry",
       };
     case "paused":


### PR DESCRIPTION
## Problem

A single transient Ormah Cloud timeout can leave an already-open Protection panel showing **Cloud protection is offline** after connectivity has recovered. The user must manually retry, reopen the panel, or refresh through the CLI. This was observed on Desktop 0.3.19 while both `https://api.ormah.me` and the authenticated entitlement endpoint were healthy again.

## Solution

- While the Protection panel remains open, retry the canonical account + protection refresh after 5, 15, 30, and 60 seconds, then at a capped 60-second interval.
- Retry initial status-read failures too, including failures that occur before an offline status payload exists.
- Reset retry state immediately when protection recovers or the panel closes.
- Preserve the explicit repair action for users who do not want to wait.
- Explain that Ormah retries automatically and local changes remain safe.

This only refreshes status while the panel is visible. It does not silently start an upload or change protection settings.

## Verification

- `npm run build`
- `npm test -- --run` (21 passed)
- deterministic backoff/cap tests
- `git diff --check`

Fixes #197
