### PR TITLE
fix: repair confirmed-use memory lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,8 +122,23 @@ ORMAH_LOG_INGEST_INTERVAL_MINUTES=10
 ORMAH_CORE_MEMORY_CAP=50
 ORMAH_WORKING_DECAY_DAYS=14
 
+# Lifecycle policy (exponential retrievability; S is the ~37% point).
+# The default initial stability is -7 / ln(0.3) ≈ 5.814 days, so an unused
+# node crosses R=0.3 after seven mathematical days. Reinforcement constants
+# are policy defaults, not fitted FSRS parameters.
+# ORMAH_FSRS_INITIAL_STABILITY=5.814084815577761
+# ORMAH_FSRS_DECAY_THRESHOLD=0.3
+# ORMAH_FSRS_REINFORCEMENT_GAIN=0.5
+# ORMAH_FSRS_REINFORCEMENT_SATURATION_EXPONENT=0.5
+# ORMAH_FSRS_REINFORCEMENT_SPACING_CAP=2.0
+# ORMAH_FSRS_MAX_STABILITY=365.0
+# ORMAH_FSRS_STABILITY_GROWTH=1.5  # deprecated; retained for compatibility, ignored
+
 # Importance scoring
 # ORMAH_IMPORTANCE_RECOMPUTE_INTERVAL_MINUTES=120
+# Importance recency uses its own half-life, independent of lifecycle stability.
+# ORMAH_IMPORTANCE_RECENCY_HALF_LIFE_DAYS=14.0
+# ORMAH_DECAY_IMPORTANCE_THRESHOLD=0.5  # deprecated; no longer gates decay
 
 # Memory consolidation (requires LLM)
 # ORMAH_CONSOLIDATION_INTERVAL_MINUTES=360

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Whisper evaluates standing preferences through a separate applicability path. Th
 
 Whisper feedback can learn from transcript files after they stop changing: a local heuristic records clear usage for free, and an optional LLM judge can classify ambiguous turns into positive, negative, or uncertain retrieval signals.
 
