### PR TITLE
fix(protection): keep backup visible and stop stranding a stale offline state

### DIFF
--- a/src/ormah/cloud/state.py
+++ b/src/ormah/cloud/state.py
@@ -663,6 +663,44 @@ def cloud_status_payload(
                 else ProtectionState.SIGN_IN_REQUIRED
             )
 
+    # A protection intent that outlived its expiry is finished, whatever the
+    # last write recorded. Reporting it as still pending or running invites
+    # callers to offer a "resume" that can only fail with intent_expired.
+    intent_status = state.pending_protection_status
+    intent_live = (
+        state.pending_protection_intent_id is not None
+        and intent_status not in TERMINAL_PROTECTION_INTENT_STATUSES
+    )
+    if (
+        intent_live
+        and state.pending_protection_expires_at is not None
+        and _as_utc(state.pending_protection_expires_at) <= now
+    ):
+        intent_status = ProtectionIntentStatus.EXPIRED
+        intent_live = False
+
+    # OFFLINE is durable: it is written when a cloud call fails and is only
+    # rewritten by the next operation. Nothing performs that next operation
+    # unless scheduled backups are enabled or an intent is still live, so a
+    # transient failure — a laptop whose resolver was not up yet at login —
+    # would otherwise strand the user forever on "Ormah will retry
+    # automatically" while nothing retries. Report the state the user can
+    # actually act on, and keep the original failure visible as the reason.
+    stranded_offline = (
+        protection_state is ProtectionState.OFFLINE
+        and not settings.cloud_backup_enabled
+        and not intent_live
+    )
+    if stranded_offline:
+        protection_state = ProtectionState.LOCAL_ONLY
+    if protection_state is ProtectionState.OFFLINE or stranded_offline:
+        detail = state.last_error_message or "Ormah Cloud could not be reached."
+        warnings.append(
+            f"The last Ormah Cloud attempt did not finish: {detail}"
+            if not stranded_offline
+            else f"Cloud protection was never finished setting up: {detail}"
+        )
+
     return {
         "schema_version": state.schema_version,
         "enabled": settings.cloud_backup_enabled,
@@ -674,7 +712,7 @@ def cloud_status_payload(
         "protection_enabled_at": _serialize_time(state.protection_enabled_at),
         "protection_disabled_at": _serialize_time(state.protection_disabled_at),
         "protection_intent_id": state.pending_protection_intent_id,
-        "protection_intent_status": _serialize_enum(state.pending_protection_status),
+        "protection_intent_status": _serialize_enum(intent_status),
         "protection_intent_created_at": _serialize_time(
             state.pending_protection_created_at
         ),

--- a/tests/test_cloud_state.py
+++ b/tests/test_cloud_state.py
@@ -615,3 +615,139 @@ def test_admin_cloud_status_is_thin_wrapper(monkeypatch):
 
     assert routes_admin.cloud_status(request) == expected
     assert any(route.path == "/admin/cloud-status" for route in routes_admin.router.routes)
+
+
+def _stranded_offline_state(memory_dir: Path, state_dir: Path, *, expires_at, status):
+    """The exact shape a failed first enable leaves behind: never enabled,
+    OFFLINE recorded once, and an intent that nothing will finish."""
+
+    store_id = str(uuid.uuid4())
+    intent_id = str(uuid.uuid4())
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    save_state(
+        store_id,
+        CloudState(
+            protection_state=ProtectionState.OFFLINE,
+            pending_protection_intent_id=intent_id,
+            pending_protection_store_id=store_id,
+            pending_protection_expires_at=expires_at,
+            pending_protection_status=status,
+            last_operation_id=intent_id,
+            last_operation_kind=ProtectionOperationKind.ENABLE,
+            last_operation_phase=ProtectionOperationPhase.FAILED,
+            last_error_code=ProtectionReasonCode.OFFLINE,
+            last_error_message=(
+                "Could not reach Ormah Cloud: [Errno 8] nodename nor servname "
+                "provided, or not known"
+            ),
+        ),
+        memory_dir=memory_dir,
+        state_dir=state_dir,
+    )
+    return intent_id
+
+
+def test_cloud_status_does_not_strand_a_never_enabled_store_on_a_stale_offline(tmp_path):
+    """A one-off resolver failure must not claim a retry that nobody will run.
+
+    Regression: a failed enable on a laptop whose DNS was not up yet left
+    protection_state=offline durably. Backups were never enabled and the intent
+    expired, so no operation ever rewrote it, and the panel kept promising
+    "Ormah will retry automatically" a week later.
+    """
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    state_dir = tmp_path / "state"
+    failed_at = datetime(2026, 8, 2, 14, 49, tzinfo=timezone.utc)
+    _stranded_offline_state(
+        memory_dir,
+        state_dir,
+        expires_at=failed_at + timedelta(minutes=30),
+        status=ProtectionIntentStatus.PENDING,
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=False),
+        entitlement="active",
+        now=failed_at + timedelta(days=7),
+        state_dir=state_dir,
+    )
+
+    assert payload["protection_state"] == ProtectionState.LOCAL_ONLY.value
+    assert payload["protection_intent_status"] == ProtectionIntentStatus.EXPIRED.value
+    assert any("nodename nor servname" in warning for warning in payload["warnings"])
+    assert any("never finished setting up" in warning for warning in payload["warnings"])
+
+
+def test_cloud_status_keeps_offline_while_scheduled_backups_still_retry(tmp_path):
+    """Offline is honest when the backup job is enabled — it really does retry."""
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    state_dir = tmp_path / "state"
+    failed_at = datetime(2026, 8, 2, 14, 49, tzinfo=timezone.utc)
+    _stranded_offline_state(
+        memory_dir,
+        state_dir,
+        expires_at=failed_at + timedelta(minutes=30),
+        status=ProtectionIntentStatus.COMPLETED,
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=True),
+        entitlement="active",
+        now=failed_at + timedelta(days=7),
+        state_dir=state_dir,
+    )
+
+    assert payload["protection_state"] == ProtectionState.OFFLINE.value
+    assert any("did not finish" in warning for warning in payload["warnings"])
+    assert any("nodename nor servname" in warning for warning in payload["warnings"])
+
+
+def test_cloud_status_keeps_offline_while_an_unexpired_intent_can_still_resume(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    state_dir = tmp_path / "state"
+    failed_at = datetime(2026, 8, 2, 14, 49, tzinfo=timezone.utc)
+    _stranded_offline_state(
+        memory_dir,
+        state_dir,
+        expires_at=failed_at + timedelta(minutes=30),
+        status=ProtectionIntentStatus.RUNNING,
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=False),
+        entitlement="active",
+        now=failed_at + timedelta(minutes=5),
+        state_dir=state_dir,
+    )
+
+    assert payload["protection_state"] == ProtectionState.OFFLINE.value
+    assert payload["protection_intent_status"] == ProtectionIntentStatus.RUNNING.value
+
+
+def test_cloud_status_never_offers_resume_for_an_expired_running_intent(tmp_path):
+    """An intent that expired mid-run is finished; "resume" could only fail."""
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    state_dir = tmp_path / "state"
+    failed_at = datetime(2026, 8, 2, 14, 49, tzinfo=timezone.utc)
+    _stranded_offline_state(
+        memory_dir,
+        state_dir,
+        expires_at=failed_at + timedelta(minutes=30),
+        status=ProtectionIntentStatus.RUNNING,
+    )
+
+    payload = cloud_status_payload(
+        Settings(memory_dir=memory_dir, cloud_backup_enabled=True),
+        entitlement="active",
+        now=failed_at + timedelta(hours=2),
+        state_dir=state_dir,
+    )
+
+    assert payload["protection_intent_status"] == ProtectionIntentStatus.EXPIRED.value

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -22,12 +22,14 @@ import {
   effectiveProtectionState,
   operationPhaseIsActive,
   productBridge,
+  protectionActions,
   protectionCompletionSummary,
   protectionPresentation,
   protectionReconnectDelay,
   protectionRepairAction,
   recoveryKitSectionVisible,
   type AccountStatus,
+  type ProtectionActionKind,
   type BillingOffer,
   type OperationPhase,
   type ProtectionOperation,
@@ -120,6 +122,15 @@ function operationLabel(
     default: return "Finishing protection check";
   }
 }
