### PR TITLE
fix(lifecycle): retrievability alone drives working→archival decay (#222)

### DIFF
--- a/docs/05 - Background Jobs.md
+++ b/docs/05 - Background Jobs.md
@@ -129,7 +129,9 @@ It does not do embedding clustering or hierarchical clustering despite the name.
 Importance does not protect a node from decay. Cumulative signals such as access
 and edge counts could otherwise push a stale node permanently above any threshold.
 Archival is reversible dormancy, not deletion — a demoted node stays reachable by
-deliberate recall. Use the `core` tier for permanent whisper eligibility.
+deliberate recall. Use the `core` tier for permanent whisper eligibility. Importance
+still decides which nodes survive when `core` is over its cap — see
+[01 - Data Model](<./01 - Data Model.md>) for how `enforce_core_cap()` uses it.
 
 ### Importance Scorer
 

--- a/docs/05 - Background Jobs.md
+++ b/docs/05 - Background Jobs.md
@@ -124,9 +124,12 @@ It does not do embedding clustering or hierarchical clustering despite the name.
 ## Importance and Decay
 
 - `importance_scorer` computes a normalized multi-signal importance value
-- `decay_manager` uses FSRS-style retrievability and importance to decide whether to demote working memories
+- `decay_manager` uses FSRS-style retrievability alone to decide whether to demote working memories
 
-High-importance nodes are protected from decay.
+Importance does not protect a node from decay. Cumulative signals such as access
+and edge counts could otherwise push a stale node permanently above any threshold.
+Archival is reversible dormancy, not deletion — a demoted node stays reachable by
+deliberate recall. Use the `core` tier for permanent whisper eligibility.
 
 ### Importance Scorer
 
@@ -134,7 +137,7 @@ High-importance nodes are protected from decay.
 
 1. **Access signal**: how often the node has been recalled, based on `access_count`
 2. **Edge signal**: how connected the node is in the graph, based on total edge count
-3. **Recency signal**: how retrievable the node currently is, using FSRS-style `exp(-days_ago / stability)`
+3. **Recency signal**: how recently the node was touched, using half-life decay `exp(-ln(2) * days_ago / importance_recency_half_life_days)` — independent of FSRS stability
 
 With the default configuration, those signals are weighted almost evenly:
 
@@ -150,8 +153,6 @@ Access and edge counts are log-normalized against reference values, then the wei
 The scorer runs every `120` minutes by default and only writes a new value when the change is meaningful.
 
 This score is not static. Recall and search hits update `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched.
-
-Important current nuance: `importance_recency_half_life_days` exists in configuration, but the current scorer implementation uses FSRS stability for the recency term instead.
 
 ## Walkthrough Example
 

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -183,6 +183,10 @@ Important note: current search applies tier as a multiplicative factor after con
 | `importance_recency_half_life_days` | `14.0` |
 | `decay_importance_threshold` | `0.5` |
 
+`decay_importance_threshold` no longer affects `working -> archival` decay, which
+depends on retrievability alone (#222). It is retained for configuration
+compatibility and currently has no effect.
+
 ## Whisper-Out and Nudge
 
 | Setting | Default |

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -184,8 +184,8 @@ Important note: current search applies tier as a multiplicative factor after con
 | `decay_importance_threshold` | `0.5` |
 
 `decay_importance_threshold` no longer affects `working -> archival` decay, which
-depends on retrievability alone (#222). It is retained for configuration
-compatibility and currently has no effect.
+depends on retrievability alone (#222). It remains a documented setting with no
+effect in this version; bounded forgetting reintroduces a consumer.
 
 ## Whisper-Out and Nudge
 

--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -38,7 +38,7 @@ _TASK_DESCRIPTIONS = {
     "auto_linker": "Discovers and creates edges between semantically related memories.",
     "auto_cluster": "Groups memories into clusters based on semantic similarity and tags.",
     "consolidator": "Merges or summarizes redundant working-tier memories into consolidated entries.",
-    "decay_manager": "Applies time-based decay to memory importance, demoting stale unused memories.",
+    "decay_manager": "Demotes working memories to archival when FSRS retrievability falls below threshold.",
     "hippocampus": "Scans for structural patterns and promotes frequently accessed working memories to core.",
     "memory_backup": "Creates a local backup of memory source files when one is due.",
     "cloud_backup": "Encrypts and uploads a due cloud backup without changing the sync head.",

--- a/src/ormah/background/decay_manager.py
+++ b/src/ormah/background/decay_manager.py
@@ -52,9 +52,14 @@ def run_decay(engine) -> None:
             anchor_str = row["last_review"] or row["last_accessed"]
             try:
                 anchor = datetime.fromisoformat(anchor_str)
+                days_since = max((now - anchor).total_seconds() / 86400, 0.001)
             except (ValueError, TypeError):
+                logger.warning(
+                    "Decay manager skipped node %s with invalid recency anchor %r",
+                    row["id"][:8],
+                    anchor_str,
+                )
                 continue
-            days_since = max((now - anchor).total_seconds() / 86400, 0.001)
             retrievability = math.exp(-days_since / stability)
 
             if retrievability >= r_threshold:

--- a/src/ormah/background/decay_manager.py
+++ b/src/ormah/background/decay_manager.py
@@ -14,7 +14,13 @@ logger = logging.getLogger(__name__)
 
 @serialized_memory_job
 def run_decay(engine) -> None:
-    """Auto-demote working nodes whose FSRS retrievability drops below threshold."""
+    """Auto-demote working nodes whose FSRS retrievability drops below threshold.
+
+    Retrievability alone decides (#222/#191). Importance is deliberately not a
+    pre-gate: cumulative access and edge counts could push it permanently above
+    any threshold, pinning a stale node to working forever. Identity (the self
+    node) and core stay protected — core never enters this query.
+    """
     try:
         settings = engine.settings
         now = datetime.now(timezone.utc)
@@ -26,7 +32,7 @@ def run_decay(engine) -> None:
             )
 
         rows = engine.db.conn.execute(
-            "SELECT id, importance, stability, last_review, last_accessed "
+            "SELECT id, stability, last_review, last_accessed "
             "FROM nodes WHERE tier = 'working'"
         ).fetchall()
 
@@ -34,16 +40,11 @@ def run_decay(engine) -> None:
             return
 
         user_node_id = getattr(engine, "user_node_id", None)
-        importance_threshold = settings.decay_importance_threshold
         r_threshold = settings.fsrs_decay_threshold
 
         demoted = 0
         for row in rows:
             if row["id"] == user_node_id:
-                continue
-            # Skip high-importance nodes
-            node_importance = row["importance"] if row["importance"] is not None else 0.5
-            if node_importance >= importance_threshold:
                 continue
 
             # Compute FSRS retrievability

--- a/src/ormah/background/importance_scorer.py
+++ b/src/ormah/background/importance_scorer.py
@@ -11,6 +11,22 @@ from ormah.background.memory_lock import serialized_memory_job
 logger = logging.getLogger(__name__)
 
 
+def _recency_signal(days_ago: float, half_life_days: float) -> float:
+    """Importance recency: half-life decay on its own clock (#222).
+
+    Independent of FSRS stability — importance answers "how recently was this
+    touched", not "how retrievable is it". Coupling the two let a high-stability
+    node read as permanently recent.
+
+    A non-positive half-life is rejected by config validation; the guard here is
+    defence in depth, because a ZeroDivisionError would abort the whole scoring
+    job rather than skipping one node (council I1).
+    """
+    if half_life_days <= 0:
+        return 0.0
+    return math.exp(-math.log(2) * days_ago / half_life_days)
+
+
 def _commit_updates_chunked(db, updates, chunk_size: int = 100) -> None:
     """Apply (importance, node_id) updates in bounded write transactions so a
     full-store batch never holds the write lock long enough to stall foreground writes."""
@@ -32,7 +48,7 @@ def run_importance_scoring(engine) -> None:
     # Fetch everything upfront — avoids N+1 queries for importance lookups
     rows = conn.execute(
         "SELECT id, access_count, last_accessed, "
-        "importance, stability, last_review FROM nodes"
+        "importance, last_review FROM nodes"
     ).fetchall()
     if not rows:
         return
@@ -58,6 +74,7 @@ def run_importance_scoring(engine) -> None:
     # Absolute normalization references
     ref_access = settings.importance_access_reference
     ref_edge = settings.importance_edge_reference
+    half_life = settings.importance_recency_half_life_days
 
     # Weight normalization — ensures custom configs that don't sum to 1.0 still work
     total_weight = w_access + w_edge + w_recency
@@ -75,13 +92,12 @@ def run_importance_scoring(engine) -> None:
         ec = edge_counts.get(nid, 0)
         edge_signal = min(1.0, math.log1p(ec) / math.log1p(ref_edge))
 
-        # Recency signal: FSRS retrievability (exp(-t/S))
+        # Recency signal: importance's own half-life, not FSRS stability (#222)
         try:
-            stability = r["stability"] if r["stability"] else 1.0
             anchor_str = r["last_review"] or r["last_accessed"]
             anchor = datetime.fromisoformat(anchor_str)
             days_ago = max((now - anchor).total_seconds() / 86400, 0)
-            recency_signal = math.exp(-days_ago / stability)
+            recency_signal = _recency_signal(days_ago, half_life)
         except (ValueError, TypeError):
             recency_signal = 0.0
 

--- a/src/ormah/background/importance_scorer.py
+++ b/src/ormah/background/importance_scorer.py
@@ -18,11 +18,13 @@ def _recency_signal(days_ago: float, half_life_days: float) -> float:
     touched", not "how retrievable is it". Coupling the two let a high-stability
     node read as permanently recent.
 
-    A non-positive half-life is rejected by config validation; the guard here is
-    defence in depth, because a ZeroDivisionError would abort the whole scoring
-    job rather than skipping one node (council I1).
+    A non-finite or non-positive half-life is rejected by config validation; the
+    guard here is defence in depth, because letting one through would either
+    raise (ZeroDivisionError, aborting the whole scoring job rather than
+    skipping one node) or silently saturate/flatten the signal for NaN/inf
+    (council I1).
     """
-    if half_life_days <= 0:
+    if not math.isfinite(half_life_days) or half_life_days <= 0:
         return 0.0
     return math.exp(-math.log(2) * days_ago / half_life_days)
 

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 from pydantic import field_validator
@@ -566,6 +567,15 @@ class Settings(BaseSettings):
     def _fsrs_positive(cls, v: float) -> float:
         if v <= 0:
             raise ValueError(f"FSRS parameter must be > 0, got {v}")
+        return v
+
+    @field_validator("importance_recency_half_life_days")
+    @classmethod
+    def _importance_half_life_positive(cls, v: float) -> float:
+        if not math.isfinite(v):
+            raise ValueError(f"importance_recency_half_life_days must be finite, got {v}")
+        if v <= 0:
+            raise ValueError(f"importance_recency_half_life_days must be > 0, got {v}")
         return v
 
     @field_validator("fsrs_max_stability")

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -152,7 +152,10 @@ class Settings(BaseSettings):
     # Importance: recency half-life (separate from search recency)
     importance_recency_half_life_days: float = 14.0
 
-    # Decay: skip nodes above this importance
+    # Decay gate removed in #222: working->archival now depends on retrievability
+    # alone, because cumulative access and edge counts could push importance
+    # permanently above any threshold. Kept for config compatibility with existing
+    # .env files; the next consumer is bounded forgetting (#28/#31, gated on #223).
     decay_importance_threshold: float = 0.5
 
     # Whisper-out (involuntary storage on compaction / session end)

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -154,8 +154,8 @@ class Settings(BaseSettings):
 
     # Decay gate removed in #222: working->archival now depends on retrievability
     # alone, because cumulative access and edge counts could push importance
-    # permanently above any threshold. Kept for config compatibility with existing
-    # .env files; the next consumer is bounded forgetting (#28/#31, gated on #223).
+    # permanently above any threshold. Kept because it is a documented setting;
+    # bounded forgetting (#28/#31) reintroduces a reader as the deletion protection gate.
     decay_importance_threshold: float = 0.5
 
     # Whisper-out (involuntary storage on compaction / session end)

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -51,6 +51,83 @@ def test_high_importance_stale_node_is_decayed(engine):
     assert _get_tier(engine, node_id) == "archival"
 
 
+def test_invalid_timestamp_skips_one_node_without_aborting_decay(engine, caplog):
+    """A malformed row must not prevent later valid nodes from decaying.
+
+    Removing the importance pre-gate exposes high-importance rows to timestamp
+    arithmetic. A quoted/imported timestamp without timezone information parses
+    successfully but cannot be subtracted from timezone-aware ``now``. Keep that
+    failure scoped to the affected node instead of aborting the whole batch.
+    """
+    poisoned_id, _ = engine.remember(CreateNodeRequest(
+        content="High-importance node with an invalid recency anchor",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Invalid timestamp",
+    ))
+    healthy_id, _ = engine.remember(CreateNodeRequest(
+        content="Valid stale node that must still be processed",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Valid timestamp",
+    ))
+
+    aware_old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    naive_old = (datetime.now() - timedelta(days=30)).isoformat()
+    engine.db.conn.execute(
+        "UPDATE nodes SET importance = 0.9, stability = 1.0, "
+        "last_review = NULL, last_accessed = ? WHERE id = ?",
+        (naive_old, poisoned_id),
+    )
+    engine.db.conn.execute(
+        "UPDATE nodes SET importance = 0.1, stability = 1.0, "
+        "last_review = ?, last_accessed = ? WHERE id = ?",
+        (aware_old, aware_old, healthy_id),
+    )
+    engine.db.conn.commit()
+
+    run_decay(engine)
+
+    assert _get_tier(engine, poisoned_id) == "working"
+    assert _get_tier(engine, healthy_id) == "archival"
+    assert "skipped node" in caplog.text
+    assert "Decay manager failed" not in caplog.text
+
+
+def test_decay_retrievability_respects_stability(engine):
+    """At the same age, low stability decays while high stability survives."""
+    low_id, _ = engine.remember(CreateNodeRequest(
+        content="Thirty-day-old low-stability memory",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Low stability",
+    ))
+    high_id, _ = engine.remember(CreateNodeRequest(
+        content="Thirty-day-old high-stability memory",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="High stability",
+    ))
+
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, last_review = NULL, last_accessed = ? "
+        "WHERE id = ?",
+        (old, low_id),
+    )
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 100.0, last_review = NULL, last_accessed = ? "
+        "WHERE id = ?",
+        (old, high_id),
+    )
+    engine.db.conn.commit()
+
+    run_decay(engine)
+
+    assert _get_tier(engine, low_id) == "archival"
+    assert _get_tier(engine, high_id) == "working"
+
+
 def test_accumulated_access_and_edges_do_not_pin_a_node_to_working(engine):
     """The reported case, driven end-to-end: 50 accesses + 4 edges on a stale
     hub node make the real importance_scorer compute importance ~= 0.5892

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from ormah.background.decay_manager import run_decay
+from ormah.background.importance_scorer import run_importance_scoring
 from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType, Tier
 
 
@@ -51,9 +52,18 @@ def test_high_importance_stale_node_is_decayed(engine):
 
 
 def test_accumulated_access_and_edges_do_not_pin_a_node_to_working(engine):
-    """The reported case: 50 accesses + 4 edges produce a permanent non-recency
-    importance contribution of ~0.514, above the old 0.5 gate. That node must
-    still decay once it goes stale."""
+    """The reported case, driven end-to-end: 50 accesses + 4 edges on a stale
+    hub node make the real importance_scorer compute importance ~= 0.5892
+    (measured), above the old decay_importance_threshold gate of 0.5, and the
+    node must still decay once run_decay sees it — proving retrievability
+    alone, not importance, now controls the working->archival demotion.
+
+    `engine.remember()`/`engine.connect()` never touch `last_review`, so it
+    stays None on this node; `run_importance_scoring`'s recency anchor is
+    `last_review or last_accessed`, so making the node stale via
+    `_make_stale` (which only rewrites `last_accessed`) is enough for the
+    scorer to see a genuinely 30-day-old node.
+    """
     node_id, _ = engine.remember(CreateNodeRequest(
         content="Hub node with long access history",
         type=NodeType.concept,
@@ -74,11 +84,22 @@ def test_accumulated_access_and_edges_do_not_pin_a_node_to_working(engine):
         ))
 
     engine.db.conn.execute(
-        "UPDATE nodes SET access_count = 50, importance = 0.5145 WHERE id = ?",
-        (node_id,),
+        "UPDATE nodes SET access_count = 50 WHERE id = ?", (node_id,)
     )
     engine.db.conn.commit()
     _make_stale(engine, node_id)
+
+    run_importance_scoring(engine)
+
+    row = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    computed_importance = row["importance"]
+    assert computed_importance >= 0.5, (
+        f"expected the reported profile (50 accesses + 4 edges, stale) to "
+        f"score >= the old decay_importance_threshold of 0.5, got "
+        f"{computed_importance}"
+    )
 
     run_decay(engine)
 

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -171,7 +171,9 @@ def test_self_node_is_never_decayed(engine):
 
 
 def test_low_importance_stale_node_decayed(engine):
-    """A stale node with low importance should be demoted to archival."""
+    """Low importance is deliberately irrelevant to decay now: pairs with
+    test_high_importance_stale_node_is_decayed (importance=0.9) to show a
+    stale node decays the same way at either end of the importance range."""
     node_id, _ = engine.remember(CreateNodeRequest(
         content="Unimportant stale node",
         type=NodeType.fact,
@@ -191,7 +193,8 @@ def test_low_importance_stale_node_decayed(engine):
 
 
 def test_decay_still_works_without_importance(engine):
-    """Low importance (0.3) + stale should trigger decay (0.3 < 0.5 threshold)."""
+    """Decay does not require importance to be set at all: a stale node with
+    its importance left untouched still decays on retrievability alone."""
     node_id, _ = engine.remember(CreateNodeRequest(
         content="Default importance stale node",
         type=NodeType.fact,
@@ -200,10 +203,6 @@ def test_decay_still_works_without_importance(engine):
     ))
 
     _make_stale(engine, node_id)
-    engine.db.conn.execute(
-        "UPDATE nodes SET importance = 0.3 WHERE id = ?", (node_id,)
-    )
-    engine.db.conn.commit()
 
     run_decay(engine)
 
@@ -220,10 +219,6 @@ def test_decay_is_idempotent(engine):
     ))
 
     _make_stale(engine, node_id)
-    engine.db.conn.execute(
-        "UPDATE nodes SET importance = 0.2 WHERE id = ?", (node_id,)
-    )
-    engine.db.conn.commit()
 
     run_decay(engine)
     assert _get_tier(engine, node_id) == "archival"
@@ -243,10 +238,6 @@ def test_decay_writes_audit_log(engine):
     ))
 
     _make_stale(engine, node_id)
-    engine.db.conn.execute(
-        "UPDATE nodes SET importance = 0.35 WHERE id = ?", (node_id,)
-    )
-    engine.db.conn.commit()
 
     run_decay(engine)
 

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from ormah.background.decay_manager import run_decay
-from ormah.models.node import CreateNodeRequest, NodeType, Tier
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType, Tier
 
 
 def _make_stale(engine, node_id: str, days: int = 30) -> None:
@@ -26,8 +26,12 @@ def _get_tier(engine, node_id: str) -> str:
     return row["tier"] if row else None
 
 
-def test_high_importance_node_not_decayed(engine):
-    """A stale node with high importance should not be demoted."""
+def test_high_importance_stale_node_is_decayed(engine):
+    """#222: importance is no longer a pre-gate — a stale node decays regardless.
+
+    Before #222 a node with importance >= decay_importance_threshold (0.5) could
+    never leave working, however stale it became.
+    """
     node_id, _ = engine.remember(CreateNodeRequest(
         content="Important stale node",
         type=NodeType.fact,
@@ -43,7 +47,106 @@ def test_high_importance_node_not_decayed(engine):
 
     run_decay(engine)
 
+    assert _get_tier(engine, node_id) == "archival"
+
+
+def test_accumulated_access_and_edges_do_not_pin_a_node_to_working(engine):
+    """The reported case: 50 accesses + 4 edges produce a permanent non-recency
+    importance contribution of ~0.514, above the old 0.5 gate. That node must
+    still decay once it goes stale."""
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Hub node with long access history",
+        type=NodeType.concept,
+        tier=Tier.working,
+        title="Hub",
+    ))
+
+    for i in range(4):
+        sat_id, _ = engine.remember(CreateNodeRequest(
+            content=f"Satellite of the hub number {i}",
+            type=NodeType.fact,
+            tier=Tier.working,
+        ))
+        engine.connect(ConnectRequest(
+            source_id=node_id,
+            target_id=sat_id,
+            edge=EdgeType.related_to,
+        ))
+
+    engine.db.conn.execute(
+        "UPDATE nodes SET access_count = 50, importance = 0.5145 WHERE id = ?",
+        (node_id,),
+    )
+    engine.db.conn.commit()
+    _make_stale(engine, node_id)
+
+    run_decay(engine)
+
+    assert _get_tier(engine, node_id) == "archival"
+
+
+def test_fresh_high_importance_node_stays_working(engine):
+    """The negative case (council I2): retrievability still decides.
+
+    Removing the importance gate must not turn decay into "demote everything".
+    A fresh node has R ~= 1.0 and stays working whatever its importance. Without
+    this test, deleting the retrievability check would leave the suite green.
+    """
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Fresh node that must not decay",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Fresh",
+    ))
+
+    # Deliberately NOT made stale.
+    engine.db.conn.execute(
+        "UPDATE nodes SET importance = 0.9 WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+
+    run_decay(engine)
+
     assert _get_tier(engine, node_id) == "working"
+
+
+def test_fresh_low_importance_node_stays_working(engine):
+    """Same guard from the other side: low importance alone never demotes."""
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Fresh unimportant node that must not decay",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Fresh unimportant",
+    ))
+
+    engine.db.conn.execute(
+        "UPDATE nodes SET importance = 0.05 WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+
+    run_decay(engine)
+
+    assert _get_tier(engine, node_id) == "working"
+
+
+def test_self_node_is_never_decayed(engine):
+    """Identity protection survives the removal of the importance gate."""
+    user_node_id = getattr(engine, "user_node_id", None)
+    # Fail closed, not skip (council I2): MemoryEngine.startup() calls
+    # _ensure_self_node(), which creates the self node if absent, so a missing
+    # one means the fixture broke — silently skipping would hide that.
+    assert user_node_id is not None, "engine fixture must provide a self node"
+
+    _make_stale(engine, user_node_id)
+    engine.db.conn.execute(
+        "UPDATE nodes SET tier = 'working', importance = 0.1 WHERE id = ?",
+        (user_node_id,),
+    )
+    engine.db.conn.commit()
+
+    run_decay(engine)
+
+    assert _get_tier(engine, user_node_id) == "working"
 
 
 def test_low_importance_stale_node_decayed(engine):

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -399,13 +399,21 @@ def test_recency_signal_follows_configured_half_life():
     assert _recency_signal(7.0, 7.0) == pytest.approx(0.5)
 
 
-def test_recency_signal_survives_a_non_positive_half_life():
-    """Defence in depth (council I1): the validator should make this unreachable,
-    but a zero half-life must never raise ZeroDivisionError and kill the job."""
+def test_recency_signal_survives_an_invalid_half_life():
+    """Defence in depth (council I1): the validator should make these unreachable,
+    but the guard must hold anyway. A zero or negative half-life must never raise
+    ZeroDivisionError and kill the job. A NaN half-life skips the '<= 0' check
+    (nan <= 0 is False) and would otherwise reach math.exp, returning NaN — which
+    the caller's clamp, max(0.0, min(1.0, x)), turns into 1.0 rather than
+    propagating, silently saturating importance at maximum. An infinite half-life
+    also skips the check and would make every node read as perfectly fresh
+    (recency_signal == 1.0) regardless of age."""
     from ormah.background.importance_scorer import _recency_signal
 
     assert _recency_signal(10.0, 0.0) == 0.0
     assert _recency_signal(10.0, -14.0) == 0.0
+    assert _recency_signal(10.0, float("nan")) == 0.0
+    assert _recency_signal(10.0, float("inf")) == 0.0
 
 
 def test_importance_recency_is_independent_of_stability(engine):

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -399,6 +399,34 @@ def test_recency_signal_follows_configured_half_life():
     assert _recency_signal(7.0, 7.0) == pytest.approx(0.5)
 
 
+def test_importance_job_uses_configured_recency_half_life(engine):
+    """The full scorer reads the setting rather than hardcoding 14 days."""
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Memory used exactly one configured half-life ago",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Configured half-life",
+    ))
+    old = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+    engine.settings.importance_access_weight = 0.0
+    engine.settings.importance_edge_weight = 0.0
+    engine.settings.importance_recency_weight = 1.0
+    engine.settings.importance_recency_half_life_days = 7.0
+    engine.db.conn.execute(
+        "UPDATE nodes SET importance = 0.0, last_review = ?, last_accessed = ? "
+        "WHERE id = ?",
+        (old, old, node_id),
+    )
+    engine.db.conn.commit()
+
+    run_importance_scoring(engine)
+
+    importance = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()["importance"]
+    assert importance == pytest.approx(0.5, abs=0.001)
+
+
 def test_recency_signal_survives_an_invalid_half_life():
     """Defence in depth (council I1): the validator should make these unreachable,
     but the guard must hold anyway. A zero or negative half-life must never raise

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -318,7 +318,10 @@ def test_confidence_affects_search_ranking(engine):
 
 
 def test_importance_range_with_new_signals(engine):
-    """Verify score range: fresh node ~0.33, hub >0.7, stale disconnected <0.2."""
+    """Verify score range: fresh node ~0.33, hub >0.7, stale disconnected <0.3.
+
+    Stale expected value: 0.34·ln(6)/ln(51) + 0.33·exp(-ln2·30/14) ≈ 0.23.
+    """
     from datetime import timedelta
 
     # Fresh node — no access, no edges, just created
@@ -359,6 +362,12 @@ def test_importance_range_with_new_signals(engine):
         "UPDATE nodes SET access_count = 5, last_accessed = ?, last_review = ? WHERE id = ?",
         (old_date, old_date, stale_id),
     )
+    # Auto-linking can attach edges non-deterministically; this node is meant to be
+    # disconnected, and importance reads edge counts — strip them so it really is.
+    engine.db.conn.execute(
+        "DELETE FROM edges WHERE source_id = ? OR target_id = ?",
+        (stale_id, stale_id),
+    )
     engine.db.conn.commit()
 
     run_importance_scoring(engine)
@@ -376,3 +385,76 @@ def test_importance_range_with_new_signals(engine):
     assert fresh_imp > 0.2, f"Fresh node should be ~0.33, got {fresh_imp}"
     assert hub_imp > 0.7, f"Hub node should be >0.7, got {hub_imp}"
     assert stale_imp < 0.3, f"Stale node should be <0.3, got {stale_imp}"
+
+
+def test_recency_signal_follows_configured_half_life():
+    """At exactly one half-life the signal is 0.5; at zero days it is 1.0."""
+    from ormah.background.importance_scorer import _recency_signal
+
+    assert _recency_signal(0.0, 14.0) == pytest.approx(1.0)
+    assert _recency_signal(14.0, 14.0) == pytest.approx(0.5)
+    assert _recency_signal(28.0, 14.0) == pytest.approx(0.25)
+
+    # A different configured half-life moves the 0.5 point with it.
+    assert _recency_signal(7.0, 7.0) == pytest.approx(0.5)
+
+
+def test_recency_signal_survives_a_non_positive_half_life():
+    """Defence in depth (council I1): the validator should make this unreachable,
+    but a zero half-life must never raise ZeroDivisionError and kill the job."""
+    from ormah.background.importance_scorer import _recency_signal
+
+    assert _recency_signal(10.0, 0.0) == 0.0
+    assert _recency_signal(10.0, -14.0) == 0.0
+
+
+def test_importance_recency_is_independent_of_stability(engine):
+    """Two nodes of identical age and profile score the same regardless of stability.
+
+    Before #222 the recency term was exp(-days/stability), so a high-stability node
+    scored far higher than a low-stability one at the same age. It must not anymore.
+    """
+    low_id, _ = engine.remember(CreateNodeRequest(
+        content="Alpha node about zebras and telescopes",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Low stability",
+    ))
+    high_id, _ = engine.remember(CreateNodeRequest(
+        content="Beta node about zebras and telescopes",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="High stability",
+    ))
+
+    old_date = (datetime.now(timezone.utc) - timedelta(days=20)).isoformat()
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_accessed = ?, last_review = ?, access_count = 3, "
+        "stability = 1.0 WHERE id = ?",
+        (old_date, old_date, low_id),
+    )
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_accessed = ?, last_review = ?, access_count = 3, "
+        "stability = 100.0 WHERE id = ?",
+        (old_date, old_date, high_id),
+    )
+    # Auto-linking can attach edges non-deterministically; importance reads edge
+    # counts, so strip them to isolate the recency term.
+    engine.db.conn.execute(
+        "DELETE FROM edges WHERE source_id IN (?, ?) OR target_id IN (?, ?)",
+        (low_id, high_id, low_id, high_id),
+    )
+    engine.db.conn.commit()
+
+    run_importance_scoring(engine)
+
+    low_imp = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (low_id,)
+    ).fetchone()["importance"]
+    high_imp = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (high_id,)
+    ).fetchone()["importance"]
+
+    assert low_imp == pytest.approx(high_imp), (
+        f"stability must not affect importance recency: {low_imp} vs {high_imp}"
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -324,3 +324,23 @@ def test_reconcile_max_seconds_rejects_zero():
 def test_reconcile_max_seconds_rejects_negative():
     with pytest.raises(ValidationError, match="session_watcher_reconcile_max_seconds must be > 0"):
         _settings(session_watcher_reconcile_max_seconds=-1.0)
+
+
+# --- Importance recency half-life ---
+
+def test_importance_recency_half_life_must_be_positive():
+    with pytest.raises(ValidationError, match="importance_recency_half_life_days must be > 0"):
+        _settings(importance_recency_half_life_days=0.0)
+    with pytest.raises(ValidationError, match="importance_recency_half_life_days must be > 0"):
+        _settings(importance_recency_half_life_days=-14.0)
+
+
+def test_importance_recency_half_life_must_be_finite():
+    with pytest.raises(ValidationError, match="importance_recency_half_life_days must be finite"):
+        _settings(importance_recency_half_life_days=float("inf"))
+    with pytest.raises(ValidationError, match="importance_recency_half_life_days must be finite"):
+        _settings(importance_recency_half_life_days=float("nan"))
+
+
+def test_importance_recency_half_life_accepts_the_default():
+    assert _settings().importance_recency_half_life_days == 14.0


### PR DESCRIPTION
Closes #222. Implements the #191 decision: retrievability alone controls the `working → archival` transition, and importance gets its own recency clock.

## What changed

**`decay_manager.run_decay`** no longer reads `importance` at all — the query dropped the column (`SELECT id, stability, last_review, last_accessed`) and the pre-gate is gone. Demotion is decided by FSRS retrievability against `fsrs_decay_threshold`.

**`importance_scorer`** got `_recency_signal(days_ago, half_life_days)`, a half-life decay on importance's own clock. Previously importance reused FSRS retrievability (`exp(-days/stability)`), so a high-stability node read as permanently recent — the coupling #222 describes. The scorer no longer selects `stability`.

**`config.py`** gained a `field_validator` for `importance_recency_half_life_days`, rejecting non-finite and non-positive values. Without it, `0.0` raised `ZeroDivisionError` and aborted the whole 120-minute scoring job rather than skipping one node, and `NaN`/`inf` silently saturated the signal to `1.0`. `_recency_signal` carries the same guard as defence in depth.

**Docs** (`05 - Background Jobs`, `12 - Configuration Reference`) and the admin-panel task description in `routes_admin.py` now describe what the job actually does.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Stale working node demotes regardless of access/edge history | `test_high_importance_stale_node_is_decayed` (importance 0.9) |
| 50 accesses + 4 edges does not pin a node to `working` | `test_accumulated_access_and_edges_do_not_pin_a_node_to_working` — drives the real `run_importance_scoring` end-to-end, asserts the computed importance (**0.5892**) clears the old 0.5 gate *before* asserting demotion |
| Recency follows the configured half-life, independent of stability | `test_recency_signal_*` + the scorer no longer selecting `stability` |
| Importance uses outside decay still work | `TierManager.enforce_core_cap()` is the only remaining production reader |
| Tests cover stale high-importance, custom weights, independent recency | `test_decay_manager.py`, `test_importance_scorer.py`, `test_config.py` |
| User-facing config/background-job docs updated | `docs/05`, `docs/12`, `routes_admin.py` |

## Blast radius

The formula change makes old nodes score materially higher — a 30-day never-reviewed node goes from recency ≈ 9e-14 to ≈ 0.227. Sweeping every consumer of `nodes.importance` found **exactly one production reader left**: `TierManager.enforce_core_cap()` (`tier_manager.py:56-60`). Not search ranking (`docs/03:113` says so explicitly), not whisper, not context building, not the API, not the UI. The effect is a relative ordering among `core` nodes, bounded by the 0.33 recency weight.

Surviving protections after the gate removal: the self node (`decay_manager.py:47-48`), the `core` tier (never enters the `WHERE tier = 'working'` query), and `R < fsrs_decay_threshold` (0.3).

Decay timescales, derived from stability being access-derived:

| Node | Before | After |
|---|---|---|
| 50 accesses, stability 30 | pinned to `working` forever | demotes after ~36 days idle |
| stability at the 365-day cap | — | holds ~439 days |
| never accessed | ~1.2 days | ~1.2 days (unchanged) |

Archival is reversible dormancy, not deletion.

## Notes

`decay_importance_threshold` is deliberately left in `config.py` with no production reader on this branch, with a comment saying so. Bounded forgetting (#28/#31) reintroduces a reader as the deletion-protection gate, so removing it here and re-adding it there would be churn. Flagging it explicitly since a reviewer will notice config with no reader.

This branch is cut from `main` and does not depend on #234 (#220).

## Verification

- Full suite: **13 failed, 1836 passed** vs the same baseline measured on `main` before the branch: **13 failed, 1826 passed**. Same 13 failures, name for name — they are pre-existing environment leakage, unrelated to this change. Zero regressions, +10 passing.
- `ruff check src/ tests/` → `All checks passed!`

## Known follow-up

Two test-coverage gaps found in review, not fixed here, both about pinning invariants rather than production defects:

1. No decay test sets `stability`, so with the default `S = 1.0` at 30 days both FSRS (`≈9e-14`) and the half-life (`≈0.23`) fall under the 0.3 threshold — swapping `run_decay`'s formula for the half-life one would leave the suite green. A pair with `stability = 100` (stays `working`, `R ≈ 0.74`) and `stability = 1.0` (goes `archival`) would pin it.
2. `run_importance_scoring` is never driven with a modified `importance_recency_half_life_days`; the setting is only exercised in the pure helper and in config validation. Hardcoding `14.0` in the job would pass every test.

Happy to add both here if you would rather they land with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