+Lifecycle uses confirmed use rather than surfacing as its activity signal. Search results, UI results, graph neighbours, and bare whisper injection are observable but non-mutating; deliberate `recall_node` and source-qualified positive feedback (`explicit`, `implicit`, or `auto_llm_judge`) record use. Working memories decay to archival from retrievability alone and can return to working on confirmed use, except when explicitly superseded by consolidation. Ormah retains the exponential curve `R = exp(-t / S)`: `S` is the approximately 37% retrievability point, and the default `S ≈ 5.814` crosses `R = 0.3` after seven days. Reinforcement is bounded and cooled to one numeric stability update per node per 24 hours; these are FSRS-inspired policy defaults, not a full FSRS implementation or fitted FSRS parameters.
+
 Read more: [Whisper - Involuntary Recall](https://www.ormah.me/docs/how-ormah-works/whisper), [Search and Ranking](https://www.ormah.me/docs/how-ormah-works/search-and-ranking), [Affinity and Feedback](https://www.ormah.me/docs/operations/affinity-and-feedback)
 
 ### Memory Capture

--- a/docs/01 - Data Model.md
+++ b/docs/01 - Data Model.md
@@ -30,17 +30,18 @@ connections: list[Connection]  # Outgoing edges to other nodes
 # Scoring
 confidence: float           # [0.0-1.0] How certain we are (default: 1.0)
 importance: float           # [0.0-1.0] Computed by importance_scorer job; see 05 - Background Jobs
-access_count: int           # Times this node has been accessed/recalled
+access_count: int           # Confirmed-use count (not search/result surfacing)
 
 # Temporal
 created: datetime           # When first stored (UTC)
 updated: datetime           # Last modification (UTC)
-last_accessed: datetime     # Last recall/search hit (UTC)
-last_review: datetime | None # Last FSRS review (spaced repetition)
+last_accessed: datetime     # Last confirmed use, or creation before first use
+last_review: datetime | None # Last numeric stability update; separate from last_accessed
 valid_until: datetime | None # Expiry date (set by mark_outdated)
 
 # FSRS (Spaced Repetition)
-stability: float            # Days until ~37% retrievability (default: 1.0)
+stability: float            # Days until ~37% retrievability (default: ~5.814)
+consolidated_into: str | None # Explicit consolidation supersession replacement ID
 ```
 
 ### Connection
@@ -95,9 +96,9 @@ graph LR
         A3[Superseded facts]
     end
 
-    W1 -->|"promote<br/>(manual)"| C1
+    W1 -->|"core promotion<br/>(existing rules)"| C1
     W1 -->|"decay<br/>(FSRS auto)"| A1
-    A1 -->|"promote<br/>(manual)"| W1
+    A1 -->|"confirmed use"| W1
 ```
 
 | Tier | Cap | Decay | Search Boost | Purpose |

--- a/docs/04 - Whisper - Involuntary Recall.md
+++ b/docs/04 - Whisper - Involuntary Recall.md
@@ -98,7 +98,8 @@ The builder calls structured recall with:
 
 - `limit = whisper_max_nodes * whisper_candidate_pool_multiplier` (defaults `6 * 5 = 30`) — a deep candidate pool so the reranker and gate can rescue memories the bi-encoder under-ranked; the final injected set is still capped at `whisper_max_nodes`
 - `tiers = [core, working]`
-- `touch_access = False`
+- Lifecycle access tracking is non-mutating for whisper surfacing; the retained
+  `touch_access = False` compatibility argument is ignored by structured recall.
 
 ### 7. Thresholds and reranking
 

--- a/docs/05 - Background Jobs.md
+++ b/docs/05 - Background Jobs.md
@@ -124,9 +124,11 @@ It does not do embedding clustering or hierarchical clustering despite the name.
 ## Importance and Decay
 
 - `importance_scorer` computes a normalized multi-signal importance value
-- `decay_manager` uses FSRS-style retrievability and importance to decide whether to demote working memories
+- `decay_manager` demotes working memories from retrievability alone
 
-High-importance nodes are protected from decay.
+Importance remains useful for ranking, display, and core-cap prioritization,
+but it is not a hidden protection gate. A high-importance node that is no
+longer retrievable still becomes archival and remains deliberately recallable.
 
 ### Importance Scorer
 
@@ -134,7 +136,8 @@ High-importance nodes are protected from decay.
 
 1. **Access signal**: how often the node has been recalled, based on `access_count`
 2. **Edge signal**: how connected the node is in the graph, based on total edge count
-3. **Recency signal**: how retrievable the node currently is, using FSRS-style `exp(-days_ago / stability)`
+3. **Recency signal**: confirmed-use recency using its own configured half-life:
+   `exp(-ln(2) * age_days / importance_recency_half_life_days)`
 
 With the default configuration, those signals are weighted almost evenly:
 
@@ -149,9 +152,27 @@ Access and edge counts are log-normalized against reference values, then the wei
 
 The scorer runs every `120` minutes by default and only writes a new value when the change is meaningful.
 
-This score is not static. Recall and search hits update `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched.
+This score is not static. Confirmed use updates `access_count` and
+`last_accessed`; search hits and whisper injection do not. Edge counts and
+confirmed-use recency continue to affect importance independently of lifecycle
+stability.
 
-Important current nuance: `importance_recency_half_life_days` exists in configuration, but the current scorer implementation uses FSRS stability for the recency term instead.
+### Lifecycle semantics
+
+Ormah retains the exponential, FSRS-inspired policy curve `R = exp(-t / S)`;
+`S` is the approximately 37% retrievability point, not the 90% point used by
+the power-law FSRS convention. The default initial stability is
+`-7 / ln(0.3) ≈ 5.814`, giving a seven-day mathematical crossing of the
+`R = 0.3` decay threshold. The scheduler may demote on its next daily run.
+
+Confirmed use is exactly deliberate `recall_node` or positive feedback from
+`explicit`, `implicit`, or `auto_llm_judge`. Broad recall, UI search, bare
+whisper injection, graph activation, neighbours, `auto_heuristic`, and all
+negative feedback are not confirmed use. Every confirmed use advances the
+use/decay anchor and count, while bounded reinforcement can increase numeric
+stability at most once per node per 24 hours. The gain, saturation exponent,
+spacing cap, and maximum are configurable policy defaults, not fitted FSRS
+parameters. `last_review` is only the last numeric stability update.
 
 ## Walkthrough Example
 

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -181,7 +181,7 @@ Important note: current search applies tier as a multiplicative factor after con
 | `importance_access_reference` | `50` |
 | `importance_edge_reference` | `20` |
 | `importance_recency_half_life_days` | `14.0` |
-| `decay_importance_threshold` | `0.5` |
+| `decay_importance_threshold` | `0.5` (deprecated compatibility; no decay effect) |
 
 ## Whisper-Out and Nudge
 
@@ -233,11 +233,26 @@ Important note: current search applies tier as a multiplicative factor after con
 |---|---|
 | `core_memory_cap` | `50` |
 | `working_decay_days` | `14` |
-| `fsrs_initial_stability` | `1.0` |
+| `fsrs_initial_stability` | `5.814084815577761` |
 | `fsrs_decay_threshold` | `0.3` |
-| `fsrs_stability_growth` | `1.5` |
+| `fsrs_reinforcement_gain` | `0.5` |
+| `fsrs_reinforcement_saturation_exponent` | `0.5` |
+| `fsrs_reinforcement_spacing_cap` | `2.0` |
+| `fsrs_stability_growth` | `1.5` (deprecated compatibility; ignored) |
 | `fsrs_max_stability` | `365.0` |
 | `ingest_max_content_chars` | `100000` |
+
+`stability` retains Ormah's exponential meaning: `R = exp(-t / S)`, so `S`
+is the approximately 37% retrievability point. The default initial value
+`-7 / ln(0.3) ≈ 5.814` gives a seven-day unused working lease before the
+daily decay job observes the threshold. Reinforcement is bounded with
+`spacing = min(R^-0.2, 2.0)` and
+`S_new = min(S * (1 + gain * S^-saturation_exponent * spacing), 365)`;
+the constants are policy defaults, not fitted FSRS parameters. The old
+`fsrs_stability_growth` multiplier is retained only so existing configuration
+continues to parse and is not silently reinterpreted. The old
+`decay_importance_threshold` likewise remains parse-compatible but no longer
+gates working-to-archival decay.
 
 ## Agent-Backed Maintenance
 

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -104,8 +104,6 @@ def _apply_consolidation(
         ConnectRequest,
         CreateNodeRequest,
         EdgeType,
-        Tier,
-        UpdateNodeRequest,
     )
 
     conn = engine.db.conn
@@ -174,7 +172,10 @@ def _apply_consolidation(
             ))
         except Exception:
             pass
-        engine.update_node(node_id, UpdateNodeRequest(tier=Tier.archival))
+        # A generic derived_from edge is not supersession provenance. Record
+        # the explicit consolidation relationship so later confirmed use can
+        # remain recallable without automatically reviving the original.
+        engine.mark_consolidated(node_id, new_id)
 
     return new_id
 

--- a/src/ormah/background/decay_manager.py
+++ b/src/ormah/background/decay_manager.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-import math
 from datetime import datetime, timezone
 
 from ormah.background.memory_lock import serialized_memory_job
+from ormah.engine.lifecycle import retrievability, safe_stability
 from ormah.models.node import Tier, UpdateNodeRequest
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ def run_decay(engine) -> None:
             )
 
         rows = engine.db.conn.execute(
-            "SELECT id, importance, stability, last_review, last_accessed "
+            "SELECT id, stability, last_accessed, created "
             "FROM nodes WHERE tier = 'working'"
         ).fetchall()
 
@@ -34,29 +34,31 @@ def run_decay(engine) -> None:
             return
 
         user_node_id = getattr(engine, "user_node_id", None)
-        importance_threshold = settings.decay_importance_threshold
         r_threshold = settings.fsrs_decay_threshold
 
         demoted = 0
         for row in rows:
             if row["id"] == user_node_id:
                 continue
-            # Skip high-importance nodes
-            node_importance = row["importance"] if row["importance"] is not None else 0.5
-            if node_importance >= importance_threshold:
-                continue
-
-            # Compute FSRS retrievability
-            stability = row["stability"] if row["stability"] else 1.0
-            anchor_str = row["last_review"] or row["last_accessed"]
+            # Decay follows confirmed-use/creation recency. Importance remains
+            # a ranking/display/core-cap signal, never a hidden immortality gate.
+            stability = safe_stability(
+                row["stability"],
+                settings.fsrs_initial_stability,
+            )
+            anchor_str = row["last_accessed"] or row["created"]
             try:
                 anchor = datetime.fromisoformat(anchor_str)
             except (ValueError, TypeError):
                 continue
             days_since = max((now - anchor).total_seconds() / 86400, 0.001)
-            retrievability = math.exp(-days_since / stability)
+            node_retrievability = retrievability(
+                days_since,
+                stability,
+                fallback=settings.fsrs_initial_stability,
+            )
 
-            if retrievability >= r_threshold:
+            if node_retrievability >= r_threshold:
                 continue
 
             result = engine.update_node(row["id"], UpdateNodeRequest(tier=Tier.archival))

--- a/src/ormah/background/importance_scorer.py
+++ b/src/ormah/background/importance_scorer.py
@@ -7,6 +7,7 @@ import math
 from datetime import datetime, timezone
 
 from ormah.background.memory_lock import serialized_memory_job
+from ormah.engine.lifecycle import importance_recency
 
 logger = logging.getLogger(__name__)
 
@@ -31,8 +32,7 @@ def run_importance_scoring(engine) -> None:
 
     # Fetch everything upfront — avoids N+1 queries for importance lookups
     rows = conn.execute(
-        "SELECT id, access_count, last_accessed, "
-        "importance, stability, last_review FROM nodes"
+        "SELECT id, access_count, last_accessed, importance, created FROM nodes"
     ).fetchall()
     if not rows:
         return
@@ -75,13 +75,16 @@ def run_importance_scoring(engine) -> None:
         ec = edge_counts.get(nid, 0)
         edge_signal = min(1.0, math.log1p(ec) / math.log1p(ref_edge))
 
-        # Recency signal: FSRS retrievability (exp(-t/S))
+        # Importance recency is intentionally independent from lifecycle
+        # stability and uses confirmed-use/creation recency.
         try:
-            stability = r["stability"] if r["stability"] else 1.0
-            anchor_str = r["last_review"] or r["last_accessed"]
+            anchor_str = r["last_accessed"] or r["created"]
             anchor = datetime.fromisoformat(anchor_str)
             days_ago = max((now - anchor).total_seconds() / 86400, 0)
-            recency_signal = math.exp(-days_ago / stability)
+            recency_signal = importance_recency(
+                days_ago,
+                settings.importance_recency_half_life_days,
+            )
         except (ValueError, TypeError):
             recency_signal = 0.0
 

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -581,6 +581,14 @@ def _record_whisper_usage_signals(
                     confirmed_at=now_iso,
                 )
 
+    # The LLM judge writes its own observability and affinity rows above. A
+    # confident positive verdict is nevertheless confirmed use, so route only
+    # that lifecycle mutation through the engine's shared operation. Heuristic
+    # positives intentionally remain ranking/observability evidence only.
+    for record in judge_records:
+        if record["polarity"] == 1:
+            engine._record_confirmed_use(record["row"]["node_id"])
+
     return recorded
 
 

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from pydantic import field_validator
 from pydantic_settings import BaseSettings
 
+from ormah.engine.lifecycle import DEFAULT_INITIAL_STABILITY
+
 
 _ENV_FILES = [
     Path.home() / ".config" / "ormah" / ".env",  # Fixed global config
@@ -87,9 +89,14 @@ class Settings(BaseSettings):
     working_decay_days: int = 14  # Deprecated: superseded by FSRS-based decay
 
     # FSRS spaced repetition decay
-    fsrs_initial_stability: float = 1.0    # days; starting stability for new nodes
+    fsrs_initial_stability: float = DEFAULT_INITIAL_STABILITY  # seven-day R=0.3 lease
     fsrs_decay_threshold: float = 0.3      # R below this = decay candidate
-    fsrs_stability_growth: float = 1.5     # base multiplier on access
+    # Deprecated compatibility setting. Reinforcement now uses the explicit
+    # additive gain below; this old multiplier is intentionally ignored.
+    fsrs_stability_growth: float = 1.5
+    fsrs_reinforcement_gain: float = 0.5
+    fsrs_reinforcement_saturation_exponent: float = 0.5
+    fsrs_reinforcement_spacing_cap: float = 2.0
     fsrs_max_stability: float = 365.0      # cap at 1 year
 
     # Search
@@ -151,7 +158,7 @@ class Settings(BaseSettings):
     # Importance: recency half-life (separate from search recency)
     importance_recency_half_life_days: float = 14.0
 
-    # Decay: skip nodes above this importance
+    # Deprecated compatibility setting; working-tier decay is retrievability-only.
     decay_importance_threshold: float = 0.5
 
     # Whisper-out (involuntary storage on compaction / session end)
@@ -561,11 +568,24 @@ class Settings(BaseSettings):
             raise ValueError(f"threshold must be 0–1, got {v}")
         return v
 
-    @field_validator("fsrs_initial_stability", "fsrs_stability_growth")
+    @field_validator(
+        "fsrs_initial_stability",
+        "fsrs_stability_growth",
+        "fsrs_reinforcement_gain",
+        "fsrs_reinforcement_saturation_exponent",
+        "fsrs_reinforcement_spacing_cap",
+    )
     @classmethod
     def _fsrs_positive(cls, v: float) -> float:
         if v <= 0:
             raise ValueError(f"FSRS parameter must be > 0, got {v}")
+        return v
+
+    @field_validator("fsrs_reinforcement_spacing_cap")
+    @classmethod
+    def _fsrs_spacing_cap_at_least_one(cls, v: float) -> float:
+        if v < 1:
+            raise ValueError(f"fsrs_reinforcement_spacing_cap must be >= 1, got {v}")
         return v
 
     @field_validator("fsrs_max_stability")

--- a/src/ormah/engine/lifecycle.py
+++ b/src/ormah/engine/lifecycle.py
@@ -1,0 +1,139 @@
+"""Versioned lifecycle policy math.
+
+The stored ``stability`` value keeps Ormah's original exponential meaning: it
+is the number of days at which retrievability reaches ``exp(-1)`` (about 37%).
+This module is deliberately small so decay and confirmed-use reinforcement do
+not grow separate interpretations of the policy.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+
+
+LIFECYCLE_MODEL_VERSION = 1
+LIFECYCLE_MODEL_META_KEY = "lifecycle_model_version"
+FSRS_BOOTSTRAP_META_KEY = "fsrs_migrated"
+DECAY_THRESHOLD = 0.3
+DEFAULT_INITIAL_STABILITY = -7.0 / math.log(DECAY_THRESHOLD)
+
+
+def safe_stability(value: float | int | None, fallback: float) -> float:
+    """Return a finite positive stability value for legacy/corrupt rows."""
+    try:
+        candidate = float(value) if value is not None else fallback
+    except (TypeError, ValueError):
+        candidate = fallback
+    if not math.isfinite(candidate) or candidate <= 0:
+        return fallback
+    return candidate
+
+
+def nonnegative_age_days(age_days: float | int | None) -> float:
+    """Normalize an elapsed-day value without allowing NaN into policy math."""
+    try:
+        age = float(age_days) if age_days is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+    if math.isnan(age):
+        return 0.0
+    return max(age, 0.0)
+
+
+def elapsed_days(anchor: datetime, now: datetime) -> float:
+    """Return non-negative elapsed days between two timezone-aware datetimes."""
+    return nonnegative_age_days((now - anchor).total_seconds() / 86400.0)
+
+
+def retrievability(age_days: float, stability: float, *, fallback: float) -> float:
+    """Compute the retained exponential retrievability curve ``exp(-t / S)``."""
+    age = nonnegative_age_days(age_days)
+    stable = safe_stability(stability, fallback)
+    return math.exp(-age / stable)
+
+
+def importance_recency(age_days: float, half_life_days: float) -> float:
+    """Compute importance's independent half-life recency signal."""
+    age = nonnegative_age_days(age_days)
+    try:
+        half_life = float(half_life_days)
+    except (TypeError, ValueError):
+        half_life = 14.0
+    if not math.isfinite(half_life) or half_life <= 0:
+        half_life = 14.0
+    return math.exp(-math.log(2.0) * age / half_life)
+
+
+def reinforcement_spacing(
+    age_days: float,
+    stability: float,
+    *,
+    spacing_cap: float,
+    fallback: float,
+) -> float:
+    """Compute ``min(R**-0.2, cap)`` safely in log space.
+
+    Evaluating ``R`` first would underflow for old memories and then produce an
+    overflow when raising zero to a negative power. The equivalent logarithmic
+    form is bounded before exponentiation.
+    """
+    stable = safe_stability(stability, fallback)
+    age = nonnegative_age_days(age_days)
+    try:
+        cap = float(spacing_cap)
+    except (TypeError, ValueError):
+        cap = 2.0
+    if not math.isfinite(cap) or cap <= 0:
+        cap = 2.0
+    log_spacing = min(0.2 * age / stable, math.log(cap))
+    return math.exp(log_spacing)
+
+
+def bounded_stability_update(
+    stability: float,
+    age_days: float,
+    *,
+    gain: float,
+    saturation_exponent: float,
+    spacing_cap: float,
+    max_stability: float,
+    fallback: float,
+) -> float:
+    """Apply one bounded confirmed-use stability update.
+
+    ``S_new = min(S * (1 + g * S**-w * spacing), max_stability)``.
+    """
+    stable = safe_stability(stability, fallback)
+    maximum = safe_stability(max_stability, fallback)
+    if stable >= maximum:
+        return maximum
+    spacing = reinforcement_spacing(
+        age_days,
+        stable,
+        spacing_cap=spacing_cap,
+        fallback=fallback,
+    )
+    updated = stable * (
+        1.0 + float(gain) * (stable ** -float(saturation_exponent)) * spacing
+    )
+    if not math.isfinite(updated):
+        updated = maximum
+    return min(updated, maximum)
+
+
+def archival_deadline(
+    anchor: datetime,
+    stability: float,
+    *,
+    threshold: float,
+    fallback: float,
+) -> datetime:
+    """Return the current-model deadline at which retrievability crosses threshold.
+
+    Keeping this relation explicit gives a future model migration a stable
+    deadline to preserve without rescaling existing node stability values.
+    """
+    stable = safe_stability(stability, fallback)
+    safe_threshold = min(max(float(threshold), 1e-12), 1.0 - 1e-12)
+    return anchor + timedelta(days=stable * -math.log(safe_threshold))

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -18,6 +18,14 @@ from typing import Any
 from ormah.config import Settings
 from ormah.embeddings.text import embedding_text as _embedding_text
 from ormah.engine.context_builder import ContextBuilder
+from ormah.engine.lifecycle import (
+    FSRS_BOOTSTRAP_META_KEY,
+    LIFECYCLE_MODEL_META_KEY,
+    LIFECYCLE_MODEL_VERSION,
+    bounded_stability_update,
+    elapsed_days,
+    safe_stability,
+)
 from ormah.engine.maintenance_signal import (
     MAINTENANCE_DUE_SIGNAL,
     is_maintenance_due_signal,
@@ -147,7 +155,7 @@ class MemoryEngine:
                     (str(_EMBEDDING_SCHEMA_VERSION),),
                 )
 
-        # One-time FSRS data migration: seed stability from access patterns
+        # One-time legacy bootstrap plus versioned lifecycle semantics.
         self._migrate_fsrs()
 
         self._ensure_self_node()
@@ -159,42 +167,58 @@ class MemoryEngine:
     def _migrate_fsrs(self) -> None:
         """Seed FSRS stability from access_count on first run, updating both DB and markdown."""
         fsrs_migrated = self.db.conn.execute(
-            "SELECT value FROM meta WHERE key = 'fsrs_migrated'"
+            "SELECT value FROM meta WHERE key = ?",
+            (FSRS_BOOTSTRAP_META_KEY,),
         ).fetchone()
-        if fsrs_migrated:
-            return
+        if not fsrs_migrated:
+            rows = self.db.conn.execute(
+                "SELECT id, access_count, last_accessed FROM nodes"
+            ).fetchall()
 
-        rows = self.db.conn.execute(
-            "SELECT id, access_count, last_accessed FROM nodes"
-        ).fetchall()
+            with self.db.transaction() as conn:
+                for r in rows:
+                    access_count = r["access_count"] or 0
+                    stability = min(30.0, access_count * 2.0) if access_count > 0 else 1.0
+                    last_review = r["last_accessed"]
 
-        with self.db.transaction() as conn:
-            for r in rows:
-                access_count = r["access_count"] or 0
-                stability = min(30.0, access_count * 2.0) if access_count > 0 else 1.0
-                last_review = r["last_accessed"]
+                    # This is the pre-existing one-time bootstrap for legacy
+                    # stores. It is not a rescaling of already-migrated values.
+                    conn.execute(
+                        "UPDATE nodes SET stability = ?, last_review = ? WHERE id = ?",
+                        (stability, last_review, r["id"]),
+                    )
 
-                # Update DB
+                    node = self.file_store.load(r["id"])
+                    if node is not None:
+                        node.stability = stability
+                        if last_review:
+                            try:
+                                node.last_review = datetime.fromisoformat(last_review)
+                            except (ValueError, TypeError):
+                                pass
+                        self.file_store.save(node)
+
                 conn.execute(
-                    "UPDATE nodes SET stability = ?, last_review = ? WHERE id = ?",
-                    (stability, last_review, r["id"]),
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES (?, '1')",
+                    (FSRS_BOOTSTRAP_META_KEY,),
                 )
+            logger.info("FSRS data migration complete: seeded %d nodes from access_count", len(rows))
 
-                # Update markdown file
-                node = self.file_store.load(r["id"])
-                if node is not None:
-                    node.stability = stability
-                    if last_review:
-                        try:
-                            node.last_review = datetime.fromisoformat(last_review)
-                        except (ValueError, TypeError):
-                            pass
-                    self.file_store.save(node)
-
-            conn.execute(
-                "INSERT OR REPLACE INTO meta (key, value) VALUES ('fsrs_migrated', '1')"
-            )
-        logger.info("FSRS data migration complete: seeded %d nodes from access_count", len(rows))
+        # The boolean remains for bootstrap compatibility. The integer version
+        # records the meaning of stored stability for future curve migrations.
+        with self.db.transaction() as conn:
+            version_row = conn.execute(
+                "SELECT value FROM meta WHERE key = ?", (LIFECYCLE_MODEL_META_KEY,)
+            ).fetchone()
+            try:
+                stored_version = int(version_row["value"]) if version_row else 0
+            except (TypeError, ValueError):
+                stored_version = 0
+            if stored_version < LIFECYCLE_MODEL_VERSION:
+                conn.execute(
+                    "INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)",
+                    (LIFECYCLE_MODEL_META_KEY, str(LIFECYCLE_MODEL_VERSION)),
+                )
 
     def _seed_initial_maintenance_grace_period(self) -> None:
         """Avoid firing agent-backed maintenance immediately on fresh installs."""
@@ -238,6 +262,7 @@ class MemoryEngine:
             tags=["self", "identity"],
             title="Self",
             content="The user's identity and personal information.",
+            stability=self.settings.fsrs_initial_stability,
         )
 
         path = self.file_store.save(node)
@@ -506,6 +531,7 @@ class MemoryEngine:
             title=title,
             content=req.content,
             confidence=req.confidence,
+            stability=self.settings.fsrs_initial_stability,
         )
 
         # Mark and promote identity nodes
@@ -642,8 +668,10 @@ class MemoryEngine:
 
         resolved_node_id = node["id"]
 
-        # Touch access
-        self._touch_access(resolved_node_id)
+        # Only the deliberately requested node is confirmed use. Neighbours
+        # remain surfaced context and must not receive lifecycle mutations.
+        self._record_confirmed_use(resolved_node_id)
+        node = self.graph.get_node(resolved_node_id) or node
 
         edges = self.graph.get_edges_for(resolved_node_id)
         neighbors = self.graph.get_neighbors(resolved_node_id, depth=1)
@@ -687,8 +715,9 @@ class MemoryEngine:
         Same logic as recall_search but returns raw dicts instead of formatted text.
         Used by the UI and any consumer that needs structured data.
 
-        When *touch_access* is False, access_count and last_accessed are not
-        updated — useful for context loading that shouldn't inflate access stats.
+        ``touch_access`` is retained as a compatibility parameter but is now
+        ignored: search-result surfacing never mutates lifecycle state. Use
+        ``recall_node`` or qualified positive feedback for confirmed use.
 
         *min_relevance* overrides the deliberate-recall floor
         (settings.recall_min_relevance_score). Whisper passes 0.0: it needs
@@ -769,10 +798,6 @@ class MemoryEngine:
 
             if spread_activation:
                 results = self._spread_activation(results, limit)
-            if touch_access:
-                for r in results:
-                    if r.get("source") not in ("activated", "conflict"):
-                        self._touch_access(r["node"]["id"])
             return results
 
         # Fallback to FTS only
@@ -805,10 +830,6 @@ class MemoryEngine:
 
         if spread_activation:
             enriched = self._spread_activation(enriched, limit)
-        if touch_access:
-            for r in enriched:
-                if r.get("source") not in ("activated", "conflict"):
-                    self._touch_access(r["node"]["id"])
 
         return enriched
 
@@ -887,9 +908,6 @@ class MemoryEngine:
                     )
 
             results = self._spread_activation(results, limit)
-            for r in results:
-                if r.get("source") not in ("activated", "conflict"):
-                    self._touch_access(r["node"]["id"])
             whisper_log_ids = self._log_feedback_candidates(
                 query_for_log,
                 [
@@ -933,9 +951,6 @@ class MemoryEngine:
             )
 
         enriched = self._spread_activation(enriched, limit)
-        for r in enriched:
-            if r.get("source") not in ("activated", "conflict"):
-                self._touch_access(r["node"]["id"])
         whisper_log_ids = self._log_feedback_candidates(
             query_for_log,
             [
@@ -1012,6 +1027,22 @@ class MemoryEngine:
         )
 
         return f"Updated [{node.type.value}]: {node.title or node.content[:80]}\nID: {node.id}"
+
+    @_serialized_memory_operation
+    def mark_consolidated(self, node_id: str, replacement_id: str) -> bool:
+        """Record explicit consolidation supersession on an original node."""
+        node = self.file_store.load(node_id)
+        if node is None:
+            return False
+        if node.consolidated_into == replacement_id and node.tier == Tier.archival:
+            return True
+
+        node.consolidated_into = replacement_id
+        node.tier = Tier.archival
+        node.touch_updated()
+        path = self.file_store.save(node)
+        self.builder.index_single(path)
+        return True
 
     @_serialized_memory_operation
     def delete_node(self, node_id: str) -> str | None:
@@ -1933,31 +1964,89 @@ class MemoryEngine:
             self_node.touch_updated()
             self.file_store.save(self_node)
 
-    def _touch_access(self, node_id: str) -> None:
-        """Update access stats and FSRS stability on both disk and DB."""
+    @_serialized_memory_operation
+    def _record_confirmed_use(self, node_id: str) -> bool:
+        """Record one confirmed use and apply the lifecycle policy atomically.
+
+        This is the only lifecycle entry point for deliberate node recall and
+        qualified positive feedback. It deliberately separates the confirmed-
+        use anchor (``last_accessed``) from the numeric stability timestamp
+        (``last_review``): repeated uses remain genuine access events while the
+        stability update is cooled down to once per 24 hours.
+        """
         node = self.file_store.load(node_id)
         if node is None:
-            return
+            return False
         now = datetime.now(timezone.utc)
 
-        # FSRS stability update
-        review_anchor = node.last_review or node.last_accessed
-        days_since = max((now - review_anchor).total_seconds() / 86400, 0.001)
-        retrievability = math.exp(-days_since / node.stability)
-        new_stability = node.stability * self.settings.fsrs_stability_growth * (retrievability ** -0.2)
-        node.stability = round(min(new_stability, self.settings.fsrs_max_stability), 2)
-        node.last_review = now
+        old_stability = safe_stability(
+            node.stability,
+            self.settings.fsrs_initial_stability,
+        )
+        review_anchor = node.last_review or node.last_accessed or node.created
+        days_since_review = elapsed_days(review_anchor, now)
+        cooldown_elapsed = node.last_review is None or days_since_review >= 1.0
 
-        # Standard access tracking
+        reinforced = old_stability
+        if cooldown_elapsed:
+            reinforced = bounded_stability_update(
+                old_stability,
+                days_since_review,
+                gain=self.settings.fsrs_reinforcement_gain,
+                saturation_exponent=self.settings.fsrs_reinforcement_saturation_exponent,
+                spacing_cap=self.settings.fsrs_reinforcement_spacing_cap,
+                max_stability=self.settings.fsrs_max_stability,
+                fallback=self.settings.fsrs_initial_stability,
+            )
+
+        promoting = (
+            node.tier == Tier.archival
+            and node.consolidated_into is None
+        )
+        final_stability = reinforced
+        if promoting and cooldown_elapsed:
+            # Reinforce from the old value first, then apply the initial lease
+            # floor. Flooring first would amplify a single old recall.
+            final_stability = min(
+                max(reinforced, self.settings.fsrs_initial_stability),
+                self.settings.fsrs_max_stability,
+            )
+
+        stability_changed = (
+            not math.isclose(final_stability, old_stability, rel_tol=0.0, abs_tol=1e-12)
+            or not math.isclose(node.stability, old_stability, rel_tol=0.0, abs_tol=1e-12)
+        )
+        if stability_changed:
+            node.stability = final_stability
+            node.last_review = now
+
+        if promoting:
+            node.tier = Tier.working
         node.last_accessed = now
         node.access_count += 1
 
+        # Match the repository's source-of-truth mutation convention: hold the
+        # engine/file lock, save markdown atomically, then stamp the derived
+        # SQLite row in the same serialized lifecycle operation.
         self.file_store.save(node)
         with self.db.transaction() as conn:
             conn.execute(
-                "UPDATE nodes SET access_count = ?, last_accessed = ?, stability = ?, last_review = ? WHERE id = ?",
-                (node.access_count, node.last_accessed.isoformat(), node.stability, node.last_review.isoformat(), node_id),
+                """
+                UPDATE nodes
+                SET tier = ?, access_count = ?, last_accessed = ?,
+                    stability = ?, last_review = ?
+                WHERE id = ?
+                """,
+                (
+                    node.tier.value,
+                    node.access_count,
+                    node.last_accessed.isoformat(),
+                    node.stability,
+                    node.last_review.isoformat() if node.last_review else None,
+                    node_id,
+                ),
             )
+        return True
 
     # --- Private helpers ---
 
@@ -2495,6 +2584,7 @@ class MemoryEngine:
             return None, None, f"No whisper_log entry found for node {node_id}"
         return resolved_node_id, row, None
 
+    @_serialized_memory_operation
     def submit_feedback(
         self,
         node_id: str,
@@ -2608,6 +2698,9 @@ class MemoryEngine:
                     """,
                     (resolved_node_id,),
                 )
+
+        if signal > 0 and source in {"explicit", "implicit", "auto_llm_judge"}:
+            self._record_confirmed_use(resolved_node_id)
 
         return f"Feedback recorded for node {resolved_node_id[:8]}..."
 

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -138,9 +138,9 @@ class IndexBuilder:
             INSERT OR REPLACE INTO nodes
             (id, type, tier, source, space, title, content, created, updated,
              last_accessed, access_count, confidence, importance,
-             valid_until, stability, last_review, file_path, file_hash)
+             valid_until, stability, last_review, consolidated_into, file_path, file_hash)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?)
+                    ?, ?, ?, ?, ?, ?)
             """,
             (
                 node.id,
@@ -159,6 +159,7 @@ class IndexBuilder:
                 node.valid_until.isoformat() if node.valid_until else None,
                 node.stability,
                 node.last_review.isoformat() if node.last_review else None,
+                node.consolidated_into,
                 str(path),
                 file_hash,
             ),

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -141,6 +141,7 @@ class Database:
                 ("valid_until", "ALTER TABLE nodes ADD COLUMN valid_until TEXT"),
                 ("stability", "ALTER TABLE nodes ADD COLUMN stability REAL DEFAULT 1.0"),
                 ("last_review", "ALTER TABLE nodes ADD COLUMN last_review TEXT"),
+                ("consolidated_into", "ALTER TABLE nodes ADD COLUMN consolidated_into TEXT"),
             ]
             for col_name, ddl in enrichment_migrations:
                 if col_name not in node_cols:

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     valid_until TEXT,
     stability REAL DEFAULT 1.0,
     last_review TEXT,
+    consolidated_into TEXT,
     file_path TEXT NOT NULL,
     file_hash TEXT NOT NULL,
     seq INTEGER NOT NULL DEFAULT 0

--- a/src/ormah/models/node.py
+++ b/src/ormah/models/node.py
@@ -56,8 +56,11 @@ class MemoryNode(BaseModel):
     access_count: int = 0
     confidence: float = Field(default=1.0, ge=0.0, le=1.0)
     importance: float = Field(default=0.5, ge=0.0, le=1.0)
-    stability: float = Field(default=1.0, ge=0.0)  # FSRS: days until ~37% retrievability
-    last_review: datetime | None = None  # last stability update (distinct from last_accessed)
+    # The model default is a legacy parser/schema fallback. Production node
+    # creation supplies Settings.fsrs_initial_stability explicitly.
+    stability: float = Field(default=1.0, ge=0.0)  # days until ~37% retrievability
+    last_review: datetime | None = None  # last numeric stability update
+    consolidated_into: str | None = None  # explicit consolidation supersession provenance
     valid_until: datetime | None = None
     deleted_at: datetime | None = None  # tombstone stamp; ordering for sync merges uses this, never `updated`
     space: str | None = None

--- a/src/ormah/store/markdown.py
+++ b/src/ormah/store/markdown.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import math
+import logging
 
 import frontmatter
 
 from ormah.models.node import Connection, EdgeType, MemoryNode, NodeType, Tier
+
+logger = logging.getLogger(__name__)
 
 
 def parse_node(text: str) -> MemoryNode:
@@ -30,6 +34,16 @@ def parse_node(text: str) -> MemoryNode:
     deleted_at_raw = meta.get("deleted_at")
     deleted_at = _parse_dt(deleted_at_raw) if deleted_at_raw else None
 
+    raw_stability = meta.get("stability", 1.0)
+    try:
+        stability = float(raw_stability)
+    except (TypeError, ValueError):
+        stability = 1.0
+        logger.warning("Invalid legacy stability %r for node %s; using 1.0", raw_stability, meta.get("id"))
+    if not math.isfinite(stability) or stability <= 0:
+        logger.warning("Invalid legacy stability %r for node %s; using 1.0", raw_stability, meta.get("id"))
+        stability = 1.0
+
     return MemoryNode(
         id=meta["id"],
         type=NodeType(meta["type"]),
@@ -41,8 +55,9 @@ def parse_node(text: str) -> MemoryNode:
         access_count=meta.get("access_count", 0),
         confidence=meta.get("confidence", 1.0),
         importance=meta.get("importance", 0.5),
-        stability=meta.get("stability", 1.0),
+        stability=stability,
         last_review=_parse_dt(meta["last_review"]) if meta.get("last_review") else None,
+        consolidated_into=meta.get("consolidated_into"),
         valid_until=valid_until,
         deleted_at=deleted_at,
         space=meta.get("space"),
@@ -71,6 +86,8 @@ def serialize_node(node: MemoryNode) -> str:
 
     if node.last_review is not None:
         meta["last_review"] = _format_dt(node.last_review)
+    if node.consolidated_into is not None:
+        meta["consolidated_into"] = node.consolidated_into
     if node.valid_until is not None:
         meta["valid_until"] = _format_dt(node.valid_until)
     if node.deleted_at is not None:

--- a/tests/test_api/test_routes.py
+++ b/tests/test_api/test_routes.py
@@ -68,6 +68,23 @@ def test_recall_not_found(client):
     assert resp.status_code == 404
 
 
+def test_ui_search_does_not_record_confirmed_use(client):
+    created = client.post("/agent/remember", json={
+        "content": "UI search surfacing is not confirmed use.",
+        "type": "fact",
+        "title": "UI surfacing",
+    }).json()
+    node_id = created["node_id"]
+
+    response = client.get("/ui/search", params={"q": "UI surfacing"})
+    assert response.status_code == 200
+    assert any(node["id"] == node_id for node in response.json())
+
+    graph = client.get("/ui/graph").json()
+    node = next(node for node in graph["nodes"] if node["id"] == node_id)
+    assert node["access_count"] == 0
+
+
 def test_stats(client):
     resp = client.get("/stats")
     assert resp.status_code == 200

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -26,8 +26,8 @@ def _get_tier(engine, node_id: str) -> str:
     return row["tier"] if row else None
 
 
-def test_high_importance_node_not_decayed(engine):
-    """A stale node with high importance should not be demoted."""
+def test_high_importance_stale_node_still_decays(engine):
+    """Historical access/importance cannot make stale working nodes immortal."""
     node_id, _ = engine.remember(CreateNodeRequest(
         content="Important stale node",
         type=NodeType.fact,
@@ -37,13 +37,13 @@ def test_high_importance_node_not_decayed(engine):
 
     _make_stale(engine, node_id)
     engine.db.conn.execute(
-        "UPDATE nodes SET importance = 0.9 WHERE id = ?", (node_id,)
+        "UPDATE nodes SET access_count = 50, importance = 0.9 WHERE id = ?", (node_id,)
     )
     engine.db.conn.commit()
 
     run_decay(engine)
 
-    assert _get_tier(engine, node_id) == "working"
+    assert _get_tier(engine, node_id) == "archival"
 
 
 def test_low_importance_stale_node_decayed(engine):

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -211,6 +211,65 @@ def test_recency_decay(engine):
     assert recent_imp > old_imp
 
 
+def test_importance_keeps_cumulative_access_and_edge_signals(engine):
+    hub_id, _ = engine.remember(CreateNodeRequest(
+        content="A frequently used connected memory", type=NodeType.fact, title="Hub"
+    ))
+    neighbor_ids = []
+    for i in range(4):
+        nid, _ = engine.remember(CreateNodeRequest(
+            content=f"Connected supporting memory {i}", type=NodeType.fact, title=f"Neighbor {i}"
+        ))
+        neighbor_ids.append(nid)
+        engine.connect(ConnectRequest(source_id=hub_id, target_id=nid))
+
+    old_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    engine.db.conn.execute(
+        "UPDATE nodes SET access_count = 50, last_accessed = ?, importance = 0.0 WHERE id = ?",
+        (old_date, hub_id),
+    )
+    engine.db.conn.commit()
+    run_importance_scoring(engine)
+
+    importance = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (hub_id,)
+    ).fetchone()["importance"]
+    assert importance > 0.0
+
+
+def test_importance_recency_does_not_reuse_stability(engine):
+    first_id, _ = engine.remember(CreateNodeRequest(
+        content="Same age, short stability", type=NodeType.fact, title="Short stability"
+    ))
+    second_id, _ = engine.remember(CreateNodeRequest(
+        content="Same age, long stability", type=NodeType.fact, title="Long stability"
+    ))
+    old_date = (datetime.now(timezone.utc) - timedelta(days=14)).isoformat()
+    engine.db.conn.execute(
+        "UPDATE nodes SET access_count = 0, importance = 0.0, stability = ?, last_accessed = ? "
+        "WHERE id IN (?, ?)",
+        (1.0, old_date, first_id, second_id),
+    )
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = ? WHERE id = ?", (365.0, second_id)
+    )
+    engine.db.conn.commit()
+    engine.settings.importance_access_weight = 0.0
+    engine.settings.importance_edge_weight = 0.0
+    engine.settings.importance_recency_weight = 1.0
+
+    run_importance_scoring(engine)
+
+    first = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (first_id,)
+    ).fetchone()["importance"]
+    second = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (second_id,)
+    ).fetchone()["importance"]
+    assert first == pytest.approx(0.5, abs=0.01)
+    assert second == pytest.approx(first, abs=0.01)
+
+
 def test_batch_query_used(engine):
     """Edge count should be fetched with batch queries, not N per-node queries."""
     # Create a few nodes

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -24,7 +24,7 @@ from ormah.background.session_watcher import (
     stop_session_watcher,
 )
 from ormah.engine.memory_engine import MemoryEngine
-from ormah.models.node import CreateNodeRequest
+from ormah.models.node import CreateNodeRequest, Tier
 from ormah.transcript.parser import parse_transcript
 
 _LLM_PATCH = "ormah.background.llm_client.llm_generate"
@@ -309,6 +309,7 @@ def test_record_whisper_usage_signal_promotes_clear_reference(engine, tmp_path):
     assert affinity["node_id"] == node_id
     assert affinity["signal"] == 1
     assert affinity["source"] == "auto_heuristic"
+    assert engine.file_store.load(node_id).access_count == 0
 
 
 def test_record_whisper_usage_signal_keeps_unreferenced_neutral(engine, tmp_path):
@@ -389,6 +390,11 @@ def test_llm_judge_promotes_used_verdict(engine, tmp_path):
         type="fact",
         title="Blue deployment rollback marker",
     ))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    engine.file_store.save(node)
+    with engine.db.transaction() as conn:
+        conn.execute("UPDATE nodes SET tier = 'archival' WHERE id = ?", (node_id,))
     whisper_log_id = _insert_injected_whisper_log(
         engine,
         node_id=node_id,
@@ -432,6 +438,9 @@ def test_llm_judge_promotes_used_verdict(engine, tmp_path):
     assert affinity is not None
     assert affinity["signal"] == 1
     assert affinity["source"] == "auto_llm_judge"
+    updated = engine.file_store.load(node_id)
+    assert updated.tier == Tier.working
+    assert updated.access_count == 1
 
 
 def test_llm_judge_falls_back_to_json_object_mode(engine, tmp_path):

--- a/tests/test_engine/test_lifecycle.py
+++ b/tests/test_engine/test_lifecycle.py
@@ -1,0 +1,257 @@
+"""Deterministic tests for the versioned lifecycle policy and confirmed use."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ormah.engine.lifecycle import (
+    DEFAULT_INITIAL_STABILITY,
+    LIFECYCLE_MODEL_VERSION,
+    archival_deadline,
+    bounded_stability_update,
+    importance_recency,
+    reinforcement_spacing,
+    retrievability,
+)
+from ormah.config import Settings
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType, Tier
+
+
+def _backdate(engine, node_id: str, *, days: float, stability: float, tier: Tier) -> None:
+    anchor = datetime.now(timezone.utc) - timedelta(days=days)
+    node = engine.file_store.load(node_id)
+    node.stability = stability
+    node.tier = tier
+    node.last_accessed = anchor
+    node.last_review = anchor
+    engine.file_store.save(node)
+    with engine.db.transaction() as conn:
+        conn.execute(
+            """
+            UPDATE nodes
+            SET tier = ?, stability = ?, last_accessed = ?, last_review = ?
+            WHERE id = ?
+            """,
+            (tier.value, stability, anchor.isoformat(), anchor.isoformat(), node_id),
+        )
+
+
+def test_default_initial_stability_is_the_seven_day_threshold_anchor():
+    assert DEFAULT_INITIAL_STABILITY == pytest.approx(5.814084815577761)
+    assert retrievability(7.0, DEFAULT_INITIAL_STABILITY, fallback=1.0) == pytest.approx(0.3)
+
+
+def test_lifecycle_settings_are_explicit_and_validated(tmp_path):
+    settings = Settings(memory_dir=tmp_path)
+    assert settings.fsrs_reinforcement_gain == 0.5
+    assert settings.fsrs_reinforcement_saturation_exponent == 0.5
+    assert settings.fsrs_reinforcement_spacing_cap == 2.0
+    with pytest.raises(ValueError):
+        Settings(memory_dir=tmp_path, fsrs_reinforcement_spacing_cap=0.5)
+
+
+def test_production_creation_uses_configured_initial_stability(engine):
+    engine.settings.fsrs_initial_stability = 12.5
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Configured initial stability", type=NodeType.fact, title="Configured"
+    ))
+    assert engine.file_store.load(node_id).stability == pytest.approx(12.5)
+
+
+def test_bounded_update_uses_old_stability_before_promotion_floor():
+    reinforced = bounded_stability_update(
+        1.0,
+        30.0,
+        gain=0.5,
+        saturation_exponent=0.5,
+        spacing_cap=2.0,
+        max_stability=365.0,
+        fallback=1.0,
+    )
+    assert reinforced == pytest.approx(2.0)
+    assert max(reinforced, DEFAULT_INITIAL_STABILITY) == pytest.approx(
+        DEFAULT_INITIAL_STABILITY
+    )
+
+
+def test_spacing_is_finite_and_matches_near_threshold_value():
+    spacing = reinforcement_spacing(
+        10_000_000.0,
+        1.0,
+        spacing_cap=2.0,
+        fallback=1.0,
+    )
+    assert math.isfinite(spacing)
+    assert spacing == pytest.approx(2.0)
+    assert reinforcement_spacing(
+        -math.log(0.3),
+        1.0,
+        spacing_cap=2.0,
+        fallback=1.0,
+    ) == pytest.approx(1.272, abs=0.001)
+
+
+def test_saturated_policy_reaches_default_cap_in_about_74_updates():
+    stability = 1.0
+    updates = 0
+    while stability < 365.0:
+        stability = bounded_stability_update(
+            stability,
+            0.0,
+            gain=0.5,
+            saturation_exponent=0.5,
+            spacing_cap=2.0,
+            max_stability=365.0,
+            fallback=1.0,
+        )
+        updates += 1
+    assert updates == 74
+
+
+def test_importance_recency_has_its_own_half_life():
+    assert importance_recency(14.0, 14.0) == pytest.approx(0.5)
+    assert importance_recency(14.0, 7.0) == pytest.approx(0.25)
+
+
+def test_archival_deadline_is_explicit_for_future_model_migrations():
+    anchor = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    deadline = archival_deadline(
+        anchor,
+        DEFAULT_INITIAL_STABILITY,
+        threshold=0.3,
+        fallback=1.0,
+    )
+    assert (deadline - (anchor + timedelta(days=7))).total_seconds() == pytest.approx(0, abs=1)
+
+
+def test_confirmed_use_promotes_after_reinforcing_old_stability(engine):
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="An archival memory that was deliberately recalled.",
+        type=NodeType.fact,
+        title="Recall me",
+    ))
+    _backdate(engine, node_id, days=30, stability=1.0, tier=Tier.archival)
+
+    assert engine._record_confirmed_use(node_id) is True
+
+    node = engine.file_store.load(node_id)
+    assert node.tier == Tier.working
+    assert node.stability == pytest.approx(DEFAULT_INITIAL_STABILITY)
+    assert node.access_count == 1
+    assert node.last_review is not None
+    indexed = engine.db.conn.execute(
+        "SELECT tier, stability, access_count FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    assert indexed["tier"] == "working"
+    assert indexed["stability"] == pytest.approx(DEFAULT_INITIAL_STABILITY)
+    assert indexed["access_count"] == 1
+    version = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"
+    ).fetchone()
+    assert version["value"] == str(LIFECYCLE_MODEL_VERSION)
+
+
+def test_repeated_same_day_confirmed_use_updates_anchor_but_not_stability(engine):
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="A node used repeatedly in one session.",
+        type=NodeType.fact,
+        title="Repeated use",
+    ))
+    _backdate(engine, node_id, days=2, stability=1.0, tier=Tier.working)
+
+    for _ in range(10):
+        assert engine._record_confirmed_use(node_id) is True
+
+    node = engine.file_store.load(node_id)
+    assert node.access_count == 10
+    assert node.last_review is not None
+    assert node.last_accessed > node.last_review - timedelta(seconds=1)
+    first_update_stability = node.stability
+    first_review = node.last_review
+
+    assert engine._record_confirmed_use(node_id) is True
+    node_after = engine.file_store.load(node_id)
+    assert node_after.access_count == 11
+    assert node_after.stability == pytest.approx(first_update_stability)
+    assert node_after.last_review == first_review
+
+
+def test_generic_derived_from_does_not_block_promotion_but_consolidation_does(engine):
+    generic_id, _ = engine.remember(CreateNodeRequest(
+        content="A generally derived memory.", type=NodeType.fact, title="Generic"
+    ))
+    replacement_id, _ = engine.remember(CreateNodeRequest(
+        content="Another memory.", type=NodeType.fact, title="Replacement"
+    ))
+    _backdate(engine, generic_id, days=30, stability=1.0, tier=Tier.archival)
+    engine.connect(ConnectRequest(
+        source_id=replacement_id,
+        target_id=generic_id,
+        edge=EdgeType.derived_from,
+        weight=1.0,
+    ))
+
+    engine._record_confirmed_use(generic_id)
+    assert engine.file_store.load(generic_id).tier == Tier.working
+
+    consolidated_id, _ = engine.remember(CreateNodeRequest(
+        content="A deliberately superseded original.", type=NodeType.fact, title="Superseded"
+    ))
+    _backdate(engine, consolidated_id, days=30, stability=1.0, tier=Tier.archival)
+    assert engine.mark_consolidated(consolidated_id, replacement_id) is True
+    engine._record_confirmed_use(consolidated_id)
+    consolidated = engine.file_store.load(consolidated_id)
+    assert consolidated.consolidated_into == replacement_id
+    assert consolidated.tier == Tier.archival
+
+
+@pytest.mark.parametrize("use_fts_fallback", [False, True])
+def test_broad_recall_is_non_mutating_on_hybrid_and_fts_paths(engine, use_fts_fallback):
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Search result surfacing is not confirmed use.",
+        type=NodeType.fact,
+        title="Surfacing semantics",
+    ))
+    before = engine.file_store.load(node_id)
+    result = {"node": engine.graph.get_node(node_id), "score": 1.0, "source": "hybrid"}
+
+    if use_fts_fallback:
+        with patch.object(engine, "_get_hybrid_search", return_value=None), \
+             patch.object(engine.graph, "fts_search", return_value=[{"id": node_id, "score": 1.0}]):
+            engine.recall_search_structured(
+                "surfacing semantics", limit=1, spread_activation=False, min_relevance=0.0
+            )
+    else:
+        fake_search = MagicMock()
+        fake_search.search.return_value = [result]
+        with patch.object(engine, "_get_hybrid_search", return_value=fake_search):
+            engine.recall_search_structured(
+                "surfacing semantics", limit=1, spread_activation=False, min_relevance=0.0
+            )
+
+    after = engine.file_store.load(node_id)
+    assert after.access_count == before.access_count == 0
+    assert after.last_accessed == before.last_accessed
+    assert after.last_review == before.last_review
+    assert after.stability == before.stability
+
+
+def test_recall_node_confirms_only_requested_node_not_neighbors(engine):
+    requested_id, _ = engine.remember(CreateNodeRequest(
+        content="The deliberately fetched memory.", type=NodeType.fact, title="Requested"
+    ))
+    neighbor_id, _ = engine.remember(CreateNodeRequest(
+        content="A surfaced graph neighbor.", type=NodeType.fact, title="Neighbor"
+    ))
+    engine.connect(ConnectRequest(
+        source_id=requested_id, target_id=neighbor_id, edge=EdgeType.related_to
+    ))
+
+    engine.recall_node(requested_id)
+
+    assert engine.file_store.load(requested_id).access_count == 1
+    assert engine.file_store.load(neighbor_id).access_count == 0

--- a/tests/test_engine/test_mutation_stamping.py
+++ b/tests/test_engine/test_mutation_stamping.py
@@ -139,11 +139,11 @@ def test_mark_outdated_advances_updated(engine):
     assert _updated(engine.file_store, node_id) > PAST
 
 
-def test_engine_access_tracking_does_not_advance_updated(engine):
+def test_confirmed_use_does_not_advance_updated(engine):
     node_id = _create(engine, "Read often", "Frequently accessed fact.")
     _backdate(engine.file_store, node_id)
 
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
 
     node = engine.file_store.load(node_id)
     assert node.updated == PAST

--- a/tests/test_engine/test_scoring_signals.py
+++ b/tests/test_engine/test_scoring_signals.py
@@ -365,12 +365,10 @@ class TestSpaceScoring:
 
 
 class TestSpreadingActivationAccessIsolation:
-    """Verify that _touch_access is only called for direct search matches,
-    not for nodes injected by spreading activation."""
+    """Verify that surfacing never records confirmed lifecycle use."""
 
-    def test_touch_access_skips_activated_nodes(self, engine):
-        """Spreading activation results (source=activated/conflict) must not
-        get their access_count bumped."""
+    def test_search_does_not_touch_direct_or_activated_nodes(self, engine):
+        """Neither direct results nor graph-added neighbours get access bumps."""
         # Create three nodes via the engine
         from ormah.models.node import CreateNodeRequest
 
@@ -437,18 +435,18 @@ class TestSpreadingActivationAccessIsolation:
             with patch.object(engine, "_spread_activation", side_effect=mock_spread):
                 engine.recall_search_structured("test query", limit=10)
 
-        # Verify: A and C should have access_count incremented
+        # Search results are observability events, not confirmed use.
         node_a_after = engine.file_store.load(id_a)
         node_c_after = engine.file_store.load(id_c)
-        assert node_a_after.access_count == initial_a + 1
-        assert node_c_after.access_count == initial_c + 1
+        assert node_a_after.access_count == initial_a
+        assert node_c_after.access_count == initial_c
 
         # B (activated neighbor) should NOT have access_count incremented
         node_b_after = engine.file_store.load(id_b)
         assert node_b_after.access_count == initial_b
 
-    def test_touch_access_skips_conflict_nodes(self, engine):
-        """Nodes with source=conflict should also be skipped."""
+    def test_search_does_not_touch_conflict_nodes(self, engine):
+        """Conflict expansion remains non-mutating lifecycle surfacing."""
         from ormah.models.node import CreateNodeRequest
 
         id_a, _ = engine.remember(CreateNodeRequest(

--- a/tests/test_engine/test_submit_feedback.py
+++ b/tests/test_engine/test_submit_feedback.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from ormah.models.node import CreateNodeRequest
+from ormah.models.node import CreateNodeRequest, Tier
 
 
 # ---------------------------------------------------------------------------
@@ -53,6 +53,42 @@ def _insert_review_log(conn, node_id: str, session_id: str = "sess-abc") -> int:
 
 
 class TestSubmitFeedbackBasic:
+
+    def test_positive_feedback_is_confirmed_use_and_promotes_exact_node(self, engine):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="A memory confirmed by feedback.",
+            title="Confirmed feedback",
+        ))
+        node = engine.file_store.load(node_id)
+        node.tier = Tier.archival
+        engine.file_store.save(node)
+        with engine.db.transaction() as conn:
+            conn.execute("UPDATE nodes SET tier = 'archival' WHERE id = ?", (node_id,))
+        whisper_log_id = _insert_whisper_log(engine.db.conn, node_id)
+
+        engine.submit_feedback(node_id, 1, "explicit", whisper_log_id=whisper_log_id)
+
+        updated = engine.file_store.load(node_id)
+        assert updated.tier == Tier.working
+        assert updated.access_count == 1
+
+    def test_negative_feedback_remains_affinity_only(self, engine):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content="A memory rejected for this prompt.",
+            title="Rejected feedback",
+        ))
+        node = engine.file_store.load(node_id)
+        node.tier = Tier.archival
+        engine.file_store.save(node)
+        with engine.db.transaction() as conn:
+            conn.execute("UPDATE nodes SET tier = 'archival' WHERE id = ?", (node_id,))
+        whisper_log_id = _insert_whisper_log(engine.db.conn, node_id)
+
+        engine.submit_feedback(node_id, -1, "explicit", whisper_log_id=whisper_log_id)
+
+        updated = engine.file_store.load(node_id)
+        assert updated.tier == Tier.archival
+        assert updated.access_count == 0
 
     def test_no_whisper_log_returns_error(self, engine):
         result = engine.submit_feedback("nonexistent-id", 1)

--- a/tests/test_index/test_migration_seq.py
+++ b/tests/test_index/test_migration_seq.py
@@ -44,6 +44,7 @@ def test_init_schema_migrates_legacy_db_without_seq(tmp_path):
 
         cols = [r[1] for r in db.conn.execute("PRAGMA table_info(nodes)").fetchall()]
         assert "seq" in cols
+        assert "consolidated_into" in cols
         idx = db.conn.execute(
             "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_nodes_seq'"
         ).fetchone()

--- a/tests/test_store/test_markdown.py
+++ b/tests/test_store/test_markdown.py
@@ -1,5 +1,7 @@
 """Tests for markdown parsing and serialization."""
 
+import pytest
+
 from ormah.models.node import Connection, EdgeType, MemoryNode, NodeType, Tier
 from ormah.store.markdown import parse_node, serialize_node
 
@@ -16,6 +18,7 @@ def test_roundtrip():
         connections=[
             Connection(target="abc123", edge=EdgeType.supports, weight=0.9),
         ],
+        consolidated_into="replacement-123",
     )
 
     text = serialize_node(node)
@@ -32,6 +35,7 @@ def test_roundtrip():
     assert len(parsed.connections) == 1
     assert parsed.connections[0].target == "abc123"
     assert parsed.connections[0].edge == EdgeType.supports
+    assert parsed.consolidated_into == "replacement-123"
 
 
 def test_parse_minimal():
@@ -51,6 +55,20 @@ This is a simple fact."""
     assert node.tier == Tier.working  # default
     assert node.connections == []
     assert node.deleted_at is None  # legacy files without deleted_at parse fine
+
+
+@pytest.mark.parametrize("value", [None, 0, -1, "not-a-number", "nan"])
+def test_parse_invalid_legacy_stability_uses_compatibility_fallback(value):
+    text = f"""---
+id: invalid-stability-{str(value).replace(' ', '-')}
+type: fact
+created: 2026-01-01T00:00:00Z
+updated: 2026-01-01T00:00:00Z
+stability: {value if value is not None else 'null'}
+---
+Legacy node."""
+    node = parse_node(text)
+    assert node.stability == 1.0
 
 
 def test_deleted_at_roundtrip():


### PR DESCRIPTION
## Problem and root causes

Ormah treated broad recall/search results as memory use. The overloaded `_touch_access` path updated access count, recency, review time, and stability for surfaced results, while importance could permanently block decay and the configured importance half-life was unused. Reinforcement was unbounded, same-session uses compounded, `fsrs_initial_stability` was disconnected from production creation, and archival promotion had no production caller. Consolidation used only generic `derived_from` edges, which do not prove supersession.

## Solution

### #220 — separate surfacing from confirmed use

- Removed lifecycle writes from hybrid recall, FTS fallback, structured recall, formatted recall, UI search, whisper/context loading, and graph/conflict expansion.
- Added one serialized `_record_confirmed_use` lifecycle operation.
- `recall_node(id)` confirms exactly the requested node; returned neighbours remain non-mutating.
- Positive `explicit` and `implicit` feedback confirms exactly its resolved node.
- The session watcher `auto_llm_judge` positive path uses the same lifecycle operation after writing its own signal/affinity rows; `auto_heuristic` does not.
- Retrieval, whisper, signal, affinity, and feedback observability logging remains intact.

### #222 — retrievability controls decay

- Working-to-archival decay now uses retrievability alone, with existing self/identity protection retained.
- `decay_importance_threshold` remains parse-compatible but is deprecated and has no decay effect.
- Importance still supports ranking, display, and core-cap prioritization.
- Importance recency now uses `exp(-ln(2) * age_days / importance_recency_half_life_days)` and the confirmed-use/creation anchor, independently of stability.

### #221 — bounded reinforcement and cooldown

- Centralized lifecycle math in `src/ormah/engine/lifecycle.py`.
- Retained `R(t, S) = exp(-t / S)`; `S` is the approximately 37% point.
- Confirmed use applies:
  `spacing = min(R^-0.2, spacing_cap)`
  `S_new = min(S * (1 + gain * S^-saturation_exponent * spacing), max_stability)`
- Spacing is computed in log space, so underflowed `R=0` never reaches a negative power.
- Defaults are gain `0.5`, saturation exponent `0.5`, spacing cap `2.0`, and max stability `365`.
- Every confirmed use increments `access_count` and advances `last_accessed`; `last_review` advances only when numeric stability changes, at most once per 24 hours.
- Added integer `lifecycle_model_version` metadata (current version `1`) while retaining `fsrs_migrated` for bootstrap compatibility. Existing stability values are not rescaled.
- The old `fsrs_stability_growth=1.5` remains parse-compatible, explicitly deprecated, and ignored rather than being reinterpreted as additive gain.

### #223 — seven-day lease, promotion, and provenance

- `fsrs_initial_stability` defaults to `-7 / ln(0.3) = 5.814084815577761` and is supplied on every production node creation path.
- Archival confirmed use promotes to working unless `consolidated_into` is explicitly set.
- Promotion reinforces from the old stability first, then applies the initial-stability floor; `S=1` after 30 days becomes `2`, then the floor, not an amplified floor-first update.
- Added `consolidated_into` to the MemoryNode model, markdown, SQLite schema/migration, and index builder. The consolidator stamps originals with the replacement ID while demoting them.
- Generic `derived_from` relationships remain promotable.

## Exact lifecycle invariants

- Confirmed use is only deliberate `recall_node` or positive `explicit`, `implicit`, or `auto_llm_judge` feedback.
- Surfacing, UI results, whisper injection, graph activation, conflict expansion, neighbours, `auto_heuristic`, and all negative feedback are not confirmed use.
- Negative feedback remains prompt-specific affinity evidence and never lowers stability or tier.
- Core is never demoted by confirmed-use lifecycle handling.
- Archival is dormant and deliberately recallable; explicit consolidation supersession is reversible for recall but does not automatically promote.
- Exponential semantics are retained and existing stability values are not rescaled.

## Schema/config/migration notes

- Added `nodes.consolidated_into` with a migration-safe nullable column and markdown fallback compatibility.
- Added `meta.lifecycle_model_version`; existing `fsrs_migrated` remains intact.
- Invalid/null/zero legacy stability values use an explicit finite compatibility fallback rather than causing divide-by-zero or infinite reinforcement.
- Added validated `fsrs_reinforcement_gain`, `fsrs_reinforcement_saturation_exponent`, and `fsrs_reinforcement_spacing_cap` settings.
- Documented the exponential curve, seven-day mathematical crossing, daily scheduler cadence, anchor semantics, deprecated settings, and FSRS-inspired policy status.

## Verification

- `uv run --cache-dir /tmp/uv-cache ruff check ...` on all changed Python files: passed.
- Focused lifecycle/API/index/store/background suite: `247 passed, 2 failed`; the two failures are unchanged auto-link/conflict tests blocked by sqlite-vec KNN syntax.
- Broad deterministic suite: `ORMAH_LLM_PROVIDER=none uv run --cache-dir /tmp/uv-cache pytest -q` → `1835 passed, 26 failed, 1 deselected`.
- Clean `origin/main` reproduction of representative failures: `4 failed` with the same sqlite-vec KNN error in auto-link, conflict, and worker-thread vector search, plus the existing setup binary-detection assumption. The lifecycle-focused tests themselves pass.
- The sqlite-vec error is: `A LIMIT or k = ? constraint is required on vec0 knn queries`.

## Risks and residual follow-ups

- #218 remains out of scope: source qualification is intentionally the interim policy until signal strength is calibrated.
- #224 remains out of scope: no Q3 conflict-system changes were made.
- #28/#31 remain out of scope: no bounded-forgetting deletion, retention, or reclamation changes were made.
- #192 remains out of scope: consolidator prompt/truncation behavior was not redesigned.
- Existing sqlite-vec and environment setup failures need their own repair.

Closes #220
Closes #221
Closes #222
Closes #223