### PR TITLE
feat(protection): show this device against the cloud, and which way to move

### DIFF
--- a/desktop/src-tauri/permissions/desktop.toml
+++ b/desktop/src-tauri/permissions/desktop.toml
@@ -26,6 +26,7 @@ commands.allow = [
   "logout_account",
   "billing_offer",
   "protection_status",
+  "remote_snapshot",
   "create_protection_intent",
   "bind_protection_intent",
   "cancel_protection_intent",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -176,6 +176,7 @@ pub fn run() {
             product_bridge::logout_account,
             product_bridge::billing_offer,
             product_bridge::protection_status,
+            product_bridge::remote_snapshot,
             product_bridge::create_protection_intent,
             product_bridge::bind_protection_intent,
             product_bridge::cancel_protection_intent,

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -191,6 +191,12 @@ pub async fn protection_status(window: WebviewWindow) -> Result<Value, String> {
 }
 
 #[tauri::command]
+pub async fn remote_snapshot(window: WebviewWindow) -> Result<Value, String> {
+    require_product_origin(&window)?;
+    request_sanitized("GET", "/admin/cloud/protection/remote", None).await
+}
+
+#[tauri::command]
 pub async fn create_protection_intent(window: WebviewWindow) -> Result<Value, String> {
     require_product_origin(&window)?;
     request_sanitized("POST", "/admin/cloud/protection/intents", Some(json!({}))).await

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -1259,4 +1259,34 @@ mod tests {
             );
         }
     }
+
+    /// The invoke handler exposing a command is not enough: Tauri also gates it
+    /// on the capability ACL, and a command missing there fails only at
+    /// runtime, in the webview, with nothing at compile time to catch it.
+    #[test]
+    fn every_bridge_command_is_allowed_by_the_product_capability() {
+        let lib_rs = include_str!("lib.rs");
+        let permissions = include_str!("../permissions/desktop.toml");
+        let allowed = permissions
+            .split_once("identifier = \"desktop-product-bridge\"")
+            .expect("product bridge permission set is missing")
+            .1;
+
+        let handled: Vec<&str> = lib_rs
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix("product_bridge::"))
+            .filter_map(|rest| rest.strip_suffix(','))
+            .collect();
+
+        assert!(handled.len() > 20, "expected the full bridge handler list");
+        for command in handled {
+            assert!(
+                allowed.contains(&format!("\"{command}\"")),
+                "command `{command}` is registered in the invoke handler but not \
+                 allowed by the desktop-product-bridge capability; the product UI \
+                 would be denied at runtime",
+            );
+        }
+    }
+
 }

--- a/src/ormah/api/routes_protection.py
+++ b/src/ormah/api/routes_protection.py
@@ -14,6 +14,7 @@ from ormah.cloud.entitlements import load_entitlement_cache, status_from_cache
 from ormah.cloud.operations import ProtectionOperationCoordinator
 from ormah.cloud.protection import CloudProtectionService, safe_product_error_message
 from ormah.cloud.recovery import RecoveryKitError, RecoveryKitService
+from ormah.cloud.restore import CloudRestoreError, newest_cloud_snapshot
 from ormah.cloud.state import (
     CloudStateError,
     ProtectionOperation,
@@ -169,6 +170,56 @@ def protection_status(request: Request):
         for warning in payload.get("warnings", [])
     ]
     return payload
+
+
+@router.get("/remote")
+def remote_snapshot(request: Request):
+    """Describe the newest cloud backup, including one uploaded by another device.
+
+    Local state records only this device's own uploads and verifications, so a
+    second machine's backup cannot be seen without asking the cloud. Failures
+    degrade to a redacted reason instead of an error status: not knowing what
+    the cloud holds must never take the protection panel down.
+    """
+
+    settings = request.app.state.engine.settings
+    unavailable = {
+        "snapshot_id": None,
+        "created_at": None,
+        "size_bytes": None,
+        "from_this_device": False,
+        "restore_tested_here": False,
+        "error": None,
+    }
+    try:
+        newest = newest_cloud_snapshot(settings)
+    except CloudRestoreError as exc:
+        return {
+            **unavailable,
+            "error": safe_product_error_message(
+                str(exc), getattr(settings, "account_token", None)
+            ),
+        }
+    except Exception as exc:
+        return {
+            **unavailable,
+            "error": safe_product_error_message(
+                f"Could not read cloud backups: {exc}",
+                getattr(settings, "account_token", None),
+            ),
+        }
+    if newest is None:
+        return unavailable
+
+    state = cloud_status_payload(settings, entitlement=_cached_entitlement(settings))
+    snapshot_id = newest["snapshot_id"]
+    return {
+        **newest,
+        "from_this_device": snapshot_id == state.get("last_successful_backup_snapshot_id"),
+        # A device can only vouch for a check it ran itself.
+        "restore_tested_here": snapshot_id == state.get("last_verified_snapshot_id"),
+        "error": None,
+    }
 
 
 @router.post("/intents")

--- a/src/ormah/cloud/restore.py
+++ b/src/ormah/cloud/restore.py
@@ -111,6 +111,43 @@ def _committed_blobs(client, store_id: str) -> list[dict[str, Any]]:
     return [blob for blob in blobs if isinstance(blob, dict)]
 
 
+def newest_cloud_snapshot(settings) -> dict[str, Any] | None:
+    """Describe the newest committed snapshot without downloading anything.
+
+    A device records only its own uploads, so a second machine's backup is
+    invisible in local state. One listing call closes that gap: snapshot ids
+    are server-generated ULIDs, so the newest is the lexical maximum. Nothing
+    is decrypted and no cloud-visible metadata is added — the listing already
+    carries these fields.
+    """
+
+    if not settings.account_token:
+        raise CloudRestoreError(
+            "Ormah Cloud login is required before reading cloud backups.",
+            "sign_in_required",
+        )
+    store_id = _existing_store_id(settings.memory_dir)
+    client = client_from_settings(settings)
+    try:
+        blobs = _committed_blobs(client, store_id)
+    finally:
+        close = getattr(client, "close", None)
+        if close is not None:
+            try:
+                close()
+            except Exception:
+                pass
+    if not blobs:
+        return None
+    newest = max(blobs, key=_snapshot_id)
+    size = newest.get("size_bytes")
+    return {
+        "snapshot_id": _snapshot_id(newest),
+        "created_at": _snapshot_created_at(newest),
+        "size_bytes": size if isinstance(size, int) and size >= 0 else None,
+    }
+
+
 def _candidate_blobs(
     blobs: list[dict[str, Any]], requested: str | None
 ) -> list[dict[str, Any]]:

