### PR TITLE
fix(desktop): accept safely redacted auth diagnostics

### DIFF
--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -1062,7 +1062,8 @@ mod tests {
     fn protection_payload_rejects_secret_bearing_fields() {
         assert!(reject_forbidden_response_fields(&json!({
             "state": "protected",
-            "operation": { "id": "safe" }
+            "operation": { "id": "safe" },
+            "message": "Invalid <redacted-credential>"
         }))
         .is_ok());
         for key in [

--- a/src/ormah/cloud/protection.py
+++ b/src/ormah/cloud/protection.py
@@ -103,7 +103,7 @@ def safe_error_message(value: object, *sensitive_values: str | None) -> str:
     message = str(value)
     message = _URL_RE.sub("<redacted-url>", message)
     message = _QUERY_SECRET_RE.sub(r"\1<redacted>", message)
-    message = _BEARER_RE.sub("Bearer <redacted>", message)
+    message = _BEARER_RE.sub("<redacted-credential>", message)
     message = _AGE_SECRET_RE.sub("<redacted-age-key>", message)
     message = _NODE_PATH_RE.sub(r"\1/<redacted>.md", message)
     for sensitive in sensitive_values:

--- a/tests/test_cloud_protection.py
+++ b/tests/test_cloud_protection.py
@@ -648,6 +648,26 @@ def test_product_error_redacts_nonsecret_local_path():
     assert message == "Could not write <redacted-path>"
 
 
+def test_product_error_uses_bridge_safe_placeholder_for_bearer_diagnostics():
+    message = protection.safe_product_error_message(
+        "Authorization failed: Bearer opaque-cloud-token; invalid bearer token."
+    )
+
+    assert "opaque-cloud-token" not in message
+    assert "bearer " not in message.lower()
+    assert message == (
+        "Authorization failed: <redacted-credential> invalid <redacted-credential>"
+    )
+
+
+def test_product_error_repairs_persisted_legacy_bearer_placeholder():
+    message = protection.safe_product_error_message(
+        "The previous request failed with Bearer <redacted>"
+    )
+
+    assert message == "The previous request failed with <redacted-credential>"
+
+
 def test_offline_upload_preserves_verification_health_and_redacts_persisted_error(
     tmp_path, monkeypatch, cloud_state_dir
 ):


### PR DESCRIPTION
## Problem

After moving a desktop installation from staging to production, OTP verification can succeed but the following protection refresh can fail with `The local Ormah service returned forbidden data.`

`safe_error_message()` represented both real bearer material and harmless bearer-auth diagnostics as `Bearer <redacted>`. The native bridge correctly rejects any string containing `Bearer ...`, so the two security layers disagreed about the safe representation. Previously persisted diagnostics could keep triggering the failure after a successful login.

Closes #241.

## Fix

- redact bearer material and bearer-auth phrases to the neutral `<redacted-credential>` placeholder
- sanitize existing persisted `Bearer <redacted>` diagnostics when they are read again
- explicitly lock the Python/Rust contract: the neutral placeholder is accepted, while actual bearer credentials remain rejected

No token handling or bridge permission is loosened.

## Verification

- `tests/test_cloud_protection.py`: 50 passed
- Rust `protection_payload_rejects_secret_bearing_fields`: passed
- Ruff on affected Python files: passed
- `git diff --check`: passed
- combined protection API suite encountered the known sandbox TestClient/AnyIO stall after the directly affected tests passed