### PR TITLE
fix(hippocampus): close watcher startup gap

### DIFF
--- a/src/ormah/background/hippocampus.py
+++ b/src/ormah/background/hippocampus.py
@@ -148,19 +148,21 @@ class HippocampusHandler(FileSystemEventHandler):
         watch_dir: Path,
         debounce_seconds: float,
         ignore_patterns: list[str] | None = None,
+        state: dict | None = None,
     ) -> None:
         self.engine = engine
         self.watch_dir = watch_dir
         self.debounce_seconds = debounce_seconds
         self.ignore_patterns = ignore_patterns or []
-        self._state = _load_state(watch_dir)
+        self._state = state if state is not None else _load_state(watch_dir)
         self._timers: dict[str, Timer] = {}
-        self._lock = Lock()
+        self._timer_lock = Lock()
+        self._ingest_lock = Lock()
 
     def _schedule_ingest(self, path: Path) -> None:
         """Schedule a debounced ingestion for the given file."""
         key = str(path)
-        with self._lock:
+        with self._timer_lock:
             if key in self._timers:
                 self._timers[key].cancel()
             timer = Timer(
@@ -174,9 +176,26 @@ class HippocampusHandler(FileSystemEventHandler):
 
     def _do_ingest(self, path: Path) -> None:
         """Actually ingest the file (called after debounce)."""
-        with self._lock:
+        with self._timer_lock:
             self._timers.pop(str(path), None)
-        _ingest_file(self.engine, path, self._state, self.watch_dir, self.ignore_patterns)
+        with self._ingest_lock:
+            _ingest_file(
+                self.engine,
+                path,
+                self._state,
+                self.watch_dir,
+                self.ignore_patterns,
+            )
+
+    def reconcile(self) -> int:
+        """Scan with the live handler's state, serialized against watcher events."""
+        with self._ingest_lock:
+            return _scan_directory(
+                self.engine,
+                self.watch_dir,
+                self.ignore_patterns,
+                state=self._state,
+            )
 
     def on_created(self, event):
         if not event.is_directory and event.src_path.endswith(".md"):
@@ -191,9 +210,12 @@ def _scan_directory(
     engine: MemoryEngine,
     watch_dir: Path,
     ignore_patterns: list[str] | None = None,
+    *,
+    state: dict | None = None,
 ) -> int:
     """Scan a directory for new/changed .md files. Returns count of files ingested."""
-    state = _load_state(watch_dir)
+    if state is None:
+        state = _load_state(watch_dir)
     ingested = 0
     for md_file in sorted(watch_dir.rglob("*.md")):
         if md_file.name == _STATE_FILENAME:
@@ -217,8 +239,9 @@ def _scan_directory(
 def start_hippocampus(engine: MemoryEngine) -> list[Observer]:
     """Start file watchers for all configured hippocampus directories.
 
-    Performs an initial catch-up scan of each directory, then starts
-    real-time watchers. Returns list of Observer instances for shutdown.
+    Performs an initial catch-up scan, starts each real-time watcher, then
+    reconciles once more to close the scan-to-watcher handoff gap. Returns
+    list of Observer instances for shutdown.
     """
     s = engine.settings
     if not s.hippocampus_enabled or not s.hippocampus_watch_dirs:
@@ -231,18 +254,53 @@ def start_hippocampus(engine: MemoryEngine) -> list[Observer]:
         watch_dir = Path(watch_dir).expanduser().resolve()
         watch_dir.mkdir(parents=True, exist_ok=True)
 
-        # Catch-up scan
-        ingested = _scan_directory(engine, watch_dir, ignore_patterns)
+        # Catch up files that predate watcher startup. The same state object is
+        # handed to the live handler so the post-start reconciliation and queued
+        # filesystem events share one hash-based exactly-once gate.
+        state = _load_state(watch_dir)
+        ingested = _scan_directory(
+            engine,
+            watch_dir,
+            ignore_patterns,
+            state=state,
+        )
         if ingested:
             logger.info("Hippocampus catch-up: ingested %d files from %s", ingested, watch_dir)
 
         # Start real-time watcher
-        handler = HippocampusHandler(engine, watch_dir, s.hippocampus_debounce_seconds, ignore_patterns)
+        handler = HippocampusHandler(
+            engine,
+            watch_dir,
+            s.hippocampus_debounce_seconds,
+            ignore_patterns,
+            state=state,
+        )
         observer = Observer()
         observer.schedule(handler, str(watch_dir), recursive=True)
         observer.start()
+
+        # Close the scan-to-watcher handoff gap. A file can appear after the
+        # catch-up scan but before the Observer thread has installed its OS watch.
+        # Reconcile after start while sharing the handler's state and ingest lock;
+        # if a queued event sees the same hash later, it becomes a no-op.
+        try:
+            reconciled = handler.reconcile()
+        except BaseException:
+            # Reconciliation is part of watcher startup. Do not leak this observer
+            # or any previously started directory watchers if startup cannot finish.
+            observer.stop()
+            observer.join(timeout=5)
+            stop_hippocampus(observers)
+            raise
+
         observers.append(observer)
         logger.info("Hippocampus watcher started on %s", watch_dir)
+        if reconciled:
+            logger.info(
+                "Hippocampus startup reconciliation: ingested %d files from %s",
+                reconciled,
+                watch_dir,
+            )
 
     return observers
 

--- a/tests/test_background/test_hippocampus.py
+++ b/tests/test_background/test_hippocampus.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable
 from unittest.mock import patch
 
+from watchdog.events import FileCreatedEvent
 
 from ormah.background.hippocampus import (
     HippocampusHandler,
@@ -47,6 +49,16 @@ _SAMPLE_MD = (
 )
 
 
+def _wait_for(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
+    """Wait for an asynchronous condition without relying on a fixed sleep."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.02)
+    assert predicate(), f"condition was not met within {timeout} seconds"
+
+
 def test_initial_scan_ingests_existing_files(engine, tmp_path):
     """Files present before watcher starts get ingested on catch-up scan."""
     watch_dir = tmp_path / "watch"
@@ -79,12 +91,98 @@ def test_new_file_triggers_ingestion(engine, tmp_path):
         observers = start_hippocampus(engine)
         try:
             (watch_dir / "new_session.md").write_text(_SAMPLE_MD)
-            # Wait for debounce + processing
-            time.sleep(0.5)
+            _wait_for(lambda: "new_session.md" in _load_state(watch_dir))
             state = _load_state(watch_dir)
             assert "new_session.md" in state
         finally:
             stop_hippocampus(observers)
+
+
+def test_startup_reconciliation_catches_file_created_while_observer_starts(
+    engine, tmp_path,
+):
+    """A file landing in the scan-to-watcher handoff is still ingested."""
+    watch_dir = tmp_path / "watch"
+    watch_dir.mkdir()
+    md_file = watch_dir / "during_startup.md"
+
+    engine.settings.hippocampus_watch_dirs = [watch_dir]
+    engine.settings.hippocampus_enabled = True
+
+    class ObserverWithoutEvents:
+        def schedule(self, handler, path, recursive):
+            self.handler = handler
+
+        def start(self):
+            # Simulate a file created after the catch-up scan but before the live
+            # observer can deliver events for the directory.
+            md_file.write_text(_SAMPLE_MD)
+
+        def stop(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    with (
+        patch("ormah.background.hippocampus.Observer", ObserverWithoutEvents),
+        patch(_LLM_PATCH, return_value=_LLM_RESPONSE),
+    ):
+        observers = start_hippocampus(engine)
+
+    try:
+        assert "during_startup.md" in _load_state(watch_dir)
+    finally:
+        stop_hippocampus(observers)
+
+
+def test_startup_event_and_reconciliation_ingest_exactly_once(engine, tmp_path):
+    """The live event and reconciliation scan share one deduplication state."""
+    watch_dir = tmp_path / "watch"
+    watch_dir.mkdir()
+    md_file = watch_dir / "during_startup.md"
+
+    engine.settings.hippocampus_watch_dirs = [watch_dir]
+    engine.settings.hippocampus_enabled = True
+    engine.settings.hippocampus_debounce_seconds = 0.05
+
+    created_observers = []
+
+    class ObserverWithStartupEvent:
+        def __init__(self):
+            created_observers.append(self)
+
+        def schedule(self, handler, path, recursive):
+            self.handler = handler
+
+        def start(self):
+            md_file.write_text(_SAMPLE_MD)
+            self.handler.on_created(FileCreatedEvent(str(md_file)))
+
+        def stop(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    with (
+        patch("ormah.background.hippocampus.Observer", ObserverWithStartupEvent),
+        patch(_LLM_PATCH, return_value=_LLM_RESPONSE) as llm_generate,
+    ):
+        observers = start_hippocampus(engine)
+        handler = created_observers[0].handler
+        _wait_for(
+            lambda: (
+                "during_startup.md" in _load_state(watch_dir)
+                and not handler._timers
+            )
+        )
+
+    try:
+        assert "during_startup.md" in _load_state(watch_dir)
+        assert llm_generate.call_count == 1
+    finally:
+        stop_hippocampus(observers)
 
 
 def test_modified_file_re_ingested(engine, tmp_path):


### PR DESCRIPTION
Closes #244.

## Problem

Hippocampus scanned each directory before starting its asynchronous Watchdog observer. A Markdown file created after that scan but before the OS watch was ready could be missed. The CI test exposed the same handoff race twice: the watcher logged as started, but the new file never reached `.hippocampus_state` before shutdown.

The test also used a fixed 0.5-second sleep, so it could not distinguish a missed event from slow asynchronous processing.

## Solution

- Share one in-memory state object between the catch-up scan, live handler, and startup reconciliation.
- Serialize live event ingestion and reconciliation with a dedicated ingest lock.
- Reconcile once after `Observer.start()` to catch files created in the scan-to-watcher gap.
- Keep hash-based deduplication on that shared state, so a queued live event after reconciliation becomes a no-op.
- Clean up started observers if reconciliation fails during startup.
- Replace the fixed test sleep with bounded condition polling.

## Regression coverage

- A deterministic fake observer creates a file during `start()` without emitting an event; startup reconciliation must ingest it.
- A second fake emits a live event for the same startup file; reconciliation and the event must produce one extraction.
- The original real-Watchdog test waits for the state transition rather than a fixed delay.

## Verification

- `tests/test_background/test_hippocampus.py`: 16 passed
- `tests/test_background`: 200 passed
- Startup race tests repeated 20 times: 60 passed
- `ruff check src/ tests/`: passed
- Full local suite: 1,840 passed, 1 unrelated failure in `test_cloud_settings.py` caused by the local Python 3.14 environment expecting a transient `.env.lock`; this branch does not touch cloud settings
