### PR TITLE
chore(release): prepare 0.14.11 and desktop 0.3.24

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.23"
+version = "0.3.24"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.10",
+  "version": "0.14.11",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.10"
+version = "0.14.11"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

- bump the Ormah Python package and Claude plugin to 0.14.11
- bump the desktop app to 0.3.24
- prepare the desktop build to bundle the production-cloud Checkout handoff fixes merged in #228

## Verification

- version metadata consistency check passed
- `npm test -- --run` in `ui/`: 45 passed
- `npm run build` in `ui/`: passed
- `.venv/bin/ruff check src tests`: passed
- full Python suite began cleanly but stalled in the known sandbox AnyIO/TestClient path; the functional commit already passed merged CI

## Release order after merge

1. publish/tag Python `v0.14.11`
2. wait for PyPI to report `0.14.11`
3. tag `desktop-v0.3.24` so the desktop workflow can verify and bundle that Python version