### PR TITLE
fix(lock-order): hoist the index sweep's FileStore calls out of its write txn (fixes #207)

### DIFF
--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -37,11 +37,20 @@ class IndexBuilder:
 
         # Two-pass: nodes first, then edges (to satisfy FK constraints)
         paths = list(self.file_store.list_paths())
+        hashes: dict[Path, str] = {}
+        for path in paths:
+            try:
+                hashes[path] = self.file_store.file_hash(path)
+            except Exception as e:
+                logger.warning("Failed to hash %s: %s", path, e)
+
         count = 0
         with self.db.transaction():
             for path in paths:
+                if path not in hashes:
+                    continue
                 try:
-                    self._index_file_nodes_only(path)
+                    self._index_file_nodes_only(path, hashes[path])
                     count += 1
                 except Exception as e:
                     logger.warning("Failed to index %s: %s", path, e)
@@ -67,12 +76,8 @@ class IndexBuilder:
         indexed_ids = set(indexed.keys())
         disk_ids: set[str] = set()
 
-        # Both FileStore calls take L_mem -- the engine hands FileStore its own lock
-        # (FileStore(nodes_dir, self._memory_operation_lock)). Calling them inside the write txn
-        # would request L_mem while holding L_db, the reverse of the L_mem -> L_db order every
-        # @serialized_memory_job background job takes: a deadlock cycle, and this job runs every
-        # 60s. Hoisting also halves the I/O done under L_db. full_rebuild already hoists
-        # list_paths for the same reason.
+        # FileStore calls take L_mem. Complete them before the write transaction so no builder
+        # path requests L_mem while holding L_db, the reverse of the order used by memory jobs.
         paths = self.file_store.list_paths()
         hashes: dict[Path, str] = {}
         for path in paths:
@@ -93,11 +98,11 @@ class IndexBuilder:
                     disk_ids.add(node.id)
 
                     if node.id not in indexed:
-                        self._index_file(path)
+                        self._index_file(path, file_hash)
                         added += 1
                     elif indexed[node.id] != file_hash:
                         self._remove_node(node.id, keep_vectors=True)
-                        self._index_file(path)
+                        self._index_file(path, file_hash)
                         updated += 1
                 except Exception as e:
                     logger.warning("Failed to process %s: %s", path, e)
@@ -112,20 +117,20 @@ class IndexBuilder:
     def index_single(self, path: Path) -> None:
         """Index or re-index a single file."""
         node = parse_node(path.read_text(encoding="utf-8"))
+        file_hash = self.file_store.file_hash(path)
         with self.db.transaction():
             self._remove_node(node.id)
-            self._index_file(path)
+            self._index_file(path, file_hash)
 
-    def _index_file(self, path: Path) -> None:
+    def _index_file(self, path: Path, file_hash: str) -> None:
         """Index a single markdown file into the database (nodes + edges)."""
-        self._index_file_nodes_only(path)
+        self._index_file_nodes_only(path, file_hash)
         self._index_file_edges(path)
 
-    def _index_file_nodes_only(self, path: Path) -> None:
+    def _index_file_nodes_only(self, path: Path, file_hash: str) -> None:
         """Index node, tags, and FTS from a markdown file (no edges)."""
         text = path.read_text(encoding="utf-8")
         node = parse_node(text)
