### PR TITLE
fix: surfacing must not be confirmed use (#220)

### DIFF
--- a/docs/01 - Data Model.md
+++ b/docs/01 - Data Model.md
@@ -35,7 +35,7 @@ access_count: int           # Times this node has been accessed/recalled
 # Temporal
 created: datetime           # When first stored (UTC)
 updated: datetime           # Last modification (UTC)
-last_accessed: datetime     # Last recall/search hit (UTC)
+last_accessed: datetime     # Last confirmed use (UTC) — not a search hit
 last_review: datetime | None # Last FSRS review (spaced repetition)
 valid_until: datetime | None # Expiry date (set by mark_outdated)
 

--- a/docs/01 - Data Model.md
+++ b/docs/01 - Data Model.md
@@ -35,7 +35,7 @@ access_count: int           # Times this node has been accessed/recalled
 # Temporal
 created: datetime           # When first stored (UTC)
 updated: datetime           # Last modification (UTC)
-last_accessed: datetime     # Last confirmed use (UTC) — not a search hit
+last_accessed: datetime     # Last recall/search hit (UTC)
 last_review: datetime | None # Last FSRS review (spaced repetition)
 valid_until: datetime | None # Expiry date (set by mark_outdated)
 

--- a/docs/04 - Whisper - Involuntary Recall.md
+++ b/docs/04 - Whisper - Involuntary Recall.md
@@ -98,7 +98,7 @@ The builder calls structured recall with:
 
 - `limit = whisper_max_nodes * whisper_candidate_pool_multiplier` (defaults `6 * 5 = 30`) — a deep candidate pool so the reranker and gate can rescue memories the bi-encoder under-ranked; the final injected set is still capped at `whisper_max_nodes`
 - `tiers = [core, working]`
-- `touch_access = False`
+- search never writes lifecycle fields (access_count, last_accessed, stability, last_review) — that write happens only on confirmed use
 
 ### 7. Thresholds and reranking
 

--- a/docs/04 - Whisper - Involuntary Recall.md
+++ b/docs/04 - Whisper - Involuntary Recall.md
@@ -98,7 +98,7 @@ The builder calls structured recall with:
 
 - `limit = whisper_max_nodes * whisper_candidate_pool_multiplier` (defaults `6 * 5 = 30`) — a deep candidate pool so the reranker and gate can rescue memories the bi-encoder under-ranked; the final injected set is still capped at `whisper_max_nodes`
 - `tiers = [core, working]`
-- search never writes lifecycle fields (access_count, last_accessed, stability, last_review) — that write happens only on confirmed use
+- `touch_access = False`
 
 ### 7. Thresholds and reranking
 

--- a/docs/04 - Whisper - Involuntary Recall.md
+++ b/docs/04 - Whisper - Involuntary Recall.md
@@ -98,7 +98,7 @@ The builder calls structured recall with:
 
 - `limit = whisper_max_nodes * whisper_candidate_pool_multiplier` (defaults `6 * 5 = 30`) — a deep candidate pool so the reranker and gate can rescue memories the bi-encoder under-ranked; the final injected set is still capped at `whisper_max_nodes`
 - `tiers = [core, working]`
-- `touch_access = False`
+- search never writes lifecycle fields (`access_count`, `last_accessed`, `stability`, `last_review`) — that write happens only on confirmed use
 
 ### 7. Thresholds and reranking
 

--- a/docs/05 - Background Jobs.md
+++ b/docs/05 - Background Jobs.md
@@ -132,7 +132,7 @@ High-importance nodes are protected from decay.
 
 `importance_scorer` recomputes node importance from three dynamic signals:
 
-1. **Access signal**: how often the node's use has been *confirmed*, based on `access_count`
+1. **Access signal**: how often the node has been recalled, based on `access_count`
 2. **Edge signal**: how connected the node is in the graph, based on total edge count
 3. **Recency signal**: how retrievable the node currently is, using FSRS-style `exp(-days_ago / stability)`
 
@@ -149,7 +149,7 @@ Access and edge counts are log-normalized against reference values, then the wei
 
 The scorer runs every `120` minutes by default and only writes a new value when the change is meaningful.
 
-This score is not static. **Confirmed use** updates `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched. Merely being surfaced does not: search results, UI search, whisper injection and graph expansion write no lifecycle fields (issue #220). Confirmed use is a deliberate `recall_node`, or qualified positive feedback — `explicit`, `implicit` or `auto_llm_judge`. Because `access_count` now counts confirmations rather than appearances, its values are far smaller than before, and `importance_access_reference` is calibrated against the old scale.
+This score is not static. Recall and search hits update `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched.
 
 Important current nuance: `importance_recency_half_life_days` exists in configuration, but the current scorer implementation uses FSRS stability for the recency term instead.
 

--- a/docs/05 - Background Jobs.md
+++ b/docs/05 - Background Jobs.md
@@ -132,7 +132,7 @@ High-importance nodes are protected from decay.
 
 `importance_scorer` recomputes node importance from three dynamic signals:
 
-1. **Access signal**: how often the node has been recalled, based on `access_count`
+1. **Access signal**: how often the node's use has been *confirmed*, based on `access_count`
 2. **Edge signal**: how connected the node is in the graph, based on total edge count
 3. **Recency signal**: how retrievable the node currently is, using FSRS-style `exp(-days_ago / stability)`
 
@@ -149,7 +149,7 @@ Access and edge counts are log-normalized against reference values, then the wei
 
 The scorer runs every `120` minutes by default and only writes a new value when the change is meaningful.
 
-This score is not static. Recall and search hits update `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched.
+This score is not static. **Confirmed use** updates `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched. Merely being surfaced does not: search results, UI search, whisper injection, and graph expansion write no lifecycle fields (issue #220). Confirmed use is a deliberate `recall_node`, or qualified positive feedback — `explicit`, `implicit`, or `auto_llm_judge`. Because `access_count` now counts confirmations rather than appearances, its values are far smaller than before, and `importance_access_reference` is calibrated against the old scale.
 
 Important current nuance: `importance_recency_half_life_days` exists in configuration, but the current scorer implementation uses FSRS stability for the recency term instead.
 

--- a/docs/05 - Background Jobs.md
+++ b/docs/05 - Background Jobs.md
@@ -132,7 +132,7 @@ High-importance nodes are protected from decay.
 
 `importance_scorer` recomputes node importance from three dynamic signals:
 
-1. **Access signal**: how often the node has been recalled, based on `access_count`
+1. **Access signal**: how often the node's use has been *confirmed*, based on `access_count`
 2. **Edge signal**: how connected the node is in the graph, based on total edge count
 3. **Recency signal**: how retrievable the node currently is, using FSRS-style `exp(-days_ago / stability)`
 
@@ -149,7 +149,7 @@ Access and edge counts are log-normalized against reference values, then the wei
 
 The scorer runs every `120` minutes by default and only writes a new value when the change is meaningful.
 
-This score is not static. Recall and search hits update `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched.
+This score is not static. **Confirmed use** updates `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched. Merely being surfaced does not: search results, UI search, whisper injection and graph expansion write no lifecycle fields (issue #220). Confirmed use is a deliberate `recall_node`, or qualified positive feedback — `explicit`, `implicit` or `auto_llm_judge`. Because `access_count` now counts confirmations rather than appearances, its values are far smaller than before, and `importance_access_reference` is calibrated against the old scale.
 
 Important current nuance: `importance_recency_half_life_days` exists in configuration, but the current scorer implementation uses FSRS stability for the recency term instead.
 

--- a/eval/recall/runner.py
+++ b/eval/recall/runner.py
@@ -71,7 +71,6 @@ def _eval_case(case: dict, engine, k: int, min_score: float, injection_gate: flo
                 # default_space) — mirror it so space scoring is measured.
                 default_space=case.get("space"),
                 tiers=["core", "working"],
-                touch_access=False,
             )
         except Exception as e:
             logger.warning("recall_search_structured failed for case %s: %s", case["id"], e)

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -558,6 +558,7 @@ def _record_whisper_usage_signals(
                 },
             })
 
+    confirmed_node_ids: list[str] = []
     with engine.db.transaction() as conn:
         for record in judge_records:
             row = record["row"]
@@ -580,6 +581,38 @@ def _record_whisper_usage_signals(
                     source=_LLM_JUDGE_AFFINITY_SOURCE,
                     confirmed_at=now_iso,
                 )
+            # Issue #220: the same at-most-once claim submit_feedback takes, not a
+            # parallel polarity check. has_llm_judge only sees this watcher's own
+            # signal source, so it is blind to feedback submitted through MCP — the
+            # claim is what makes one whisper event reinforce once across both
+            # callers. Note _insert_affinity must run first: it reads changes()
+            # nowhere, but the claim helper does, so nothing may sit between its
+            # INSERT and its read.
+            if engine._claim_confirmed_use(
+                conn,
+                row["id"],
+                row["node_id"],
+                signal=record["polarity"],
+                source=_LLM_JUDGE_AFFINITY_SOURCE,
+            ):
+                confirmed_node_ids.append(row["node_id"])
+
+    # Issue #220: reinforcement runs after the transaction commits. db.transaction()
+    # holds a process-level lock for its whole body and _record_confirmed_use writes
+    # markdown to disk, so doing this inside would stall every writer in the process
+    # for the length of N file saves — and would take db_lock before memory_lock,
+    # inverting the order every serialized writer uses.
+    #
+    # Each node is isolated: the signals and claims above are already committed, so
+    # letting one node's failure escape would abort the ingest slice, skip every later
+    # node, and leave both has_llm_judge set and the claims taken — nothing would ever
+    # retry them. Failures here are logged, never raised. This is the at-most-once
+    # contract, stated in 00-overview.md.
+    for node_id in confirmed_node_ids:
+        try:
+            engine._record_confirmed_use(node_id)
+        except Exception:
+            logger.exception("confirmed-use reinforcement failed for node %s", node_id)
 
     return recorded
 

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -607,7 +607,7 @@ def _record_whisper_usage_signals(
     # letting one node's failure escape would abort the ingest slice, skip every later
     # node, and leave both has_llm_judge set and the claims taken — nothing would ever
     # retry them. Failures here are logged, never raised. This is the at-most-once
-    # contract, stated in 00-overview.md.
+    # contract.
     for node_id in confirmed_node_ids:
         try:
             engine._record_confirmed_use(node_id)

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -520,7 +520,6 @@ class ContextBuilder:
             "limit": max_nodes * max(candidate_pool_multiplier, 1),
             "default_space": space,
             "tiers": ["core", "working"],
-            "touch_access": False,
             # Whisper needs the raw pool — it applies its own floors and an
             # absolute-signal gate; the deliberate-recall floor would drop
             # length-penalized long docs before the reranker can rescue them.
@@ -893,7 +892,6 @@ class ContextBuilder:
                     default_space=space,
                     types=["preference"],
                     tiers=["core", "working"],
-                    touch_access=False,
                     min_relevance=0.0,
                     auto_temporal=False,
                     spread_activation=False,

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2615,7 +2615,7 @@ class MemoryEngine:
         # Isolated, and never propagated. The affinity and signals rows are already
         # durably committed and the route returns this value straight to the caller,
         # so raising here would report a failure for evidence that was recorded. The
-        # contract is at-most-once (see 00-overview.md): the claim stays taken and
+        # contract is at-most-once: the claim stays taken and
         # this reinforcement is simply lost, as a logged miss.
         if became_confirmed:
             try:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -696,7 +696,17 @@ class MemoryEngine:
                     source="explicit",
                 )
         if claimed:
-            self._record_confirmed_use(resolved_node_id)
+            # Isolated, and never propagated — the same contract submit_feedback and the
+            # session watcher already implement. The claim is committed and the fetch has
+            # already succeeded, so raising here would cost the agent its answer over a
+            # lifecycle write. At-most-once means the claim stays taken and this
+            # reinforcement is simply a logged miss; a retry would only log a second event.
+            try:
+                self._record_confirmed_use(resolved_node_id)
+            except Exception:
+                logger.exception(
+                    "confirmed-use reinforcement failed for node %s", resolved_node_id
+                )
         node_for_format = dict(node)
         if resolved_node_id in whisper_log_ids:
             node_for_format["_whisper_log_id"] = whisper_log_ids[resolved_node_id]
@@ -1965,11 +1975,17 @@ class MemoryEngine:
             return
         now = datetime.now(timezone.utc)
 
-        # FSRS stability update
+        # FSRS stability update. Node.stability is Field(ge=0.0), so 0 is a valid
+        # persisted value that would divide by zero here — and, once past that, keep
+        # new_stability pinned at 0 forever. decay_manager and importance_scorer already
+        # guard this same division; this was the one consumer that did not, and the
+        # ZeroDivisionError landed in the caller's isolating except as a silent lost
+        # reinforcement on a claim that had already been committed.
         review_anchor = node.last_review or node.last_accessed
         days_since = max((now - review_anchor).total_seconds() / 86400, 0.001)
-        retrievability = math.exp(-days_since / node.stability)
-        new_stability = node.stability * self.settings.fsrs_stability_growth * (retrievability ** -0.2)
+        stability = node.stability if node.stability else self.settings.fsrs_initial_stability
+        retrievability = math.exp(-days_since / stability)
+        new_stability = stability * self.settings.fsrs_stability_growth * (retrievability ** -0.2)
         node.stability = round(min(new_stability, self.settings.fsrs_max_stability), 2)
         node.last_review = now
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -647,9 +647,6 @@ class MemoryEngine:
 
         resolved_node_id = node["id"]
 
-        # Record confirmed use: this is a deliberate single-node fetch
-        self._record_confirmed_use(resolved_node_id)
-
         edges = self.graph.get_edges_for(resolved_node_id)
         neighbors = self.graph.get_neighbors(resolved_node_id, depth=1)
         whisper_log_ids = self._log_feedback_candidates(
@@ -661,6 +658,31 @@ class MemoryEngine:
             space=node.get("space"),
             surface="recall_node",
         )
+
+        # Record confirmed use: this is a deliberate single-node fetch.
+        #
+        # Issue #220: claim this node's own event first. _log_feedback_candidates
+        # above created a whisper_log row for it and the formatter hands that id to
+        # the agent, whose instructions say to submit_feedback(+1) with it when the
+        # memory is drawn on. Without the claim, that feedback finds the event
+        # unclaimed and reinforces a second time — one fetch counting twice, on the
+        # most deliberate surface there is. Claiming here makes the later feedback a
+        # no-op and leaves this reinforcement untouched.
+        #
+        # The mutator stays outside the transaction: it does file I/O, and with
+        # @_serialized_memory_operation calling it inside would take db_lock before
+        # memory_lock, inverting the order every serialized writer uses.
+        target_log_id = whisper_log_ids.get(resolved_node_id)
+        if target_log_id is not None:
+            with self.db.transaction() as conn:
+                self._claim_confirmed_use(
+                    conn,
+                    target_log_id,
+                    resolved_node_id,
+                    signal=1,
+                    source="explicit",
+                )
+        self._record_confirmed_use(resolved_node_id)
         node_for_format = dict(node)
         if resolved_node_id in whisper_log_ids:
             node_for_format["_whisper_log_id"] = whisper_log_ids[resolved_node_id]

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -669,20 +669,34 @@ class MemoryEngine:
         # most deliberate surface there is. Claiming here makes the later feedback a
         # no-op and leaves this reinforcement untouched.
         #
+        # The claim result gates the mutator, and is not merely taken. The row above
+        # is committed by _log_feedback_candidates before this transaction opens, so
+        # in that window a concurrent submit_feedback using the no-whisper_log_id
+        # fallback resolves the same newest row and can claim it first. Reinforcing
+        # regardless would make one fetch count twice — the exact invariant the claim
+        # exists to hold. A lost claim means the winner already reinforced.
+        #
+        # No claim, no reinforcement: reinforcement fires on the claim, never on the
+        # request. When _log_feedback_candidates fails it returns {}, leaving no event
+        # to latch on, and an unlatched reinforcement here would be the request-driven
+        # path this issue removes.
+        #
         # The mutator stays outside the transaction: it does file I/O, and with
         # @_serialized_memory_operation calling it inside would take db_lock before
         # memory_lock, inverting the order every serialized writer uses.
         target_log_id = whisper_log_ids.get(resolved_node_id)
+        claimed = False
         if target_log_id is not None:
             with self.db.transaction() as conn:
-                self._claim_confirmed_use(
+                claimed = self._claim_confirmed_use(
                     conn,
                     target_log_id,
                     resolved_node_id,
                     signal=1,
                     source="explicit",
                 )
-        self._record_confirmed_use(resolved_node_id)
+        if claimed:
+            self._record_confirmed_use(resolved_node_id)
         node_for_format = dict(node)
         if resolved_node_id in whisper_log_ids:
             node_for_format["_whisper_log_id"] = whisper_log_ids[resolved_node_id]

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2543,8 +2543,19 @@ class MemoryEngine:
         key omits polarity and is never updated, so deriving it from there makes
         -1 followed by +1 never confirm at all.
 
-        Fail-closed: an unqualified signal, a source outside the allowlist, or a
-        missing whisper_log_id claims nothing.
+        Fail-closed: an unqualified signal, a source outside the allowlist, a
+        missing whisper_log_id, or an event that was never injected claims
+        nothing. was_injected = 1 is the provenance test: only a memory the
+        agent actually saw can have been used. The session-start review path
+        (_find_review_candidate, _REVIEW_FRAMING) deliberately hands the agent a
+        was_injected = 0 event and asks whether it *would* have been useful, and
+        that answer is relevance, not use. The other two callers already satisfy
+        this — _log_feedback_candidates hardcodes was_injected = 1 and the
+        session watcher filters on it — so the condition costs them nothing.
+
+        Enforced in SQL rather than by the caller so a future fourth caller
+        cannot reopen the hole. changes() returns 0 both for a non-injected
+        event and for an already-taken claim; both mean "do not reinforce".
 
         MUST be called inside the caller's transaction. Claiming after the
         mutator instead would let two concurrent confirmations both pass and
@@ -2556,10 +2567,12 @@ class MemoryEngine:
         conn.execute(
             """
             INSERT INTO confirmed_use_claims (whisper_log_id, node_id, claimed_at)
-            VALUES (?, ?, datetime('now'))
+            SELECT wl.id, ?, datetime('now')
+            FROM whisper_log wl
+            WHERE wl.id = ? AND wl.was_injected = 1
             ON CONFLICT DO NOTHING
             """,
-            (whisper_log_id, node_id),
+            (node_id, whisper_log_id),
         )
         return conn.execute("SELECT changes()").fetchone()[0] == 1
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -642,8 +642,8 @@ class MemoryEngine:
 
         resolved_node_id = node["id"]
 
-        # Touch access
-        self._touch_access(resolved_node_id)
+        # Record confirmed use: this is a deliberate single-node fetch
+        self._record_confirmed_use(resolved_node_id)
 
         edges = self.graph.get_edges_for(resolved_node_id)
         neighbors = self.graph.get_neighbors(resolved_node_id, depth=1)
@@ -678,7 +678,7 @@ class MemoryEngine:
 
     def recall_search_structured(
         self, query: str, limit: int = 10, default_space: str | None = None,
-        touch_access: bool = True, min_relevance: float | None = None,
+        min_relevance: float | None = None,
         auto_temporal: bool = True, spread_activation: bool = True,
         query_vec: Any | None = None, **filters,
     ) -> list[dict]:
@@ -686,9 +686,6 @@ class MemoryEngine:
 
         Same logic as recall_search but returns raw dicts instead of formatted text.
         Used by the UI and any consumer that needs structured data.
-
-        When *touch_access* is False, access_count and last_accessed are not
-        updated — useful for context loading that shouldn't inflate access stats.
 
         *min_relevance* overrides the deliberate-recall floor
         (settings.recall_min_relevance_score). Whisper passes 0.0: it needs
@@ -769,10 +766,6 @@ class MemoryEngine:
 
             if spread_activation:
                 results = self._spread_activation(results, limit)
-            if touch_access:
-                for r in results:
-                    if r.get("source") not in ("activated", "conflict"):
-                        self._touch_access(r["node"]["id"])
             return results
 
         # Fallback to FTS only
@@ -805,10 +798,6 @@ class MemoryEngine:
 
         if spread_activation:
             enriched = self._spread_activation(enriched, limit)
-        if touch_access:
-            for r in enriched:
-                if r.get("source") not in ("activated", "conflict"):
-                    self._touch_access(r["node"]["id"])
 
         return enriched
 
@@ -887,9 +876,6 @@ class MemoryEngine:
                     )
 
             results = self._spread_activation(results, limit)
-            for r in results:
-                if r.get("source") not in ("activated", "conflict"):
-                    self._touch_access(r["node"]["id"])
             whisper_log_ids = self._log_feedback_candidates(
                 query_for_log,
                 [
@@ -933,9 +919,6 @@ class MemoryEngine:
             )
 
         enriched = self._spread_activation(enriched, limit)
-        for r in enriched:
-            if r.get("source") not in ("activated", "conflict"):
-                self._touch_access(r["node"]["id"])
         whisper_log_ids = self._log_feedback_candidates(
             query_for_log,
             [
@@ -1933,8 +1916,9 @@ class MemoryEngine:
             self_node.touch_updated()
             self.file_store.save(self_node)
 
-    def _touch_access(self, node_id: str) -> None:
-        """Update access stats and FSRS stability on both disk and DB."""
+    @_serialized_memory_operation
+    def _record_confirmed_use(self, node_id: str) -> None:
+        """Record a confirmed use: update access stats and FSRS stability on disk and DB."""
         node = self.file_store.load(node_id)
         if node is None:
             return

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -50,6 +50,11 @@ logger = logging.getLogger(__name__)
 # Higher factor = tighter structural link = more activation propagated.
 _EMBEDDING_SCHEMA_VERSION = 2
 
+# Issue #220: the only feedback sources that count as confirmed use. Fail-closed —
+# anything not listed here, and every negative signal, does not reinforce.
+# auto_heuristic is excluded pending #218 signal calibration.
+_CONFIRMED_USE_SOURCES = frozenset({"explicit", "implicit", "auto_llm_judge"})
+
 
 def _generate_title(content: str, max_chars: int = 60) -> str:
     """Generate a short title from the first line/sentence of content."""
@@ -2479,6 +2484,49 @@ class MemoryEngine:
             return None, None, f"No whisper_log entry found for node {node_id}"
         return resolved_node_id, row, None
 
+    def _claim_confirmed_use(
+        self,
+        conn,
+        whisper_log_id: int | None,
+        node_id: str,
+        *,
+        signal: int,
+        source: str,
+    ) -> bool:
+        """Take the at-most-once confirmed-use claim for one (event, node) pair.
+
+        Returns True only for the caller that actually inserts the claim, so a
+        whisper event reinforces at most once no matter how many qualified
+        positives arrive, from how many sources, in what order.
+
+        The claim is a durable monotonic latch, deliberately independent of
+        affinity and signals. affinity is mutable — explicit feedback UPDATEs the
+        single row per (node_id, whisper_log_id) — so deriving confirmation from
+        it makes a +1/-1/+1 cycle confirm twice, and makes a pre-existing
+        auto_heuristic row swallow a later qualified positive. The signals unique
+        key omits polarity and is never updated, so deriving it from there makes
+        -1 followed by +1 never confirm at all.
+
+        Fail-closed: an unqualified signal, a source outside the allowlist, or a
+        missing whisper_log_id claims nothing.
+
+        MUST be called inside the caller's transaction. Claiming after the
+        mutator instead would let two concurrent confirmations both pass and
+        both reinforce; @_serialized_memory_operation keeps the read-modify-write
+        correct but cannot enforce once-per-event.
+        """
+        if whisper_log_id is None or signal != 1 or source not in _CONFIRMED_USE_SOURCES:
+            return False
+        conn.execute(
+            """
+            INSERT INTO confirmed_use_claims (whisper_log_id, node_id, claimed_at)
+            VALUES (?, ?, datetime('now'))
+            ON CONFLICT DO NOTHING
+            """,
+            (whisper_log_id, node_id),
+        )
+        return conn.execute("SELECT changes()").fetchone()[0] == 1
+
     def submit_feedback(
         self,
         node_id: str,
@@ -2488,12 +2536,30 @@ class MemoryEngine:
     ) -> str:
         """Record feedback while preventing retention from deleting its event."""
         with self.db.transaction():
-            return self._submit_feedback_locked(
+            resolved_node_id, became_confirmed, message = self._submit_feedback_locked(
                 node_id=node_id,
                 signal=signal,
                 source=source,
                 whisper_log_id=whisper_log_id,
             )
+        # Reinforcement runs after the transaction commits: db.transaction() holds a
+        # process-level lock for its whole body, and _record_confirmed_use does file
+        # I/O. Calling it inside would also take db_lock before memory_lock, inverting
+        # the order every serialized writer uses.
+        #
+        # Isolated, and never propagated. The affinity and signals rows are already
+        # durably committed and the route returns this value straight to the caller,
+        # so raising here would report a failure for evidence that was recorded. The
+        # contract is at-most-once (see 00-overview.md): the claim stays taken and
+        # this reinforcement is simply lost, as a logged miss.
+        if became_confirmed:
+            try:
+                self._record_confirmed_use(resolved_node_id)
+            except Exception:
+                logger.exception(
+                    "confirmed-use reinforcement failed for node %s", resolved_node_id
+                )
+        return message
 
     def _submit_feedback_locked(
         self,
@@ -2501,7 +2567,7 @@ class MemoryEngine:
         signal: int,
         source: str = "explicit",
         whisper_log_id: int | None = None,
-    ) -> str:
+    ) -> tuple[str | None, bool, str]:
         """Record explicit or implicit feedback signal for a whisper candidate.
 
         When *whisper_log_id* is supplied, feedback attaches to that exact
@@ -2514,7 +2580,7 @@ class MemoryEngine:
             node_id, whisper_log_id,
         )
         if error is not None:
-            return error
+            return None, False, error
         assert resolved_node_id is not None
         assert row is not None
 
@@ -2526,6 +2592,13 @@ class MemoryEngine:
         whisper_log_id = row["id"]
 
         with self.db.transaction() as conn:
+            became_confirmed = self._claim_confirmed_use(
+                conn,
+                whisper_log_id,
+                resolved_node_id,
+                signal=signal,
+                source=source,
+            )
             conn.execute(
                 """
                 INSERT INTO affinity
@@ -2593,7 +2666,11 @@ class MemoryEngine:
                     (resolved_node_id,),
                 )
 
-        return f"Feedback recorded for node {resolved_node_id[:8]}..."
+        return (
+            resolved_node_id,
+            became_confirmed,
+            f"Feedback recorded for node {resolved_node_id[:8]}...",
+        )
 
     def _is_duplicate_memory(self, content: str) -> bool:
         """Check if a very similar memory already exists using vector search."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -729,7 +729,7 @@ class MemoryEngine:
 
     def recall_search_structured(
         self, query: str, limit: int = 10, default_space: str | None = None,
-        min_relevance: float | None = None,
+        *, min_relevance: float | None = None,
         auto_temporal: bool = True, spread_activation: bool = True,
         query_vec: Any | None = None, **filters,
     ) -> list[dict]:

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -224,7 +224,13 @@ CREATE INDEX IF NOT EXISTS idx_whisper_decisions_logged  ON whisper_decisions(lo
 -- ON DELETE CASCADE, not SET NULL: the other whisper_log_id foreign keys use
 -- SET NULL because their columns are nullable. On a NOT NULL column SET NULL
 -- would make whisper_log_cleanup's DELETE fail with a constraint violation.
--- CASCADE also keeps this table bounded by whisper_log's own retention.
+--
+-- Note the CASCADE does not, in practice, bound this table. whisper_log_cleanup
+-- only deletes rows with was_injected = 0 and no affinity or signals, while
+-- _log_feedback_candidates hardcodes was_injected = 1 and both claiming callers
+-- write an affinity row in the same transaction — so no claimable parent is ever
+-- collected. The table grows one small row per confirmed use. That is not a
+-- capacity concern, but do not rely on the cascade for retention.
 --
 -- node_id deliberately carries NO foreign key. It would buy nothing: the only
 -- writer is _claim_confirmed_use, which receives a node id submit_feedback has
@@ -233,8 +239,7 @@ CREATE INDEX IF NOT EXISTS idx_whisper_decisions_logged  ON whisper_decisions(lo
 -- existing feedback tests fabricate node ids that were never inserted into
 -- nodes, which is a legitimate pattern here, and a reference would force them
 -- all to change. A claim outliving its node is harmless: the latch only ever
--- prevents a second reinforcement, and the whisper_log CASCADE above already
--- bounds the table.
+-- prevents a second reinforcement.
 CREATE TABLE IF NOT EXISTS confirmed_use_claims (
     whisper_log_id INTEGER NOT NULL REFERENCES whisper_log(id) ON DELETE CASCADE,
     node_id        TEXT NOT NULL,

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -211,6 +211,37 @@ CREATE TABLE IF NOT EXISTS whisper_decisions (
 CREATE INDEX IF NOT EXISTS idx_whisper_decisions_session ON whisper_decisions(session_id);
 CREATE INDEX IF NOT EXISTS idx_whisper_decisions_logged  ON whisper_decisions(logged_at);
 
+-- Issue #220: at-most-once latch for confirmed use. One row per (whisper event,
+-- node) pair, taken by whichever qualified positive signal arrives first, and
+-- never deleted. This is deliberately NOT derived from affinity or signals:
+-- affinity is mutable (explicit feedback UPDATEs the single row per event, so a
+-- +1/-1/+1 cycle would confirm twice) and the signals unique key omits polarity
+-- (so -1 followed by +1 collides and a real confirmation would never fire).
+--
+-- whisper_log_id is NOT NULL because SQLite permits repeated NULLs in a PRIMARY
+-- KEY, which would defeat the latch entirely.
+--
+-- ON DELETE CASCADE, not SET NULL: the other whisper_log_id foreign keys use
+-- SET NULL because their columns are nullable. On a NOT NULL column SET NULL
+-- would make whisper_log_cleanup's DELETE fail with a constraint violation.
+-- CASCADE also keeps this table bounded by whisper_log's own retention.
+--
+-- node_id deliberately carries NO foreign key. It would buy nothing: the only
+-- writer is _claim_confirmed_use, which receives a node id submit_feedback has
+-- already resolved against the store, so the constraint would guard against a
+-- bug the code cannot commit. It would cost real scope, though — several
+-- existing feedback tests fabricate node ids that were never inserted into
+-- nodes, which is a legitimate pattern here, and a reference would force them
+-- all to change. A claim outliving its node is harmless: the latch only ever
+-- prevents a second reinforcement, and the whisper_log CASCADE above already
+-- bounds the table.
+CREATE TABLE IF NOT EXISTS confirmed_use_claims (
+    whisper_log_id INTEGER NOT NULL REFERENCES whisper_log(id) ON DELETE CASCADE,
+    node_id        TEXT NOT NULL,
+    claimed_at     TEXT NOT NULL,
+    PRIMARY KEY (whisper_log_id, node_id)
+);
+
 CREATE TABLE IF NOT EXISTS review_log (
     id          INTEGER PRIMARY KEY AUTOINCREMENT,
     node_id     TEXT NOT NULL,

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -301,7 +301,7 @@ def test_confidence_affects_search_ranking(engine):
 
     # Search for the content — confidence_factor in search should differentiate
     results = engine.recall_search_structured(
-        "caching architecture", limit=10, touch_access=False,
+        "caching architecture", limit=10,
     )
 
     # Find both nodes in results

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -2296,3 +2296,297 @@ def test_reconcile_skips_never_seen_when_lookback_negative(engine, tmp_path):
     assert recovered == 0
     assert ingest_calls == []
     assert rel not in handler._state
+
+
+# --- Issue #220: confirmed use from the auto_llm_judge path -----------------
+
+_LIFECYCLE_FIELDS = ("access_count", "last_accessed", "stability", "last_review")
+
+
+def _lifecycle(engine, node_id):
+    """The four lifecycle fields, from the markdown file and the SQLite row."""
+    node = engine.file_store.load(node_id)
+    row = engine.db.conn.execute(
+        "SELECT access_count, last_accessed, stability, last_review FROM nodes WHERE id = ?",
+        (node_id,),
+    ).fetchone()
+    return {
+        "file": tuple(getattr(node, f) for f in _LIFECYCLE_FIELDS),
+        "db": tuple(row[f] for f in _LIFECYCLE_FIELDS),
+    }
+
+
+def test_llm_judge_used_verdict_records_confirmed_use(engine, tmp_path):
+    """Issue #220: a positive auto_llm_judge verdict confirms use for its node."""
+    prompt = "What deployment marker should we use?"
+    response = "That guidance is the right one for the rollout."
+    transcript_path = tmp_path / "judge-confirms-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Use blue deployment markers when rollback plans need quick visual checks.",
+        type="fact",
+        title="Blue deployment rollback marker",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="judge-confirms-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    before = _lifecycle(engine, node_id)
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "used",
+            "confidence": 0.88,
+            "reason": "The answer endorses the injected deployment guidance.",
+        }]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response):
+        _record_whisper_usage_signals(engine, transcript)
+
+    after = _lifecycle(engine, node_id)
+    assert after != before, "the judged-used node was not confirmed"
+    assert after["file"][0] == before["file"][0] + 1, "access_count did not advance by one"
+    assert after["db"][0] == after["file"][0], "file and DB disagree on access_count"
+
+    # The signal and affinity rows must still be written — confirmed use is
+    # additional behaviour, not a replacement for observability.
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert affinity is not None
+    assert affinity["source"] == "auto_llm_judge"
+
+
+def test_llm_judge_unused_verdict_does_not_record_confirmed_use(engine, tmp_path):
+    """A negative verdict is affinity evidence only — it never reinforces."""
+    prompt = "What deployment marker should we use?"
+    response = "Ignore that; we are switching to a completely different scheme."
+    transcript_path = tmp_path / "judge-unused-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Use blue deployment markers when rollback plans need quick visual checks.",
+        type="fact",
+        title="Blue deployment rollback marker",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="judge-unused-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    before = _lifecycle(engine, node_id)
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "unused",
+            "confidence": 0.9,
+            "reason": "The answer rejects the injected guidance.",
+        }]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response):
+        _record_whisper_usage_signals(engine, transcript)
+
+    assert _lifecycle(engine, node_id) == before, "an unused verdict changed lifecycle fields"
+
+
+def test_heuristic_positive_does_not_record_confirmed_use(engine, tmp_path):
+    """Issue #220: auto_heuristic yields polarity 1 but never confirms use.
+
+    The heuristic path is excluded pending #218 signal calibration. This is the
+    case that matters: it is positive, so only the source keeps it out.
+    """
+    prompt = "How should we solve feedback collection?"
+    response = "The right fix is the transcript watcher mines feedback usage approach."
+    transcript_path = tmp_path / "heuristic-no-confirm-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="The transcript watcher mines feedback usage from completed transcripts.",
+        type="fact",
+        title="Transcript watcher mines feedback usage",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="heuristic-no-confirm-session", prompt=prompt,
+    )
+
+    before = _lifecycle(engine, node_id)
+
+    recorded = _record_whisper_usage_signals(engine, transcript)
+
+    # The heuristic signal is still recorded — this is about lifecycle, not observability.
+    assert recorded == 1
+    signal = engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert signal["polarity"] == 1
+
+    assert _lifecycle(engine, node_id) == before, "auto_heuristic confirmed use — it must not"
+
+    # And it claimed nothing, so a later qualified positive can still confirm.
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert claim is None, "the heuristic path took a confirmed-use claim"
+
+
+def test_replaying_the_judge_does_not_reconfirm(engine, tmp_path):
+    """Issue #220: a second pass over the same transcript reinforces nothing.
+
+    has_llm_judge already excludes an event that was judged before, so the
+    replay should not even reach the confirm loop — and the claim latch stops it
+    a second time if it does. Two independent guards, deliberately.
+    """
+    prompt = "What deployment marker should we use?"
+    response = "That guidance is the right one for the rollout."
+    transcript_path = tmp_path / "judge-replay-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Use blue deployment markers when rollback plans need quick visual checks.",
+        type="fact",
+        title="Blue deployment rollback marker",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="judge-replay-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "used",
+            "confidence": 0.88,
+            "reason": "The answer endorses the injected deployment guidance.",
+        }]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response):
+        _record_whisper_usage_signals(engine, transcript)
+    after_first = _lifecycle(engine, node_id)
+
+    with patch(_LLM_PATCH, return_value=llm_response):
+        _record_whisper_usage_signals(engine, transcript)
+
+    assert _lifecycle(engine, node_id) == after_first, (
+        "replaying the judge reinforced the same event twice"
+    )
+
+
+def test_feedback_claim_makes_the_judge_a_noop(engine, tmp_path):
+    """Issue #220 cross-caller contract: one event, one reinforcement, two callers.
+
+    This is the case has_llm_judge cannot cover: it only looks at signals whose
+    source is transcript_watcher_llm_judge, so it is blind to feedback submitted
+    through MCP. Before the claim latch, an implicit +1 followed by a positive
+    judge verdict on the same whisper event reinforced it twice.
+    """
+    prompt = "What deployment marker should we use?"
+    response = "That guidance is the right one for the rollout."
+    transcript_path = tmp_path / "judge-cross-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Use blue deployment markers when rollback plans need quick visual checks.",
+        type="fact",
+        title="Blue deployment rollback marker",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="judge-cross-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    engine.submit_feedback(node_id, signal=1, source="implicit", whisper_log_id=whisper_log_id)
+    after_feedback = _lifecycle(engine, node_id)
+
+    llm_response = json.dumps({
+        "verdicts": [{
+            "whisper_log_id": whisper_log_id,
+            "verdict": "used",
+            "confidence": 0.88,
+            "reason": "The answer endorses the injected deployment guidance.",
+        }]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    # The judge's own signal and affinity rows are still written — observability
+    # is not what the claim gates.
+    assert recorded >= 1, "the judge signal was not recorded"
+    assert _lifecycle(engine, node_id) == after_feedback, (
+        "the judge reinforced an event already confirmed through submit_feedback"
+    )
+
+
+def test_one_failing_node_does_not_skip_the_rest_of_the_batch(engine, tmp_path):
+    """Issue #220: reinforcement is isolated per node, for any exception.
+
+    The judge signals and the claims are already committed when this loop runs,
+    so an escaping exception would abort the slice and — because has_llm_judge is
+    now set and the claims are taken — the retry would never reinforce these
+    events. The later nodes would lose their only chance at confirmation.
+
+    ZeroDivisionError is the realistic case, not a contrived one: stability is
+    Field(default=1.0, ge=0.0), so zero is legal, and the mutator divides by it.
+    """
+    prompt = "What deployment marker should we use?"
+    response = "Both of those notes are exactly right."
+    transcript_path = tmp_path / "judge-batch-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    first_id, _ = engine.remember(CreateNodeRequest(
+        content="Use blue deployment markers when rollback plans need quick visual checks.",
+        type="fact", title="Blue deployment rollback marker",
+    ))
+    second_id, _ = engine.remember(CreateNodeRequest(
+        content="Roll back within one minute when the marker check fails.",
+        type="fact", title="Rollback timing",
+    ))
+    log_ids = [
+        _insert_injected_whisper_log(
+            engine, node_id=node_id, session_id="judge-batch-session", prompt=prompt,
+        )
+        for node_id in (first_id, second_id)
+    ]
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    before_second = _lifecycle(engine, second_id)
+
+    real_mutator = engine._record_confirmed_use
+
+    def failing_for_first(node_id):
+        if node_id == first_id:
+            raise ZeroDivisionError("float division by zero")
+        return real_mutator(node_id)
+
+    llm_response = json.dumps({
+        "verdicts": [
+            {"whisper_log_id": log_id, "verdict": "used", "confidence": 0.9,
+             "reason": "endorsed"}
+            for log_id in log_ids
+        ]
+    })
+    with patch(_LLM_PATCH, return_value=llm_response), \
+         patch.object(engine, "_record_confirmed_use", side_effect=failing_for_first):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    # Both nodes go through the heuristic pass unreferenced (the response text
+    # matches neither node's id/title/content), then both go to the judge pass:
+    # 2 heuristic signals + 2 judge signals.
+    assert recorded == 4, "the signals themselves must still be recorded"
+    assert _lifecycle(engine, second_id) != before_second, (
+        "the first node's failure skipped the second node's reinforcement"
+    )

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -1,0 +1,181 @@
+"""Contract tests for issue #220: surfacing must not be confirmed use.
+
+Every assertion reads the four lifecycle fields from BOTH the markdown file and
+the SQLite row. A test that checked only the database would pass while the file
+rotted, and vice versa.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api.routes_ui import router as ui_router
+from ormah.config import Settings
+from ormah.engine.memory_engine import MemoryEngine
+from ormah.models.node import CreateNodeRequest
+
+LIFECYCLE_FIELDS = ("access_count", "last_accessed", "stability", "last_review")
+
+
+def _snapshot(engine, node_id):
+    """Capture the four lifecycle fields from the markdown file and the DB row."""
+    node = engine.file_store.load(node_id)
+    row = engine.db.conn.execute(
+        "SELECT access_count, last_accessed, stability, last_review FROM nodes WHERE id = ?",
+        (node_id,),
+    ).fetchone()
+    return {
+        "file": tuple(getattr(node, f) for f in LIFECYCLE_FIELDS),
+        "db": tuple(row[f] for f in LIFECYCLE_FIELDS),
+    }
+
+
+def _make_nodes(engine, count=2):
+    """Create *count* nodes that a search for 'caching' will match."""
+    ids = []
+    for i in range(count):
+        node_id, _ = engine.remember(CreateNodeRequest(
+            content=f"caching architecture note number {i}",
+            title=f"Caching {i}",
+            type="fact",
+            tier="working",
+        ))
+        ids.append(node_id)
+    return ids
+
+
+@pytest.fixture
+def fts_only(engine):
+    """Force the FTS fallback path by removing hybrid search."""
+    with patch.object(engine, "_get_hybrid_search", return_value=None):
+        yield engine
+
+
+# --- Non-mutation contracts (issue #220 acceptance criteria) ---------------
+
+def test_recall_search_does_not_write_lifecycle(engine):
+    """Contract 1: broad formatted recall over N nodes mutates nothing."""
+    ids = _make_nodes(engine)
+    before = {i: _snapshot(engine, i) for i in ids}
+
+    engine.recall_search("caching architecture", limit=10)
+
+    for node_id in ids:
+        assert _snapshot(engine, node_id) == before[node_id], (
+            f"recall_search mutated lifecycle fields on {node_id}"
+        )
+
+
+def test_recall_search_fts_fallback_does_not_write_lifecycle(fts_only):
+    """Contract 2: the FTS fallback path mutates nothing either."""
+    engine = fts_only
+    ids = _make_nodes(engine)
+    before = {i: _snapshot(engine, i) for i in ids}
+
+    engine.recall_search("caching architecture", limit=10)
+
+    for node_id in ids:
+        assert _snapshot(engine, node_id) == before[node_id]
+
+
+def test_recall_search_structured_does_not_write_lifecycle(engine):
+    """Contract 3: called with no lifecycle kwarg — the default was the bug."""
+    ids = _make_nodes(engine)
+    before = {i: _snapshot(engine, i) for i in ids}
+
+    engine.recall_search_structured("caching architecture", limit=10)
+
+    for node_id in ids:
+        assert _snapshot(engine, node_id) == before[node_id]
+
+
+def test_recall_search_structured_fts_fallback_does_not_write_lifecycle(fts_only):
+    """Contract 4: same for the FTS fallback."""
+    engine = fts_only
+    ids = _make_nodes(engine)
+    before = {i: _snapshot(engine, i) for i in ids}
+
+    engine.recall_search_structured("caching architecture", limit=10)
+
+    for node_id in ids:
+        assert _snapshot(engine, node_id) == before[node_id]
+
+
+def test_ui_search_route_does_not_write_lifecycle(tmp_memory_dir):
+    """Contract 5: the UI search route.
+
+    This is the test that fails on clean upstream/main: routes_ui.search_nodes
+    calls recall_search_structured without the kwarg, so the True default
+    reinforced every result. Exercised through the route, not the engine.
+    """
+    settings = Settings(memory_dir=tmp_memory_dir, backup_dir=tmp_memory_dir.parent / "backups")
+    engine = MemoryEngine(settings)
+    engine.startup()
+    try:
+        ids = _make_nodes(engine)
+        before = {i: _snapshot(engine, i) for i in ids}
+
+        app = FastAPI()
+        app.include_router(ui_router)
+        app.state.engine = engine
+        with TestClient(app) as client:
+            resp = client.get("/ui/search", params={"q": "caching architecture"})
+        assert resp.status_code == 200
+
+        for node_id in ids:
+            assert _snapshot(engine, node_id) == before[node_id], (
+                f"UI search mutated lifecycle fields on {node_id}"
+            )
+    finally:
+        engine.shutdown()
+
+
+def test_whisper_does_not_write_lifecycle(engine):
+    """Contract 6: whisper still mutates nothing after losing its flag.
+
+    Whisper was already correct (it passed touch_access=False). This pins that
+    it stays correct once the flag is gone.
+    """
+    from ormah.engine.context_builder import ContextBuilder
+
+    ids = _make_nodes(engine)
+    before = {i: _snapshot(engine, i) for i in ids}
+
+    builder = ContextBuilder(engine.graph, engine=engine)
+    builder.build_whisper_context("caching architecture", space=None, max_nodes=8)
+
+    for node_id in ids:
+        assert _snapshot(engine, node_id) == before[node_id]
+
+
+def test_concurrent_confirmed_use_does_not_lose_increments(engine):
+    """Issue #220: _record_confirmed_use is atomic across its read-modify-write.
+
+    Without @_serialized_memory_operation, two threads can both load the same
+    access_count and both save count+1, collapsing two confirmations into one.
+    """
+    import threading
+
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    before = engine.file_store.load(target).access_count
+
+    threads = [threading.Thread(target=engine._record_confirmed_use, args=(target,))
+               for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    after = engine.file_store.load(target)
+    assert after.access_count == before + 8, (
+        f"lost increments: expected {before + 8}, got {after.access_count}"
+    )
+    row = engine.db.conn.execute(
+        "SELECT access_count FROM nodes WHERE id = ?", (target,)
+    ).fetchone()
+    assert row["access_count"] == after.access_count, "file and DB disagree after concurrency"

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -451,3 +451,65 @@ def test_recall_node_claims_its_own_event(engine):
     assert _snapshot(engine, target) == after_recall, (
         "feedback on the event recall_node itself surfaced reinforced it a second time"
     )
+
+
+def test_recall_node_does_not_reinforce_when_it_loses_the_claim(engine):
+    """Contract 7b: recall_node reinforces only if it actually took the claim.
+
+    _log_feedback_candidates commits the new whisper_log row in its own
+    transaction, and only afterwards does recall_node open the claim
+    transaction. In that gap the event is committed but unclaimed, so a
+    concurrent submit_feedback using the supported no-whisper_log_id fallback
+    resolves that very row — it is the newest one for the node — and claims it
+    first. recall_node discards its own claim result and reinforces regardless,
+    so one fetch counts twice and the at-most-once latch is violated by the
+    caller that introduced it.
+
+    The barrier is deterministic rather than timed: the competing feedback runs
+    inside a wrapper around _log_feedback_candidates, which is exactly the
+    committed-but-unclaimed window, with no transaction open and no lock held.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+
+    before = _snapshot(engine, target)
+    real_log_candidates = engine._log_feedback_candidates
+
+    def claim_the_event_first(*args, **kwargs):
+        logged = real_log_candidates(*args, **kwargs)
+        engine.submit_feedback(target, signal=1, source="explicit")
+        return logged
+
+    with patch.object(engine, "_log_feedback_candidates", side_effect=claim_the_event_first):
+        engine.recall_node(target)
+
+    after = _snapshot(engine, target)
+    assert after["file"][0] == before["file"][0] + 1, (
+        "one whisper event reinforced twice: access_count "
+        f"{before['file'][0]} -> {after['file'][0]}"
+    )
+    assert after["db"][0] == after["file"][0], "file and DB disagree on access_count"
+
+
+def test_recall_node_does_not_reinforce_without_an_event_to_claim(engine):
+    """Contract 7c: no claim, no reinforcement — not even on the deliberate surface.
+
+    _log_feedback_candidates swallows its own failures and returns {}, leaving
+    recall_node with no whisper_log row to latch on. Reinforcing anyway would be
+    the request-driven path this issue removes: the plan's constraint is that
+    reinforcement fires on the claim, never on the request. Pins the deliberate
+    side of the fix for contract 7b, which would otherwise look like an oversight
+    and invite a `claimed or target_log_id is None` regression.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+
+    before = _snapshot(engine, target)
+
+    with patch.object(engine, "_log_feedback_candidates", return_value={}):
+        engine.recall_node(target)
+
+    assert _snapshot(engine, target) == before, (
+        "recall_node reinforced with no event to claim — reinforcement followed the "
+        "request instead of the claim"
+    )

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -418,3 +418,36 @@ def test_reinforcement_failure_does_not_fail_the_feedback_call(engine):
         (log_id, target),
     ).fetchone()
     assert affinity is not None, "the feedback evidence was rolled back"
+
+
+def test_recall_node_claims_its_own_event(engine):
+    """Contract 7a: one deliberate fetch reinforces once, even when the agent
+    then submits feedback on the event recall_node handed it.
+
+    recall_node calls _log_feedback_candidates, which creates a whisper_log row
+    for the very node it just confirmed and returns its id — the formatter
+    attaches it as _whisper_log_id, and the agent instructions tell the model to
+    submit_feedback(+1) with that id when it draws on the memory. Without a claim
+    taken by recall_node itself, that feedback finds the event unclaimed and
+    reinforces a second time, so one fetch counts twice. Found by whole-branch
+    review, reproduced before the fix as access_count 0 -> 1 -> 2.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+
+    before = _snapshot(engine, target)
+    engine.recall_node(target)
+    after_recall = _snapshot(engine, target)
+    assert after_recall != before, "recall_node did not confirm its own node"
+
+    row = engine.db.conn.execute(
+        "SELECT id FROM whisper_log WHERE node_id = ? ORDER BY id DESC LIMIT 1",
+        (target,),
+    ).fetchone()
+    assert row is not None, "recall_node logged no feedback candidate for its own node"
+
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=row["id"])
+
+    assert _snapshot(engine, target) == after_recall, (
+        "feedback on the event recall_node itself surfaced reinforced it a second time"
+    )

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -578,3 +578,36 @@ def test_review_relevance_feedback_does_not_confirm_use(engine):
         (held_back_id, target),
     ).fetchone()
     assert affinity is not None, "review feedback stopped recording affinity"
