### PR TITLE
fix(desktop): recover Checkout intent before handoff

### DIFF
--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -28,6 +28,7 @@ import {
   productBridge,
   protectionActions,
   protectionCompletionSummary,
+  protectionIntentNeedsReplacement,
   protectionPresentation,
   protectionReconnectDelay,
   protectionRepairAction,
@@ -564,8 +565,11 @@ export default function ProtectionPanel({
     setBusy(true);
     setError(null);
     try {
+      const replaceIntent = protectionIntentNeedsReplacement(operation, status);
       const resolved = await resolveCheckoutIntent(
-        operation?.protection_intent_id || status?.protection_intent_id,
+        replaceIntent
+          ? null
+          : operation?.protection_intent_id || status?.protection_intent_id,
         productBridge.createIntent,
       );
       const intentId = resolved.intentId;
@@ -585,7 +589,7 @@ export default function ProtectionPanel({
     } finally {
       setBusy(false);
     }
-  }, [bindAndContinue, operation?.protection_intent_id, status?.protection_intent_id]);
+  }, [bindAndContinue, operation, status]);
 
   const checkPayment = useCallback(async (silent = false) => {
     if (checkoutCheckInFlight.current) return;
@@ -607,6 +611,11 @@ export default function ProtectionPanel({
     try {
       const bound = await productBridge.bindIntent(intentId);
       setOperation(bound);
+      if (protectionIntentNeedsReplacement(bound)) {
+        setCheckoutConfirmation("idle");
+        await beginProtection();
+        return;
+      }
       if (
         bound.protection_state === "subscription_required"
         || bound.reason_code === "subscription_required"
@@ -622,7 +631,12 @@ export default function ProtectionPanel({
       checkoutCheckInFlight.current = false;
       if (!silent) setBusy(false);
     }
-  }, [bindAndContinue, operation?.protection_intent_id, status?.protection_intent_id]);
+  }, [
+    beginProtection,
+    bindAndContinue,
+    operation?.protection_intent_id,
+    status?.protection_intent_id,
+  ]);
 
   useEffect(() => {
     if (checkoutConfirmation !== "waiting") return;
@@ -761,8 +775,7 @@ export default function ProtectionPanel({
       return;
     }
     if (repairAction === "subscribe") {
-      setView("checkout");
-      if (!offer) productBridge.offer().then(setOffer).catch(() => undefined);
+      await beginProtection();
       return;
     }
     if (repairAction === "resume") {
@@ -785,7 +798,7 @@ export default function ProtectionPanel({
     }
     reconnectAttempt.current = 0;
     await refresh();
-  }, [beginProtection, offer, refresh, repairAction, runOperation, status]);
+  }, [beginProtection, refresh, repairAction, runOperation, status]);
 
   const actions = useMemo(
     () => protectionActions(
@@ -818,10 +831,9 @@ export default function ProtectionPanel({
         await runRepairAction();
         return;
       case "subscribe":
-        setView("checkout");
-        if (!offer) productBridge.offer().then(setOffer).catch(() => undefined);
+        await beginProtection();
     }
-  }, [beginProtection, offer, runOperation, runRepairAction]);
+  }, [beginProtection, runOperation, runRepairAction]);
 
   return (
     <aside className={`side-panel protection-panel ${open ? "open" : ""}`} aria-hidden={!open}>

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -28,6 +28,7 @@ import {
   protectionPresentation,
   protectionReconnectDelay,
   protectionRepairAction,
+  resolveCheckoutIntent,
   recoveryKitSectionVisible,
   type AccountStatus,
   type ProtectionActionKind,
@@ -555,11 +556,15 @@ export default function ProtectionPanel({
   }, [onClose]);
 
   const openCheckout = useCallback(async () => {
-    const intentId = operation?.protection_intent_id || status?.protection_intent_id;
-    if (!intentId) return;
     setBusy(true);
     setError(null);
     try {
+      const resolved = await resolveCheckoutIntent(
+        operation?.protection_intent_id || status?.protection_intent_id,
+        productBridge.createIntent,
+      );
+      const intentId = resolved.intentId;
+      if (resolved.created) setOperation(resolved.created);
       const handoff = await productBridge.openCheckout(intentId);
       if (handoff.status === "already_subscribed") {
         await bindAndContinue(intentId);
@@ -579,7 +584,15 @@ export default function ProtectionPanel({
   const checkPayment = useCallback(async (silent = false) => {
     if (checkoutCheckInFlight.current) return;
     const intentId = operation?.protection_intent_id || status?.protection_intent_id;
-    if (!intentId) return;
+    if (!intentId) {
+      setCheckoutPolling(false);
+      if (!silent) {
+        setError(
+          "The protection request is no longer available. Choose Subscribe with Stripe to start again.",
+        );
+      }
+      return;
+    }
     checkoutCheckInFlight.current = true;
     setBusy(true);
     setError(null);

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -19,6 +19,9 @@ import {
   X,
 } from "lucide-react";
 import {
+  CHECKOUT_CONFIRMATION_INTERVAL_MS,
+  checkoutConfirmationAfterCheck,
+  checkoutConfirmationIsDelayed,
   isDesktopApp,
   effectiveProtectionState,
   operationPhaseIsActive,
@@ -31,6 +34,7 @@ import {
   resolveCheckoutIntent,
   recoveryKitSectionVisible,
   type AccountStatus,
+  type CheckoutConfirmation,
   type ProtectionActionKind,
   type RemoteSnapshot,
   type BillingOffer,
@@ -213,7 +217,8 @@ export default function ProtectionPanel({
   const [loading, setLoading] = useState(false);
   const [refreshFailed, setRefreshFailed] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [checkoutPolling, setCheckoutPolling] = useState(false);
+  const [checkoutConfirmation, setCheckoutConfirmation] =
+    useState<CheckoutConfirmation>("idle");
   const [confirmStop, setConfirmStop] = useState(false);
   const [recoveryBusy, setRecoveryBusy] = useState<"save" | "print" | null>(null);
   const [recoveryError, setRecoveryError] = useState<string | null>(null);
@@ -567,12 +572,13 @@ export default function ProtectionPanel({
       if (resolved.created) setOperation(resolved.created);
       const handoff = await productBridge.openCheckout(intentId);
       if (handoff.status === "already_subscribed") {
+        setCheckoutConfirmation("idle");
         await bindAndContinue(intentId);
       } else {
         if (!handoff.opened) {
           setError("Your subscription is still being processed. Check again shortly or manage it in Stripe.");
         }
-        setCheckoutPolling(true);
+        setCheckoutConfirmation("waiting");
       }
     } catch (err) {
       setError(errorMessage(err, "Checkout could not open."));
@@ -585,7 +591,7 @@ export default function ProtectionPanel({
     if (checkoutCheckInFlight.current) return;
     const intentId = operation?.protection_intent_id || status?.protection_intent_id;
     if (!intentId) {
-      setCheckoutPolling(false);
+      setCheckoutConfirmation("idle");
       if (!silent) {
         setError(
           "The protection request is no longer available. Choose Subscribe with Stripe to start again.",
@@ -594,44 +600,51 @@ export default function ProtectionPanel({
       return;
     }
     checkoutCheckInFlight.current = true;
-    setBusy(true);
-    setError(null);
+    if (!silent) {
+      setBusy(true);
+      setError(null);
+    }
     try {
       const bound = await productBridge.bindIntent(intentId);
       setOperation(bound);
-      if (bound.protection_state === "subscription_required" || bound.reason_code === "subscription_required") {
-        if (!silent) setError("Payment is not active yet. Stripe may still be processing it.");
+      if (
+        bound.protection_state === "subscription_required"
+        || bound.reason_code === "subscription_required"
+      ) {
+        setCheckoutConfirmation(checkoutConfirmationAfterCheck(false, !silent));
         return;
       }
-      setCheckoutPolling(false);
+      setCheckoutConfirmation(checkoutConfirmationAfterCheck(true, !silent));
       await bindAndContinue(intentId);
     } catch (err) {
-      setError(errorMessage(err, "Payment status is unavailable."));
+      if (!silent) setError(errorMessage(err, "Payment status is unavailable."));
     } finally {
       checkoutCheckInFlight.current = false;
-      setBusy(false);
+      if (!silent) setBusy(false);
     }
   }, [bindAndContinue, operation?.protection_intent_id, status?.protection_intent_id]);
 
   useEffect(() => {
-    if (!checkoutPolling) return;
+    if (checkoutConfirmation !== "waiting") return;
     let checks = 0;
     const poll = window.setInterval(() => {
       checks += 1;
-      if (checks >= 20) {
+      if (checkoutConfirmationIsDelayed(checks)) {
         window.clearInterval(poll);
-        setCheckoutPolling(false);
+        setCheckoutConfirmation("delayed");
         return;
       }
       void checkPayment(true);
-    }, 3000);
-    const onFocus = () => void checkPayment(false);
+    }, CHECKOUT_CONFIRMATION_INTERVAL_MS);
+    // Returning from the browser is an early hint, not proof that Stripe has
+    // finished. Keep the normal wait alive if the first focused check is early.
+    const onFocus = () => void checkPayment(true);
     window.addEventListener("focus", onFocus);
     return () => {
       window.clearInterval(poll);
       window.removeEventListener("focus", onFocus);
     };
-  }, [checkoutPolling, checkPayment]);
+  }, [checkoutConfirmation, checkPayment]);
 
   const runOperation = useCallback(async (action: "backup" | "verify" | "disable") => {
     setBusy(true);
@@ -968,6 +981,11 @@ export default function ProtectionPanel({
 
           {view === "checkout" && (
             <section className="protection-step">
+              <button className="step-back" onClick={() => {
+                setCheckoutConfirmation("idle");
+                setError(null);
+                setView("summary");
+              }}>Back to protection</button>
               <h3>Start cloud protection</h3>
               <p>Card details are handled by Stripe in your browser. Ormah never receives them.</p>
               {offer && (
@@ -980,13 +998,22 @@ export default function ProtectionPanel({
                 {busy ? <LoaderCircle className="spin" size={15} /> : <ExternalLink size={15} />}
                 Subscribe with Stripe
               </button>
-              {checkoutPolling && (
+              {checkoutConfirmation === "waiting" && (
                 <div className="checkout-waiting">
                   <LoaderCircle className="spin" size={15} /> Waiting for Stripe to confirm payment
                 </div>
               )}
-                <button className="protection-secondary" disabled={busy} onClick={() => void checkPayment(false)}>
-                <RefreshCw size={14} /> I've paid, check again
+              {checkoutConfirmation === "delayed" && (
+                <div className="checkout-delayed" role="status">
+                  Stripe is taking longer than usual. You will not be charged again by checking.
+                </div>
+              )}
+              <button
+                className="protection-secondary"
+                disabled={busy}
+                onClick={() => void checkPayment(false)}
+              >
+                <RefreshCw size={14} /> Check subscription status
               </button>
             </section>
           )}

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -9,6 +9,7 @@ import {
   protectionRepairAction,
   protectionPresentation,
   recoveryKitSectionVisible,
+  resolveCheckoutIntent,
   verificationIsOverdue,
   type ProtectionAction,
   type ProtectionActionKind,
@@ -16,6 +17,62 @@ import {
   type ProtectionState,
   type RemoteSnapshot,
 } from "./productBridge";
+
+describe("resolveCheckoutIntent", () => {
+  it("reuses a durable intent without creating another", async () => {
+    let calls = 0;
+    const result = await resolveCheckoutIntent("intent-existing", async () => {
+      calls += 1;
+      throw new Error("must not run");
+    });
+
+    expect(result).toEqual({ intentId: "intent-existing", created: null });
+    expect(calls).toBe(0);
+  });
+
+  it("recovers a lost transient intent before opening Checkout", async () => {
+    const created = {
+      operation_id: "operation",
+      kind: "enable" as const,
+      status: "completed" as const,
+      submitted_at: "2026-08-13T22:00:00Z",
+      started_at: null,
+      finished_at: null,
+      phase: "completed" as const,
+      protection_state: "subscription_required" as const,
+      reason_code: null,
+      message: null,
+      snapshot_id: null,
+      protection_intent_id: "intent-created",
+    };
+
+    await expect(resolveCheckoutIntent(null, async () => created)).resolves.toEqual({
+      intentId: "intent-created",
+      created,
+    });
+  });
+
+  it("surfaces a precise failure instead of silently doing nothing", async () => {
+    const missing = {
+      operation_id: "operation",
+      kind: "enable" as const,
+      status: "failed" as const,
+      submitted_at: "2026-08-13T22:00:00Z",
+      started_at: null,
+      finished_at: null,
+      phase: "failed" as const,
+      protection_state: "subscription_required" as const,
+      reason_code: null,
+      message: null,
+      snapshot_id: null,
+      protection_intent_id: null,
+    };
+
+    await expect(resolveCheckoutIntent(undefined, async () => missing)).rejects.toThrow(
+      "durable request for Checkout",
+    );
+  });
+});
 
 describe("protectionPresentation", () => {
   it.each<ProtectionState>([

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -8,6 +8,7 @@ import {
   effectiveProtectionState,
   operationPhaseIsActive,
   protectionCompletionSummary,
+  protectionIntentNeedsReplacement,
   protectionActions,
   protectionReconnectDelay,
   protectionRepairAction,
@@ -25,16 +26,39 @@ import {
 describe("checkout confirmation", () => {
   it("keeps waiting through normal delayed-payment confirmation", () => {
     expect(CHECKOUT_CONFIRMATION_INTERVAL_MS).toBe(3_000);
-    expect(CHECKOUT_CONFIRMATION_MAX_CHECKS).toBe(100);
+    expect(CHECKOUT_CONFIRMATION_MAX_CHECKS).toBe(40);
     expect(checkoutConfirmationIsDelayed(20)).toBe(false);
-    expect(checkoutConfirmationIsDelayed(99)).toBe(false);
-    expect(checkoutConfirmationIsDelayed(100)).toBe(true);
+    expect(checkoutConfirmationIsDelayed(39)).toBe(false);
+    expect(checkoutConfirmationIsDelayed(40)).toBe(true);
   });
 
   it("does not stop waiting when the app regains focus before Stripe is ready", () => {
     expect(checkoutConfirmationAfterCheck(false, false)).toBe("waiting");
     expect(checkoutConfirmationAfterCheck(false, true)).toBe("delayed");
     expect(checkoutConfirmationAfterCheck(true, false)).toBe("idle");
+  });
+});
+
+describe("protection intent recovery", () => {
+  const operation = (reasonCode: string | null) => ({
+    operation_id: "operation",
+    kind: "enable" as const,
+    phase: "canceled" as const,
+    protection_state: "paused" as const,
+    reason_code: reasonCode,
+    message: null,
+    snapshot_id: null,
+    protection_intent_id: "intent",
+  });
+
+  it("replaces terminal intents but keeps repairable subscription state", () => {
+    expect(protectionIntentNeedsReplacement(operation("intent_expired"))).toBe(true);
+    expect(protectionIntentNeedsReplacement(operation("intent_canceled"))).toBe(true);
+    expect(protectionIntentNeedsReplacement(operation("subscription_required"))).toBe(false);
+    expect(protectionIntentNeedsReplacement(operation(null))).toBe(false);
+    expect(protectionIntentNeedsReplacement(null, status({
+      protection_intent_status: "expired",
+    }))).toBe(true);
   });
 });
 

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CHECKOUT_CONFIRMATION_INTERVAL_MS,
+  CHECKOUT_CONFIRMATION_MAX_CHECKS,
+  checkoutConfirmationAfterCheck,
+  checkoutConfirmationIsDelayed,
   effectiveProtectionState,
   operationPhaseIsActive,
   protectionCompletionSummary,
@@ -17,6 +21,22 @@ import {
   type ProtectionState,
   type RemoteSnapshot,
 } from "./productBridge";
+
+describe("checkout confirmation", () => {
+  it("keeps waiting through normal delayed-payment confirmation", () => {
+    expect(CHECKOUT_CONFIRMATION_INTERVAL_MS).toBe(3_000);
+    expect(CHECKOUT_CONFIRMATION_MAX_CHECKS).toBe(100);
+    expect(checkoutConfirmationIsDelayed(20)).toBe(false);
+    expect(checkoutConfirmationIsDelayed(99)).toBe(false);
+    expect(checkoutConfirmationIsDelayed(100)).toBe(true);
+  });
+
+  it("does not stop waiting when the app regains focus before Stripe is ready", () => {
+    expect(checkoutConfirmationAfterCheck(false, false)).toBe("waiting");
+    expect(checkoutConfirmationAfterCheck(false, true)).toBe("delayed");
+    expect(checkoutConfirmationAfterCheck(true, false)).toBe("idle");
+  });
+});
 
 describe("resolveCheckoutIntent", () => {
   it("reuses a durable intent without creating another", async () => {

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -187,6 +187,22 @@ export interface BillingHandoff {
   opened: boolean;
 }
 
+export const CHECKOUT_CONFIRMATION_INTERVAL_MS = 3_000;
+export const CHECKOUT_CONFIRMATION_MAX_CHECKS = 100;
+export type CheckoutConfirmation = "idle" | "waiting" | "delayed";
+
+export function checkoutConfirmationIsDelayed(completedChecks: number): boolean {
+  return completedChecks >= CHECKOUT_CONFIRMATION_MAX_CHECKS;
+}
+
+export function checkoutConfirmationAfterCheck(
+  subscriptionActive: boolean,
+  explicitCheck: boolean,
+): CheckoutConfirmation {
+  if (subscriptionActive) return "idle";
+  return explicitCheck ? "delayed" : "waiting";
+}
+
 export interface CheckoutIntentResolution {
   intentId: string;
   created: ProtectionOperation | null;

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -187,6 +187,27 @@ export interface BillingHandoff {
   opened: boolean;
 }
 
+export interface CheckoutIntentResolution {
+  intentId: string;
+  created: ProtectionOperation | null;
+}
+
+export async function resolveCheckoutIntent(
+  existingIntentId: string | null | undefined,
+  createIntent: () => Promise<ProtectionOperation>,
+): Promise<CheckoutIntentResolution> {
+  if (existingIntentId) return { intentId: existingIntentId, created: null };
+
+  const created = await createIntent();
+  if (created.reason_code) {
+    throw new Error(created.message || "Protection could not prepare Checkout.");
+  }
+  if (!created.protection_intent_id) {
+    throw new Error("Protection could not create a durable request for Checkout.");
+  }
+  return { intentId: created.protection_intent_id, created };
+}
+
 export interface LogoutResult {
   signed_in: false;
   revoked_remotely: boolean;

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -188,7 +188,7 @@ export interface BillingHandoff {
 }
 
 export const CHECKOUT_CONFIRMATION_INTERVAL_MS = 3_000;
-export const CHECKOUT_CONFIRMATION_MAX_CHECKS = 100;
+export const CHECKOUT_CONFIRMATION_MAX_CHECKS = 40;
 export type CheckoutConfirmation = "idle" | "waiting" | "delayed";
 
 export function checkoutConfirmationIsDelayed(completedChecks: number): boolean {
@@ -201,6 +201,16 @@ export function checkoutConfirmationAfterCheck(
 ): CheckoutConfirmation {
   if (subscriptionActive) return "idle";
   return explicitCheck ? "delayed" : "waiting";
+}
+
+export function protectionIntentNeedsReplacement(
+  operation: ProtectionOperation | null | undefined,
+  status?: ProtectionStatus | null,
+): boolean {
+  return operation?.reason_code === "intent_expired"
+    || operation?.reason_code === "intent_canceled"
+    || status?.protection_intent_status === "expired"
+    || status?.protection_intent_status === "canceled";
 }
 
 export interface CheckoutIntentResolution {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1473,6 +1473,16 @@ body.in-app .node-detail.tier-core {
   font-size: 11px;
 }
 
+.checkout-delayed {
+  margin-top: 12px;
+  padding: 10px;
+  border-left: 2px solid var(--accent);
+  background: rgba(217, 164, 106, 0.06);
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
 .protection-facts {
   display: grid;
   gap: 11px;


### PR DESCRIPTION
Closes #226.

## Problem

The Protect panel could remain on its Checkout view after transient React operation state was lost. If durable status also lacked the intent ID, clicking **Subscribe with Stripe** returned silently before invoking the native bridge: no browser, error, or feedback.

This was exposed during controlled production acceptance. A separate operator error also showed that a desktop-only `ORMAH_CLOUD_API_URL` override does not reconfigure the managed Python daemon; that distinct environment-selection issue is tracked in #225 and was corrected locally through the full-dictionary env writer plus daemon restart.

## Change

- resolve a Checkout intent before invoking the native handoff
- reuse an existing durable intent when present
- create and retain a new durable intent when transient state was lost
- surface malformed/unrecoverable intent state as a visible error
- stop manual payment checks from silently returning when their intent is unavailable

## Verification

- `npm test` -> 42 passed
- `npm run build` -> passed
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml product_bridge --lib` -> 19 passed
- `uv run ruff check src/ tests/` -> clean
- full Python suite -> 1838 passed, one unrelated deterministic baseline failure in `test_cloud_settings.py::test_cloud_setting_preserves_unrelated_env_lines_and_updates_runtime`, tracked as #227 (filelock 3.25 removes the lock inode on release)

No Stripe URL, token, or payment data is exposed to the web UI; the existing Rust-side exact-host validation remains unchanged.