--- a/tests/test_api/test_protection_routes.py
+++ b/tests/test_api/test_protection_routes.py
@@ -597,3 +597,90 @@ def test_recovery_confirmation_failure_does_not_leak_service_error(protection_ap
     assert response.status_code == 409
     assert response.json() == {"detail": "The saved recovery kit could not be verified."}
     assert "secret" not in response.text.lower()
+
+
+def test_remote_reports_a_backup_made_by_another_device(protection_app, monkeypatch):
+    """The only signal a second machine leaves is a snapshot this device did not upload."""
+
+    client, _, _, _ = protection_app
+    monkeypatch.setattr(
+        routes_protection,
+        "cloud_status_payload",
+        lambda settings, **kwargs: {
+            "last_successful_backup_snapshot_id": "01MINE",
+            "last_verified_snapshot_id": "01MINE",
+        },
+    )
+    monkeypatch.setattr(
+        routes_protection,
+        "newest_cloud_snapshot",
+        lambda settings: {
+            "snapshot_id": "01THEIRS",
+            "created_at": "2026-08-09T09:14:00+00:00",
+            "size_bytes": 1238414,
+        },
+    )
+
+    payload = client.get("/admin/cloud/protection/remote", headers=HEADERS).json()
+
+    assert payload["snapshot_id"] == "01THEIRS"
+    assert payload["from_this_device"] is False
+    # This device never checked that snapshot, so it cannot vouch for it.
+    assert payload["restore_tested_here"] is False
+    assert payload["error"] is None
+
+
+def test_remote_recognises_this_devices_own_verified_upload(protection_app, monkeypatch):
+    client, _, _, _ = protection_app
+    monkeypatch.setattr(
+        routes_protection,
+        "cloud_status_payload",
+        lambda settings, **kwargs: {
+            "last_successful_backup_snapshot_id": "01MINE",
+            "last_verified_snapshot_id": "01MINE",
+        },
+    )
+    monkeypatch.setattr(
+        routes_protection,
+        "newest_cloud_snapshot",
+        lambda settings: {
+            "snapshot_id": "01MINE",
+            "created_at": "2026-08-09T17:03:44+00:00",
+            "size_bytes": 10,
+        },
+    )
+
+    payload = client.get("/admin/cloud/protection/remote", headers=HEADERS).json()
+
+    assert payload["from_this_device"] is True
+    assert payload["restore_tested_here"] is True
+
+
+def test_remote_degrades_without_taking_the_panel_down(protection_app, monkeypatch):
+    """Not knowing what the cloud holds must never break protection status."""
+
+    client, _, _, _ = protection_app
+
+    def unreachable(settings):
+        raise RuntimeError("nodename nor servname provided: never-return-this-token")
+
+    monkeypatch.setattr(routes_protection, "newest_cloud_snapshot", unreachable)
+
+    response = client.get("/admin/cloud/protection/remote", headers=HEADERS)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["snapshot_id"] is None
+    assert payload["from_this_device"] is False
+    assert payload["error"]
+    assert "never-return-this-token" not in response.text
+
+
+def test_remote_reports_an_empty_store_without_error(protection_app, monkeypatch):
+    client, _, _, _ = protection_app
+    monkeypatch.setattr(routes_protection, "newest_cloud_snapshot", lambda settings: None)
+
+    payload = client.get("/admin/cloud/protection/remote", headers=HEADERS).json()
+
+    assert payload["snapshot_id"] is None
+    assert payload["error"] is None

--- a/tests/test_cli_cloud_backup.py
+++ b/tests/test_cli_cloud_backup.py
@@ -366,3 +366,98 @@ def test_cli_restore_rejects_missing_source(capsys):
         main()
 
     assert "Provide a local backup name or use --cloud" in capsys.readouterr().err
+
+
+def test_newest_cloud_snapshot_picks_the_lexical_maximum_without_downloading(
+    tmp_path, monkeypatch
+):
+    """Snapshot ids are server-generated ULIDs, so newest is the lexical max.
+
+    Listing order is not guaranteed, and nothing may be downloaded or decrypted
+    just to answer "what does the cloud hold?".
+    """
+
+    from ormah.cloud import restore
+
+    store_id = str(uuid.uuid4())
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    settings = Settings(memory_dir=memory_dir, account_token="test-token")
+
+    listed = {
+        "blobs": [
+            {
+                "snapshot_id": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+                "size_bytes": 10,
+                "created_at": "2026-08-01T10:00:00+00:00",
+            },
+            {
+                "snapshot_id": "01KZKQNY89FGP5CTS04GT7Y3JX",
+                "size_bytes": 1238414,
+                "created_at": "2026-08-09T17:03:44+00:00",
+            },
+            {
+                "snapshot_id": "01KZKNPSKVN8CQYRP9K9PHB67K",
+                "size_bytes": 1319221,
+                "created_at": "2026-08-09T16:29:16+00:00",
+            },
+        ]
+    }
+
+    class ListingClient:
+        def __init__(self):
+            self.closed = False
+
+        def list_blobs(self, requested_store_id):
+            assert requested_store_id == store_id
+            return listed
+
+        def close(self):
+            self.closed = True
+
+    client = ListingClient()
+    monkeypatch.setattr(restore, "client_from_settings", lambda settings: client)
+
+    def refuse(*args, **kwargs):
+        raise AssertionError("listing must not download a bundle")
+
+    monkeypatch.setattr(restore, "download_file", refuse)
+
+    newest = restore.newest_cloud_snapshot(settings)
+
+    assert newest["snapshot_id"] == "01KZKQNY89FGP5CTS04GT7Y3JX"
+    assert newest["created_at"] == "2026-08-09T17:03:44+00:00"
+    assert newest["size_bytes"] == 1238414
+    assert client.closed is True
+
+
+def test_newest_cloud_snapshot_reports_an_empty_store_as_nothing(tmp_path, monkeypatch):
+    from ormah.cloud import restore
+
+    store_id = str(uuid.uuid4())
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    (memory_dir / ".store_id").write_text(store_id + "\n", encoding="utf-8")
+    settings = Settings(memory_dir=memory_dir, account_token="test-token")
+
+    class EmptyClient:
+        def list_blobs(self, requested_store_id):
+            return {"blobs": []}
+
+    monkeypatch.setattr(restore, "client_from_settings", lambda settings: EmptyClient())
+
+    assert restore.newest_cloud_snapshot(settings) is None
+
+
+def test_newest_cloud_snapshot_requires_sign_in(tmp_path):
+    from ormah.cloud import restore
+
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    settings = Settings(memory_dir=memory_dir, account_token=None)
+
+    with pytest.raises(restore.CloudRestoreError) as excinfo:
+        restore.newest_cloud_snapshot(settings)
+
+    assert excinfo.value.reason_code == "sign_in_required"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -326,6 +326,7 @@ export default function App() {
       />
       <ProtectionPanel
         open={activePanel === "protection"}
+        nodeCount={graph.nodes.length}
         onClose={() => setActivePanel(null)}
         onToast={addToast}
         onStatusChange={handleProtectionStatusChange}

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
+  ArrowUpDown,
   Check,
   ChevronRight,
   Circle,
@@ -24,12 +25,14 @@ import {
   productBridge,
   protectionActions,
   protectionCompletionSummary,
+  transferState,
   protectionPresentation,
   protectionReconnectDelay,
   protectionRepairAction,
   recoveryKitSectionVisible,
   type AccountStatus,
   type ProtectionActionKind,
+  type RemoteSnapshot,
   type BillingOffer,
   type OperationPhase,
   type ProtectionOperation,
@@ -39,6 +42,8 @@ import RecoveryKitSection from "./RecoveryKitSection";
 
 interface Props {
   open: boolean;
+  /** Total memories on this device, for the device-versus-cloud comparison. */
+  nodeCount?: number | null;
   onClose: () => void;
   onToast: (message: string, type?: "success" | "error" | "info") => void;
   onStatusChange?: (status: ProtectionStatus) => void;
@@ -98,28 +103,28 @@ function operationLabel(
     switch (phase) {
       case "pending": return "Queued";
       case "running":
-      case "discovering": return "Finding your latest recovery point";
+      case "discovering": return "Finding your newest backup";
       case "downloading": return "Downloading encrypted memory";
       case "decrypting": return "Decrypting on this device";
       case "checking": return "Checking every memory file";
       case "safety_backup": return "Protecting your current memory first";
-      case "restoring": return "Restoring verified memory";
+      case "restoring": return "Restoring proven memory";
       case "rebuilding": return "Rebuilding local search";
       case "reloading": return "Refreshing your memory graph";
-      default: return "Finishing recovery";
+      default: return "Finishing restore";
     }
   }
   switch (phase) {
     case "pending": return "Queued";
     case "running":
-    case "preparing": return "Creating a local recovery point";
+    case "preparing": return "Preparing a backup";
     case "encrypting": return "Encrypting on this device";
     case "uploading": return "Uploading encrypted data";
-    case "finalizing": return "Securing the cloud recovery point";
-    case "downloading": return "Downloading a temporary recovery test";
+    case "finalizing": return "Securing the cloud backup";
+    case "downloading": return "Downloading a temporary test copy";
     case "verifying": return "Decrypting and checking every file";
     case "rebuilding": return "Rebuilding memory and testing search";
-    default: return "Finishing protection check";
+    default: return "Finishing the check";
   }
 }
 
@@ -127,23 +132,24 @@ const ACTION_ICONS: Record<ProtectionActionKind, JSX.Element> = {
   signin: <LogIn size={16} />,
   protect: <ShieldCheck size={16} />,
   backup: <RefreshCw size={15} />,
+  restore: <CloudDownload size={15} />,
   verify: <ShieldCheck size={15} />,
   repair: <RefreshCw size={15} />,
   subscribe: <CreditCard size={15} />,
 };
 
 const PROTECTION_STAGES = [
-  { phase: "preparing", label: "Create local recovery point" },
+  { phase: "preparing", label: "Prepare a backup" },
   { phase: "encrypting", label: "Encrypt on this device" },
   { phase: "uploading", label: "Upload encrypted data" },
-  { phase: "finalizing", label: "Secure cloud recovery point" },
+  { phase: "finalizing", label: "Secure the cloud backup" },
   { phase: "downloading", label: "Download a temporary test copy" },
   { phase: "verifying", label: "Decrypt and check every file" },
   { phase: "rebuilding", label: "Rebuild memory and test search" },
 ] as const;
 
 const RESTORE_PREPARE_STAGES = [
-  { phase: "discovering", label: "Find latest recovery point" },
+  { phase: "discovering", label: "Find the newest backup" },
   { phase: "downloading", label: "Download encrypted memory" },
   { phase: "decrypting", label: "Decrypt on this device" },
   { phase: "checking", label: "Check files, identity, and search" },
@@ -151,7 +157,7 @@ const RESTORE_PREPARE_STAGES = [
 
 const RESTORE_APPLY_STAGES = [
   { phase: "safety_backup", label: "Save current memory locally" },
-  { phase: "restoring", label: "Replace with verified recovery point" },
+  { phase: "restoring", label: "Replace with the proven backup" },
   { phase: "rebuilding", label: "Rebuild local search" },
   { phase: "reloading", label: "Refresh the memory graph" },
 ] as const;
@@ -171,11 +177,11 @@ function restorePhaseIndex(
 
 function operationSuccessMessage(operation: ProtectionOperation): string {
   switch (operation.kind) {
-    case "enable": return "Memory protected and verified.";
-    case "backup": return "Encrypted recovery point uploaded and restore-tested.";
-    case "verify": return "Recovery point verified.";
+    case "enable": return "Memory backed up and proven to restore.";
+    case "backup": return "Encrypted backup uploaded and proven to restore.";
+    case "verify": return "Backup proven to restore.";
     case "disable": return "Future cloud backups stopped.";
-    case "restore": return "Latest verified memory restored.";
+    case "restore": return "Newest backup restored.";
     default: return "Operation completed.";
   }
 }
@@ -188,6 +194,7 @@ function errorMessage(value: unknown, fallback: string): string {
 
 export default function ProtectionPanel({
   open,
+  nodeCount = null,
   onClose,
   onToast,
   onStatusChange,
@@ -195,6 +202,7 @@ export default function ProtectionPanel({
 }: Props) {
   const [account, setAccount] = useState<AccountStatus | null>(null);
   const [status, setStatus] = useState<ProtectionStatus | null>(null);
+  const [remote, setRemote] = useState<RemoteSnapshot | null>(null);
   const [offer, setOffer] = useState<BillingOffer | null>(null);
   const [operation, setOperation] = useState<ProtectionOperation | null>(null);
   const [view, setView] = useState<View>("summary");
@@ -238,6 +246,12 @@ export default function ProtectionPanel({
       setRefreshFailed(false);
       onStatusChange?.(nextStatus);
       setError(null);
+      // One listing call, and only for a store that has something in the
+      // cloud. A failure here costs the device-versus-cloud comparison, never
+      // the panel itself, so it is deliberately not awaited into the catch.
+      if (nextStatus.enabled || nextStatus.store_id) {
+        productBridge.remoteSnapshot().then(setRemote).catch(() => setRemote(null));
+      }
       if (nextAccount.signed_in && !offerRequested.current) {
         offerRequested.current = true;
         productBridge.offer().then(setOffer).catch(() => {
@@ -664,7 +678,7 @@ export default function ProtectionPanel({
 
   const activeOperation = operationIsActive(operation);
   const presentation = useMemo(
-    () => protectionPresentation(effectiveProtectionState(operation, status)),
+    () => protectionPresentation(effectiveProtectionState(operation, status), status),
     [operation, status],
   );
   const price = formatPrice(offer);
@@ -753,9 +767,12 @@ export default function ProtectionPanel({
       Boolean(account?.signed_in),
       effectiveProtectionState(operation, status),
       status,
+      remote,
     ),
-    [account?.signed_in, operation, status],
+    [account?.signed_in, operation, remote, status],
   );
+
+  const transfer = useMemo(() => transferState(status, remote), [remote, status]);
 
   const runProtectionAction = useCallback(async (kind: ProtectionActionKind) => {
     switch (kind) {
@@ -770,6 +787,9 @@ export default function ProtectionPanel({
       case "backup":
       case "verify":
         await runOperation(kind);
+        return;
+      case "restore":
+        await beginRestore();
         return;
       case "repair":
         await runRepairAction();
@@ -1036,6 +1056,37 @@ export default function ProtectionPanel({
             </section>
           )}
 
+          {view === "summary" && !activeLabel && status?.enabled && (
+            <section className="protection-machines" aria-label="This device and the cloud">
+              <div className="protection-machine">
+                <span>This device</span>
+                <strong>{nodeCount === null ? "—" : `${new Intl.NumberFormat().format(nodeCount)} memories`}</strong>
+                <span>backed up {formatDate(status.last_successful_upload_at)}</span>
+              </div>
+              <div className="protection-machine-link" aria-hidden="true"><ArrowUpDown size={15} /></div>
+              <div className="protection-machine">
+                <span>Cloud</span>
+                {/* Not being able to read the listing is not the same as the
+                    cloud being empty, and must never be shown as one. */}
+                <strong>{
+                  !remote || remote.error
+                    ? "unavailable"
+                    : remote.created_at
+                      ? `newest ${formatDate(remote.created_at)}`
+                      : "no backup yet"
+                }</strong>
+                {remote?.snapshot_id && (
+                  <span>{remote.from_this_device ? "from this device" : "from another device"}</span>
+                )}
+                {remote?.restore_tested_here && <span className="protection-proven">proven to restore</span>}
+              </div>
+            </section>
+          )}
+
+          {view === "summary" && !activeLabel && transfer.headline && (
+            <p className={`protection-direction direction-${transfer.direction}`}>{transfer.headline}</p>
+          )}
+
           {view === "summary" && !activeLabel && (
             <section className="protection-actions">
               {actions.map((action) => (
@@ -1050,29 +1101,6 @@ export default function ProtectionPanel({
                   {action.reason && <p className="protection-action-reason">{action.reason}</p>}
                 </div>
               ))}
-            </section>
-          )}
-
-          {view === "summary" && !activeLabel && (
-            <section className="restore-entry">
-              <div>
-                <CloudDownload size={17} />
-                <div>
-                  <strong>Recover this memory</strong>
-                  <span>Restore the latest cloud recovery point that passes local checks.</span>
-                </div>
-              </div>
-              <button className="protection-secondary" disabled={busy} onClick={() => void beginRestore()}>
-                Restore latest verified backup
-              </button>
-            </section>
-          )}
-
-          {(status?.last_successful_verify_at || status?.last_successful_upload_at) && (
-            <section className="protection-facts" aria-label="Protection details">
-              <div><span>Last verified restorable</span><strong>{formatDate(status.last_successful_verify_at)}</strong></div>
-              <div><span>Last encrypted upload</span><strong>{formatDate(status.last_successful_upload_at)}</strong></div>
-              <div><span>Cloud can read</span><strong>metadata only</strong></div>
             </section>
           )}
 

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -9,10 +9,13 @@ import {
   protectionRepairAction,
   protectionPresentation,
   recoveryKitSectionVisible,
+  transferState,
+  verificationIsOverdue,
   type ProtectionAction,
   type ProtectionActionKind,
   type ProtectionStatus,
   type ProtectionState,
+  type RemoteSnapshot,
 } from "./productBridge";
 
 describe("protectionPresentation", () => {
@@ -27,25 +30,38 @@ describe("protectionPresentation", () => {
     expect(result.action).toBe("wait");
   });
 
-  it("makes an uploaded but unchecked backup an explicit recovery action", () => {
+  it("warns about an unchecked upload only when no check has ever passed", () => {
     const result = protectionPresentation("verification_pending");
 
-    expect(result.title).toBe("Recovery check needed");
+    expect(result.title).toBe("Backup not proven restorable");
     expect(result.tone).toBe("warning");
     expect(result.action).toBe("retry");
   });
 
-  it("uses the verified claim only for the protected state", () => {
+  it("stays calm while a routine weekly check is still pending", () => {
+    // Daily uploads and weekly checks make this the normal resting state; an
+    // amber panel six days in seven trains the user to ignore it.
+    const result = protectionPresentation(
+      "verification_pending",
+      status({ last_successful_verify_at: new Date(Date.now() - 86_400_000).toISOString() }),
+    );
+
+    expect(result.tone).toBe("success");
+    expect(result.title).toBe("Protected");
+  });
+
+  it("uses the proven claim only for the protected state", () => {
     const result = protectionPresentation("protected");
 
-    expect(result.title).toBe("Protected and verified");
+    expect(result.title).toBe("Protected");
+    expect(result.detail).toContain("prove it restores");
     expect(result.tone).toBe("success");
   });
 
-  it("keeps retained recovery points explicit when uploads stop", () => {
+  it("keeps retained backups explicit when uploads stop", () => {
     const result = protectionPresentation("stopped");
 
-    expect(result.detail).toContain("recovery points remain available");
+    expect(result.detail).toContain("Existing backups remain available");
     expect(result.action).toBe("resume");
   });
 
@@ -226,6 +242,81 @@ describe("effectiveProtectionState", () => {
   });
 });
 
+describe("verificationIsOverdue", () => {
+  const now = Date.parse("2026-08-09T18:00:00Z");
+
+  it("treats a never-proven backup as overdue", () => {
+    expect(verificationIsOverdue(status({ last_successful_verify_at: null }), now)).toBe(true);
+    expect(verificationIsOverdue(null, now)).toBe(true);
+  });
+
+  it("tolerates one missed weekly check before calling it overdue", () => {
+    // Uploads are daily and checks weekly, so an unchecked upload is normal.
+    expect(verificationIsOverdue(
+      status({ last_successful_verify_at: "2026-08-04T18:00:00Z" }),
+      now,
+    )).toBe(false);
+    expect(verificationIsOverdue(
+      status({ last_successful_verify_at: "2026-07-20T18:00:00Z" }),
+      now,
+    )).toBe(true);
+  });
+});
+
+function remote(overrides: Partial<RemoteSnapshot> = {}): RemoteSnapshot {
+  return {
+    snapshot_id: "01KZKQNY89FGP5CTS04GT7Y3JX",
+    created_at: "2026-08-09T17:03:44Z",
+    size_bytes: 1238414,
+    from_this_device: true,
+    restore_tested_here: true,
+    error: null,
+    ...overrides,
+  };
+}
+
+describe("transferState", () => {
+  it("cannot judge direction without a readable cloud listing", () => {
+    expect(transferState(status({}), null).direction).toBe("unknown");
+    expect(transferState(status({}), remote({ error: "offline" })).direction).toBe("unknown");
+    expect(transferState(status({}), remote({ snapshot_id: null })).direction).toBe("unknown");
+  });
+
+  it("reads a snapshot this device did not upload as the other machine's work", () => {
+    const result = transferState(
+      status({ protection_state: "protected" }),
+      remote({ from_this_device: false }),
+    );
+
+    expect(result.direction).toBe("cloud_newer");
+    expect(result.headline).toContain("Another device");
+  });
+
+  it("names unbacked-up local changes", () => {
+    const result = transferState(status({ protection_state: "changes_pending" }), remote());
+
+    expect(result.direction).toBe("device_newer");
+    expect(result.headline).toContain("not backed up");
+  });
+
+  it("says plainly when both sides moved", () => {
+    const result = transferState(
+      status({ protection_state: "changes_pending" }),
+      remote({ from_this_device: false }),
+    );
+
+    expect(result.direction).toBe("diverged");
+    expect(result.headline).toContain("replaces this device's changes");
+  });
+
+  it("confirms agreement when the newest backup is this device's own", () => {
+    const result = transferState(status({ protection_state: "protected" }), remote());
+
+    expect(result.direction).toBe("in_sync");
+    expect(result.headline).toContain("Up to date");
+  });
+});
+
 describe("protectionActions", () => {
   const find = (
     actions: ProtectionAction[],
@@ -233,55 +324,105 @@ describe("protectionActions", () => {
   ): ProtectionAction | undefined => actions.find((action) => action.kind === kind);
 
   it("offers only sign-in before an account exists", () => {
-    const actions = protectionActions(false, "protected", status({}));
+    const actions = protectionActions(false, "protected", status({}), remote());
 
     expect(actions.map((action) => action.kind)).toEqual(["signin"]);
   });
 
-  it("makes backup the single primary action when changes are unprotected", () => {
+  it("leads with restore when another device holds newer memory", () => {
+    const actions = protectionActions(
+      true,
+      "protected",
+      status({ protection_state: "protected" }),
+      remote({ from_this_device: false }),
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["restore", "backup"]);
+    expect(find(actions, "restore")?.variant).toBe("primary");
+    expect(find(actions, "backup")?.variant).toBe("secondary");
+  });
+
+  it("leads with backup when this device holds unprotected changes", () => {
     const actions = protectionActions(
       true,
       "changes_pending",
       status({ protection_state: "changes_pending" }),
+      remote(),
     );
 
-    expect(actions).toEqual([{
-      kind: "backup",
-      label: "Back up now",
-      variant: "primary",
-      disabled: false,
-      reason: null,
-    }]);
+    expect(actions.map((action) => action.kind)).toEqual(["backup", "restore"]);
+    expect(find(actions, "backup")?.variant).toBe("primary");
+  });
+
+  it("refuses to favour either side once both have moved", () => {
+    // Pulling discards local changes and pushing supersedes the other machine,
+    // so neither may be styled as the obvious thing to click.
+    const actions = protectionActions(
+      true,
+      "changes_pending",
+      status({ protection_state: "changes_pending" }),
+      remote({ from_this_device: false }),
+    );
+
+    expect(actions.every((action) => action.variant === "secondary")).toBe(true);
+    expect(find(actions, "backup")?.reason).toContain("stays in the cloud");
+    expect(find(actions, "restore")?.reason).toContain("Replaces this device's memory");
   });
 
   it("does not let a healthy store present backup as an outstanding task", () => {
-    // A primary button reads as "do this next". After a successful enable there
-    // is nothing to do, and the recovery-kit prompt is the real outstanding task.
-    const actions = protectionActions(true, "protected", status({ protection_state: "protected" }));
+    const actions = protectionActions(
+      true,
+      "protected",
+      status({ protection_state: "protected" }),
+      remote(),
+    );
 
-    expect(actions.map((action) => action.kind)).toEqual(["backup"]);
-    const backup = find(actions, "backup");
-    expect(backup?.variant).toBe("secondary");
-    expect(backup?.disabled).toBe(false);
-    expect(backup?.reason).toContain("Already uploaded and restore-tested");
+    expect(find(actions, "backup")?.variant).toBe("secondary");
+    expect(find(actions, "backup")?.disabled).toBe(false);
+    expect(find(actions, "restore")).toBeDefined();
   });
 
-  it("prefers verification but keeps backup usable and explained when a check is pending", () => {
+  it("keeps a routine unchecked upload free of a check prompt", () => {
+    // Daily uploads with a weekly check mean this is the normal resting state.
     const actions = protectionActions(
       true,
       "verification_pending",
-      status({ protection_state: "verification_pending", last_error_code: null }),
+      status({
+        protection_state: "verification_pending",
+        last_successful_verify_at: new Date(Date.now() - 86_400_000).toISOString(),
+      }),
+      remote(),
     );
 
-    expect(actions.map((action) => action.kind)).toEqual(["verify", "backup"]);
-    expect(find(actions, "verify")?.variant).toBe("primary");
+    expect(find(actions, "verify")).toBeUndefined();
+    expect(find(actions, "backup")).toBeDefined();
+  });
 
-    const backup = find(actions, "backup");
-    expect(backup?.label).toBe("Back up now");
-    expect(backup?.variant).toBe("secondary");
-    // A manual backup restore-tests its own upload, so it is slower here, not unsafe.
-    expect(backup?.disabled).toBe(false);
-    expect(backup?.reason).toContain("restore-tests that one instead");
+  it("asks for a check only once one is genuinely overdue", () => {
+    const actions = protectionActions(
+      true,
+      "verification_pending",
+      status({
+        protection_state: "verification_pending",
+        last_successful_verify_at: null,
+      }),
+      remote(),
+    );
+
+    expect(actions[0].kind).toBe("verify");
+    expect(actions[0].variant).toBe("primary");
+  });
+
+  it("offers restore on a machine that has never been protected itself", () => {
+    // How a second device adopts an existing memory.
+    const actions = protectionActions(
+      true,
+      "local_only",
+      status({ protection_state: "local_only", enabled: false }),
+      remote({ from_this_device: false }),
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["protect", "restore"]);
   });
 
   it("keeps backup visible and explained while cloud protection is offline", () => {
@@ -289,12 +430,12 @@ describe("protectionActions", () => {
       true,
       "offline",
       status({ protection_state: "offline", enabled: false }),
+      remote(),
     );
 
     expect(find(actions, "repair")?.label).toBe("Check connection");
-    const backup = find(actions, "backup");
-    expect(backup?.disabled).toBe(true);
-    expect(backup?.reason).toContain("Ormah Cloud is unreachable");
+    expect(find(actions, "backup")?.disabled).toBe(true);
+    expect(find(actions, "backup")?.reason).toContain("Ormah Cloud is unreachable");
   });
 
   it("does not duplicate backup when repair is itself the backup retry", () => {
@@ -302,6 +443,7 @@ describe("protectionActions", () => {
       true,
       "offline",
       status({ protection_state: "offline", enabled: true }),
+      null,
     );
 
     expect(actions.map((action) => action.kind)).toEqual(["repair"]);
@@ -313,24 +455,12 @@ describe("protectionActions", () => {
       true,
       "attention_required",
       status({ protection_state: "attention_required", last_error_code: "quota_exceeded" }),
+      null,
     );
 
     expect(find(actions, "repair")).toBeUndefined();
-    const backup = find(actions, "backup");
-    expect(backup?.disabled).toBe(true);
-    expect(backup?.reason).toContain("Resolve the problem above");
-  });
-
-  it("keeps the repair path primary and backup explained during a verify failure", () => {
-    const actions = protectionActions(
-      true,
-      "attention_required",
-      status({ protection_state: "attention_required", last_error_code: "verification_failed" }),
-    );
-
-    expect(actions.map((action) => action.kind)).toEqual(["repair", "backup"]);
-    expect(find(actions, "repair")?.label).toBe("Retry recovery check");
     expect(find(actions, "backup")?.disabled).toBe(true);
+    expect(find(actions, "backup")?.reason).toContain("Resolve the problem above");
   });
 
   it("never hides backup from a signed-in, protected store without saying why", () => {
@@ -352,7 +482,7 @@ describe("protectionActions", () => {
     ];
 
     for (const state of states) {
-      const actions = protectionActions(true, state, status({ protection_state: state }));
+      const actions = protectionActions(true, state, status({ protection_state: state }), remote());
 
       expect(actions.length).toBeGreaterThan(0);
       for (const action of actions) {
@@ -360,14 +490,12 @@ describe("protectionActions", () => {
       }
 
       const backup = find(actions, "backup");
-      const repair = find(actions, "repair");
       if (onboarding.includes(state)) {
-        // Protection does not exist yet; "Protect this memory" is the entry point.
         expect(find(actions, "protect")).toBeDefined();
         continue;
       }
       if (!backup) {
-        expect(repair?.label).toBe("Retry encrypted backup");
+        expect(find(actions, "repair")?.label).toBe("Retry encrypted backup");
         continue;
       }
       if (backup.disabled) expect(backup.reason).toBeTruthy();

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -218,6 +218,7 @@ export const productBridge = {
   logout: () => native<LogoutResult>("logout_account"),
   offer: () => native<BillingOffer>("billing_offer"),
   status: () => native<ProtectionStatus>("protection_status"),
+  remoteSnapshot: () => native<RemoteSnapshot>("remote_snapshot"),
   createIntent: () => native<ProtectionOperation>("create_protection_intent"),
   bindIntent: (intentId: string) =>
     native<ProtectionOperation>("bind_protection_intent", { intentId }),
@@ -311,10 +312,83 @@ export function protectionRepairAction(status: ProtectionStatus): ProtectionRepa
   return "none";
 }
 
+/** The newest committed cloud backup, which may come from another device. */
+export interface RemoteSnapshot {
+  snapshot_id: string | null;
+  created_at: string | null;
+  size_bytes: number | null;
+  from_this_device: boolean;
+  /** Only this device's own checks count; it cannot vouch for another's. */
+  restore_tested_here: boolean;
+  error: string | null;
+}
+
+export type TransferDirection =
+  | "in_sync"
+  | "cloud_newer"
+  | "device_newer"
+  | "diverged"
+  | "unknown";
+
+export interface TransferState {
+  direction: TransferDirection;
+  headline: string | null;
+}
+
+// Two intervals of the weekly restore-verification job. Inside that window an
+// unchecked upload is the normal resting state, not a problem, so it must not
+// paint the panel with a warning.
+const VERIFICATION_OVERDUE_AFTER_MS = 14 * 24 * 60 * 60 * 1000;
+
+export function verificationIsOverdue(
+  status: ProtectionStatus | null | undefined,
+  now: number = Date.now(),
+): boolean {
+  if (!status?.last_successful_verify_at) return true;
+  const verifiedAt = new Date(status.last_successful_verify_at).getTime();
+  if (!Number.isFinite(verifiedAt)) return true;
+  return now - verifiedAt > VERIFICATION_OVERDUE_AFTER_MS;
+}
+
+/**
+ * Which way memory needs to move between this device and the cloud.
+ *
+ * The cloud copy is newer whenever the newest snapshot is not the one this
+ * device uploaded — that is the only signal a second machine leaves behind.
+ */
+export function transferState(
+  status: ProtectionStatus | null | undefined,
+  remote: RemoteSnapshot | null | undefined,
+): TransferState {
+  if (!remote || remote.error || !remote.snapshot_id) {
+    return { direction: "unknown", headline: null };
+  }
+  const cloudNewer = !remote.from_this_device;
+  const deviceNewer = status?.protection_state === "changes_pending";
+
+  if (cloudNewer && deviceNewer) {
+    return {
+      direction: "diverged",
+      headline: "Both have newer memory. Restoring replaces this device's changes.",
+    };
+  }
+  if (cloudNewer) {
+    return { direction: "cloud_newer", headline: "Another device has newer memory." };
+  }
+  if (deviceNewer) {
+    return {
+      direction: "device_newer",
+      headline: "This device has changes that are not backed up yet.",
+    };
+  }
+  return { direction: "in_sync", headline: "Up to date with the cloud." };
+}
+
 export type ProtectionActionKind =
   | "signin"
   | "protect"
   | "backup"
+  | "restore"
   | "verify"
   | "repair"
   | "subscribe";
@@ -329,6 +403,7 @@ export interface ProtectionAction {
 }
 
 const BACKUP_LABEL = "Back up now";
+const RESTORE_LABEL = "Restore newest backup";
 
 const REPAIR_LABELS: Record<Exclude<ProtectionRepairAction, "none">, string> = {
   verify: "Retry recovery check",
@@ -349,17 +424,61 @@ function blockedBackup(reason: string): ProtectionAction {
   };
 }
 
+/** Push and pull, ordered and weighted by which side holds newer memory. */
+function transferActions(direction: TransferDirection): ProtectionAction[] {
+  const backup: ProtectionAction = {
+    kind: "backup",
+    label: BACKUP_LABEL,
+    variant: "secondary",
+    disabled: false,
+    reason: null,
+  };
+  const restore: ProtectionAction = {
+    kind: "restore",
+    label: RESTORE_LABEL,
+    variant: "secondary",
+    disabled: false,
+    reason: "Replaces this device's memory. Ormah checks the backup and shows"
+      + " what is inside before anything changes, and saves a local safety copy first.",
+  };
+
+  switch (direction) {
+    case "cloud_newer":
+      return [{ ...restore, variant: "primary" }, backup];
+    case "device_newer":
+      return [{ ...backup, variant: "primary" }, restore];
+    // Neither side is safe to favour: pulling discards local changes and
+    // pushing supersedes the other machine. Make the user choose deliberately.
+    case "diverged":
+      return [
+        { ...backup, reason: "Uploads this device's changes. The other device's newer memory stays in the cloud." },
+        restore,
+      ];
+    default:
+      return [
+        {
+          ...backup,
+          reason: "Ormah backs up on a schedule; this captures changes since then straight away.",
+        },
+        restore,
+      ];
+  }
+}
+
 /**
  * The summary-view actions for one protection state.
  *
  * Backup is the product's core capability, so it never vanishes from a signed-in
  * summary without a reason attached. States that cannot accept a new upload
- * return it disabled and explained rather than omitted.
+ * return it disabled and explained rather than omitted. Restore appears
+ * whenever the cloud actually holds something to restore — including on a
+ * machine that has never been protected itself.
  */
 export function protectionActions(
   signedIn: boolean,
   state: ProtectionState,
   status: ProtectionStatus | null | undefined,
+  remote?: RemoteSnapshot | null,
 ): ProtectionAction[] {
   if (!signedIn) {
     return [{
@@ -379,77 +498,67 @@ export function protectionActions(
     disabled: false,
     reason: null,
   }];
+  const restorable = Boolean(remote?.snapshot_id);
+  const { direction } = transferState(status, remote);
+  const restoreOnly: ProtectionAction[] = restorable
+    ? [{
+      kind: "restore",
+      label: RESTORE_LABEL,
+      variant: "secondary",
+      disabled: false,
+      reason: "Brings the newest cloud backup onto this device.",
+    }]
+    : [];
 
   switch (state) {
     case "local_only":
     case "sign_in_required":
     case "stopped":
-      return [{
-        kind: "protect",
-        label: "Protect this memory",
-        variant: "primary",
-        disabled: false,
-        reason: null,
-      }];
-
-    // Nothing is outstanding, so backup must not claim the primary slot: a
-    // full-width primary button reads as "do this next" and makes a healthy
-    // store look like it still owes work. It also has to lose that slot to the
-    // recovery-kit prompt, which is a genuine outstanding task.
-    case "protected":
-      return [{
-        kind: "backup",
-        label: BACKUP_LABEL,
-        variant: "secondary",
-        disabled: false,
-        reason: "Already uploaded and restore-tested. Ormah backs up on a schedule;"
-          + " this captures changes since then straight away.",
-      }];
-
-    case "changes_pending":
-      return [{
-        kind: "backup",
-        label: BACKUP_LABEL,
-        variant: "primary",
-        disabled: false,
-        reason: null,
-      }];
-
-    case "verification_pending":
-      // A manual backup uploads *and* restore-tests the new snapshot, so it is
-      // safe here — only slower and more bandwidth than checking what is
-      // already uploaded. Demote it, do not block it.
       return [
         {
-          kind: "verify",
-          label: "Verify this recovery point",
+          kind: "protect",
+          label: "Protect this memory",
           variant: "primary",
           disabled: false,
           reason: null,
         },
-        {
-          kind: "backup",
-          label: BACKUP_LABEL,
-          variant: "secondary",
-          disabled: false,
-          reason:
-            "Uploads another recovery point and restore-tests that one instead."
-            + " Checking the backup you already uploaded is faster.",
-        },
+        ...restoreOnly,
+      ];
+
+    case "protected":
+    case "changes_pending":
+      return transferActions(direction);
+
+    case "verification_pending":
+      // An unchecked upload inside the weekly check window is the normal
+      // resting state. Only offer the manual check once it is genuinely
+      // overdue, so a routine condition stops looking like a task.
+      return [
+        ...(verificationIsOverdue(status)
+          ? [{
+            kind: "verify" as const,
+            label: "Check this backup restores",
+            variant: "primary" as const,
+            disabled: false,
+            reason: null,
+          }]
+          : []),
+        ...transferActions(direction),
       ];
 
     case "offline":
     case "attention_required": {
       // When repair *is* the backup retry, a second backup button would be a
       // duplicate of the primary action.
-      if (repair === "backup") return repairButton;
+      if (repair === "backup") return [...repairButton, ...restoreOnly];
       return [
         ...repairButton,
         blockedBackup(
           state === "offline"
             ? "Ormah Cloud is unreachable. Ormah keeps retrying, and your changes stay safe on this device."
-            : "Resolve the problem above before creating another recovery point.",
+            : "Resolve the problem above before backing up again.",
         ),
+        ...restoreOnly,
       ];
     }
 
@@ -463,16 +572,20 @@ export function protectionActions(
           disabled: false,
           reason: null,
         },
-        blockedBackup("An active subscription is required to upload new recovery points."),
+        blockedBackup("An active subscription is required to upload new backups."),
+        ...restoreOnly,
       ];
 
     default:
       // initializing, uploading_first_backup, verifying_first_backup
-      return [blockedBackup("Ormah is already working on this recovery point.")];
+      return [blockedBackup("Ormah is already working on this backup.")];
   }
 }
 
-export function protectionPresentation(state: ProtectionState): ProtectionPresentation {
+export function protectionPresentation(
+  state: ProtectionState,
+  status?: ProtectionStatus | null,
+): ProtectionPresentation {
   switch (state) {
     case "sign_in_required":
       return {
@@ -485,7 +598,7 @@ export function protectionPresentation(state: ProtectionState): ProtectionPresen
       return {
         tone: "neutral",
         title: "Subscription required",
-        detail: "Subscribe to create encrypted, verified recovery points.",
+        detail: "Subscribe to keep encrypted backups that are proven to restore.",
         action: "subscribe",
       };
     case "initializing":
@@ -498,37 +611,50 @@ export function protectionPresentation(state: ProtectionState): ProtectionPresen
     case "uploading_first_backup":
       return {
         tone: "working",
-        title: "Uploading encrypted recovery point",
+        title: "Uploading encrypted backup",
         detail: "Only ciphertext is leaving this machine.",
         action: "wait",
       };
     case "verifying_first_backup":
       return {
         tone: "working",
-        title: "Checking recovery",
+        title: "Proving it restores",
         detail: "Downloading, decrypting, rebuilding, and probing a temporary copy.",
         action: "wait",
       };
     case "verification_pending":
-      return {
-        tone: "warning",
-        title: "Recovery check needed",
-        detail: "Your newest encrypted backup is uploaded but has not yet passed a restore test."
-          + " Verify it before creating another recovery point.",
-        action: "retry",
-      };
+      // Scheduled backups upload daily and the check runs weekly, so an
+      // unchecked upload is where a healthy store spends most of its life.
+      // Warn only once the check is genuinely overdue, or the panel cries
+      // wolf six days in seven.
+      return verificationIsOverdue(status)
+        ? {
+          tone: "warning",
+          title: "Backup not proven restorable",
+          detail: "Your newest backup is uploaded, but Ormah has not been able to"
+            + " confirm it restores. Run a check to be sure.",
+          action: "retry",
+        }
+        : {
+          tone: "success",
+          title: "Protected",
+          detail: "Your newest backup is uploaded. Ormah restore-tests it on a"
+            + " schedule, and your last proven backup stays available.",
+          action: "backup",
+        };
     case "protected":
       return {
         tone: "success",
-        title: "Protected and verified",
-        detail: "The latest recovery point was restored and checked on this device.",
+        title: "Protected",
+        detail: "Your newest backup was downloaded, decrypted, and rebuilt on this"
+          + " device to prove it restores.",
         action: "backup",
       };
     case "changes_pending":
       return {
-        tone: "warning",
-        title: "Changes waiting for protection",
-        detail: "Your last verified recovery point remains available.",
+        tone: "neutral",
+        title: "Changes not backed up yet",
+        detail: "Your last proven backup stays available until this device uploads again.",
         action: "backup",
       };
     case "offline":
@@ -542,14 +668,14 @@ export function protectionPresentation(state: ProtectionState): ProtectionPresen
       return {
         tone: "warning",
         title: "Cloud uploads are paused",
-        detail: "Local memory and retained recovery points remain available.",
+        detail: "Local memory and existing backups remain available.",
         action: "subscribe",
       };
     case "stopped":
       return {
         tone: "neutral",
         title: "Cloud protection stopped",
-        detail: "Existing recovery points remain available. Billing is managed separately.",
+        detail: "Existing backups remain available. Billing is managed separately.",
         action: "resume",
       };
     case "attention_required":
@@ -563,7 +689,7 @@ export function protectionPresentation(state: ProtectionState): ProtectionPresen
       return {
         tone: "neutral",
         title: "Protect this memory",
-        detail: "Keep an encrypted, verified recovery copy that Ormah Cloud cannot read.",
+        detail: "Keep an encrypted backup that Ormah Cloud cannot read, proven to restore.",
         action: "protect",
       };
   }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1401,6 +1401,59 @@ body.in-app .node-detail.tier-core {
 
 .protection-action + .protection-action { margin-top: 10px; }
 
+.protection-machines {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 22px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+  padding: 18px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.protection-machine {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.protection-machine > span {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.protection-machine > span:first-child {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.protection-machine > strong {
+  color: var(--text-bright);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.protection-machine .protection-proven { color: var(--node-self); }
+
+.protection-machine-link {
+  display: flex;
+  justify-content: center;
+  padding-top: 18px;
+  color: var(--text-muted);
+}
+
+.protection-direction {
+  margin: 0;
+  padding: 12px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.protection-direction.direction-in_sync { color: var(--node-self); }
+.protection-direction.direction-diverged { color: var(--text-bright); }
+
 .protection-action-reason {
   margin: 6px 0 0;
   color: var(--text-muted);


### PR DESCRIPTION
Re-lands PR #204, whose content never reached `main`.

## What happened

#204 was stacked on #203's branch. #203 merged into `main` at 17:58:50; #204
merged 21 seconds later — into `fix/protection-actions-and-stranded-offline`,
its original base, because the retarget to `main` did not take effect before
the merge. GitHub reports #204 as `MERGED`, and it is, but into a feature
branch rather than `main`.

Verified against `main` before opening this: `remote_snapshot` was absent from
the routes, the capability ACL, and the invoke handler.

This branch cherry-picks #204's two commits onto current `main`. `git diff`
against the original branch is empty — the content is byte-identical, nothing
was reconstructed by hand.

## Contents (unchanged from #204)

- `GET /admin/cloud/protection/remote` — one listing call, no download, no
  decryption, no new cloud-visible metadata. Lets a device see a backup made
  by another machine, which local state cannot show.
- Panel leads with this device beside the cloud, states which way memory needs
  to move, and puts push and pull under it. When both sides have moved neither
  action is primary.
- `verification_pending` no longer paints the panel amber or asks for a manual
  check until one is genuinely overdue — uploads are daily, checks weekly, so
  it is where a healthy store spends most of its life.
- Copy settles on three nouns: backup, check, recovery kit.
- Capability-ACL guard test: a command registered in the invoke handler but
  missing from `desktop-product-bridge` is denied at runtime in the webview
  with nothing failing at compile time. That bug was real in #204 and is fixed
  here; the test fails with the offending command named if it recurs.

## Verification

Re-run on this branch, on top of `main`:

- Python: 1837 passed, ruff clean
- UI: 43 passed
- Rust: 29 passed

Also exercised end to end on an Apple Silicon Mac against the live cloud: the
endpoint returned the newest snapshot correctly attributed to this device and
restore-tested here, and a locally built desktop app rendered the panel.