-        file_hash = self.file_store.file_hash(path)
         conn = self.db.conn
 
         conn.execute(

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -67,10 +67,28 @@ class IndexBuilder:
         indexed_ids = set(indexed.keys())
         disk_ids: set[str] = set()
 
+        # Both FileStore calls take L_mem -- the engine hands FileStore its own lock
+        # (FileStore(nodes_dir, self._memory_operation_lock)). Calling them inside the write txn
+        # would request L_mem while holding L_db, the reverse of the L_mem -> L_db order every
+        # @serialized_memory_job background job takes: a deadlock cycle, and this job runs every
+        # 60s. Hoisting also halves the I/O done under L_db. full_rebuild already hoists
+        # list_paths for the same reason.
+        paths = self.file_store.list_paths()
+        hashes: dict[Path, str] = {}
+        for path in paths:
+            try:
+                hashes[path] = self.file_store.file_hash(path)
+            except Exception as e:
+                # A file removed between listing and hashing. This used to be swallowed by the
+                # per-path try inside the loop; keep it non-fatal rather than killing the job.
+                logger.warning("Failed to hash %s: %s", path, e)
+
         with self.db.transaction():
-            for path in self.file_store.list_paths():
+            for path in paths:
+                if path not in hashes:
+                    continue  # hashing failed above; already logged
                 try:
-                    file_hash = self.file_store.file_hash(path)
+                    file_hash = hashes[path]
                     node = parse_node(path.read_text(encoding="utf-8"))
                     disk_ids.add(node.id)
 

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -56,7 +56,7 @@ def test_incremental_update(db, file_store):
     assert rows[0] == 2
 
 
-# --- lock order (0.14.8 restore-exclusion lock) ---
+# --- lock order (0.14.7+ restore-exclusion lock) ---
 
 
 def test_incremental_update_does_not_deadlock_against_a_memory_job(engine):
@@ -102,3 +102,51 @@ def test_incremental_update_does_not_deadlock_against_a_memory_job(engine):
 
     assert not builder_thread.is_alive(), "incremental_update held L_db while waiting for L_mem"
     assert not job_thread.is_alive(), "memory job held L_mem while waiting for L_db"
+
+
+def test_builder_never_takes_file_lock_inside_write_transaction(engine):
+    """All builder entry points must finish FileStore calls before taking L_db."""
+    real_lock = engine._memory_operation_lock
+    violations: list[int] = []
+
+    class OrderProbe:
+        def __enter__(self):
+            tx_depth = getattr(engine.db._local, "tx_depth", 0)
+            if tx_depth > 0:
+                violations.append(tx_depth)
+            return real_lock.__enter__()
+
+        def __exit__(self, *args):
+            return real_lock.__exit__(*args)
+
+    engine.file_store._operation_lock = OrderProbe()
+
+    # Exercise full rebuild and single-file indexing.
+    engine.builder.full_rebuild()
+    single = MemoryNode(
+        type=NodeType.fact,
+        source="agent:test",
+        content="single content",
+        title="single",
+    )
+    single_path = engine.file_store.save(single)
+    engine.builder.index_single(single_path)
+
+    # Exercise every incremental branch: new, changed, then deleted.
+    incremental = MemoryNode(
+        type=NodeType.fact,
+        source="agent:test",
+        content="new content",
+        title="incremental",
+    )
+    engine.file_store.save(incremental)
+    assert engine.builder.incremental_update() == (1, 0)
+
+    incremental.content = "changed content"
+    engine.file_store.save(incremental)
+    assert engine.builder.incremental_update() == (0, 1)
+
+    engine.file_store.delete(incremental.id)
+    assert engine.builder.incremental_update() == (0, 0)
+
+    assert not violations, f"FileStore lock acquired inside db.transaction(): {violations}"

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -1,7 +1,9 @@
 """Tests for index builder."""
 
+import threading
+
 from ormah.index.builder import IndexBuilder
-from ormah.models.node import MemoryNode, NodeType
+from ormah.models.node import CreateNodeRequest, MemoryNode, NodeType
 
 
 def test_full_rebuild(db, file_store):
@@ -52,3 +54,51 @@ def test_incremental_update(db, file_store):
 
     rows = db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()
     assert rows[0] == 2
+
+
+# --- lock order (0.14.8 restore-exclusion lock) ---
+
+
+def test_incremental_update_does_not_deadlock_against_a_memory_job(engine):
+    """incremental_update must take L_mem BEFORE L_db, like every memory job.
+
+    The restore-exclusion lock decorates 8 FileStore methods with the engine's own RLock
+    (L_mem) -- MemoryEngine passes it in: FileStore(nodes_dir, self._memory_operation_lock).
+    incremental_update opens the write txn (L_db) and only then calls file_store.list_paths /
+    file_hash: L_db -> L_mem. Every @serialized_memory_job background job goes L_mem -> L_db.
+    Opposite orders on two locks = deadlock, and index_updater runs every 60s.
+    """
+    engine.remember(CreateNodeRequest(
+        content="indexed content", type=NodeType.fact, title="indexed content"))
+
+    builder_reached_file_store = threading.Event()
+    job_holds_mem = threading.Event()
+    real_list_paths = engine.file_store.list_paths
+
+    def instrumented_list_paths():
+        # Before the fix this runs INSIDE the write txn: this thread holds L_db and is one call
+        # away from taking L_mem. Let the memory job grab L_mem first, then reach for it.
+        # After the fix this runs BEFORE the txn, so no L_db is held and nothing can cycle.
+        builder_reached_file_store.set()
+        job_holds_mem.wait(timeout=1.0)  # times out once this thread already holds L_mem
+        return real_list_paths()
+
+    engine.file_store.list_paths = instrumented_list_paths
+
+    def memory_job():
+        """What @serialized_memory_job + a write txn do on every background job: L_mem, L_db."""
+        builder_reached_file_store.wait(timeout=5.0)
+        with engine._memory_operation_lock:
+            job_holds_mem.set()
+            with engine.db.transaction():
+                pass
+
+    builder_thread = threading.Thread(target=engine.builder.incremental_update, daemon=True)
+    job_thread = threading.Thread(target=memory_job, daemon=True)
+    builder_thread.start()
+    job_thread.start()
+    builder_thread.join(timeout=10.0)
+    job_thread.join(timeout=10.0)
+
+    assert not builder_thread.is_alive(), "incremental_update held L_db while waiting for L_mem"
+    assert not job_thread.is_alive(), "memory job held L_mem while waiting for L_db"


### PR DESCRIPTION
Fixes #207

## Problem

`incremental_update` opened the write txn (`L_db`) and then called `file_store.list_paths` and `file_hash`, both decorated with the engine's restore-exclusion RLock (`L_mem`, handed to `FileStore` by the engine): `L_db → L_mem`. Every `@serialized_memory_job` background job takes `L_mem → L_db`. Opposite orders on two locks deadlock, and `index_updater` runs every 60s — a live 0.14.x server froze all writes ~2 minutes after each start while reads kept serving.

Verified live by py-spy on the reporting install: `auto_linker` held `L_mem` (`acquired: True`) waiting on `L_db` at `auto_linker.py:312` while `index_updater` held `L_db` waiting on `L_mem` at `builder.py:119`, both jobs stamped with an identical t0. An external `BEGIN IMMEDIATE` returned `database is locked` on 10 consecutive probes over 60s while read-only connections passed. `/admin/health` answered in 2ms throughout; `/agent/whisper` and `/agent/recall` never answered at all.

## Fix

Hoisting both calls above the txn removes the inversion at the root without retaining any new lock. Adding `@serialized_memory_job` to the job was rejected: it would hold `L_mem` across the whole loop (36k files on the reporting store) every 60s, trading the deadlock for sustained write starvation. `full_rebuild` already hoists `list_paths` — this aligns `incremental_update` with the pattern in its own file, and moves half the loop's I/O out from under `L_db`.

The hashes are pre-computed in an explicit loop rather than a comprehension so that a file removed between listing and hashing stays non-fatal: the loop's own try/except used to absorb exactly that, and a bare comprehension would let it kill the job.

## Test

`test(index): reproduce the incremental_update lock-order deadlock` drives the exact interleaving: the builder holds `L_db` inside its write txn and reaches for `L_mem` via `file_store.list_paths`, while a memory job holds `L_mem` and reaches for `L_db`. It hung past a 10s join before this change and passes after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
