### PR TITLE
chore(release): prepare 0.14.10 and desktop 0.3.23

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.22"
+version = "0.3.23"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.22"
+version = "0.3.23"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.9",
+  "version": "0.14.10",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.9"
+version = "0.14.10"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Bumps the Python package and Claude plugin to **0.14.10**, and the desktop shell to **0.3.23**.

## What ships

#213 — the protection panel no longer claims another device is ahead after you have just restored from it. The direction inference is gone, along with the button weighting that expressed the same false claim as emphasis. Push and pull now appear in one stable order.

## Why the desktop version moves

The desktop half of this release contains no desktop code.

The product UI is served by the Python daemon from `src/ormah/ui_dist`, so the fix travels in the wheel. But `sidecar.rs:301` installs `ormah==<compiled version>` exactly, so an app already in the field asks uv for `0.14.9` forever and would never pick up `0.14.10`. Recompiling the shell with the higher pin is the only way the fix reaches anyone.

That coupling is the subject of #214.

## Release order

PyPI first, then the desktop tag. A desktop build pinning a version that is not yet on PyPI would fail `uv tool install` on every machine that took the update.

1. Merge this PR
2. Run the Python Release workflow → `ormah-0.14.10-py3-none-any.whl` to PyPI
3. Tag `desktop-v0.3.23` → signed and notarized macOS arm64 + Linux x86_64, updater feed refreshed

## Files

Five version strings, matching the shape of the 0.14.9 release: `pyproject.toml`, `integrations/claude-plugin/.claude-plugin/plugin.json`, `desktop/src-tauri/tauri.conf.json`, `desktop/src-tauri/Cargo.toml`, `desktop/src-tauri/Cargo.lock`. No references to `0.14.9` remain outside the lockfile's dependency graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)