### PR TITLE
fix(release): provide repository context when publishing updater feed

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -233,7 +233,8 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#desktop-v}"
           BASE_URL="https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}"
-          gh release view "$GITHUB_REF_NAME" --json body --jq .body > release-notes.txt
+          REPO="${{ github.repository }}"
+          gh release view "$GITHUB_REF_NAME" -R "$REPO" --json body --jq .body > release-notes.txt
 
           APPIMAGE=$(find dist -name '*.AppImage' | head -1)
           DEB=$(find dist -name '*.deb' | head -1)
@@ -265,7 +266,6 @@ jobs:
           EOF
           cat latest.json
 
-          REPO="${{ github.repository }}"
           if gh release view desktop-latest -R "$REPO" > /dev/null 2>&1; then
             gh release upload desktop-latest latest.json --clobber -R "$REPO"
           else

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -114,6 +114,13 @@ class TestReleaseWorkflow:
         assert "id-token: write" in workflow
         assert "gh release create" in workflow
 
+    def test_desktop_publish_commands_have_explicit_repository_context(self):
+        root = Path(__file__).resolve().parents[1]
+        workflow = (root / ".github/workflows/desktop-release.yml").read_text()
+
+        assert 'REPO="${{ github.repository }}"' in workflow
+        assert 'gh release view "$GITHUB_REF_NAME" -R "$REPO"' in workflow
+
 
 class TestEvalCliFallback:
     def test_eval_command_exits_cleanly_when_harness_is_missing(self, monkeypatch, capsys):


### PR DESCRIPTION
## Problem

Desktop `0.3.20` built, signed, notarized, and uploaded successfully, but the final updater-feed publication step failed because the checkout-free publish job ran `gh release view` without an explicit repository. GitHub CLI attempted to discover `.git` and exited with `fatal: not a git repository`.

## Fix

- pass `-R "$REPO"` to the versioned release lookup
- define the repository before the first GitHub CLI call
- add a packaging regression test for explicit repository context

## Verification

- `uv run pytest tests/test_packaging.py -q` (`9 passed`)
- `uv run ruff check tests/test_packaging.py`
- `git diff --check`

The existing signed `0.3.20` artifacts remain valid; the rolling feed is repaired separately from those artifacts without rebuilding or bumping versions.
