### PR TITLE
fix(lifecycle): bound stability reinforcement and add a per-day cooldown (#221)

### DIFF
--- a/docs/01 - Data Model.md
+++ b/docs/01 - Data Model.md
@@ -30,13 +30,13 @@ connections: list[Connection]  # Outgoing edges to other nodes
 # Scoring
 confidence: float           # [0.0-1.0] How certain we are (default: 1.0)
 importance: float           # [0.0-1.0] Computed by importance_scorer job; see 05 - Background Jobs
-access_count: int           # Times this node has been accessed/recalled
+access_count: int           # Number of confirmed uses
 
 # Temporal
 created: datetime           # When first stored (UTC)
 updated: datetime           # Last modification (UTC)
-last_accessed: datetime     # Last confirmed use (UTC) — not a search hit
-last_review: datetime | None # Last FSRS review (spaced repetition)
+last_accessed: datetime     # Last confirmed use (UTC), not a search hit; the decay/spacing anchor
+last_review: datetime | None # Last numeric stability update; gated by the reinforcement cooldown, so it can lag last_accessed
 valid_until: datetime | None # Expiry date (set by mark_outdated)
 
 # FSRS (Spaced Repetition)

--- a/docs/05 - Background Jobs.md
+++ b/docs/05 - Background Jobs.md
@@ -124,7 +124,7 @@ It does not do embedding clustering or hierarchical clustering despite the name.
 ## Importance and Decay
 
 - `importance_scorer` computes a normalized multi-signal importance value
-- `decay_manager` uses FSRS-style retrievability alone to decide whether to demote working memories
+- `decay_manager` uses FSRS-style retrievability alone to decide whether to demote working memories, anchored on `last_accessed` (the last confirmed use) rather than on `last_review` (the last numeric stability update), which the reinforcement cooldown can leave a window behind
 
 Importance does not protect a node from decay. Cumulative signals such as access
 and edge counts could otherwise push a stale node permanently above any threshold.
@@ -154,7 +154,7 @@ Access and edge counts are log-normalized against reference values, then the wei
 
 The scorer runs every `120` minutes by default and only writes a new value when the change is meaningful.
 
-This score is not static. **Confirmed use** updates `access_count`, `last_accessed`, `last_review`, and `stability`, so a memory's importance changes over time as it is used, connected, or left untouched. Merely being surfaced does not: search results, UI search, whisper injection, and graph expansion write no lifecycle fields (issue #220). Confirmed use is a deliberate `recall_node`, or qualified positive feedback — `explicit`, `implicit`, or `auto_llm_judge`. Because `access_count` now counts confirmations rather than appearances, its values are far smaller than before, and `importance_access_reference` is calibrated against the old scale.
+This score is not static. **Confirmed use** updates `access_count` and `last_accessed` on every event, while `stability` and `last_review` move at most once per `fsrs_reinforcement_cooldown_days`, so a memory's importance changes over time as it is used, connected, or left untouched. Merely being surfaced does not: search results, UI search, whisper injection, and graph expansion write no lifecycle fields (issue #220). Confirmed use is a deliberate `recall_node`, or qualified positive feedback — `explicit`, `implicit`, or `auto_llm_judge`. Because `access_count` now counts confirmations rather than appearances, its values are far smaller than before, and `importance_access_reference` is calibrated against the old scale.
 
 ## Walkthrough Example
 

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -239,9 +239,43 @@ effect in this version; bounded forgetting reintroduces a consumer.
 | `working_decay_days` | `14` |
 | `fsrs_initial_stability` | `1.0` |
 | `fsrs_decay_threshold` | `0.3` |
-| `fsrs_stability_growth` | `1.5` |
 | `fsrs_max_stability` | `365.0` |
+| `fsrs_growth_factor` | `0.5` |
+| `fsrs_growth_exponent` | `0.5` |
+| `fsrs_spacing_cap` | `2.0` |
+| `fsrs_reinforcement_cooldown_days` | `1.0` |
 | `ingest_max_content_chars` | `100000` |
+
+Reinforcement is bounded and diminishing (#221):
+
+```text
+spacing = min(R^-0.2, fsrs_spacing_cap)
+S'      = min(S * (1 + fsrs_growth_factor * S^-fsrs_growth_exponent * spacing),
+              fsrs_max_stability)
+```
+
+`fsrs_spacing_cap` keeps a very old memory from reaching the ceiling in a single
+use, and `fsrs_growth_exponent` shrinks each step as stability rises — roughly 74
+eligible updates take a node from `1.0` to the default cap.
+`fsrs_reinforcement_cooldown_days` allows at most one numeric stability update per
+node per window; use still advances `last_accessed` on every event.
+
+Because of that, `last_review` can lag real use by a full cooldown window, and any
+job that treats it as a recency signal will read an actively used memory as stale.
+Decay and importance therefore anchor on `last_accessed`. If you add a consumer
+that anchors on `last_review` instead, keep
+`fsrs_reinforcement_cooldown_days < -ln(fsrs_decay_threshold) x stability`
+(about `1.2` days at the default threshold and an initial stability of `1.0`), or
+that consumer will treat the cooldown lag as decay.
+`fsrs_stability_growth` was removed in #221: it was a base multiplier, and the new
+`fsrs_growth_factor` is an additive term with different semantics.
+
+Downgrading to a build older than #221 after upgrading is **not supported**. The
+store records which lifecycle model wrote its `stability` values, and an older
+binary does not know that key: it keeps writing with the unbounded formula while
+leaving the version marker at the newer value, so a later upgrade trusts a marker
+that no longer describes the data. Roll the binary back only together with a
+backup taken before the upgrade.
 
 ## Agent-Backed Maintenance
 

--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -256,9 +256,13 @@ S'      = min(S * (1 + fsrs_growth_factor * S^-fsrs_growth_exponent * spacing),
 
 `fsrs_spacing_cap` keeps a very old memory from reaching the ceiling in a single
 use, and `fsrs_growth_exponent` shrinks each step as stability rises — roughly 74
-eligible updates take a node from `1.0` to the default cap.
+eligible updates take a node from `1.0` to `fsrs_max_stability`.
 `fsrs_reinforcement_cooldown_days` allows at most one numeric stability update per
 node per window; use still advances `last_accessed` on every event.
+`fsrs_reinforcement_cooldown_days = 0` is a legal value that disables the cooldown
+entirely, which allows unbounded-feeling growth within a single session — 74
+recalls in one sitting reach `fsrs_max_stability`. This reproduces #221's
+user-visible symptom and is currently legal and undocumented outside this note.
 
 Because of that, `last_review` can lag real use by a full cooldown window, and any
 job that treats it as a recency signal will read an actively used memory as stale.
@@ -269,6 +273,13 @@ that anchors on `last_review` instead, keep
 that consumer will treat the cooldown lag as decay.
 `fsrs_stability_growth` was removed in #221: it was a base multiplier, and the new
 `fsrs_growth_factor` is an additive term with different semantics.
+
+Upgrading does not rescale `stability` values written by the old unbounded
+formula. Only future growth is bounded; a memory the old formula pushed to
+`fsrs_max_stability` stays there and will not decay for roughly
+`-ln(fsrs_decay_threshold) x fsrs_max_stability` days of disuse (about 440 at
+the defaults). Correcting existing values would require a rescaling migration,
+deliberately not done here.
 
 Downgrading to a build older than #221 after upgrading is **not supported**. The
 store records which lifecycle model wrote its `stability` values, and an older

--- a/src/ormah/background/decay_manager.py
+++ b/src/ormah/background/decay_manager.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-import math
 from datetime import datetime, timezone
 
+from ormah import lifecycle
 from ormah.background.memory_lock import serialized_memory_job
 from ormah.models.node import Tier, UpdateNodeRequest
 
@@ -47,9 +47,11 @@ def run_decay(engine) -> None:
             if row["id"] == user_node_id:
                 continue
 
-            # Compute FSRS retrievability
-            stability = row["stability"] if row["stability"] else 1.0
-            anchor_str = row["last_review"] or row["last_accessed"]
+            # Compute FSRS retrievability through the shared implementation (#221).
+            # Anchor on use, not on the numeric stability update: the per-day
+            # reinforcement cooldown can leave last_review a full window behind
+            # the last use, and an actively used node must not read as stale.
+            anchor_str = row["last_accessed"] or row["last_review"]
             try:
                 anchor = datetime.fromisoformat(anchor_str)
                 days_since = max((now - anchor).total_seconds() / 86400, 0.001)
@@ -60,7 +62,15 @@ def run_decay(engine) -> None:
                     anchor_str,
                 )
                 continue
-            retrievability = math.exp(-days_since / stability)
+            # Pass the stored stability raw and let lifecycle own the zero case,
+            # with the SAME fallback reinforcement uses. Hardcoding 1.0 here
+            # while reinforcement falls back to fsrs_initial_stability is how
+            # the two paths silently disagree (council round 3, I3).
+            retrievability = lifecycle.retrievability(
+                days_since,
+                row["stability"],
+                fallback_stability=settings.fsrs_initial_stability,
+            )
 
             if retrievability >= r_threshold:
                 continue

--- a/src/ormah/background/importance_scorer.py
+++ b/src/ormah/background/importance_scorer.py
@@ -96,7 +96,10 @@ def run_importance_scoring(engine) -> None:
 
         # Recency signal: importance's own half-life, not FSRS stability (#222)
         try:
-            anchor_str = r["last_review"] or r["last_accessed"]
+            # Anchor on use, not on the numeric stability update (#221): the
+            # reinforcement cooldown can leave last_review a full window behind
+            # the last use, and a memory used today must not read as stale.
+            anchor_str = r["last_accessed"] or r["last_review"]
             anchor = datetime.fromisoformat(anchor_str)
             days_ago = max((now - anchor).total_seconds() / 86400, 0)
             recency_signal = _recency_signal(days_ago, half_life)

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -90,8 +90,14 @@ class Settings(BaseSettings):
     # FSRS spaced repetition decay
     fsrs_initial_stability: float = 1.0    # days; starting stability for new nodes
     fsrs_decay_threshold: float = 0.3      # R below this = decay candidate
-    fsrs_stability_growth: float = 1.5     # base multiplier on access
+    fsrs_stability_growth: float = 1.5     # base multiplier on access; removed in Task 3
     fsrs_max_stability: float = 365.0      # cap at 1 year
+    # Bounded reinforcement (#221/#191): S' = S * (1 + g * S^-w * spacing).
+    # Initial policy values, not fitted — deliberately configurable.
+    fsrs_growth_factor: float = 0.5        # g; size of one reinforcement step
+    fsrs_growth_exponent: float = 0.5      # w; damps the step as stability rises
+    fsrs_spacing_cap: float = 2.0          # ceiling on the R^-0.2 spacing factor
+    fsrs_reinforcement_cooldown_days: float = 1.0  # min days between numeric updates
 
     # Search
     fts_weight: float = 0.4
@@ -565,7 +571,31 @@ class Settings(BaseSettings):
             raise ValueError(f"threshold must be 0–1, got {v}")
         return v
 
-    @field_validator("fsrs_initial_stability", "fsrs_stability_growth")
+    @field_validator(
+        "fsrs_initial_stability",
+        "fsrs_max_stability",
+        "fsrs_growth_factor",
+        "fsrs_growth_exponent",
+        "fsrs_spacing_cap",
+        "fsrs_reinforcement_cooldown_days",
+    )
+    @classmethod
+    def _fsrs_finite(cls, v: float) -> float:
+        # The bounds checks below cannot do this: every `v <= 0` / `v < 1` /
+        # `v < 0` comparison is False for NaN, so NaN passes all of them, and
+        # infinity satisfies them outright. A NaN growth factor propagates NaN
+        # into stability, which is then serialized into the Markdown frontmatter;
+        # a NaN cooldown raises inside timedelta.
+        if not math.isfinite(v):
+            raise ValueError(f"FSRS parameter must be finite, got {v}")
+        return v
+
+    @field_validator(
+        "fsrs_initial_stability",
+        "fsrs_stability_growth",
+        "fsrs_growth_factor",
+        "fsrs_growth_exponent",
+    )
     @classmethod
     def _fsrs_positive(cls, v: float) -> float:
         if v <= 0:
@@ -579,6 +609,22 @@ class Settings(BaseSettings):
             raise ValueError(f"importance_recency_half_life_days must be finite, got {v}")
         if v <= 0:
             raise ValueError(f"importance_recency_half_life_days must be > 0, got {v}")
+        return v
+
+    @field_validator("fsrs_spacing_cap")
+    @classmethod
+    def _fsrs_spacing_cap_min(cls, v: float) -> float:
+        # Below 1 the spacing factor would shrink stability on use.
+        if v < 1:
+            raise ValueError(f"fsrs_spacing_cap must be >= 1, got {v}")
+        return v
+
+    @field_validator("fsrs_reinforcement_cooldown_days")
+    @classmethod
+    def _fsrs_cooldown_non_negative(cls, v: float) -> float:
+        # 0 is valid: it disables the cooldown.
+        if v < 0:
+            raise ValueError(f"fsrs_reinforcement_cooldown_days must be >= 0, got {v}")
         return v
 
     @field_validator("fsrs_max_stability")

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -90,7 +90,6 @@ class Settings(BaseSettings):
     # FSRS spaced repetition decay
     fsrs_initial_stability: float = 1.0    # days; starting stability for new nodes
     fsrs_decay_threshold: float = 0.3      # R below this = decay candidate
-    fsrs_stability_growth: float = 1.5     # base multiplier on access; removed in Task 3
     fsrs_max_stability: float = 365.0      # cap at 1 year
     # Bounded reinforcement (#221/#191): S' = S * (1 + g * S^-w * spacing).
     # Initial policy values, not fitted — deliberately configurable.
@@ -592,7 +591,6 @@ class Settings(BaseSettings):
 
     @field_validator(
         "fsrs_initial_stability",
-        "fsrs_stability_growth",
         "fsrs_growth_factor",
         "fsrs_growth_exponent",
     )

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -7,7 +7,6 @@ import hashlib
 from contextlib import contextmanager
 from functools import wraps
 import logging
-import math
 import re
 import threading
 import uuid
@@ -15,6 +14,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from ormah import lifecycle
 from ormah.config import Settings
 from ormah.embeddings.text import embedding_text as _embedding_text
 from ormah.engine.context_builder import ContextBuilder
@@ -1969,25 +1969,38 @@ class MemoryEngine:
 
     @_serialized_memory_operation
     def _record_confirmed_use(self, node_id: str) -> None:
-        """Record a confirmed use: update access stats and FSRS stability on disk and DB."""
+        """Record confirmed use, updating stability only when it is off cooldown.
+
+        Serialized because the cooldown is a check-then-write pair (#221,
+        council round 3): the recall paths that call this are not themselves
+        serialized, so two concurrent recalls would both read a stale
+        last_review and both bump stability. _memory_operation_lock is an
+        RLock, so the call sites that already hold it re-enter safely.
+        """
         node = self.file_store.load(node_id)
         if node is None:
             return
         now = datetime.now(timezone.utc)
 
-        # FSRS stability update. Node.stability is Field(ge=0.0), so 0 is a valid
-        # persisted value that would divide by zero here — and, once past that, keep
-        # new_stability pinned at 0 forever. decay_manager and importance_scorer already
-        # guard this same division; this was the one consumer that did not, and the
-        # ZeroDivisionError landed in the caller's isolating except as a silent lost
-        # reinforcement on a claim that had already been committed.
-        review_anchor = node.last_review or node.last_accessed
-        days_since = max((now - review_anchor).total_seconds() / 86400, 0.001)
-        stability = node.stability if node.stability else self.settings.fsrs_initial_stability
-        retrievability = math.exp(-days_since / stability)
-        new_stability = stability * self.settings.fsrs_stability_growth * (retrievability ** -0.2)
-        node.stability = round(min(new_stability, self.settings.fsrs_max_stability), 2)
-        node.last_review = now
+        # One numeric stability update per node per cooldown window (#221): the
+        # old formula let ten same-session touches compound to ~57x. The access
+        # anchor below still advances on every call, so decay never mistakes an
+        # actively used node for a stale one.
+        if lifecycle.reinforcement_due(
+            node.last_review, now, self.settings.fsrs_reinforcement_cooldown_days
+        ):
+            anchor = node.last_review or node.last_accessed
+            days_since = max((now - anchor).total_seconds() / 86400, 0.0)
+            node.stability = lifecycle.reinforced_stability(
+                node.stability,
+                days_since,
+                growth_factor=self.settings.fsrs_growth_factor,
+                growth_exponent=self.settings.fsrs_growth_exponent,
+                spacing_cap=self.settings.fsrs_spacing_cap,
+                max_stability=self.settings.fsrs_max_stability,
+                initial_stability=self.settings.fsrs_initial_stability,
+            )
+            node.last_review = now
 
         # Standard access tracking
         node.last_accessed = now
@@ -1996,8 +2009,15 @@ class MemoryEngine:
         self.file_store.save(node)
         with self.db.transaction() as conn:
             conn.execute(
-                "UPDATE nodes SET access_count = ?, last_accessed = ?, stability = ?, last_review = ? WHERE id = ?",
-                (node.access_count, node.last_accessed.isoformat(), node.stability, node.last_review.isoformat(), node_id),
+                "UPDATE nodes SET access_count = ?, last_accessed = ?, stability = ?, "
+                "last_review = ? WHERE id = ?",
+                (
+                    node.access_count,
+                    node.last_accessed.isoformat(),
+                    node.stability,
+                    node.last_review.isoformat() if node.last_review else None,
+                    node_id,
+                ),
             )
 
     # --- Private helpers ---

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -194,10 +194,12 @@ class MemoryEngine:
         which could say migrated/not-migrated and nothing else; it maps to
         version 1.
 
-        Every fallback here fails closed at 1 (already migrated), because the
+        An ambiguous signal fails closed at 1 (already migrated), because the
         only action version 0 unlocks is a destructive one: the seed overwrites
         stability and rewrites the Markdown. Skipping a needed seed leaves
-        defaults in place; running an unneeded one destroys real values.
+        defaults in place; running an unneeded one destroys real values. Only
+        the total absence of any signal — no version key, no legacy flag, and
+        no node carrying last_review — returns 0.
         """
         row = self.db.conn.execute(
             "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2034,6 +2034,15 @@ class MemoryEngine:
         serialized, so two concurrent recalls would both read a stale
         last_review and both bump stability. _memory_operation_lock is an
         RLock, so the call sites that already hold it re-enter safely.
+
+        Lock order: this decorator acquires the memory lock before the body
+        opens db.transaction(), i.e. memory-lock -> db-lock. The inverse order
+        (db-lock -> memory-lock, via file_store calls inside a transaction)
+        exists in _seed_stability_from_access_count, _migrate_identity_tiers,
+        and _ensure_self_node, but all three run only from startup() before the
+        server serves, so the two orders never interleave today. Invariant this
+        depends on: never call file_store inside db.transaction() outside
+        startup().
         """
         node = self.file_store.load(node_id)
         if node is None:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1983,9 +1983,10 @@ class MemoryEngine:
         now = datetime.now(timezone.utc)
 
         # One numeric stability update per node per cooldown window (#221): the
-        # old formula let ten same-session touches compound to ~57x. The access
-        # anchor below still advances on every call, so decay never mistakes an
-        # actively used node for a stale one.
+        # old formula let ten same-session touches compound to ~57x. last_accessed
+        # below still advances on every call, and Task 4 repoints decay and
+        # importance at it, so a node in active use never reads as stale even
+        # though last_review now lags by up to one cooldown window.
         if lifecycle.reinforcement_due(
             node.last_review, now, self.settings.fsrs_reinforcement_cooldown_days
         ):

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2057,7 +2057,10 @@ class MemoryEngine:
         if lifecycle.reinforcement_due(
             node.last_review, now, self.settings.fsrs_reinforcement_cooldown_days
         ):
-            anchor = node.last_review or node.last_accessed
+            # reinforcement cooldown can leave last_review a full window behind
+            # a use that already landed inside it (PR #239 review comment):
+            # last_accessed is the actual spacing signal, last_review only gates.
+            anchor = node.last_accessed or node.last_review
             days_since = max((now - anchor).total_seconds() / 86400, 0.0)
             node.stability = lifecycle.reinforced_stability(
                 node.stability,

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -55,6 +55,11 @@ _EMBEDDING_SCHEMA_VERSION = 2
 # auto_heuristic is excluded pending #218 signal calibration.
 _CONFIRMED_USE_SOURCES = frozenset({"explicit", "implicit", "auto_llm_judge"})
 
+# Lifecycle-model version. 1 = the legacy FSRS seed (previously recorded as the
+# boolean meta key 'fsrs_migrated'); 2 = bounded reinforcement (#221). An integer
+# so a future curve migration can tell which model produced the stored values.
+LIFECYCLE_MODEL_VERSION = 2
+
 
 def _generate_title(content: str, max_chars: int = 60) -> str:
     """Generate a short title from the first line/sentence of content."""
@@ -162,13 +167,67 @@ class MemoryEngine:
         self._warmup_reranker()
 
     def _migrate_fsrs(self) -> None:
-        """Seed FSRS stability from access_count on first run, updating both DB and markdown."""
-        fsrs_migrated = self.db.conn.execute(
-            "SELECT value FROM meta WHERE key = 'fsrs_migrated'"
-        ).fetchone()
-        if fsrs_migrated:
+        """Seed FSRS stability once, and record the store's lifecycle-model version."""
+        version = self._lifecycle_model_version()
+        if version >= LIFECYCLE_MODEL_VERSION:
             return
 
+        if version == 0:
+            self._seed_stability_from_access_count()
+
+        with self.db.transaction() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                "('lifecycle_model_version', ?)",
+                (str(LIFECYCLE_MODEL_VERSION),),
+            )
+            # Keep the legacy flag in sync so rolling back to a binary that only
+            # knows 'fsrs_migrated' does not reseed a store built under #221.
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES ('fsrs_migrated', '1')"
+            )
+
+    def _lifecycle_model_version(self) -> int:
+        """Read the store's lifecycle-model version, upgrading the legacy flag.
+
+        Stores written before #221 only carry the boolean 'fsrs_migrated' key,
+        which could say migrated/not-migrated and nothing else; it maps to
+        version 1.
+
+        Every fallback here fails closed at 1 (already migrated), because the
+        only action version 0 unlocks is a destructive one: the seed overwrites
+        stability and rewrites the Markdown. Skipping a needed seed leaves
+        defaults in place; running an unneeded one destroys real values.
+        """
+        row = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"
+        ).fetchone()
+        if row:
+            try:
+                return int(row["value"])
+            except (TypeError, ValueError):
+                return 1
+
+        legacy = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'fsrs_migrated'"
+        ).fetchone()
+        if legacy:
+            return 1
+
+        # No meta at all. SQLite is derived and excluded from backups
+        # (backup.py:331-334), so this is also what a fresh-device restore or a
+        # deleted index looks like — not only a genuinely pre-FSRS store. Ask
+        # the durable source instead: last_review lives in the Markdown
+        # frontmatter (markdown.py:72-73) and is restored on rebuild
+        # (builder.py:161), so any store that ever seeded or reinforced carries
+        # it. Seeding over that would overwrite stability the user actually earned.
+        reviewed = self.db.conn.execute(
+            "SELECT 1 FROM nodes WHERE last_review IS NOT NULL LIMIT 1"
+        ).fetchone()
+        return 1 if reviewed else 0
+
+    def _seed_stability_from_access_count(self) -> None:
+        """Seed FSRS stability from access_count, updating both DB and markdown."""
         rows = self.db.conn.execute(
             "SELECT id, access_count, last_accessed FROM nodes"
         ).fetchall()
