### PR TITLE
chore(release): prepare 0.14.7 and desktop 0.3.20

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.19"
+version = "0.3.20"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.6"
+version = "0.14.7"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Ormah Python package and Claude plugin to `0.14.7`
- bump Desktop app and Rust package to `0.3.20`
- pin one desktop release containing latest-verified restore, signed in-app updates, and cloud offline recovery

## Verification
- `python3.12 .github/release/verify_release_versions.py 0.14.7`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`

## Release order
1. Merge this PR.
2. Run the protected Python release workflow for `0.14.7`.
3. After PyPI confirms `0.14.7`, tag the same main commit `desktop-v0.3.20`.