+
+
+def test_legacy_fallback_on_a_held_back_event_does_not_confirm(engine):
+    """Contract 11a: the fallback's accepted loss, pinned deliberately.
+
+    submit_feedback without whisper_log_id resolves to the node's newest
+    whisper row, injected or not. When that row is a held-back review
+    candidate, no claim is taken even though an older injected event exists —
+    a legitimate reinforcement is lost in silence. Accepted: failing closed is
+    the right side to err on under the at-most-once contract, and the fallback
+    already documents itself as not exact. Fixing the fallback's selection
+    would also move which event affinity and signals attach to, which is a
+    different defect. This test exists so that loss stays a decision rather
+    than becoming a surprise.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    injected_id = _seed_whisper_log(engine, target)
+    held_back_id = _seed_held_back_whisper_log(engine, target)
+    assert held_back_id > injected_id, "the held-back event must be the newer row"
+
+    before = _snapshot(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="implicit")
+
+    assert _snapshot(engine, target) == before, (
+        "the legacy fallback reinforced through a held-back event"
+    )
+    # The fallback still attaches its evidence to the newest event — unchanged.
+    affinity = engine.db.conn.execute(
+        "SELECT whisper_log_id FROM affinity WHERE node_id = ?", (target,)
+    ).fetchone()
+    assert affinity["whisper_log_id"] == held_back_id

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -611,3 +611,67 @@ def test_legacy_fallback_on_a_held_back_event_does_not_confirm(engine):
         "SELECT whisper_log_id FROM affinity WHERE node_id = ?", (target,)
     ).fetchone()
     assert affinity["whisper_log_id"] == held_back_id
+
+
+# --- Reinforcement must survive its own hazards (2026-08-16 council R1) -----
+
+def test_confirmed_use_reinforces_a_node_whose_stability_is_zero(engine):
+    """Contract 12: stability = 0 must not silently swallow the reinforcement.
+
+    Node.stability is Field(ge=0.0), so 0 is a valid persisted value, and
+    _record_confirmed_use divides by it (retrievability = exp(-days / stability)).
+    The resulting ZeroDivisionError is caught by submit_feedback's isolating
+    except, which by design never propagates — so the caller is told "Feedback
+    recorded" while the lifecycle stays frozen. The claim is already committed,
+    so the retry hits ON CONFLICT and the reinforcement is lost for good.
+
+    decay_manager.py:50 and importance_scorer.py:80 already guard this exact
+    division; _record_confirmed_use is the one consumer that does not.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+
+    node = engine.file_store.load(target)
+    node.stability = 0.0
+    engine.file_store.save(node)
+    engine.db.conn.execute("UPDATE nodes SET stability = 0.0 WHERE id = ?", (target,))
+    engine.db.conn.commit()
+
+    injected_id = _seed_whisper_log(engine, target)
+    before = _snapshot(engine, target)
+    assert before["file"][2] == 0.0, "the fixture failed to persist stability = 0"
+
+    engine.submit_feedback(target, signal=1, source="implicit", whisper_log_id=injected_id)
+
+    after = _snapshot(engine, target)
+    assert after["file"][0] == before["file"][0] + 1, (
+        "a zero-stability node took the claim but was never reinforced"
+    )
+    assert after["db"][0] == before["db"][0] + 1, "file advanced but the DB row did not"
+    assert after["file"][2] > 0.0, "stability stayed at zero — the node can never recover"
+
+
+def test_recall_node_returns_the_node_when_reinforcement_fails(engine):
+    """Contract 13: a reinforcement failure must not cost the agent its answer.
+
+    submit_feedback (2604-2610) and the session watcher (611-615) both isolate
+    _record_confirmed_use behind try/except: the claim is already committed and
+    the evidence durably recorded, so a mutator failure is a logged miss, never
+    the caller's problem. recall_node called it bare, so the same failure threw
+    the fetch away — the agent gets nothing, the event stays claimed, and the
+    retry logs a second event that can never confirm the first.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+
+    with patch.object(engine, "_record_confirmed_use", side_effect=RuntimeError("disk gone")):
+        formatted = engine.recall_node(target)
+
+    assert formatted, "recall_node propagated a reinforcement failure instead of the node"
+    assert "Caching 0" in formatted, "recall_node returned something other than the node"
+
+    # The claim is still taken: at-most-once holds, the miss is only the mutator's.
+    claims = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM confirmed_use_claims WHERE node_id = ?", (target,)
+    ).fetchone()[0]
+    assert claims == 1, "the claim was rolled back — at-most-once no longer holds"

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -179,3 +179,242 @@ def test_concurrent_confirmed_use_does_not_lose_increments(engine):
         "SELECT access_count FROM nodes WHERE id = ?", (target,)
     ).fetchone()
     assert row["access_count"] == after.access_count, "file and DB disagree after concurrency"
+
+
+# --- Confirmed-use contracts ----------------------------------------------
+
+def _seed_whisper_log(engine, node_id, prompt="what about caching?"):
+    """Insert a whisper_log row so submit_feedback can resolve one.
+
+    submit_feedback attaches feedback to a whisper/recall event; without a row
+    it returns an error string instead of recording anything.
+    """
+    engine.recall_search(prompt, limit=10)
+    row = engine.db.conn.execute(
+        "SELECT id FROM whisper_log WHERE node_id = ? ORDER BY id DESC LIMIT 1",
+        (node_id,),
+    ).fetchone()
+    assert row is not None, "no whisper_log row was created — check the surface used"
+    return row["id"]
+
+
+def test_recall_node_confirms_only_the_requested_node(engine):
+    """Contract 7: recall_node confirms the node asked for, never its neighbours."""
+    from ormah.models.node import CreateNodeRequest
+
+    target, _ = engine.remember(CreateNodeRequest(
+        content="caching architecture target node", title="Target", type="fact", tier="working",
+    ))
+    neighbour, _ = engine.remember(CreateNodeRequest(
+        content="caching architecture neighbour node", title="Neighbour", type="fact",
+        tier="working",
+    ))
+    engine.graph.conn.execute(
+        "INSERT INTO edges (source_id, target_id, edge_type, weight, created) "
+        "VALUES (?, ?, 'related_to', 1.0, '2026-01-01T00:00:00Z')",
+        (target, neighbour),
+    )
+
+    before_target = _snapshot(engine, target)
+    before_neighbour = _snapshot(engine, neighbour)
+
+    engine.recall_node(target)
+
+    assert _snapshot(engine, target) != before_target, "recall_node did not confirm its node"
+    assert _snapshot(engine, neighbour) == before_neighbour, (
+        "recall_node confirmed a neighbour — only the requested node counts"
+    )
+
+
+@pytest.mark.parametrize("source", ["explicit", "implicit", "auto_llm_judge"])
+def test_qualified_positive_feedback_confirms_use(engine, source):
+    """Contract 8: the three allowlisted sources confirm, with signal == 1."""
+    ids = _make_nodes(engine, count=2)
+    target, other = ids[0], ids[1]
+    log_id = _seed_whisper_log(engine, target)
+
+    before_target = _snapshot(engine, target)
+    before_other = _snapshot(engine, other)
+
+    engine.submit_feedback(target, signal=1, source=source, whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) != before_target, (
+        f"positive {source} feedback did not confirm use"
+    )
+    assert _snapshot(engine, other) == before_other, "an unrelated node was confirmed"
+
+
+def test_auto_heuristic_positive_does_not_confirm(engine):
+    """Contract 9: auto_heuristic is excluded pending #218 — fail-closed."""
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    before = _snapshot(engine, target)
+    engine.submit_feedback(target, signal=1, source="auto_heuristic", whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) == before, "auto_heuristic must not confirm use"
+
+
+@pytest.mark.parametrize("source", ["explicit", "implicit", "auto_llm_judge", "auto_heuristic"])
+def test_negative_feedback_never_confirms(engine, source):
+    """Contract 10: -1 is evidence about the prompt/node pair, never a confirmed use."""
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    before = _snapshot(engine, target)
+    engine.submit_feedback(target, signal=-1, source=source, whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) == before, (
+        f"negative {source} feedback changed lifecycle fields"
+    )
+
+
+# --- Idempotency contracts (second council round: the latch, not affinity) ---
+
+def test_replaying_the_same_positive_feedback_confirms_once(engine):
+    """Contract 10a: one confirmed-use event reinforces at most once.
+
+    affinity and signals both use ON CONFLICT DO NOTHING, so a replayed request
+    records no new evidence yet still returns success. Reinforcing on every call
+    would let a retried tool call or a double-click manufacture retention.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=log_id)
+    after_first = _snapshot(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) == after_first, (
+        "replaying the same positive feedback reinforced twice"
+    )
+
+
+def test_negative_then_positive_feedback_confirms(engine):
+    """Contract 10b: a first-time positive confirms even after a negative.
+
+    The negative claims nothing (it does not qualify), so the later positive is
+    still the event's first confirmation. This is the case a naive 'did the
+    signals INSERT add a row?' gate gets wrong: the unique key is
+    (whisper_log_id, signal_type, source) with no polarity, so the second call
+    hits ON CONFLICT DO NOTHING even though it is a genuine first confirmation.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    engine.submit_feedback(target, signal=-1, source="explicit", whisper_log_id=log_id)
+    after_negative = _snapshot(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) != after_negative, (
+        "the event's first qualified positive did not confirm use"
+    )
+
+
+def test_second_source_on_an_already_confirmed_event_does_not_reconfirm(engine):
+    """Contract 10c: the event is confirmed once, not once per source.
+
+    This is the mirror failure: source is part of the signals unique key, so an
+    implicit-positive followed by an explicit-positive DOES insert a second
+    signals row. The event was already claimed; it must not reinforce again.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="implicit", whisper_log_id=log_id)
+    after_first = _snapshot(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) == after_first, (
+        "a second positive source reconfirmed an already-confirmed event"
+    )
+
+
+def test_polarity_cycle_confirms_once(engine):
+    """Contract 10d: +1 / -1 / +1 reinforces at most once — not twice.
+
+    This is the false positive that killed the affinity-derived gate. affinity
+    has one row per (node_id, whisper_log_id) and explicit feedback UPDATEs its
+    signal in place, so reading affinity would see false->true twice and
+    reinforce twice. The claim latch is never deleted, so the third call takes
+    nothing.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=log_id)
+    after_first_positive = _snapshot(engine, target)
+
+    engine.submit_feedback(target, signal=-1, source="explicit", whisper_log_id=log_id)
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) == after_first_positive, (
+        "a polarity cycle reinforced the same event twice"
+    )
+
+
+def test_unqualified_affinity_does_not_block_a_later_qualified_positive(engine):
+    """Contract 10e: a pre-existing auto_heuristic row must not swallow a real use.
+
+    This is the false negative that killed the affinity-derived gate. The
+    affinity unique key is (node_id, whisper_log_id) and only explicit feedback
+    UPDATEs the row, so an auto_heuristic positive makes a later implicit
+    positive a no-op INSERT that leaves source = auto_heuristic. Reading
+    affinity would keep the gate false forever and lose the reinforcement in
+    silence. The claim latch does not consult affinity at all.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="auto_heuristic", whisper_log_id=log_id)
+    after_heuristic = _snapshot(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="implicit", whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) != after_heuristic, (
+        "a prior auto_heuristic affinity row blocked a genuine confirmed use"
+    )
+
+
+def test_reinforcement_failure_does_not_fail_the_feedback_call(engine):
+    """Contract 10f: a raising mutator is logged, not propagated.
+
+    The route returns submit_feedback's value directly, so an exception after
+    COMMIT would 500 a call whose affinity and signals rows are already durably
+    written. ZeroDivisionError is the realistic case, not a contrived one:
+    stability is Field(default=1.0, ge=0.0), so zero is legal, and the mutator
+    divides by it. Under the at-most-once contract this reinforcement is lost —
+    that is the accepted cost, but it must be a logged miss, not an API error.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    before = _snapshot(engine, target)
+
+    with patch.object(
+        engine, "_record_confirmed_use", side_effect=ZeroDivisionError("float division by zero")
+    ):
+        message = engine.submit_feedback(
+            target, signal=1, source="explicit", whisper_log_id=log_id
+        )
+
+    assert "Feedback recorded" in message, "a failed reinforcement broke the feedback contract"
+    assert _snapshot(engine, target) == before, "lifecycle advanced despite the failure"
+
+    # The evidence itself is committed — this is about lifecycle, not observability.
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ? AND node_id = ?",
+        (log_id, target),
+    ).fetchone()
+    assert affinity is not None, "the feedback evidence was rolled back"

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -513,3 +513,68 @@ def test_recall_node_does_not_reinforce_without_an_event_to_claim(engine):
         "recall_node reinforced with no event to claim — reinforcement followed the "
         "request instead of the claim"
     )