@@ -196,9 +255,6 @@ class MemoryEngine:
                             pass
                     self.file_store.save(node)
 
-            conn.execute(
-                "INSERT OR REPLACE INTO meta (key, value) VALUES ('fsrs_migrated', '1')"
-            )
         logger.info("FSRS data migration complete: seeded %d nodes from access_count", len(rows))
 
     def _seed_initial_maintenance_grace_period(self) -> None:

--- a/src/ormah/lifecycle.py
+++ b/src/ormah/lifecycle.py
@@ -1,0 +1,89 @@
+"""Centralized memory-lifecycle math (#221, decided in #191).
+
+The FSRS curve used to be written out in the engine and in every background job
+that needed it, so a curve change meant editing three call sites that could
+silently diverge. Everything numeric about retrievability, spacing, and
+reinforcement lives here instead: pure functions, no I/O, no settings object, no
+database. Callers pass the knobs in.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta
+
+# Shape of the spacing curve, fixed by #191. Deliberately not configurable — the
+# knobs are the bounds around it (spacing cap, growth factor/exponent).
+_SPACING_EXPONENT = 0.2
+
+
+def retrievability(
+    days_since: float, stability: float, *, fallback_stability: float = 1.0
+) -> float:
+    """``R = exp(-t / S)`` — the probability the memory is still retrievable.
+
+    ``Node.stability`` is ``Field(ge=0.0)``, so ``S = 0`` is a representable value
+    that would make the exponent infinite; it falls back to *fallback_stability*.
+    """
+    effective_stability = stability if stability else fallback_stability
+    return math.exp(-max(days_since, 0.0) / effective_stability)
+
+
+def spacing_factor(
+    days_since: float, stability: float, cap: float, *, fallback_stability: float = 1.0
+) -> float:
+    """``min(R^-0.2, cap)``, computed without ever materializing ``R``.
+
+    ``R`` underflows to ``0.0`` once ``t / S`` passes ~745, and ``0.0 ** -0.2``
+    raises ``ZeroDivisionError``. Since ``R^-0.2 == exp(0.2 * t / S)``, working on
+    the exponent keeps the result finite at any age, and returning the cap as soon
+    as the exponent reaches ``log(cap)`` keeps ``exp`` away from its own overflow.
+    """
+    effective_stability = stability if stability else fallback_stability
+    exponent = _SPACING_EXPONENT * max(days_since, 0.0) / effective_stability
+    if exponent >= math.log(cap):
+        return cap
+    return min(math.exp(exponent), cap)
+
+
+def reinforced_stability(
+    stability: float,
+    days_since: float,
+    *,
+    growth_factor: float,
+    growth_exponent: float,
+    spacing_cap: float,
+    max_stability: float,
+    initial_stability: float,
+) -> float:
+    """``S' = min(S * (1 + g * S^-w * spacing), max_stability)``.
+
+    Bounded and diminishing: the ``S^-w`` term shrinks each step as stability
+    rises, and the capped spacing factor stops a single very old node from
+    reaching the ceiling in one use.
+    """
+    effective_stability = stability if stability else initial_stability
+    spacing = spacing_factor(
+        days_since,
+        effective_stability,
+        spacing_cap,
+        fallback_stability=initial_stability,
+    )
+    grown = effective_stability * (
+        1 + growth_factor * effective_stability**-growth_exponent * spacing
+    )
+    return round(min(grown, max_stability), 2)
+
+
+def reinforcement_due(
+    last_review: datetime | None, now: datetime, cooldown_days: float
+) -> bool:
+    """True when a node's numeric stability update is off cooldown.
+
+    ``last_review`` tracks the last numeric update, which is distinct from
+    ``last_accessed``: use advances the decay anchor on every event, while the
+    stability number moves at most once per cooldown window.
+    """
+    if last_review is None:
+        return True
+    return (now - last_review) >= timedelta(days=cooldown_days)

--- a/src/ormah/lifecycle.py
+++ b/src/ormah/lifecycle.py
@@ -1,10 +1,13 @@
-"""Centralized memory-lifecycle math (#221, decided in #191).
+"""The single definition of Ormah's memory-lifecycle math.
 
-The FSRS curve used to be written out in the engine and in every background job
-that needed it, so a curve change meant editing three call sites that could
-silently diverge. Everything numeric about retrievability, spacing, and
-reinforcement lives here instead: pure functions, no I/O, no settings object, no
-database. Callers pass the knobs in.
+Every numeric rule about retrievability, spacing, and reinforcement lives here,
+so the engine and the background jobs share one curve rather than each carrying
+a copy that can drift. Changing how memory decays or strengthens means editing
+this module and nothing else.
+
+Pure functions only: no I/O, no settings object, no database. Callers own the
+state and pass the knobs in, which keeps the curve independently testable and
+free of any caller's lifecycle.
 """
 
 from __future__ import annotations

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime, timedelta, timezone
 
+import pytest
 
 from ormah.background.decay_manager import run_decay
 from ormah.background.importance_scorer import run_importance_scoring
@@ -349,3 +350,97 @@ def test_decay_cleans_pending_proposals(engine):
         "SELECT COUNT(*) FROM proposals WHERE type = 'decay' AND status = 'pending'"
     ).fetchone()[0]
     assert count_after == 0
