### PR TITLE
fix(protection): stop claiming another device is ahead after a restore

### DIFF
--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -25,7 +25,6 @@ import {
   productBridge,
   protectionActions,
   protectionCompletionSummary,
-  transferState,
   protectionPresentation,
   protectionReconnectDelay,
   protectionRepairAction,
@@ -772,8 +771,6 @@ export default function ProtectionPanel({
     [account?.signed_in, operation, remote, status],
   );
 
-  const transfer = useMemo(() => transferState(status, remote), [remote, status]);
-
   const runProtectionAction = useCallback(async (kind: ProtectionActionKind) => {
     switch (kind) {
       case "signin":
@@ -1081,10 +1078,6 @@ export default function ProtectionPanel({
                 {remote?.restore_tested_here && <span className="protection-proven">proven to restore</span>}
               </div>
             </section>
-          )}
-
-          {view === "summary" && !activeLabel && transfer.headline && (
-            <p className={`protection-direction direction-${transfer.direction}`}>{transfer.headline}</p>
           )}
 
           {view === "summary" && !activeLabel && (

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -9,7 +9,6 @@ import {
   protectionRepairAction,
   protectionPresentation,
   recoveryKitSectionVisible,
-  transferState,
   verificationIsOverdue,
   type ProtectionAction,
   type ProtectionActionKind,
@@ -275,48 +274,6 @@ function remote(overrides: Partial<RemoteSnapshot> = {}): RemoteSnapshot {
   };
 }
 
-describe("transferState", () => {
-  it("cannot judge direction without a readable cloud listing", () => {
-    expect(transferState(status({}), null).direction).toBe("unknown");
-    expect(transferState(status({}), remote({ error: "offline" })).direction).toBe("unknown");
-    expect(transferState(status({}), remote({ snapshot_id: null })).direction).toBe("unknown");
-  });
-
-  it("reads a snapshot this device did not upload as the other machine's work", () => {
-    const result = transferState(
-      status({ protection_state: "protected" }),
-      remote({ from_this_device: false }),
-    );
-
-    expect(result.direction).toBe("cloud_newer");
-    expect(result.headline).toContain("Another device");
-  });
-
-  it("names unbacked-up local changes", () => {
-    const result = transferState(status({ protection_state: "changes_pending" }), remote());
-
-    expect(result.direction).toBe("device_newer");
-    expect(result.headline).toContain("not backed up");
-  });
-
-  it("says plainly when both sides moved", () => {
-    const result = transferState(
-      status({ protection_state: "changes_pending" }),
-      remote({ from_this_device: false }),
-    );
-
-    expect(result.direction).toBe("diverged");
-    expect(result.headline).toContain("replaces this device's changes");
-  });
-
-  it("confirms agreement when the newest backup is this device's own", () => {
-    const result = transferState(status({ protection_state: "protected" }), remote());
-
-    expect(result.direction).toBe("in_sync");
-    expect(result.headline).toContain("Up to date");
-  });
-});
-
 describe("protectionActions", () => {
   const find = (
     actions: ProtectionAction[],
@@ -329,7 +286,10 @@ describe("protectionActions", () => {
     expect(actions.map((action) => action.kind)).toEqual(["signin"]);
   });
 
-  it("leads with restore when another device holds newer memory", () => {
+  it("does not read another device's upload as this device being behind", () => {
+    // A restore records nothing locally, so a machine that has just pulled this
+    // very snapshot still reports `from_this_device: false`. Urging it to
+    // restore again told it to redo the work it had only just finished.
     const actions = protectionActions(
       true,
       "protected",
@@ -337,9 +297,21 @@ describe("protectionActions", () => {
       remote({ from_this_device: false }),
     );
 
-    expect(actions.map((action) => action.kind)).toEqual(["restore", "backup"]);
-    expect(find(actions, "restore")?.variant).toBe("primary");
+    expect(find(actions, "restore")?.variant).toBe("secondary");
     expect(find(actions, "backup")?.variant).toBe("secondary");
+  });
+
+  it("keeps push and pull in one stable order whatever the cloud holds", () => {
+    const ours = protectionActions(true, "protected", status({}), remote());
+    const theirs = protectionActions(
+      true,
+      "protected",
+      status({}),
+      remote({ from_this_device: false }),
+    );
+
+    expect(ours.map((action) => action.kind)).toEqual(["backup", "restore"]);
+    expect(theirs.map((action) => action.kind)).toEqual(ours.map((action) => action.kind));
   });
 
   it("leads with backup when this device holds unprotected changes", () => {
@@ -354,9 +326,7 @@ describe("protectionActions", () => {
     expect(find(actions, "backup")?.variant).toBe("primary");
   });
 
-  it("refuses to favour either side once both have moved", () => {
-    // Pulling discards local changes and pushing supersedes the other machine,
-    // so neither may be styled as the obvious thing to click.
+  it("always says what restoring costs before it is chosen", () => {
     const actions = protectionActions(
       true,
       "changes_pending",
@@ -364,9 +334,8 @@ describe("protectionActions", () => {
       remote({ from_this_device: false }),
     );
 
-    expect(actions.every((action) => action.variant === "secondary")).toBe(true);
-    expect(find(actions, "backup")?.reason).toContain("stays in the cloud");
     expect(find(actions, "restore")?.reason).toContain("Replaces this device's memory");
+    expect(find(actions, "restore")?.reason).toContain("safety copy");
   });
 
   it("does not let a healthy store present backup as an outstanding task", () => {

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -323,18 +323,6 @@ export interface RemoteSnapshot {
   error: string | null;
 }
 
-export type TransferDirection =
-  | "in_sync"
-  | "cloud_newer"
-  | "device_newer"
-  | "diverged"
-  | "unknown";
-
-export interface TransferState {
-  direction: TransferDirection;
-  headline: string | null;
-}
-
 // Two intervals of the weekly restore-verification job. Inside that window an
 // unchecked upload is the normal resting state, not a problem, so it must not
 // paint the panel with a warning.
@@ -348,40 +336,6 @@ export function verificationIsOverdue(
   const verifiedAt = new Date(status.last_successful_verify_at).getTime();
   if (!Number.isFinite(verifiedAt)) return true;
   return now - verifiedAt > VERIFICATION_OVERDUE_AFTER_MS;
-}
-
-/**
- * Which way memory needs to move between this device and the cloud.
- *
- * The cloud copy is newer whenever the newest snapshot is not the one this
- * device uploaded — that is the only signal a second machine leaves behind.
- */
-export function transferState(
-  status: ProtectionStatus | null | undefined,
-  remote: RemoteSnapshot | null | undefined,
-): TransferState {
-  if (!remote || remote.error || !remote.snapshot_id) {
-    return { direction: "unknown", headline: null };
-  }
-  const cloudNewer = !remote.from_this_device;
-  const deviceNewer = status?.protection_state === "changes_pending";
-
-  if (cloudNewer && deviceNewer) {
-    return {
-      direction: "diverged",
-      headline: "Both have newer memory. Restoring replaces this device's changes.",
-    };
-  }
-  if (cloudNewer) {
-    return { direction: "cloud_newer", headline: "Another device has newer memory." };
-  }
-  if (deviceNewer) {
-    return {
-      direction: "device_newer",
-      headline: "This device has changes that are not backed up yet.",
-    };
-  }
-  return { direction: "in_sync", headline: "Up to date with the cloud." };
 }
 
 export type ProtectionActionKind =
@@ -424,14 +378,32 @@ function blockedBackup(reason: string): ProtectionAction {
   };
 }
 
-/** Push and pull, ordered and weighted by which side holds newer memory. */
-function transferActions(direction: TransferDirection): ProtectionAction[] {
+/**
+ * Push and pull, always offered together in a fixed order.
+ *
+ * Ormah deliberately does not guess which side holds newer memory. The only
+ * signal the cloud carries is who *uploaded* the newest snapshot, and a restore
+ * records nothing, so a device that has just pulled that very snapshot still
+ * looks behind. Weighting the buttons on that signal told a machine it was out
+ * of date immediately after it had caught up. The panel states each side's facts
+ * instead and lets the person decide which way to move.
+ *
+ * The one direction Ormah does know is local: unbacked-up changes on this
+ * device. That comes from local state, not from the cloud listing, so it is
+ * safe to lead with backup.
+ */
+function pushPullActions(
+  status: ProtectionStatus | null | undefined,
+): ProtectionAction[] {
+  const unsavedChanges = status?.protection_state === "changes_pending";
   const backup: ProtectionAction = {
     kind: "backup",
     label: BACKUP_LABEL,
-    variant: "secondary",
+    variant: unsavedChanges ? "primary" : "secondary",
     disabled: false,
-    reason: null,
+    reason: unsavedChanges
+      ? "Uploads the changes this device has made since its last backup."
+      : "Ormah backs up on a schedule; this captures changes since then straight away.",
   };
   const restore: ProtectionAction = {
     kind: "restore",
@@ -441,28 +413,7 @@ function transferActions(direction: TransferDirection): ProtectionAction[] {
     reason: "Replaces this device's memory. Ormah checks the backup and shows"
       + " what is inside before anything changes, and saves a local safety copy first.",
   };
-
-  switch (direction) {
-    case "cloud_newer":
-      return [{ ...restore, variant: "primary" }, backup];
-    case "device_newer":
-      return [{ ...backup, variant: "primary" }, restore];
-    // Neither side is safe to favour: pulling discards local changes and
-    // pushing supersedes the other machine. Make the user choose deliberately.
-    case "diverged":
-      return [
-        { ...backup, reason: "Uploads this device's changes. The other device's newer memory stays in the cloud." },
-        restore,
-      ];
-    default:
-      return [
-        {
-          ...backup,
-          reason: "Ormah backs up on a schedule; this captures changes since then straight away.",
-        },
-        restore,
-      ];
-  }
+  return [backup, restore];
 }
 
 /**
@@ -499,7 +450,6 @@ export function protectionActions(
     reason: null,
   }];
   const restorable = Boolean(remote?.snapshot_id);
-  const { direction } = transferState(status, remote);
   const restoreOnly: ProtectionAction[] = restorable
     ? [{
       kind: "restore",
@@ -527,7 +477,7 @@ export function protectionActions(
 
     case "protected":
     case "changes_pending":
-      return transferActions(direction);
+      return pushPullActions(status);
 
     case "verification_pending":
       // An unchecked upload inside the weekly check window is the normal
@@ -543,7 +493,7 @@ export function protectionActions(
             reason: null,
           }]
           : []),
-        ...transferActions(direction),
+        ...pushPullActions(status),
       ];
 
     case "offline":

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1443,17 +1443,6 @@ body.in-app .node-detail.tier-core {
   color: var(--text-muted);
 }
 
-.protection-direction {
-  margin: 0;
-  padding: 12px 0 0;
-  font-size: 11px;
-  line-height: 1.5;
-  color: var(--text);
-}
-
-.protection-direction.direction-in_sync { color: var(--node-self); }
-.protection-direction.direction-diverged { color: var(--text-bright); }
-
 .protection-action-reason {
   margin: 6px 0 0;
   color: var(--text-muted);


### PR DESCRIPTION
## What was wrong

You back up on Linux, restore on the Mac, and the Mac still says **"Another device has newer memory"** with **Restore newest backup** styled as the primary action — right after it had caught up.

The direction signal was one comparison, `routes_protection.py:218`:

```python
"from_this_device": snapshot_id == state.get("last_successful_backup_snapshot_id"),
```

No content, no node counts, no timestamps — just *did this device upload the newest snapshot?* Restoring one records nothing: protection state carries only `last_successful_backup_snapshot_id` and `last_verified_snapshot_id`, with no equivalent for a restore. So a device that has just pulled a snapshot still answers "no", and keeps answering "no" until it uploads something of its own.

The same value also drove button weighting (`transferActions`), so removing only the sentence would have left the identical false claim expressed as emphasis.

## What this does

Drops the inference instead of adding restore tracking. Deleted `TransferDirection`, `TransferState`, `transferState()`, `transferActions()`, the headline element, and the `.protection-direction` styles.

`protectionActions` now calls `pushPullActions(status)`: **Back up now**, then **Restore newest backup**, in one stable order, both secondary — except when `protection_state === "changes_pending"`, where backup leads. That case comes from local state rather than the cloud listing, so it is actually knowable.

The two-column `THIS DEVICE ⇅ CLOUD` block is untouched and still reports "from this device" / "from another device". It states the facts; it no longer draws a conclusion from them.

## The alternative, not taken

Persist `last_restored_snapshot_id` and treat "this device holds it" as upload-or-restore. That would give a correct direction signal, and is the way back if one is ever wanted. It was not worth the state for the value the sentence was delivering.

## Tests

- Regression test pinning the reported case: a snapshot from another device no longer demotes this one.
- Ordering test: push/pull order is identical whoever uploaded the newest backup.
- Removed the four `transferState` tests and the two that asserted direction-weighted ordering; kept the one that pins restore's "replaces this device's memory / safety copy" caption.

`tsc --noEmit` clean, 39/39 vitest, bundle builds.

Not covered: no manual pass over the running app. The visual change is a deleted `<p>` and its CSS rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)