+
+const ACTION_ICONS: Record<ProtectionActionKind, JSX.Element> = {
+  signin: <LogIn size={16} />,
+  protect: <ShieldCheck size={16} />,
+  backup: <RefreshCw size={15} />,
+  verify: <ShieldCheck size={15} />,
+  repair: <RefreshCw size={15} />,
+  subscribe: <CreditCard size={15} />,
+};
 
 const PROTECTION_STAGES = [
   { phase: "preparing", label: "Create local recovery point" },
@@ -737,6 +748,38 @@ export default function ProtectionPanel({
     await refresh();
   }, [beginProtection, offer, refresh, repairAction, runOperation, status]);
 
+  const actions = useMemo(
+    () => protectionActions(
+      Boolean(account?.signed_in),
+      effectiveProtectionState(operation, status),
+      status,
+    ),
+    [account?.signed_in, operation, status],
+  );
+
+  const runProtectionAction = useCallback(async (kind: ProtectionActionKind) => {
+    switch (kind) {
+      case "signin":
+        setLoginPurpose("account");
+        setError(null);
+        setView("email");
+        return;
+      case "protect":
+        await beginProtection();
+        return;
+      case "backup":
+      case "verify":
+        await runOperation(kind);
+        return;
+      case "repair":
+        await runRepairAction();
+        return;
+      case "subscribe":
+        setView("checkout");
+        if (!offer) productBridge.offer().then(setOffer).catch(() => undefined);
+    }
+  }, [beginProtection, offer, runOperation, runRepairAction]);
+
   return (
     <aside className={`side-panel protection-panel ${open ? "open" : ""}`} aria-hidden={!open}>
       <div className="side-panel-header">
@@ -995,49 +1038,18 @@ export default function ProtectionPanel({
 
           {view === "summary" && !activeLabel && (
             <section className="protection-actions">
-              {!account?.signed_in && (
-                <button className="protection-primary" disabled={busy} onClick={() => {
-                  setLoginPurpose("account");
-                  setError(null);
-                  setView("email");
-                }}>
-                  <LogIn size={16} /> Sign in to Ormah Cloud
-                </button>
-              )}
-              {account?.signed_in && ["local_only", "sign_in_required", "stopped"].includes(status?.protection_state || "local_only") && (
-                <button className="protection-primary" disabled={busy} onClick={() => void beginProtection()}>
-                  <ShieldCheck size={16} /> Protect this memory
-                </button>
-              )}
-              {account?.signed_in && ["protected", "changes_pending"].includes(status?.protection_state || "") && (
-                <button className="protection-primary" disabled={busy} onClick={() => void runOperation("backup")}>
-                  <RefreshCw size={15} /> Back up now
-                </button>
-              )}
-              {account?.signed_in && status?.protection_state === "verification_pending" && (
-                <button className="protection-primary" disabled={busy} onClick={() => void runOperation("verify")}>
-                  <ShieldCheck size={15} /> Verify this recovery point
-                </button>
-              )}
-              {["attention_required", "offline"].includes(status?.protection_state || "") && repairAction !== "none" && (
-                <button className="protection-primary" disabled={busy} onClick={() => void runRepairAction()}>
-                  <RefreshCw size={15} />
-                  {repairAction === "verify" ? "Retry recovery check"
-                    : repairAction === "signin" ? "Sign in again"
-                      : repairAction === "subscribe" ? "Reactivate subscription"
-                        : repairAction === "refresh" ? "Check connection"
-                          : repairAction === "resume" ? "Resume protection"
-                            : "Retry encrypted backup"}
-                </button>
-              )}
-              {["subscription_required", "paused"].includes(status?.protection_state || "") && (
-                <button className="protection-primary" disabled={busy} onClick={() => {
-                  setView("checkout");
-                  if (!offer) productBridge.offer().then(setOffer).catch(() => undefined);
-                }}>
-                  <CreditCard size={15} /> Reactivate protection
-                </button>
-              )}
+              {actions.map((action) => (
+                <div className="protection-action" key={action.kind}>
+                  <button
+                    className={action.variant === "primary" ? "protection-primary" : "protection-secondary"}
+                    disabled={busy || action.disabled}
+                    onClick={() => void runProtectionAction(action.kind)}
+                  >
+                    {ACTION_ICONS[action.kind]} {action.label}
+                  </button>
+                  {action.reason && <p className="protection-action-reason">{action.reason}</p>}
+                </div>
+              ))}
             </section>
           )}
 

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -4,10 +4,13 @@ import {
   effectiveProtectionState,
   operationPhaseIsActive,
   protectionCompletionSummary,
+  protectionActions,
   protectionReconnectDelay,
   protectionRepairAction,
   protectionPresentation,
   recoveryKitSectionVisible,
+  type ProtectionAction,
+  type ProtectionActionKind,
   type ProtectionStatus,
   type ProtectionState,
 } from "./productBridge";
@@ -220,6 +223,142 @@ describe("effectiveProtectionState", () => {
     };
 
     expect(effectiveProtectionState(running, durable)).toBe("verifying_first_backup");
+  });
+});
+
+describe("protectionActions", () => {
+  const find = (
+    actions: ProtectionAction[],
+    kind: ProtectionActionKind,
+  ): ProtectionAction | undefined => actions.find((action) => action.kind === kind);
+
+  it("offers only sign-in before an account exists", () => {
+    const actions = protectionActions(false, "protected", status({}));
+
+    expect(actions.map((action) => action.kind)).toEqual(["signin"]);
+  });
+
+  it.each<ProtectionState>(["protected", "changes_pending"])(
+    "makes backup the single primary action in %s",
+    (state) => {
+      const actions = protectionActions(true, state, status({ protection_state: state }));
+
+      expect(actions).toEqual([{
+        kind: "backup",
+        label: "Back up now",
+        variant: "primary",
+        disabled: false,
+        reason: null,
+      }]);
+    },
+  );
+
+  it("prefers verification but keeps backup usable and explained when a check is pending", () => {
+    const actions = protectionActions(
+      true,
+      "verification_pending",
+      status({ protection_state: "verification_pending", last_error_code: null }),
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["verify", "backup"]);
+    expect(find(actions, "verify")?.variant).toBe("primary");
+
+    const backup = find(actions, "backup");
+    expect(backup?.label).toBe("Back up now");
+    expect(backup?.variant).toBe("secondary");
+    // A manual backup restore-tests its own upload, so it is slower here, not unsafe.
+    expect(backup?.disabled).toBe(false);
+    expect(backup?.reason).toContain("restore-tests that one instead");
+  });
+
+  it("keeps backup visible and explained while cloud protection is offline", () => {
+    const actions = protectionActions(
+      true,
+      "offline",
+      status({ protection_state: "offline", enabled: false }),
+    );
+
+    expect(find(actions, "repair")?.label).toBe("Check connection");
+    const backup = find(actions, "backup");
+    expect(backup?.disabled).toBe(true);
+    expect(backup?.reason).toContain("Ormah Cloud is unreachable");
+  });
+
+  it("does not duplicate backup when repair is itself the backup retry", () => {
+    const actions = protectionActions(
+      true,
+      "offline",
+      status({ protection_state: "offline", enabled: true }),
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["repair"]);
+    expect(find(actions, "repair")?.label).toBe("Retry encrypted backup");
+  });
+
+  it("blocks backup with a reason while an unrepairable failure stands", () => {
+    const actions = protectionActions(
+      true,
+      "attention_required",
+      status({ protection_state: "attention_required", last_error_code: "quota_exceeded" }),
+    );
+
+    expect(find(actions, "repair")).toBeUndefined();
+    const backup = find(actions, "backup");
+    expect(backup?.disabled).toBe(true);
+    expect(backup?.reason).toContain("Resolve the problem above");
+  });
+
+  it("keeps the repair path primary and backup explained during a verify failure", () => {
+    const actions = protectionActions(
+      true,
+      "attention_required",
+      status({ protection_state: "attention_required", last_error_code: "verification_failed" }),
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["repair", "backup"]);
+    expect(find(actions, "repair")?.label).toBe("Retry recovery check");
+    expect(find(actions, "backup")?.disabled).toBe(true);
+  });
+
+  it("never hides backup from a signed-in, protected store without saying why", () => {
+    const onboarding: ProtectionState[] = ["local_only", "sign_in_required", "stopped"];
+    const states: ProtectionState[] = [
+      "local_only",
+      "sign_in_required",
+      "subscription_required",
+      "initializing",
+      "uploading_first_backup",
+      "verifying_first_backup",
+      "verification_pending",
+      "protected",
+      "changes_pending",
+      "offline",
+      "paused",
+      "stopped",
+      "attention_required",
+    ];
+
+    for (const state of states) {
+      const actions = protectionActions(true, state, status({ protection_state: state }));
+
+      expect(actions.length).toBeGreaterThan(0);
+      for (const action of actions) {
+        if (action.disabled) expect(action.reason).toBeTruthy();
+      }
+
+      const backup = find(actions, "backup");
+      const repair = find(actions, "repair");
+      if (onboarding.includes(state)) {
+        // Protection does not exist yet; "Protect this memory" is the entry point.
+        expect(find(actions, "protect")).toBeDefined();
+        continue;
+      }
+      if (!backup) {
+        expect(repair?.label).toBe("Retry encrypted backup");
+        continue;
+      }
+      if (backup.disabled) expect(backup.reason).toBeTruthy();
+    }
   });
 });
 

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -238,20 +238,33 @@ describe("protectionActions", () => {
     expect(actions.map((action) => action.kind)).toEqual(["signin"]);
   });
 
-  it.each<ProtectionState>(["protected", "changes_pending"])(
-    "makes backup the single primary action in %s",
-    (state) => {
-      const actions = protectionActions(true, state, status({ protection_state: state }));
+  it("makes backup the single primary action when changes are unprotected", () => {
+    const actions = protectionActions(
+      true,
+      "changes_pending",
+      status({ protection_state: "changes_pending" }),
+    );
 
-      expect(actions).toEqual([{
-        kind: "backup",
-        label: "Back up now",
-        variant: "primary",
-        disabled: false,
-        reason: null,
-      }]);
-    },
-  );
+    expect(actions).toEqual([{
+      kind: "backup",
+      label: "Back up now",
+      variant: "primary",
+      disabled: false,
+      reason: null,
+    }]);
+  });
+
+  it("does not let a healthy store present backup as an outstanding task", () => {
+    // A primary button reads as "do this next". After a successful enable there
+    // is nothing to do, and the recovery-kit prompt is the real outstanding task.
+    const actions = protectionActions(true, "protected", status({ protection_state: "protected" }));
+
+    expect(actions.map((action) => action.kind)).toEqual(["backup"]);
+    const backup = find(actions, "backup");
+    expect(backup?.variant).toBe("secondary");
+    expect(backup?.disabled).toBe(false);
+    expect(backup?.reason).toContain("Already uploaded and restore-tested");
+  });
 
   it("prefers verification but keeps backup usable and explained when a check is pending", () => {
     const actions = protectionActions(

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -392,7 +392,20 @@ export function protectionActions(
         reason: null,
       }];
 
+    // Nothing is outstanding, so backup must not claim the primary slot: a
+    // full-width primary button reads as "do this next" and makes a healthy
+    // store look like it still owes work. It also has to lose that slot to the
+    // recovery-kit prompt, which is a genuine outstanding task.
     case "protected":
+      return [{
+        kind: "backup",
+        label: BACKUP_LABEL,
+        variant: "secondary",
+        disabled: false,
+        reason: "Already uploaded and restore-tested. Ormah backs up on a schedule;"
+          + " this captures changes since then straight away.",
+      }];
+
     case "changes_pending":
       return [{
         kind: "backup",

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -311,6 +311,154 @@ export function protectionRepairAction(status: ProtectionStatus): ProtectionRepa
   return "none";
 }
 
+export type ProtectionActionKind =
+  | "signin"
+  | "protect"
+  | "backup"
+  | "verify"
+  | "repair"
+  | "subscribe";
+
+export interface ProtectionAction {
+  kind: ProtectionActionKind;
+  label: string;
+  variant: "primary" | "secondary";
+  disabled: boolean;
+  /** Why the action is demoted or unavailable. Never null when disabled. */
+  reason: string | null;
+}
+
+const BACKUP_LABEL = "Back up now";
+
+const REPAIR_LABELS: Record<Exclude<ProtectionRepairAction, "none">, string> = {
+  verify: "Retry recovery check",
+  signin: "Sign in again",
+  subscribe: "Reactivate subscription",
+  refresh: "Check connection",
+  resume: "Resume protection",
+  backup: "Retry encrypted backup",
+};
+
+function blockedBackup(reason: string): ProtectionAction {
+  return {
+    kind: "backup",
+    label: BACKUP_LABEL,
+    variant: "secondary",
+    disabled: true,
+    reason,
+  };
+}
+
+/**
+ * The summary-view actions for one protection state.
+ *
+ * Backup is the product's core capability, so it never vanishes from a signed-in
+ * summary without a reason attached. States that cannot accept a new upload
+ * return it disabled and explained rather than omitted.
+ */
+export function protectionActions(
+  signedIn: boolean,
+  state: ProtectionState,
+  status: ProtectionStatus | null | undefined,
+): ProtectionAction[] {
+  if (!signedIn) {
+    return [{
+      kind: "signin",
+      label: "Sign in to Ormah Cloud",
+      variant: "primary",
+      disabled: false,
+      reason: null,
+    }];
+  }
+
+  const repair = status ? protectionRepairAction(status) : "none";
+  const repairButton: ProtectionAction[] = repair === "none" ? [] : [{
+    kind: "repair",
+    label: REPAIR_LABELS[repair],
+    variant: "primary",
+    disabled: false,
+    reason: null,
+  }];
+
+  switch (state) {
+    case "local_only":
+    case "sign_in_required":
+    case "stopped":
+      return [{
+        kind: "protect",
+        label: "Protect this memory",
+        variant: "primary",
+        disabled: false,
+        reason: null,
+      }];
+
+    case "protected":
+    case "changes_pending":
+      return [{
+        kind: "backup",
+        label: BACKUP_LABEL,
+        variant: "primary",
+        disabled: false,
+        reason: null,
+      }];
+
+    case "verification_pending":
+      // A manual backup uploads *and* restore-tests the new snapshot, so it is
+      // safe here — only slower and more bandwidth than checking what is
+      // already uploaded. Demote it, do not block it.
+      return [
+        {
+          kind: "verify",
+          label: "Verify this recovery point",
+          variant: "primary",
+          disabled: false,
+          reason: null,
+        },
+        {
+          kind: "backup",
+          label: BACKUP_LABEL,
+          variant: "secondary",
+          disabled: false,
+          reason:
+            "Uploads another recovery point and restore-tests that one instead."
+            + " Checking the backup you already uploaded is faster.",
+        },
+      ];
+
+    case "offline":
+    case "attention_required": {
+      // When repair *is* the backup retry, a second backup button would be a
+      // duplicate of the primary action.
+      if (repair === "backup") return repairButton;
+      return [
+        ...repairButton,
+        blockedBackup(
+          state === "offline"
+            ? "Ormah Cloud is unreachable. Ormah keeps retrying, and your changes stay safe on this device."
+            : "Resolve the problem above before creating another recovery point.",
+        ),
+      ];
+    }
+
+    case "subscription_required":
+    case "paused":
+      return [
+        {
+          kind: "subscribe",
+          label: "Reactivate protection",
+          variant: "primary",
+          disabled: false,
+          reason: null,
+        },
+        blockedBackup("An active subscription is required to upload new recovery points."),
+      ];
+
+    default:
+      // initializing, uploading_first_backup, verifying_first_backup
+      return [blockedBackup("Ormah is already working on this recovery point.")];
+  }
+}
+
 export function protectionPresentation(state: ProtectionState): ProtectionPresentation {
   switch (state) {
     case "sign_in_required":
@@ -352,7 +500,8 @@ export function protectionPresentation(state: ProtectionState): ProtectionPresen
       return {
         tone: "warning",
         title: "Recovery check needed",
-        detail: "The encrypted backup is uploaded but has not yet passed a restore test.",
+        detail: "Your newest encrypted backup is uploaded but has not yet passed a restore test."
+          + " Verify it before creating another recovery point.",
         action: "retry",
       };
     case "protected":

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1399,6 +1399,15 @@ body.in-app .node-detail.tier-core {
   opacity: 0.5;
 }
 
+.protection-action + .protection-action { margin-top: 10px; }
+
+.protection-action-reason {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
 .protection-offer {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
Two independent defects, diagnosed and fixed separately.

## 1 — `Back up now` disappeared

Every protection state rendered its own hardcoded button, so backup was
present only in `protected` and `changes_pending`. In `verification_pending`,
`offline`, `attention_required`, `subscription_required`, and `paused` it
vanished with no explanation — which reads as a deleted feature.

Action choice now comes from `protectionActions()`, a pure function the panel
renders. Backup is present for every signed-in state, demoted or disabled with
a stated reason rather than dropped.

One correction to the original diagnosis: in `verification_pending`, backup is
kept **enabled**, not disabled. `Back up now` posts to `/protection/backup` →
`backup_and_verify()`, which uploads *and* restore-tests that exact snapshot,
so it fully resolves the state. It is slower and uses more bandwidth than
checking the upload you already have — not unsafe. Verification takes the
primary slot; backup is secondary with that reason shown.

Overlapping operations remain prevented by the panel's `busy` flag and the
server's `StoreLock` (which returns a typed `store_busy` outcome). The
"latest verified backup only" restore design is untouched.

## 2 — Mac reported it could not connect

Diagnosed on the affected Apple Silicon Mac. Boundary-by-boundary evidence:

| Boundary | Result |
|---|---|
| `ormah --version` | `0.14.7` |
| Daemon on `127.0.0.1:8787` | listening, `/admin/health` → `200 ok` |
| `https://api.ormah.me/healthz` | `200`, `{"status":"ready","protocol_version":2}` |
| `https://api.ormah.me/protocol` | `200`, DNS + TLS fine |
| Local admin token | present, `0600`, valid 64-hex |
| `/admin/account/status` | `200`, signed in, entitlement `active` |

Nothing was failing live. `/admin/cloud/protection` returned the real cause:

```
"protection_state": "offline",
"enabled": false,
"protection_intent_status": "pending",
"protection_intent_expires_at": "2026-08-02T15:19:52Z",
"last_error_code": "offline",
"last_error_message": "Could not reach Ormah Cloud: [Errno 8] nodename nor servname provided, or not known"
```

`[Errno 8]` is a macOS `getaddrinfo` failure — the daemon is started by
`launchd` at login and lost that race with the resolver once, on **2 Aug**.

`protection_state` is durable: written on failure, rewritten only by the next
operation. Scheduled backups were disabled (`enabled: false` — protection was
never successfully enabled) and the intent expired 30 minutes later, so no
operation ever ran and the state never changed. A week later the panel still
said *"Cloud protection is offline — Ormah will retry automatically."* Nothing
was retrying. `protectionRepairAction` returned `refresh` for that combination,
so the only offered repair re-read the same frozen record.

`cloud_status_payload` now:
- reports `local_only` when `offline` is recorded, backups are disabled, and no
  live intent exists — nothing retries, so the panel offers `Protect this
  memory`, a path that actually works;
- keeps `offline` when scheduled backups or a live intent genuinely will retry;
- surfaces the original failure text as a warning instead of a generic message;
- reports an intent past its expiry as `expired`, so callers stop offering a
  `resume` that could only fail with `intent_expired`.

Durable state is not mutated — this is presentation only.

Verified against the affected Mac's live state, read-only:

```
protection_state  : local_only          (was: offline)
intent_status     : expired             (was: pending)
warning           : Cloud protection was never finished setting up: Could not
                    reach Ormah Cloud: [Errno 8] nodename nor servname provided,
                    or not known
```

Recovery needs no reboot and no daemon restart once this ships.

## Tests

- `ui`: 32 passed — new `protectionActions` coverage for `protected`,
  `changes_pending`, `verification_pending`, `offline`, `attention_required`,
  plus an invariant that no signed-in state hides backup without a reason.
- Python: 1830 passed, `ruff` clean — 4 new `test_cloud_state.py` regressions
  built from the captured Mac state, covering the stranded case, both cases
  where `offline` is still honest, and the expired-`running` intent.
- Rust: 28 passed (unchanged).

Not released or merged.