### PR TITLE
test(hippocampus): prove debounce quiescence instead of sleeping through it

### DIFF
--- a/tests/test_background/test_hippocampus.py
+++ b/tests/test_background/test_hippocampus.py
@@ -59,6 +59,30 @@ def _wait_for(predicate: Callable[[], bool], timeout: float = 5.0) -> None:
     assert predicate(), f"condition was not met within {timeout} seconds"
 
 
+def _drain_timers(handler: HippocampusHandler, timeout: float = 10.0) -> None:
+    """Wait until no debounce timer is armed and no ingestion is still running.
+
+    A sleep cannot show that no second ingestion is coming: a timer armed to fire later
+    runs after the window and after the counting patch is restored, so it never reaches
+    the assertion. Waiting on the handler's own timers can, and anything still armed at
+    the deadline fails the caller instead of being quietly waited out.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        with handler._timer_lock:
+            armed = list(handler._timers.values())
+        if not armed:
+            break
+        assert time.monotonic() < deadline, f"{len(armed)} debounce timer(s) never fired"
+        for timer in armed:
+            timer.join(timeout=max(0.0, deadline - time.monotonic()))
+    # No timer is armed, but _do_ingest drops its timer before taking the ingest lock,
+    # so an empty dict alone would not prove the work is done. Holding that lock does.
+    acquired = handler._ingest_lock.acquire(timeout=max(0.0, deadline - time.monotonic()))
+    assert acquired, "an ingestion was still running"
+    handler._ingest_lock.release()
+
+
 def test_initial_scan_ingests_existing_files(engine, tmp_path):
     """Files present before watcher starts get ingested on catch-up scan."""
     watch_dir = tmp_path / "watch"
@@ -263,10 +287,13 @@ def test_debounce_prevents_duplicate_ingestion(engine, tmp_path):
             handler.on_modified(FileModifiedEvent(str(md_file)))
             time.sleep(0.05)
 
-        # Wait for debounce
-        time.sleep(0.5)
+        # The debounced timer must fire at all -- wait on that, not on a budget.
+        _wait_for(lambda: call_count >= 1)
+        # Then quiesce, still inside the patch, so a late duplicate is counted rather
+        # than slipping past a fixed window with the counter already restored.
+        _drain_timers(handler)
 
-    assert call_count == 1
+        assert call_count == 1
 
 
 def test_state_file_persists(engine, tmp_path):


### PR DESCRIPTION
Follow-up to #245, which landed while this was being prepared. That PR converted
`test_new_file_triggers_ingestion` to `_wait_for` and fixed the flake that had been
reddening unrelated pull requests. This picks up the one wait in the same file it left
behind — and that one is not merely flaky, it is fail-open.

Tests only; nothing under `src/` is touched.

## The problem

`test_debounce_prevents_duplicate_ingestion` proves "no second ingestion arrived" by
sleeping, then asserts **outside** the `with patch(...)` that counts the calls:

```python
        # Wait for debounce
        time.sleep(0.5)

    assert call_count == 1
```

A `Timer` armed to fire after that window runs with the counting patch already restored, so
its call never reaches `call_count`. The duplicate the test exists to catch is invisible to
it. The margin is also thinner than the one #245 just fixed: with `debounce_seconds=0.3` and
five writes at 0.05s intervals, the surviving timer fires around t≈0.55s while the sleep
expires at t≈0.75s.

## The fix

Wait for the first call, then quiesce on the handler's own state rather than on the clock:

- drain the armed timers, and
- take the `_ingest_lock` that `_do_ingest` holds. `_do_ingest` drops its timer from
  `_timers` *before* acquiring that lock, so an empty timer dict alone would not prove the
  work is finished; holding the lock does.

The assertion then runs while the patch still counts. Anything still pending at the deadline
fails the test instead of being quietly waited out.

## Evidence

Arming a duplicate that fires past the old settle window (a 1.5s timer against a 0.6s
window):

| Structure | Result |
|---|---|
| `time.sleep(2 * debounce)`, assert outside the patch | **passes** — the duplicate is never counted |
| drain + assert inside the patch | **fails with `assert 3 == 1`** |

The test still catches what it was written for: with the debounce broken
(`debounce_seconds=0.01`, so each timer fires before the next write cancels it) it fails with
`assert 5 == 1`.

`tests/test_background/test_hippocampus.py` is green (16 passed). `ruff check` is clean.

`time.sleep(0.05)` inside the write loop is a deliberate interval between writes and is
unchanged.
