### PR TITLE
chore(release): prepare 0.14.9 and desktop 0.3.22

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.21"
+version = "0.3.22"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.8",
+  "version": "0.14.9",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.8"
+version = "0.14.9"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary\n\n- bump Ormah from 0.14.8 to 0.14.9\n- bump Desktop from 0.3.21 to 0.3.22\n- keep the Claude plugin manifest aligned with the Python package\n- make Desktop 0.3.22 compile with the Ormah 0.14.9 runtime pin\n\n## Why\n\nPR #208 fixed the index updater lock-order deadlock shipped in Ormah 0.14.7 and 0.14.8. Desktop builds pin the Ormah package version from pyproject.toml, so both patch releases must move together.\n\n## Verification\n\n- release version verifier accepts 0.14.9\n- packaging tests: 9 passed\n- Cargo metadata reports ormah-desktop 0.3.22\n- desktop build script exports ORMAH_PY_VERSION=0.14.9\n- diff check passes\n\n## Release order\n\n1. Merge this PR.\n2. Run the protected Release workflow for 0.14.9 and verify PyPI.\n3. Push desktop-v0.3.22 so Desktop Release builds against the published 0.14.9 runtime.