+
+
+def _make_decayable(engine, node_id: str) -> None:
+    """Lower importance under decay_importance_threshold.
+
+    Both the node default and the threshold are 0.5, and the gate is `>=`, so a
+    node left at its default is skipped before retrievability is ever computed.
+    """
+    engine.db.conn.execute(
+        "UPDATE nodes SET importance = 0.2 WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+
+
+def test_decay_uses_the_shared_retrievability_implementation(engine, monkeypatch):
+    """AC5: one exponential curve, shared with the reinforcement path."""
+    from ormah.background import decay_manager
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Node whose retrievability we intercept",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Intercepted",
+    ))
+    _make_stale(engine, node_id)
+    _make_decayable(engine, node_id)
+
+    calls = []
+    real = decay_manager.lifecycle.retrievability
+
+    def _spy(days_since, stability, **kwargs):
+        calls.append((days_since, stability))
+        return real(days_since, stability, **kwargs)
+
+    monkeypatch.setattr(decay_manager.lifecycle, "retrievability", _spy)
+    run_decay(engine)
+
+    assert calls, "run_decay computed retrievability without the shared helper"
+    days_since, _stability = calls[0]
+    assert days_since == pytest.approx(30, abs=1)
+
+
+def test_a_node_used_today_is_not_decayed_while_its_review_lags(engine):
+    """The cooldown can leave last_review a day behind; use must win the anchor.
+
+    With the old `last_review or last_accessed` order this node reads as 30 days
+    stale and is demoted. Step 2 pins that: the test must FAIL before the flip.
+    """
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Used today, reviewed a month ago",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Fresh use, stale review",
+    ))
+    now = datetime.now(timezone.utc)
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_accessed = ?, last_review = ?, stability = 1.0 WHERE id = ?",
+        (now.isoformat(), (now - timedelta(days=30)).isoformat(), node_id),
+    )
+    _make_decayable(engine, node_id)
+
+    run_decay(engine)
+
+    assert _get_tier(engine, node_id) == "working"
+
+
+def test_zero_stability_decays_on_the_configured_initial_stability(engine, monkeypatch):
+    """Decay must use the same zero fallback reinforcement uses (council round 3, I3).
+
+    Node.stability is Field(ge=0.0), so 0 is a real state. With the hardcoded 1.0
+    fallback a seven-day-old zero-stability node reads R = exp(-7/1) ~= 0.0009 and
+    is archived; with fsrs_initial_stability = 30 it reads exp(-7/30) ~= 0.79 and
+    must survive. The 0.3 decay threshold sits between the two, so this test can
+    only pass on the shared fallback.
+    """
+    monkeypatch.setattr(engine.settings, "fsrs_initial_stability", 30.0)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Zero stability, used a week ago",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Zero stability",
+    ))
+    now = datetime.now(timezone.utc)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 0.0, last_accessed = ?, last_review = NULL WHERE id = ?",
+        ((now - timedelta(days=7)).isoformat(), node_id),
+    )
+    engine.db.conn.commit()
+    _make_decayable(engine, node_id)
+
+    run_decay(engine)
+
+    assert _get_tier(engine, node_id) == "working"

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -427,6 +427,43 @@ def test_importance_job_uses_configured_recency_half_life(engine):
     assert importance == pytest.approx(0.5, abs=0.001)
 
 
