### PR TITLE
chore(release): prepare 0.14.8 and desktop 0.3.21

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.20"
+version = "0.3.21"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.7"
+version = "0.14.8"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump only — no behaviour change. Same five files as the 0.14.7
release (b017ca9), verified by diffing the changed-file list against it.

| File | Change |
|---|---|
| `pyproject.toml` | 0.14.7 → 0.14.8 |
| `integrations/claude-plugin/.claude-plugin/plugin.json` | 0.14.7 → 0.14.8 |
| `desktop/src-tauri/tauri.conf.json` | 0.3.20 → 0.3.21 |
| `desktop/src-tauri/Cargo.toml` | 0.3.20 → 0.3.21 |
| `desktop/src-tauri/Cargo.lock` (`ormah-desktop`) | 0.3.20 → 0.3.21 |

## What ships

- **#203** — a device stranded on a stale `offline` state. `protection_state`
  is durable and only rewritten by the next operation; with backups disabled
  and the intent expired, nothing could perform that operation, so a one-off
  resolver failure pinned the panel to "Ormah will retry automatically" while
  nothing retried and the only offered repair was a no-op refresh. Also stops
  the backup action vanishing without explanation.
- **#205** — device-versus-cloud view with push/pull direction, the
  `/protection/remote` listing endpoint, and `verification_pending` no longer
  painting the panel amber for the six days in seven that a healthy store
  spends there.

## Runtime pin

Bumping `pyproject.toml` moves the desktop's pin automatically — `build.rs`
reads it into `ORMAH_PY_VERSION`, and the desktop installs `ormah=={pin}`
exactly. Confirmed from the build script output on this branch:

```
cargo:rustc-env=ORMAH_PY_VERSION=0.14.8
```

This matters because the pin is what carries the fixes to existing installs:
without it every desktop keeps requesting 0.14.7 no matter what is on PyPI.

## Versions

Patch bumps, matching this repo's convention — #196's restore feature and
#198's updater both shipped in 0.14.7/0.3.20.

## Verification on `main` before this branch

Python 1837 passed + ruff clean, UI 43 passed, Rust 29 passed. `main` was
diffed against the independently verified branch and is byte-identical.