+
+
+# --- Review relevance is not confirmed use (2026-08-16 council round) -------
+
+def _seed_held_back_whisper_log(engine, node_id, prompt="what about caching?"):
+    """Insert the kind of event the session-start review hands to the agent.
+
+    _find_review_candidate selects rows with was_injected = 0 — memories Ormah
+    held back and never surfaced — and _REVIEW_FRAMING hands that id to the
+    agent asking for source="implicit" feedback. _seed_whisper_log cannot be
+    used here: it goes through recall_search, which writes was_injected = 1.
+
+    logged_at is a Python ISO timestamp, not SQLite's datetime('now'), because
+    _log_feedback_candidates writes ISO and the fallback orders by this column
+    as TEXT. The two formats differ at index 10 — 'T' (0x54) against ' '
+    (0x20) — so a datetime('now') row sorts BEFORE an ISO row written in the
+    same second, and the fallback would silently resolve the wrong event.
+    """
+    from datetime import datetime, timezone
+
+    cursor = engine.db.conn.execute(
+        "INSERT INTO whisper_log "
+        "(session_id, space, prompt_hash, prompt_text, prompt_vec, node_id, "
+        "score, decision_stage, was_injected, logged_at) "
+        "VALUES ('sess-review', 'myspace', 'hash-review', ?, X'', ?, 0.31, "
+        "'injection_gate', 0, ?)",
+        (prompt, node_id, datetime.now(timezone.utc).isoformat()),
+    )
+    engine.db.conn.commit()
+    return cursor.lastrowid
+
+
+def test_review_relevance_feedback_does_not_confirm_use(engine):
+    """Contract 11: judging a held-back memory relevant is not using it.
+
+    The review path deliberately surfaces an event with was_injected = 0 and
+    asks "would this have been useful?" — a relevance adjudication, not a use.
+    _claim_confirmed_use allowlists "implicit" and checks no provenance, so the
+    claim is taken and the lifecycle advances on a memory the agent never saw.
+    That is fabricated retention entering through the review door, which is what
+    issue #220 exists to close.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    held_back_id = _seed_held_back_whisper_log(engine, target)
+
+    before = _snapshot(engine, target)
+
+    engine.submit_feedback(target, signal=1, source="implicit", whisper_log_id=held_back_id)
+
+    assert _snapshot(engine, target) == before, (
+        "relevance feedback on a memory that was never surfaced reinforced it"
+    )
+    claims = engine.db.conn.execute(
+        "SELECT COUNT(*) FROM confirmed_use_claims WHERE whisper_log_id = ?",
+        (held_back_id,),
+    ).fetchone()[0]
+    assert claims == 0, "a held-back event took a confirmed-use claim"
+
+    # The judgement itself is still evidence — only the lifecycle is off limits.
+    affinity = engine.db.conn.execute(
+        "SELECT * FROM affinity WHERE whisper_log_id = ? AND node_id = ?",
+        (held_back_id, target),
+    ).fetchone()
+    assert affinity is not None, "review feedback stopped recording affinity"

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -675,3 +675,34 @@ def test_recall_node_returns_the_node_when_reinforcement_fails(engine):
         "SELECT COUNT(*) FROM confirmed_use_claims WHERE node_id = ?", (target,)
     ).fetchone()[0]
     assert claims == 1, "the claim was rolled back — at-most-once no longer holds"
+
+
+def test_recall_search_structured_rejects_positional_tuning_args(engine):
+    """Contract 14: tuning parameters are keyword-only, so a stale positional
+    call cannot silently redefine itself.
+
+    #220 removed the `touch_access` parameter, which held the 4th positional
+    slot. `min_relevance` inherited that slot, so a pre-existing positional
+    call passing False in position 4 would mean min_relevance=0 — silently
+    dropping the deliberate-recall relevance floor and admitting results below
+    it. The bare `*` turns that silent redefinition into an immediate TypeError.
+    """
+    _make_nodes(engine, count=1)
+
+    with pytest.raises(TypeError) as excinfo:
+        # The exact shape of a stale caller: `False` where touch_access used to be.
+        engine.recall_search_structured("caching architecture", 10, None, False)
+
+    assert "positional" in str(excinfo.value), (
+        f"raised for the wrong reason: {excinfo.value}"
+    )
+
+    # The supported shapes must keep working — this is the other half of the
+    # contract. `isinstance(..., list)` rather than `is not None`: the point is
+    # that the call completes and still returns the documented type.
+    assert isinstance(engine.recall_search_structured("caching architecture"), list)
+    assert isinstance(engine.recall_search_structured("caching architecture", limit=4), list)
+    assert isinstance(engine.recall_search_structured("caching architecture", 4, None), list)
+    assert isinstance(engine.recall_search_structured(
+        "caching architecture", limit=4, min_relevance=0.0, spread_activation=False,
+    ), list)

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -543,7 +543,7 @@ class TestRecallFloorAndSpaceOrdering:
         ctx, mock_search = self._search_mock(engine, results)
         with ctx:
             out = engine.recall_search_structured(
-                "project question", limit=4, default_space="proj", touch_access=False,
+                "project question", limit=4, default_space="proj",
                 query_vec=query_vec,
             )
 
@@ -566,7 +566,7 @@ class TestRecallFloorAndSpaceOrdering:
         ctx, _ = self._search_mock(engine, results)
         with ctx:
             out = engine.recall_search_structured(
-                "project question", limit=2, default_space="proj", touch_access=False,
+                "project question", limit=2, default_space="proj",
             )
 
         ids = [r["node"]["id"] for r in out if r.get("source") == "hybrid"]
@@ -581,7 +581,7 @@ class TestRecallFloorAndSpaceOrdering:
         ctx, _ = self._search_mock(engine, results)
         with ctx:
             out = engine.recall_search_structured(
-                "project question", limit=4, default_space="proj", touch_access=False,
+                "project question", limit=4, default_space="proj",
             )
 
         assert any(r["node"]["id"] == "recent-1" for r in out)
@@ -594,7 +594,6 @@ class TestRecallFloorAndSpaceOrdering:
             engine.recall_search_structured(
                 "auth changes yesterday",
                 limit=4,
-                touch_access=False,
                 query_vec=query_vec,
             )
 
@@ -616,7 +615,7 @@ class TestRecallFloorAndSpaceOrdering:
             return_value=[newer_other, older_current],
         ):
             out = engine.recall_search_structured(
-                "yesterday", limit=4, default_space="proj", touch_access=False,
+                "yesterday", limit=4, default_space="proj",
                 created_after="2026-01-01T00:00:00Z",
             )
 

--- a/tests/test_engine/test_mutation_stamping.py
+++ b/tests/test_engine/test_mutation_stamping.py
@@ -143,7 +143,7 @@ def test_engine_access_tracking_does_not_advance_updated(engine):
     node_id = _create(engine, "Read often", "Frequently accessed fact.")
     _backdate(engine.file_store, node_id)
 
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
 
     node = engine.file_store.load(node_id)
     assert node.updated == PAST

--- a/tests/test_engine/test_scoring_signals.py
+++ b/tests/test_engine/test_scoring_signals.py
@@ -364,49 +364,47 @@ class TestSpaceScoring:
 # ---------------------------------------------------------------------------
 
 
-class TestSpreadingActivationAccessIsolation:
-    """Verify that _touch_access is only called for direct search matches,
-    not for nodes injected by spreading activation."""
+def _lifecycle(engine, node_id):
+    """The four lifecycle fields, from the markdown file and the SQLite row."""
+    node = engine.file_store.load(node_id)
+    row = engine.db.conn.execute(
+        "SELECT access_count, last_accessed, stability, last_review FROM nodes WHERE id = ?",
+        (node_id,),
+    ).fetchone()
+    fields = ("access_count", "last_accessed", "stability", "last_review")
+    return {
+        "file": tuple(getattr(node, f) for f in fields),
+        "db": tuple(row[f] for f in fields),
+    }
 
-    def test_touch_access_skips_activated_nodes(self, engine):
-        """Spreading activation results (source=activated/conflict) must not
-        get their access_count bumped."""
-        # Create three nodes via the engine
+
+class TestSearchDoesNotTouchLifecycle:
+    """Issue #220: search writes no lifecycle fields, for any result source.
+
+    This class replaces TestSpreadingActivationAccessIsolation, which asserted
+    that direct matches WERE touched while activated/conflict nodes were not.
+    Direct matches are no longer touched either, so the distinction is gone.
+    """
+
+    def test_direct_activated_and_conflict_results_are_all_untouched(self, engine):
         from ormah.models.node import CreateNodeRequest
 
         id_a, _ = engine.remember(CreateNodeRequest(
-            content="Alpha direct match node",
-            title="Alpha",
-            type="fact",
-            tier="working",
+            content="Alpha direct match node", title="Alpha", type="fact", tier="working",
         ))
         id_b, _ = engine.remember(CreateNodeRequest(
-            content="Beta neighbor node",
-            title="Beta",
-            type="fact",
-            tier="working",
+            content="Beta neighbor node", title="Beta", type="fact", tier="working",
         ))
         id_c, _ = engine.remember(CreateNodeRequest(
-            content="Gamma direct match node",
-            title="Gamma",
-            type="fact",
-            tier="working",
+            content="Gamma conflicting node", title="Gamma", type="fact", tier="working",
         ))
 
-        # Record initial access counts
-        node_a = engine.file_store.load(id_a)
-        node_b = engine.file_store.load(id_b)
-        node_c = engine.file_store.load(id_c)
-        initial_a = node_a.access_count
-        initial_b = node_b.access_count
-        initial_c = node_c.access_count
-
-        # Mock _spread_activation to inject B as an activated neighbor
-        original_spread = engine._spread_activation
+        before = {
+            node_id: _lifecycle(engine, node_id) for node_id in (id_a, id_b, id_c)
+        }
 
         def mock_spread(results, limit):
-            out = original_spread(results, limit)
-            # Inject B as if it were pulled in by spreading activation from A
+            out = list(results)
             out.append({
                 "node": engine.graph.get_node(id_b),
                 "score": 0.5,
@@ -414,63 +412,9 @@ class TestSpreadingActivationAccessIsolation:
                 "activated_by": id_a,
                 "activation_edge": "related_to",
             })
-            return out
-
-        # Mock hybrid search to return A and C as direct matches
-        def mock_search(query, limit=10, **filters):
-            return [
-                {"node": engine.graph.get_node(id_a), "score": 1.0, "source": "hybrid"},
-                {"node": engine.graph.get_node(id_c), "score": 0.8, "source": "hybrid"},
-            ]
-
-        search_obj = engine._get_hybrid_search()
-        if search_obj is not None:
-            with patch.object(search_obj, "search", side_effect=mock_search), \
-                 patch.object(engine, "_spread_activation", side_effect=mock_spread):
-                engine.recall_search_structured("test query", limit=10)
-        else:
-            # FTS-only path
-            engine.graph.fts_search = MagicMock(return_value=[
-                {"id": id_a, "score": 5.0},
-                {"id": id_c, "score": 4.0},
-            ])
-            with patch.object(engine, "_spread_activation", side_effect=mock_spread):
-                engine.recall_search_structured("test query", limit=10)
-
-        # Verify: A and C should have access_count incremented
-        node_a_after = engine.file_store.load(id_a)
-        node_c_after = engine.file_store.load(id_c)
-        assert node_a_after.access_count == initial_a + 1
-        assert node_c_after.access_count == initial_c + 1
-
-        # B (activated neighbor) should NOT have access_count incremented
-        node_b_after = engine.file_store.load(id_b)
-        assert node_b_after.access_count == initial_b
-
-    def test_touch_access_skips_conflict_nodes(self, engine):
-        """Nodes with source=conflict should also be skipped."""
-        from ormah.models.node import CreateNodeRequest
-
-        id_a, _ = engine.remember(CreateNodeRequest(
-            content="Statement one",
-            title="Statement",
-            type="fact",
-            tier="working",
-        ))
-        id_conflict, _ = engine.remember(CreateNodeRequest(
-            content="Contradicting statement",
-            title="Contradiction",
-            type="fact",
-            tier="working",
-        ))
-
-        initial_conflict = engine.file_store.load(id_conflict).access_count
-
-        def mock_spread(results, limit):
-            out = list(results)
             out.append({
-                "node": engine.graph.get_node(id_conflict),
-                "score": 0.3,
+                "node": engine.graph.get_node(id_c),
+                "score": 0.4,
                 "source": "conflict",
                 "activated_by": id_a,
                 "activation_edge": "contradicts",
@@ -478,9 +422,7 @@ class TestSpreadingActivationAccessIsolation:
             return out
 
         def mock_search(query, limit=10, **filters):
-            return [
-                {"node": engine.graph.get_node(id_a), "score": 1.0, "source": "hybrid"},
-            ]
+            return [{"node": engine.graph.get_node(id_a), "score": 1.0, "source": "hybrid"}]
 
         search_obj = engine._get_hybrid_search()
         if search_obj is not None:
@@ -488,11 +430,12 @@ class TestSpreadingActivationAccessIsolation:
                  patch.object(engine, "_spread_activation", side_effect=mock_spread):
                 engine.recall_search_structured("test query", limit=10)
         else:
-            engine.graph.fts_search = MagicMock(return_value=[
-                {"id": id_a, "score": 5.0},
-            ])
+            engine.graph.fts_search = MagicMock(return_value=[{"id": id_a, "score": 5.0}])
             with patch.object(engine, "_spread_activation", side_effect=mock_spread):
                 engine.recall_search_structured("test query", limit=10)
 
-        node_conflict_after = engine.file_store.load(id_conflict)
-        assert node_conflict_after.access_count == initial_conflict
+        assert _lifecycle(engine, id_a) == before[id_a], (
+            "the direct match was touched — search must not confirm use"
+        )
+        assert _lifecycle(engine, id_b) == before[id_b], "an activated neighbour was touched"
+        assert _lifecycle(engine, id_c) == before[id_c], "a conflict neighbour was touched"


### PR DESCRIPTION
## Supersedes #229 for issue #220

#229 is a draft covering #220–#223 together on `feat/issue-220-223-memory-lifecycle`. This PR
supersedes it **for #220's scope only** — it does not implement #221 (bounded reinforcement),
#222 (retrievability-driven decay), or #223 (seven-day lease/promotion/provenance), which remain
open and unaddressed here. If this PR lands, #229 should be narrowed to #221–#223 or closed in
favor of separate PRs for each.

## What this does (#220 — surfacing must not be confirmed use)

- Removes lifecycle writes from every search/surface path (hybrid recall, FTS fallback,
  structured recall, formatted recall, UI search route, whisper/context loading).
- Adds one serialized `_record_confirmed_use` lifecycle operation.
- `recall_node(id)` confirms exactly the requested node; returned neighbours stay non-mutating.
- Positive `explicit`/`implicit` feedback confirms exactly its resolved node; `auto_heuristic`
  is excluded pending #218.
- `recall_search_structured`'s tuning parameters (`min_relevance`, `auto_temporal`,
  `spread_activation`, `query_vec`) are now keyword-only, closing a silent-corruption trap left
  behind when `touch_access` was removed: a stale positional call used to have its `False`
  reinterpreted as `min_relevance=0`, dropping the relevance floor with no error. All in-repo
  call sites already pass keyword args, so nothing else changes.
- Guards `_record_confirmed_use` against `stability == 0` (matches the same guard already
  present in `decay_manager.py` and `importance_scorer.py`) and isolates `recall_node`'s
  reinforcement behind `try/except`, matching `submit_feedback` and the session watcher.

## Review history

An internal two-peer review (Cursor + Codex) found the stability/isolation gap above and one
finding this PR does not fix: `touch_access`'s removal narrows `recall_search_structured`'s
signature, and the same review's "keyword-only" recommendation is what the last commit
implements. Full contract suite: `tests/test_engine/test_confirmed_use_contract.py`, 30 passing
tests covering non-mutation, claim exclusivity, and the fixes above.

## Known pre-existing failures (not from this branch)

12 test IDs fail locally regardless of this branch — 4 environmental root causes (fastembed
cache path assumptions, Codex MCP config fixtures, and two flaky background-job timing tests),
none reproduced in clean CI. None touch the code this PR changes.

## Out of scope, filed separately

- #232 — unknown filter keys silently dropped on FTS fallback vs. `TypeError` on hybrid search.
- #233 — known filter keys (`types`/`tiers`/`tags`) silently ignored on the FTS fallback path.

Closes #220