+def test_recency_ignores_a_lagging_last_review(engine):
+    """A node used today must not read as stale because reinforcement is on cooldown."""
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Used today, reinforced a month ago",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Lagging review",
+    ))
+    now = datetime.now(timezone.utc)
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_accessed = ?, last_review = ?, access_count = 0 "
+        "WHERE id = ?",
+        (now.isoformat(), (now - timedelta(days=30)).isoformat(), node_id),
+    )
+    # Keep the assertion about recency only; auto-linking can otherwise add an
+    # unrelated edge contribution and make the old timestamp order look healthy.
+    engine.db.conn.execute(
+        "DELETE FROM edges WHERE source_id = ? OR target_id = ?", (node_id, node_id)
+    )
+    engine.db.conn.commit()
+
+    run_importance_scoring(engine)
+
+    importance = engine.db.conn.execute(
+        "SELECT importance FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()["importance"]
+    settings = engine.settings
+    total = (
+        settings.importance_access_weight
+        + settings.importance_edge_weight
+        + settings.importance_recency_weight
+    )
+    assert importance == pytest.approx(
+        settings.importance_recency_weight / total, abs=0.02
+    )
+
+
 def test_recency_signal_survives_an_invalid_half_life():
     """Defence in depth (council I1): the validator should make these unreachable,
     but the guard must hold anyway. A zero or negative half-life must never raise

--- a/tests/test_config_fsrs.py
+++ b/tests/test_config_fsrs.py
@@ -71,3 +71,15 @@ def test_non_finite_values_from_the_environment_are_rejected(tmp_memory_dir, mon
     monkeypatch.setenv("ORMAH_FSRS_GROWTH_FACTOR", raw)
     with pytest.raises(ValidationError):
         Settings(memory_dir=tmp_memory_dir)
+
+
+def test_the_removed_growth_knob_no_longer_exists(tmp_memory_dir):
+    settings = Settings(memory_dir=tmp_memory_dir)
+    assert not hasattr(settings, "fsrs_stability_growth")
+
+
+def test_an_env_carrying_the_removed_knob_still_loads(tmp_memory_dir, monkeypatch):
+    """extra="ignore" (config.py:20) keeps an old .env from breaking startup."""
+    monkeypatch.setenv("ORMAH_FSRS_STABILITY_GROWTH", "1.5")
+    settings = Settings(memory_dir=tmp_memory_dir)
+    assert settings.fsrs_growth_factor == 0.5

--- a/tests/test_config_fsrs.py
+++ b/tests/test_config_fsrs.py
@@ -1,0 +1,73 @@
+"""Validation coverage for the bounded-reinforcement knobs (#221)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from ormah.config import Settings
+
+
+def test_defaults_match_the_decided_policy(tmp_memory_dir):
+    settings = Settings(memory_dir=tmp_memory_dir)
+    assert settings.fsrs_growth_factor == 0.5
+    assert settings.fsrs_growth_exponent == 0.5
+    assert settings.fsrs_spacing_cap == 2.0
+    assert settings.fsrs_reinforcement_cooldown_days == 1.0
+
+
+@pytest.mark.parametrize("field", ["fsrs_growth_factor", "fsrs_growth_exponent"])
+@pytest.mark.parametrize("value", [0.0, -1.0])
+def test_growth_parameters_must_be_positive(tmp_memory_dir, field, value):
+    with pytest.raises(ValidationError):
+        Settings(memory_dir=tmp_memory_dir, **{field: value})
+
+
+def test_spacing_cap_below_one_is_rejected(tmp_memory_dir):
+    """A cap under 1 would shrink stability on use instead of growing it."""
+    with pytest.raises(ValidationError):
+        Settings(memory_dir=tmp_memory_dir, fsrs_spacing_cap=0.5)
+
+
+def test_spacing_cap_of_exactly_one_is_allowed(tmp_memory_dir):
+    settings = Settings(memory_dir=tmp_memory_dir, fsrs_spacing_cap=1.0)
+    assert settings.fsrs_spacing_cap == 1.0
+
+
+def test_negative_cooldown_is_rejected(tmp_memory_dir):
+    with pytest.raises(ValidationError):
+        Settings(memory_dir=tmp_memory_dir, fsrs_reinforcement_cooldown_days=-1.0)
+
+
+def test_zero_cooldown_is_allowed(tmp_memory_dir):
+    """Zero disables the cooldown — a legitimate config, not an error."""
+    settings = Settings(memory_dir=tmp_memory_dir, fsrs_reinforcement_cooldown_days=0.0)
+    assert settings.fsrs_reinforcement_cooldown_days == 0.0
+
+
+# Every `v <= 0` / `v < 1` / `v < 0` comparison is False for NaN, so the plain
+# bounds checks let it straight through — verified against the current code:
+# Settings(fsrs_stability_growth=float("nan")) returns nan today.
+LIFECYCLE_FLOATS = [
+    "fsrs_initial_stability",
+    "fsrs_max_stability",
+    "fsrs_growth_factor",
+    "fsrs_growth_exponent",
+    "fsrs_spacing_cap",
+    "fsrs_reinforcement_cooldown_days",
+]
+
+
+@pytest.mark.parametrize("field", LIFECYCLE_FLOATS)
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_lifecycle_values_are_rejected(tmp_memory_dir, field, value):
+    with pytest.raises(ValidationError):
+        Settings(memory_dir=tmp_memory_dir, **{field: value})
+
+
+@pytest.mark.parametrize("raw", ["nan", "inf", "-inf"])
+def test_non_finite_values_from_the_environment_are_rejected(tmp_memory_dir, monkeypatch, raw):
+    """BaseSettings parses these strings into floats, so the env path needs the same guard."""
+    monkeypatch.setenv("ORMAH_FSRS_GROWTH_FACTOR", raw)
+    with pytest.raises(ValidationError):
+        Settings(memory_dir=tmp_memory_dir)

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -1,0 +1,138 @@
+"""Integer lifecycle-model version replaces the boolean fsrs_migrated flag (#221)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ormah.engine.memory_engine import LIFECYCLE_MODEL_VERSION
+from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+
+def _version(engine) -> str | None:
+    row = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"
+    ).fetchone()
+    return row["value"] if row else None
+
+
+def _make_node(engine) -> str:
+    """A real node, so the seed has something to act on — an empty table would
+    make every assertion below pass vacuously."""
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="A node the migration will or will not reseed",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Migration subject",
+    ))
+    return node_id
+
+
+def _stability(engine, node_id: str) -> float:
+    return engine.db.conn.execute(
+        "SELECT stability FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()["stability"]
+
+
+def test_the_version_constant_is_two():
+    """1 = the legacy FSRS seed; 2 = bounded reinforcement."""
+    assert LIFECYCLE_MODEL_VERSION == 2
+
+
+def test_a_fresh_store_ends_at_the_current_version(engine):
+    assert _version(engine) == "2"
+
+
+def test_a_legacy_store_is_backfilled_without_reseeding(engine):
+    """AC6: fsrs_migrated='1' means the seed already ran — record it as version 1."""
+    node_id = _make_node(engine)
+    # Simulate a store migrated by the old boolean flag: drop the new key, restore
+    # the legacy one, and set a stability the seed would overwrite if it re-ran.
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'lifecycle_model_version'")
+    engine.db.conn.execute(
+        "INSERT OR REPLACE INTO meta (key, value) VALUES ('fsrs_migrated', '1')"
+    )
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 42.0, access_count = 5 WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+
+    engine._migrate_fsrs()
+
+    assert _version(engine) == "2"
+    assert _stability(engine, node_id) == 42.0, "the seed re-ran on an already-migrated store"
+
+
+def test_an_unmigrated_store_still_gets_seeded(engine):
+    node_id = _make_node(engine)
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'lifecycle_model_version'")
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'fsrs_migrated'")
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, access_count = 5 WHERE id = ?", (node_id,)
+    )
+    # A genuinely pre-FSRS store: no node has ever been seeded or reinforced.
+    # Stated explicitly rather than assumed — this is what separates it from the
+    # rebuilt-index case below, and the whole seed decision now rests on it.
+    engine.db.conn.execute("UPDATE nodes SET last_review = NULL")
+    engine.db.conn.commit()
+
+    engine._migrate_fsrs()
+
+    assert _version(engine) == "2"
+    assert _stability(engine, node_id) == 10.0, "min(30, access_count * 2) was not applied"
+
+
+def test_a_corrupt_version_fails_closed_as_migrated(engine):
+    """Skipping a seed is inert; running one overwrites stability. Fail closed."""
+    engine.db.conn.execute(
+        "INSERT OR REPLACE INTO meta (key, value) VALUES ('lifecycle_model_version', 'banana')"
+    )
+    engine.db.conn.commit()
+
+    assert engine._lifecycle_model_version() == 1
+
+
+def test_a_rebuilt_index_does_not_reseed_earned_stability(engine):
+    """C3: SQLite is excluded from backups, so a restore arrives with no meta.
+
+    The Markdown still carries stability and last_review, so the store is not a
+    pre-FSRS one and must not be reseeded.
+
+    SCOPE, stated so nobody reads more into a green than it carries: this covers
+    the EMPTY-meta restore only. It deletes the keys by hand and calls
+    _migrate_fsrs directly — it goes through neither full_rebuild nor
+    reload_restored_graph. The same-device restore, where meta survives the
+    rebuild and _migrate_fsrs is never called, is a pre-existing defect tracked
+    outside this issue (see the scope boundary above). This test passing does
+    NOT mean restore is safe in general.
+    """
+    node_id = _make_node(engine)
+    now = datetime.now(timezone.utc)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, access_count = 7, last_review = ? WHERE id = ?",
+        (now.isoformat(), node_id),
+    )
+    # Exactly what a fresh-device restore or a deleted index looks like.
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'lifecycle_model_version'")
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'fsrs_migrated'")
+    engine.db.conn.commit()
+
+    engine._migrate_fsrs()
+
+    # Without the last_review guard the seed would write min(30, 7*2) = 14.0.
+    assert _stability(engine, node_id) == 1.0
+    assert _version(engine) == "2"
+
+
+def test_the_legacy_flag_is_written_alongside_the_version(engine):
+    """I1: a rollback to a binary that only knows fsrs_migrated must not reseed.
+
+    SCOPE, stated so a green is not over-read (council round 3, C2): this proves
+    the old binary will not RESEED. It does not prove rollback is safe. The old
+    binary still writes stability with the unbounded formula while leaving
+    lifecycle_model_version at '2', and on the next upgrade the early return
+    trusts that stale marker. Downgrade is unsupported; see the scope note above.
+    """
+    row = engine.db.conn.execute(
+        "SELECT value FROM meta WHERE key = 'fsrs_migrated'"
+    ).fetchone()
+    assert row is not None and row["value"] == "1"

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -43,11 +43,11 @@ def _backdate_review(engine, node_id: str, days: float) -> None:
 def test_ten_touches_in_one_day_produce_one_stability_update(engine):
     """AC4: ten uses, one numeric update, and the latest use time is recorded."""
     node_id = _make_node(engine)
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
 
     after_first = _row(engine, node_id)
     for _ in range(9):
-        engine._touch_access(node_id)
+        engine._record_confirmed_use(node_id)
     after_ten = _row(engine, node_id)
 
     assert after_ten["stability"] == after_first["stability"]
@@ -58,11 +58,11 @@ def test_ten_touches_in_one_day_produce_one_stability_update(engine):
 
 def test_a_touch_after_the_cooldown_moves_stability_again(engine):
     node_id = _make_node(engine)
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
     before = _row(engine, node_id)
 
     _backdate_review(engine, node_id, days=1.0)
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
     after = _row(engine, node_id)
 
     assert after["stability"] > before["stability"]
@@ -90,7 +90,7 @@ def test_reinforcement_anchors_on_last_accessed_not_a_lagging_last_review(engine
     )
     engine.db.conn.commit()
 
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
 
     assert _row(engine, node_id)["stability"] == pytest.approx(1.50, abs=0.01)
 
@@ -107,7 +107,7 @@ def test_a_thirty_day_old_node_is_bounded_to_double(engine):
     engine.db.conn.commit()
     _backdate_review(engine, node_id, days=30.0)
 
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
 
     assert _row(engine, node_id)["stability"] == 2.0
 
@@ -115,10 +115,10 @@ def test_a_thirty_day_old_node_is_bounded_to_double(engine):
 def test_the_cooldown_does_not_freeze_the_decay_anchor(engine):
     """last_accessed must keep moving so decay never sees an active node as stale."""
     node_id = _make_node(engine)
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
     first = _row(engine, node_id)
 
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
     second = _row(engine, node_id)
 
     assert second["last_accessed"] >= first["last_accessed"]
@@ -134,7 +134,7 @@ def test_reinforcement_survives_a_zero_stability_node(engine):
     engine.db.conn.execute("UPDATE nodes SET stability = 0.0 WHERE id = ?", (node_id,))
     engine.db.conn.commit()
 
-    engine._touch_access(node_id)
+    engine._record_confirmed_use(node_id)
 
     assert _row(engine, node_id)["stability"] > 0.0
 
@@ -145,7 +145,7 @@ def test_concurrent_touches_run_reinforcement_once(engine, monkeypatch):
     The sequential ten-touch test cannot see this: it is the *interleaving* that
     breaks the cooldown. Both threads read last_review before either writes it,
     both conclude they are off cooldown, and both reinforce. The recall paths
-    that reach _touch_access carry no @_serialized_memory_operation, so this is
+    that reach _record_confirmed_use carry no additional serialization, so this is
     the production shape, not a synthetic one.
 
     TWO construction choices, both load-bearing — read before editing:
@@ -203,7 +203,7 @@ def test_concurrent_touches_run_reinforcement_once(engine, monkeypatch):
 
     def _touch() -> None:
         try:
-            engine._touch_access(node_id)
+            engine._record_confirmed_use(node_id)
         except BaseException as exc:  # noqa: BLE001 - surfaced via `errors` below
             errors.append(exc)
 

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from ormah.models.node import CreateNodeRequest, NodeType, Tier
 
 
@@ -113,49 +111,83 @@ def test_reinforcement_survives_a_zero_stability_node(engine):
     assert _row(engine, node_id)["stability"] > 0.0
 
 
-def test_concurrent_touches_still_produce_one_stability_update(engine):
-    """AC4 under concurrency (council round 3, I1).
+def test_concurrent_touches_run_reinforcement_once(engine, monkeypatch):
+    """AC4 under concurrency (council round 3 I1; test rebuilt after task review).
 
-    The sequential ten-touch test above cannot see this: it is the *interleaving*
-    that breaks the cooldown. Both threads read last_review before either writes
-    it, both conclude they are off cooldown, and both bump. The recall paths that
-    reach _touch_access carry no @_serialized_memory_operation, so this is the
-    real production shape, not a synthetic one.
+    The sequential ten-touch test cannot see this: it is the *interleaving* that
+    breaks the cooldown. Both threads read last_review before either writes it,
+    both conclude they are off cooldown, and both reinforce. The recall paths
+    that reach _touch_access carry no @_serialized_memory_operation, so this is
+    the production shape, not a synthetic one.
 
-    Barrier, not a bare thread pair: without it the two threads can serialize by
-    luck and the test greens on the broken code. The barrier forces both past the
-    cooldown read before either proceeds.
+    TWO construction choices, both load-bearing — read before editing:
+
+    1. A DELAY widens the window; a Barrier would deadlock. Synchronizing the
+       threads *inside* the critical section only works while the section is
+       unguarded: once @_serialized_memory_operation is in place the second
+       thread cannot enter until the first leaves, so a barrier there would time
+       out on correct code. A sleep does not synchronize, so it is safe in both
+       states — it just makes the unguarded race overwhelmingly likely.
+
+    2. The assertion COUNTS reinforcements; it cannot be the final stability.
+       Both threads read S=1.0 and both write 1.5 — the same value. Compounding
+       to 2.25 needs read-after-write, which is the serialization the bug
+       removes, so `stability == 1.5` holds whether the race fired or not. The
+       number of reinforced_stability calls is the only signal that separates
+       one bump from two.
     """
     import threading
+    import time
+
+    from ormah import lifecycle
 
     node_id = _make_node(engine)
-    engine.db.conn.execute(
-        "UPDATE nodes SET stability = 1.0, last_review = NULL WHERE id = ?", (node_id,)
-    )
-    engine.db.conn.commit()
     node = engine.file_store.load(node_id)
     node.stability = 1.0
     node.last_review = None
     engine.file_store.save(node)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, last_review = NULL WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
 
-    barrier = threading.Barrier(2)
+    reinforcements: list[float] = []
+    real_due = lifecycle.reinforcement_due
+    real_reinforce = lifecycle.reinforced_stability
+    lock = threading.Lock()
+
+    def _slow_due(last_review, now, cooldown_days):
+        verdict = real_due(last_review, now, cooldown_days)
+        time.sleep(0.05)  # widen the check-then-write window
+        return verdict
+
+    def _counting_reinforce(*args, **kwargs):
+        with lock:
+            reinforcements.append(1.0)
+        return real_reinforce(*args, **kwargs)
+
+    import ormah.engine.memory_engine as engine_module
+
+    monkeypatch.setattr(engine_module.lifecycle, "reinforcement_due", _slow_due)
+    monkeypatch.setattr(engine_module.lifecycle, "reinforced_stability", _counting_reinforce)
+
     errors: list[BaseException] = []
 
     def _touch() -> None:
         try:
-            barrier.wait(timeout=5)
             engine._touch_access(node_id)
         except BaseException as exc:  # noqa: BLE001 - surfaced via `errors` below
             errors.append(exc)
 
-    threads = [threading.Thread(target=_touch) for _ in range(2)]
+    threads = [threading.Thread(target=_touch) for _ in range(4)]
     for t in threads:
         t.start()
     for t in threads:
-        t.join(timeout=10)
+        t.join(timeout=15)
 
     assert not errors, f"a touch thread raised: {errors}"
-    row = _row(engine, node_id)
-    # One bump from S=1.0, never two. The second bump would compound past this.
-    assert row["stability"] == pytest.approx(1.5)
-    assert row["access_count"] == 2, "both touches must still be counted"
+    assert not [t for t in threads if t.is_alive()], "a touch thread never finished"
+    assert len(reinforcements) == 1, (
+        f"cooldown ran reinforcement {len(reinforcements)} times under concurrency"
+    )
+    assert _row(engine, node_id)["access_count"] == 4, "every touch must still be counted"

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from ormah.models.node import CreateNodeRequest, NodeType, Tier
 
 
@@ -65,6 +67,32 @@ def test_a_touch_after_the_cooldown_moves_stability_again(engine):
 
     assert after["stability"] > before["stability"]
     assert after["last_review"] > before["last_review"]
+
+
+def test_reinforcement_anchors_on_last_accessed_not_a_lagging_last_review(engine):
+    """A confirmed use inside the cooldown must not be invisible to the spacing calc.
+
+    last_review gates *whether* the numeric update runs; last_accessed is the last
+    confirmed use. When they diverge (a use landed inside the cooldown, so it moved
+    last_accessed but not last_review), the growth calculation must measure the gap
+    since that last use, not since the last numeric write (PR #239 review comment).
+    """
+    node_id = _make_node(engine)
+    node = engine.file_store.load(node_id)
+    node.stability = 1.0
+    now = datetime.now(timezone.utc)
+    node.last_review = now - timedelta(hours=25)
+    node.last_accessed = now - timedelta(hours=1)
+    engine.file_store.save(node)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, last_review = ?, last_accessed = ? WHERE id = ?",
+        (node.last_review.isoformat(), node.last_accessed.isoformat(), node_id),
+    )
+    engine.db.conn.commit()
+
+    engine._touch_access(node_id)
+
+    assert _row(engine, node_id)["stability"] == pytest.approx(1.50, abs=0.01)
 
 
 def test_a_thirty_day_old_node_is_bounded_to_double(engine):

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -1,0 +1,161 @@
+"""Per-day cooldown on numeric stability updates (#221)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+
+def _row(engine, node_id: str):
+    return engine.db.conn.execute(
+        "SELECT access_count, last_accessed, stability, last_review FROM nodes WHERE id = ?",
+        (node_id,),
+    ).fetchone()
+
+
+def _make_node(engine) -> str:
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="A node whose reinforcement we are measuring",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Cooldown subject",
+    ))
+    return node_id
+
+
+def _backdate_review(engine, node_id: str, days: float) -> None:
+    """Move both timestamps back so the next touch is off cooldown."""
+    when = datetime.now(timezone.utc) - timedelta(days=days)
+    node = engine.file_store.load(node_id)
+    node.last_review = when
+    node.last_accessed = when
+    engine.file_store.save(node)
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_review = ?, last_accessed = ? WHERE id = ?",
+        (when.isoformat(), when.isoformat(), node_id),
+    )
+    engine.db.conn.commit()
+
+
+def test_ten_touches_in_one_day_produce_one_stability_update(engine):
+    """AC4: ten uses, one numeric update, and the latest use time is recorded."""
+    node_id = _make_node(engine)
+    engine._touch_access(node_id)
+
+    after_first = _row(engine, node_id)
+    for _ in range(9):
+        engine._touch_access(node_id)
+    after_ten = _row(engine, node_id)
+
+    assert after_ten["stability"] == after_first["stability"]
+    assert after_ten["last_review"] == after_first["last_review"]
+    assert after_ten["access_count"] == after_first["access_count"] + 9
+    assert after_ten["last_accessed"] > after_first["last_accessed"]
+
+
+def test_a_touch_after_the_cooldown_moves_stability_again(engine):
+    node_id = _make_node(engine)
+    engine._touch_access(node_id)
+    before = _row(engine, node_id)
+
+    _backdate_review(engine, node_id, days=1.0)
+    engine._touch_access(node_id)
+    after = _row(engine, node_id)
+
+    assert after["stability"] > before["stability"]
+    assert after["last_review"] > before["last_review"]
+
+
+def test_a_thirty_day_old_node_is_bounded_to_double(engine):
+    """AC1 end to end: the unbounded formula produced ~202.7 here."""
+    node_id = _make_node(engine)
+    node = engine.file_store.load(node_id)
+    node.stability = 1.0
+    engine.file_store.save(node)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0 WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+    _backdate_review(engine, node_id, days=30.0)
+
+    engine._touch_access(node_id)
+
+    assert _row(engine, node_id)["stability"] == 2.0
+
+
+def test_the_cooldown_does_not_freeze_the_decay_anchor(engine):
+    """last_accessed must keep moving so decay never sees an active node as stale."""
+    node_id = _make_node(engine)
+    engine._touch_access(node_id)
+    first = _row(engine, node_id)
+
+    engine._touch_access(node_id)
+    second = _row(engine, node_id)
+
+    assert second["last_accessed"] >= first["last_accessed"]
+    assert second["last_review"] == first["last_review"]
+
+
+def test_reinforcement_survives_a_zero_stability_node(engine):
+    """Node.stability is ge=0.0; exp(-t/0) used to raise ZeroDivisionError."""
+    node_id = _make_node(engine)
+    node = engine.file_store.load(node_id)
+    node.stability = 0.0
+    engine.file_store.save(node)
+    engine.db.conn.execute("UPDATE nodes SET stability = 0.0 WHERE id = ?", (node_id,))
+    engine.db.conn.commit()
+
+    engine._touch_access(node_id)
+
+    assert _row(engine, node_id)["stability"] > 0.0
+
+
+def test_concurrent_touches_still_produce_one_stability_update(engine):
+    """AC4 under concurrency (council round 3, I1).
+
+    The sequential ten-touch test above cannot see this: it is the *interleaving*
+    that breaks the cooldown. Both threads read last_review before either writes
+    it, both conclude they are off cooldown, and both bump. The recall paths that
+    reach _touch_access carry no @_serialized_memory_operation, so this is the
+    real production shape, not a synthetic one.
+
+    Barrier, not a bare thread pair: without it the two threads can serialize by
+    luck and the test greens on the broken code. The barrier forces both past the
+    cooldown read before either proceeds.
+    """
+    import threading
+
+    node_id = _make_node(engine)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, last_review = NULL WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+    node = engine.file_store.load(node_id)
+    node.stability = 1.0
+    node.last_review = None
+    engine.file_store.save(node)
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def _touch() -> None:
+        try:
+            barrier.wait(timeout=5)
+            engine._touch_access(node_id)
+        except BaseException as exc:  # noqa: BLE001 - surfaced via `errors` below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_touch) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"a touch thread raised: {errors}"
+    row = _row(engine, node_id)
+    # One bump from S=1.0, never two. The second bump would compound past this.
+    assert row["stability"] == pytest.approx(1.5)
+    assert row["access_count"] == 2, "both touches must still be counted"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,117 @@
+"""Unit tests for the centralized lifecycle math (#221)."""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ormah import lifecycle
+
+# The policy constants from #191. Kept literal here on purpose: these tests pin
+# the curve itself, not whatever config happens to hold.
+G = 0.5
+W = 0.5
+CAP = 2.0
+MAX_S = 365.0
+INITIAL_S = 1.0
+
+
+def _reinforce(stability: float, days_since: float) -> float:
+    return lifecycle.reinforced_stability(
+        stability,
+        days_since,
+        growth_factor=G,
+        growth_exponent=W,
+        spacing_cap=CAP,
+        max_stability=MAX_S,
+        initial_stability=INITIAL_S,
+    )
+
+
+def test_retrievability_matches_the_exponential_curve():
+    assert lifecycle.retrievability(0.0, 1.0) == pytest.approx(1.0)
+    assert lifecycle.retrievability(1.0, 1.0) == pytest.approx(math.exp(-1.0))
+    assert lifecycle.retrievability(7.0, 14.0) == pytest.approx(math.exp(-0.5))
+
+
+def test_retrievability_never_exceeds_one():
+    for days, stab in [(0.0, 1.0), (0.5, 100.0), (30.0, 365.0)]:
+        assert lifecycle.retrievability(days, stab) <= 1.0
+
+
+def test_retrievability_survives_zero_stability():
+    """Node.stability is Field(ge=0.0), so 0 is representable and exp(-t/0) raises."""
+    assert lifecycle.retrievability(5.0, 0.0, fallback_stability=2.0) == pytest.approx(
+        math.exp(-2.5)
+    )
+
+
+def test_stability_one_reinforced_after_thirty_days_reaches_exactly_two():
+    """AC1: the headline case from the issue. Unbounded, this jumped 1 -> 202.7."""
+    assert _reinforce(1.0, 30.0) == 2.0
+
+
+def test_spacing_stays_finite_for_an_extremely_old_node():
+    """AC2: R underflows to 0.0 past t/S ~745 and 0.0 ** -0.2 raises ZeroDivisionError."""
+    assert lifecycle.retrievability(10_000.0, 0.5) == 0.0  # the underflow is real
+    assert lifecycle.spacing_factor(10_000.0, 0.5, CAP) == CAP
+    assert _reinforce(0.5, 10_000.0) == pytest.approx(1.21)
+
+
+def test_spacing_is_capped_and_monotonic():
+    assert lifecycle.spacing_factor(0.0, 1.0, CAP) == pytest.approx(1.0)
+    assert lifecycle.spacing_factor(1.0, 1.0, CAP) == pytest.approx(math.exp(0.2))
+    assert lifecycle.spacing_factor(100.0, 1.0, CAP) == CAP
+
+
+def test_growth_diminishes_as_stability_rises():
+    """AC3: exactly 74 closely spaced updates from S=1 to the 365 cap.
+
+    "Diminishing" means the *relative* step S'/S, not the absolute increment:
+    the increment is ``g * sqrt(S) * spacing``, which grows with S. The ratio
+    ``1 + g * S^-w * spacing`` is what falls, from 1.61 toward 1.0.
+    """
+    stability = 1.0
+    ratios = []
+    steps = 0
+    while stability < MAX_S and steps < 1000:
+        new_stability = _reinforce(stability, 1.0)
+        ratios.append(new_stability / stability)
+        stability = new_stability
+        steps += 1
+
+    assert steps == 74
+    assert stability == MAX_S
+    assert ratios[0] == pytest.approx(1.61)
+    for earlier, later in zip(ratios, ratios[1:]):
+        assert later < earlier
+
+
+def test_reinforced_stability_never_exceeds_the_cap():
+    assert _reinforce(364.9, 30.0) == MAX_S
+
+
+def test_reinforced_stability_falls_back_when_stability_is_zero():
+    assert _reinforce(0.0, 0.0) == pytest.approx(1.5)
+
+
+def test_reinforcement_is_due_when_a_node_was_never_reviewed():
+    now = datetime.now(timezone.utc)
+    assert lifecycle.reinforcement_due(None, now, 1.0) is True
+
+
+def test_reinforcement_is_not_due_inside_the_cooldown_window():
+    now = datetime.now(timezone.utc)
+    assert lifecycle.reinforcement_due(now - timedelta(hours=6), now, 1.0) is False
+
+
+def test_reinforcement_is_due_once_the_cooldown_elapses():
+    now = datetime.now(timezone.utc)
+    assert lifecycle.reinforcement_due(now - timedelta(days=1), now, 1.0) is True
+
+
+def test_a_zero_cooldown_always_allows_reinforcement():
+    now = datetime.now(timezone.utc)
+    assert lifecycle.reinforcement_due(now, now, 0.0) is True


### PR DESCRIPTION
Closes #221.

## The problem

Reinforcement was unbounded. Every recall multiplied `stability` with no ceiling on how often it could happen, so ten uses in one afternoon compounded ten times. A memory used in a single burst could reach the cap and stop decaying altogether — pinned in `working` forever, which is the opposite of what a forgetting curve is for.

## What changes

**A new pure module, `src/ormah/lifecycle.py`,** owns the formulas: retrievability, spacing, reinforced stability, and cooldown eligibility. No I/O, no DB, no settings object — callers pass knobs in. `memory_engine._touch_access` and `background/decay_manager.run_decay` become thin callers of it.

**Bounded, diminishing growth,** with the curve fixed by #191 and not tuned here:

```text
spacing = min(R^-0.2, fsrs_spacing_cap)
S'      = min(S * (1 + fsrs_growth_factor * S^-fsrs_growth_exponent * spacing),
              fsrs_max_stability)
```

Each step shrinks as stability rises. From `S = 1.0`, reaching `fsrs_max_stability` takes 74 eligible updates.

**A per-node cooldown.** `stability` and `last_review` move at most once per `fsrs_reinforcement_cooldown_days`; `access_count` and `last_accessed` still move on every event. Combined with the default 1-day cooldown, those 74 updates become 74 days of daily use — the AC asked for a bound, and the composition gives a stronger one.

The check-then-write pair is a TOCTOU, so `_touch_access` is now serialized. The regression test counts reinforcement calls rather than asserting final stability: all racing threads read `S = 1.0` and write `1.5`, so the final value cannot distinguish one bump from four. Remove the decorator and the test fails `assert 4 == 1`.

**One retrievability implementation, anchored on use.** `decay_manager` calls `lifecycle.retrievability` instead of its own `math.exp`, and both decay and the importance scorer now anchor on `last_accessed` rather than `last_review` — the cooldown can leave `last_review` a full window behind real use, and an actively used memory must not read as stale.

`importance_scorer.py` gets the anchor flip and nothing else. It keeps its own inline retrievability, because #222 rewrites that line and reading `r["stability"]` there afterwards would raise an `IndexError` the surrounding handler does not catch.

**Four new config knobs** (`fsrs_growth_factor` 0.5, `fsrs_growth_exponent` 0.5, `fsrs_spacing_cap` 2.0, `fsrs_reinforcement_cooldown_days` 1.0) replace `fsrs_stability_growth`, which was a base multiplier with different semantics. Validators reject non-finite values at the config boundary — NaN compares `False` against every `<=` check downstream and would otherwise be serialized straight into frontmatter.

**`meta.fsrs_migrated` becomes `meta.lifecycle_model_version`,** an integer, so a future curve migration can tell which model produced the stored values. Every fallback in reading it resolves to "already migrated": skipping a seed is inert, running one overwrites `stability` and rewrites the Markdown.

## Migration — what happens to an existing store

On first startup, `_migrate_fsrs` reads `meta`. An existing store carries `fsrs_migrated='1'`, so it maps to version 1, the seed does **not** run, and two `meta` rows are written. **No node is touched.** Existing `stability` values are not rescaled, per this issue's own constraint.

The user-visible consequence is documented rather than silently absorbed: a memory the old unbounded formula pushed to `fsrs_max_stability` stays there and needs roughly `-ln(fsrs_decay_threshold) × fsrs_max_stability` days of disuse — about 440 at the defaults — before it decays. Only future growth is bounded. Correcting existing values would need a rescaling migration, deliberately not done here.

### The empty-`meta` case

SQLite is derived state and `backup.py` excludes `index.db` from every backup, so a fresh-device restore arrives with no `meta` at all. Mapping that to version 0 would run the seed over stability the user actually earned.

The durable signal already existed and was simply never consulted: `last_review` lives in the Markdown frontmatter and is restored on rebuild. If any node carries it, the store is not pre-FSRS and the seed is skipped.

**This covers the empty-`meta` case only.** It does nothing for a restore onto an installation whose index is still present: `full_rebuild` preserves `meta` and `reload_restored_graph` never calls `_migrate_fsrs`. That path is a pre-existing defect on `main` today — `_migrate_fsrs` already returns early on `if fsrs_migrated: return` with the same result — and it is tracked separately as #236, not fixed here.

### Downgrade

**Downgrading below this lifecycle model after upgrading is not supported.** Both `lifecycle_model_version` and `fsrs_migrated` are written together, which stops a binary that predates the new key from *reseeding*. That is all it does. The old binary keeps writing `stability` with the unbounded formula while the version marker sits at the new value, and the next upgrade trusts a marker that no longer describes the data. Roll the binary back only together with a backup taken from before the upgrade.

## Review trail

Six task-scoped reviews (one per task, each on its own diff), then a whole-branch review, then an adversarial peer round. Two findings from that round are worth surfacing rather than burying:

**Cross-process races (medium).** The reinforcement lock is an in-process `RLock`. A CLI and a server sharing one memory directory are not excluded from each other, so the cooldown's check-then-write can still interleave across processes. This is not specific to this branch — the whole engine has intra-process-only exclusion — and it is filed as #238. The repository already contains `StoreLock` for exactly this, which makes the fix a matter of applying an existing primitive.

**The `last_review` probe can be defeated by hand-authored Markdown (high).** `store/markdown.py` parses `stability` and `last_review` independently, so a hand-written file carrying `stability: 30` with no `last_review` key produces meaningful stability with no durable signal. If such a store is restored with no index, and no node anywhere in it carries `last_review`, the seed runs and overwrites it.

Real, and narrower than it sounds: it needs a store where not one node has ever been reinforced or seeded. It is also **not a regression** — on `main` today the same empty-`meta` restore seeds unconditionally, destroying the data in every case, while this branch destroys it only in the never-recalled subset. The branch narrows a pre-existing defect without closing it. Appended to #236, whose shape (durable versioning, per-node migration) is what would close it properly.

## Testing

New: `tests/test_lifecycle.py`, `tests/test_config_fsrs.py`, `tests/test_engine/test_reinforcement_cooldown.py`, `tests/test_engine/test_lifecycle_model_version.py`, plus additions to the decay and importance suites.

The tests were checked for discrimination, not just for green: removing the serialization decorator fails the concurrency test; removing the `last_review` guard makes the migration test report `14.0` instead of `1.0`; reverting the decay hardening makes a naive timestamp abort the whole run again. Each of those was run.

Full suite on this branch: 1889–1891 passing. The 11–12 failures are pre-existing and environmental on the development machine — local configuration overriding defaults in `test_config`/`test_consolidator`/`test_session_watcher`, plus `test_setup` cases around the Codex MCP config and the fastembed cache. None touch lifecycle, decay, or stability. `ruff check src/ tests/` is clean.

## Merge order

This should land **after** #234 (#220) and #235 (#222). Without #220 the branch does not literally implement "confirmed use", and #222 rewrites the same `recency_signal` line touched here.
