### PR TITLE
fix(index): reindexing a node no longer destroys its incoming edges (#123)

### DIFF
--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1545,24 +1545,15 @@ class MemoryEngine:
         ).fetchall()
         original_edges = [dict(r) for r in edge_rows]
 
-        # Capture incoming edges for the kept node that aren't in its markdown.
-        # index_single calls _remove_node which wipes ALL edges (including
-        # incoming ones like self→kept "defines").  We need to restore these.
-        kept_incoming = self.db.conn.execute(
-            "SELECT source_id, target_id, edge_type, weight, created FROM edges "
-            "WHERE target_id = ? AND source_id != ?",
-            (kept.id, removed.id),
-        ).fetchall()
-        kept_incoming_edges = [dict(r) for r in kept_incoming]
-
         # Merge tags from removed into kept
         removed_tags = set(removed.tags) - set(kept.tags)
         if removed_tags:
             kept.tags.extend(sorted(removed_tags))
 
         # Save kept node, re-index, re-embed
-        # NOTE: index_single calls _remove_node internally which wipes edges,
-        # so we must remap edges and restore incoming edges AFTER this step.
+        # NOTE: index_single rebuilds the kept node's OWN edges, so the remap of the removed
+        # node's edges must still happen AFTER this step. Since #123 it no longer touches the
+        # edges pointing AT the kept node.
         kept.touch_updated()
         path = self.file_store.save(kept)
         self.builder.index_single(path)
@@ -1573,7 +1564,8 @@ class MemoryEngine:
             self.builder._remove_node(removed.id)
 
             # Remap edges: point removed→kept (skip self-loops and duplicates)
-            # Done AFTER index_single since that wipes and rebuilds edges for kept node.
+            # Done AFTER index_single since that rebuilds the kept node's OWN edges. Since #123
+            # it no longer touches the edges pointing AT the kept node, so those need no rescue.
             affected_node_ids: set[str] = set()
             for edge in original_edges:
                 new_source = kept.id if edge["source_id"] == removed.id else edge["source_id"]
@@ -1602,20 +1594,6 @@ class MemoryEngine:
                 # Track which nodes need their markdown files updated
                 if edge["source_id"] != removed.id:
                     affected_node_ids.add(edge["source_id"])
-
-            # Restore incoming edges for the kept node that were wiped by index_single
-            for edge in kept_incoming_edges:
-                existing = conn.execute(
-                    "SELECT 1 FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = ?",
-                    (edge["source_id"], edge["target_id"], edge["edge_type"]),
-                ).fetchone()
-                if not existing:
-                    conn.execute(
-                        "INSERT INTO edges (source_id, target_id, edge_type, weight, created) "
-                        "VALUES (?, ?, ?, ?, ?)",
-                        (edge["source_id"], edge["target_id"], edge["edge_type"],
-                         edge["weight"], edge["created"]),
-                    )
 
             # Clean up auto-linker checked pairs:
             # - removed node: delete all (node is gone)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1568,6 +1568,7 @@ class MemoryEngine:
             # it no longer touches the edges pointing AT the kept node from any other node, so
             # those need no rescue.
             affected_node_ids: set[str] = set()
+            remapped_edges: list[dict] = []
             for edge in original_edges:
                 new_source = kept.id if edge["source_id"] == removed.id else edge["source_id"]
                 new_target = kept.id if edge["target_id"] == removed.id else edge["target_id"]
@@ -1600,6 +1601,15 @@ class MemoryEngine:
                     "VALUES (?, ?, ?, ?, ?)",
                     (new_source, new_target, edge["edge_type"], edge["weight"], edge["created"]),
                 )
+                # Record only the rows this loop actually inserted, so undo_merge deletes
+                # exactly those and never a pre-existing edge it never created (#123).
+                remapped_edges.append(
+                    {
+                        "source_id": new_source,
+                        "target_id": new_target,
+                        "edge_type": edge["edge_type"],
+                    }
+                )
 
             # Clean up auto-linker checked pairs:
             # - removed node: delete all (node is gone)
@@ -1619,7 +1629,7 @@ class MemoryEngine:
             conn.execute(
                 "INSERT INTO merge_history "
                 "(id, proposal_id, kept_node_id, removed_node_id, removed_node_snapshot, "
-                "original_edges, merged_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                "original_edges, remapped_edges, merged_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     merge_id,
                     proposal_id,
@@ -1627,6 +1637,7 @@ class MemoryEngine:
                     removed.id,
                     json.dumps(snapshot),
                     json.dumps(original_edges),
+                    json.dumps(remapped_edges),
                     datetime.now(timezone.utc).isoformat(),
                 ),
             )
@@ -1694,15 +1705,34 @@ class MemoryEngine:
         # Delete remapped edges that were created during merge
         # (edges involving kept_id that originated from removed_id)
         original_edges = json.loads(row["original_edges"])
-        with self.db.transaction() as conn:
+
+        # remapped_edges records exactly which rows execute_merge inserted, so undo deletes
+        # only those and never a pre-existing edge the merge skipped (#123). Access it
+        # defensively via row.keys(): a stale connection without the column, or a row written
+        # before this column existed, must fall back to deriving the remapped key from
+        # original_edges — today's behaviour.
+        if "remapped_edges" in row.keys() and row["remapped_edges"] is not None:
+            edges_to_delete = json.loads(row["remapped_edges"])
+        else:
+            edges_to_delete = []
             for edge in original_edges:
                 remapped_source = row["kept_node_id"] if edge["source_id"] == row["removed_node_id"] else edge["source_id"]
                 remapped_target = row["kept_node_id"] if edge["target_id"] == row["removed_node_id"] else edge["target_id"]
                 if remapped_source == remapped_target:
                     continue
+                edges_to_delete.append(
+                    {
+                        "source_id": remapped_source,
+                        "target_id": remapped_target,
+                        "edge_type": edge["edge_type"],
+                    }
+                )
+
+        with self.db.transaction() as conn:
+            for edge in edges_to_delete:
                 conn.execute(
                     "DELETE FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = ?",
-                    (remapped_source, remapped_target, edge["edge_type"]),
+                    (edge["source_id"], edge["target_id"], edge["edge_type"]),
                 )
 
             # Restore original edges (check both endpoints still exist)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1575,6 +1575,15 @@ class MemoryEngine:
                 if new_source == new_target:
                     continue
 
+                # Track which nodes need their markdown files updated. This must run even when
+                # the row itself is skipped below as a pre-existing duplicate: since #123
+                # index_single() no longer wipes the kept node's incoming edges, so a neighbour's
+                # edge into A can already exist before this loop runs, short-circuiting the
+                # "already exists" check below. Without recording it here, that neighbour's
+                # markdown would keep pointing at the soft-deleted removed node (#123).
+                if edge["source_id"] != removed.id:
+                    affected_node_ids.add(edge["source_id"])
+
                 # Skip if edge already exists in either direction
                 existing = conn.execute(
                     "SELECT 1 FROM edges WHERE "
@@ -1590,10 +1599,6 @@ class MemoryEngine:
                     "VALUES (?, ?, ?, ?, ?)",
                     (new_source, new_target, edge["edge_type"], edge["weight"], edge["created"]),
                 )
-
-                # Track which nodes need their markdown files updated
-                if edge["source_id"] != removed.id:
-                    affected_node_ids.add(edge["source_id"])
 
             # Clean up auto-linker checked pairs:
             # - removed node: delete all (node is gone)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1553,7 +1553,7 @@ class MemoryEngine:
         # Save kept node, re-index, re-embed
         # NOTE: index_single rebuilds the kept node's OWN edges, so the remap of the removed
         # node's edges must still happen AFTER this step. Since #123 it no longer touches the
-        # edges pointing AT the kept node.
+        # edges pointing AT the kept node from any other node.
         kept.touch_updated()
         path = self.file_store.save(kept)
         self.builder.index_single(path)
@@ -1565,7 +1565,8 @@ class MemoryEngine:
 
             # Remap edges: point removed→kept (skip self-loops and duplicates)
             # Done AFTER index_single since that rebuilds the kept node's OWN edges. Since #123
-            # it no longer touches the edges pointing AT the kept node, so those need no rescue.
+            # it no longer touches the edges pointing AT the kept node from any other node, so
+            # those need no rescue.
             affected_node_ids: set[str] = set()
             for edge in original_edges:
                 new_source = kept.id if edge["source_id"] == removed.id else edge["source_id"]

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1653,6 +1653,15 @@ class MemoryEngine:
             # mutation below. A retarget made later in this same loop must never be mistaken
             # for a pre-existing declaration by a subsequent connection to removed (#123).
             existing_kept_edges = {c.edge for c in neighbor.connections if c.target == kept.id}
+            # When the neighbour declares the same edge_type toward removed more than once,
+            # only the LAST declaration is retargeted. _index_file_edges writes edges with
+            # INSERT OR REPLACE on (source_id, target_id, edge_type), so the last markdown
+            # declaration is what becomes effective at reindex time — the retarget must keep
+            # that same winner, not the first one (#123).
+            last_removed_connection_by_edge: dict = {}
+            for c in neighbor.connections:
+                if c.target == removed.id:
+                    last_removed_connection_by_edge[c.edge] = c
             new_connections: list = []
             updated = False
             for c in neighbor.connections:
@@ -1662,9 +1671,14 @@ class MemoryEngine:
                         # would create a second (source, kept, edge_type) connection, which
                         # collides at reindex time and silently clobbers the pre-existing
                         # edge's weight (INSERT OR REPLACE, last one wins) (#123). Drop this
-                        # connection instead. Also covers two connections to removed sharing
-                        # one edge_type: the first is retargeted below and joins
-                        # existing_kept_edges, so the second is dropped here too.
+                        # connection instead. Covers every connection to removed sharing that
+                        # edge_type, since the pre-existing declaration always wins.
+                        updated = True
+                        continue
+                    if last_removed_connection_by_edge[c.edge] is not c:
+                        # An earlier duplicate declaration of this edge_type toward removed:
+                        # the later one (retargeted below) is the effective one after
+                        # reindexing, so drop this one silently (#123).
                         updated = True
                         continue
                     c.target = kept.id

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1649,12 +1649,30 @@ class MemoryEngine:
             neighbor = self.file_store.load(node_id)
             if neighbor is None:
                 continue
+            # Edge types the neighbour already declares toward kept, snapshotted before any
+            # mutation below. A retarget made later in this same loop must never be mistaken
+            # for a pre-existing declaration by a subsequent connection to removed (#123).
+            existing_kept_edges = {c.edge for c in neighbor.connections if c.target == kept.id}
+            new_connections: list = []
             updated = False
             for c in neighbor.connections:
                 if c.target == removed.id:
+                    if c.edge in existing_kept_edges:
+                        # Neighbour already declares this edge type toward kept: retargeting
+                        # would create a second (source, kept, edge_type) connection, which
+                        # collides at reindex time and silently clobbers the pre-existing
+                        # edge's weight (INSERT OR REPLACE, last one wins) (#123). Drop this
+                        # connection instead. Also covers two connections to removed sharing
+                        # one edge_type: the first is retargeted below and joins
+                        # existing_kept_edges, so the second is dropped here too.
+                        updated = True
+                        continue
                     c.target = kept.id
+                    existing_kept_edges.add(c.edge)
                     updated = True
+                new_connections.append(c)
             if updated:
+                neighbor.connections = new_connections
                 neighbor.touch_updated()
                 self.file_store.save(neighbor)
 

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -256,7 +256,8 @@ class IndexBuilder:
                 two callers keep exactly today's behaviour: `incremental_update` leaves it
                 False (it used `keep_vectors=True`, and it never re-embeds — dropping the
                 vector there is permanent loss), and `index_single` passes True (it used the
-                `keep_vectors=False` default, and its callers re-embed afterwards).
+                `keep_vectors=False` default, and its callers re-embed afterwards — except
+                `mark_outdated`, which does not).
         """
         conn = self.db.conn
         conn.execute("DELETE FROM node_tags WHERE node_id = ?", (node_id,))

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -101,7 +101,7 @@ class IndexBuilder:
                         self._index_file(path, file_hash)
                         added += 1
                     elif indexed[node.id] != file_hash:
-                        self._remove_node(node.id, keep_vectors=True)
+                        self._clear_derived(node.id)
                         self._index_file(path, file_hash)
                         updated += 1
                 except Exception as e:
@@ -119,7 +119,7 @@ class IndexBuilder:
         node = parse_node(path.read_text(encoding="utf-8"))
         file_hash = self.file_store.file_hash(path)
         with self.db.transaction():
-            self._remove_node(node.id)
+            self._clear_derived(node.id, drop_vector=True)
             self._index_file(path, file_hash)
 
     def _index_file(self, path: Path, file_hash: str) -> None:
@@ -135,12 +135,30 @@ class IndexBuilder:
 
         conn.execute(
             """
-            INSERT OR REPLACE INTO nodes
+            INSERT INTO nodes
             (id, type, tier, source, space, title, content, created, updated,
              last_accessed, access_count, confidence, importance,
              valid_until, stability, last_review, file_path, file_hash)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                type = excluded.type,
+                tier = excluded.tier,
+                source = excluded.source,
+                space = excluded.space,
+                title = excluded.title,
+                content = excluded.content,
+                created = excluded.created,
+                updated = excluded.updated,
+                last_accessed = excluded.last_accessed,
+                access_count = excluded.access_count,
+                confidence = excluded.confidence,
+                importance = excluded.importance,
+                valid_until = excluded.valid_until,
+                stability = excluded.stability,
+                last_review = excluded.last_review,
+                file_path = excluded.file_path,
+                file_hash = excluded.file_hash
             """,
             (
                 node.id,
@@ -221,15 +239,41 @@ class IndexBuilder:
                 (node.id, c.target, c.edge.value, c.weight, node.created.isoformat()),
             )
 
-    def _remove_node(self, node_id: str, *, keep_vectors: bool = False) -> None:
-        """Remove a node and its related data from the index.
+    def _clear_derived(self, node_id: str, *, drop_vector: bool = False) -> None:
+        """Clear what this node's own markdown produces, keeping the node row itself (#123).
+
+        This is the REINDEX path. The `nodes` row must survive: `edges.target_id` is
+        `REFERENCES nodes(id) ON DELETE CASCADE`, so deleting it — or writing it with
+        `INSERT OR REPLACE`, which is a delete underneath — destroys every edge pointing AT
+        this node. Those rows are declared in OTHER nodes' markdown files, which a reindex of
+        this node never reads and cannot reconstruct.
+
+        Only `source_id` edges are cleared. A row in `edges` belongs to the markdown file of
+        its source, and `_index_file_edges` reinserts exactly that set.
 
         Args:
-            keep_vectors: If True, preserve the node_vectors row. Used by
-                incremental_update where the markdown file changed but the
-                embedding content hasn't — deleting the vector would cause
-                permanent embedding loss since the index updater doesn't
-                re-embed.
+            drop_vector: delete the `node_vectors` row so the embedding is regenerated. The
+                two callers keep exactly today's behaviour: `incremental_update` leaves it
+                False (it used `keep_vectors=True`, and it never re-embeds — dropping the
+                vector there is permanent loss), and `index_single` passes True (it used the
+                `keep_vectors=False` default, and its callers re-embed afterwards).
+        """
+        conn = self.db.conn
+        conn.execute("DELETE FROM node_tags WHERE node_id = ?", (node_id,))
+        conn.execute("DELETE FROM edges WHERE source_id = ?", (node_id,))
+        conn.execute("DELETE FROM nodes_fts WHERE id = ?", (node_id,))
+        if drop_vector:
+            try:
+                conn.execute("DELETE FROM node_vectors WHERE id = ?", (node_id,))
+            except Exception:
+                pass
+
+    def _remove_node(self, node_id: str) -> None:
+        """Remove a node and everything derived from it — the file is gone from disk.
+
+        The `ON DELETE CASCADE` on `edges` is correct here: an edge pointing at a node that no
+        longer exists is a foreign-key violation. For the REINDEX path, where the node survives,
+        use `_clear_derived` instead (#123).
         """
         conn = self.db.conn
         conn.execute("DELETE FROM node_tags WHERE node_id = ?", (node_id,))
@@ -239,8 +283,7 @@ class IndexBuilder:
         conn.execute("DELETE FROM nodes_fts WHERE id = ?", (node_id,))
         conn.execute("DELETE FROM nodes WHERE id = ?", (node_id,))
         # Vector cleanup if table exists
-        if not keep_vectors:
-            try:
-                conn.execute("DELETE FROM node_vectors WHERE id = ?", (node_id,))
-            except Exception:
-                pass
+        try:
+            conn.execute("DELETE FROM node_vectors WHERE id = ?", (node_id,))
+        except Exception:
+            pass

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -249,7 +249,10 @@ class IndexBuilder:
         this node never reads and cannot reconstruct.
 
         Only `source_id` edges are cleared. A row in `edges` belongs to the markdown file of
-        its source, and `_index_file_edges` reinserts exactly that set.
+        its source, and `_index_file_edges` reinserts that set MINUS any connection whose
+        reverse of the same edge_type already exists: if that reverse row lives only in
+        `edges` and not in any markdown, this node's own declared edge is dropped until this
+        node's file changes again or a full rebuild runs.
 
         Args:
             drop_vector: delete the `node_vectors` row so the embedding is regenerated. The

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -130,6 +130,14 @@ class Database:
             if "reason" not in edge_cols:
                 conn.execute("ALTER TABLE edges ADD COLUMN reason TEXT")
 
+            # Add remapped_edges column to merge_history table if missing
+            merge_history_cols = [
+                row[1]
+                for row in conn.execute("PRAGMA table_info(merge_history)").fetchall()
+            ]
+            if "remapped_edges" not in merge_history_cols:
+                conn.execute("ALTER TABLE merge_history ADD COLUMN remapped_edges TEXT")
+
             # Add enrichment columns to nodes table if missing
             node_cols = [
                 row[1]

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -76,6 +76,9 @@ CREATE TABLE IF NOT EXISTS merge_history (
     removed_node_id TEXT NOT NULL,
     removed_node_snapshot TEXT NOT NULL,  -- full MemoryNode JSON
     original_edges TEXT NOT NULL,         -- JSON array of edge dicts
+    remapped_edges TEXT,                  -- JSON array of edges execute_merge actually inserted
+                                           -- (source_id, target_id, edge_type); NULL for rows
+                                           -- written before this column existed
     merged_at TEXT NOT NULL,
     undone_at TEXT                        -- NULL until rollback
 );

--- a/tests/test_engine/test_merge_undo.py
+++ b/tests/test_engine/test_merge_undo.py
@@ -470,3 +470,107 @@ def test_merge_retargets_neighbour_markdown_when_the_remap_is_skipped(engine):
     targets = [c.target for c in after.connections]
     assert id_b not in targets, "C's markdown still points at the removed node"
     assert id_a in targets, "C's markdown should be retargeted at the kept node"
+
+
+def test_merge_does_not_duplicate_a_collided_neighbour_connection(engine):
+    """A neighbour that already declares both C->kept and C->removed with the same edge type
+    must not end up with two connections to kept after the merge (#123).
+
+    Before the fix, execute_merge's neighbour markdown pass blindly retargets every
+    connection whose target is `removed`, so C ends up declaring `C -> A` twice with the
+    same edge type (once pre-existing, once retargeted from `C -> B`). execute_merge itself
+    does not reindex C, so this is invisible until the next incremental_update(): reindexing
+    C clears its outgoing edges and reinserts from markdown via INSERT OR REPLACE on
+    (source_id, target_id, edge_type) — last one wins, silently overwriting the pre-existing
+    0.8-weight edge with the retargeted 0.6-weight one.
+    """
+    from ormah.models.node import Connection
+
+    original_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        id_a, _ = _create_node(
+            engine, title="Kept", content="This node will be kept because it is much longer"
+        )
+        id_b, _ = _create_node(engine, title="Removed", content="Short")
+        id_c, _ = _create_node(engine, title="Third", content="An unrelated third node entirely")
+    finally:
+        engine.settings.auto_link_similarity_threshold = original_threshold
+
+    # C declares C -> A (supports, 0.8) and C -> B (supports, 0.6) — same edge type, so
+    # retargeting the B connection collides with the pre-existing A connection.
+    node_c = engine.file_store.load(id_c)
+    node_c.connections.append(Connection(target=id_a, edge=EdgeType.supports, weight=0.8))
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.6))
+    engine.file_store.save(node_c)
+    engine.builder.index_single(engine.file_store._path_for(node_c))
+
+    engine.execute_merge(id_a, id_b)
+
+    # This is the step that surfaces the clobber in production: the 60s index updater
+    # reindexes any markdown file that changed, including C's rewritten markdown.
+    engine.builder.incremental_update()
+
+    after = engine.file_store.load(id_c)
+    a_connections = [c for c in after.connections if c.target == id_a]
+    assert len(a_connections) == 1, (
+        f"C's markdown should have exactly one connection to A, got {len(a_connections)}"
+    )
+
+    row = engine.db.conn.execute(
+        "SELECT weight FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = ?",
+        (id_c, id_a, EdgeType.supports.value),
+    ).fetchone()
+    assert row is not None, "C -> A supports edge should exist"
+    assert row["weight"] == 0.8, (
+        f"C -> A supports edge should keep its original weight 0.8, got {row['weight']}"
+    )
+
+
+def test_merge_retargets_a_neighbour_connection_whose_edge_type_does_not_collide(engine):
+    """A neighbour connection to `removed` must still be retargeted when its edge type does
+    not collide with any connection the neighbour already has pointing at `kept` (#123).
+
+    Pins that the collision-avoidance fix does not over-correct into dropping every
+    retarget: C -> B (contradicts) has no matching C -> A (contradicts), so it must survive
+    as its own retargeted edge, distinct from the pre-existing C -> A (supports).
+    """
+    from ormah.models.node import Connection
+
+    original_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        id_a, _ = _create_node(
+            engine, title="Kept", content="This node will be kept because it is much longer"
+        )
+        id_b, _ = _create_node(engine, title="Removed", content="Short")
+        id_c, _ = _create_node(engine, title="Third", content="An unrelated third node entirely")
+    finally:
+        engine.settings.auto_link_similarity_threshold = original_threshold
+
+    # C declares C -> A (supports, 0.8) and C -> B (contradicts, 0.6) — different edge
+    # types, so no collision: both must survive after the merge.
+    node_c = engine.file_store.load(id_c)
+    node_c.connections.append(Connection(target=id_a, edge=EdgeType.supports, weight=0.8))
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.contradicts, weight=0.6))
+    engine.file_store.save(node_c)
+    engine.builder.index_single(engine.file_store._path_for(node_c))
+
+    engine.execute_merge(id_a, id_b)
+    engine.builder.incremental_update()
+
+    after = engine.file_store.load(id_c)
+    a_edges = {c.edge for c in after.connections if c.target == id_a}
+    assert EdgeType.supports in a_edges, "C -> A supports should still exist"
+    assert EdgeType.contradicts in a_edges, "C -> A contradicts should have been retargeted from B"
+
+    supports_row = engine.db.conn.execute(
+        "SELECT weight FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = ?",
+        (id_c, id_a, EdgeType.supports.value),
+    ).fetchone()
+    contradicts_row = engine.db.conn.execute(
+        "SELECT weight FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = ?",
+        (id_c, id_a, EdgeType.contradicts.value),
+    ).fetchone()
+    assert supports_row is not None and supports_row["weight"] == 0.8
+    assert contradicts_row is not None and contradicts_row["weight"] == 0.6

--- a/tests/test_engine/test_merge_undo.py
+++ b/tests/test_engine/test_merge_undo.py
@@ -340,3 +340,43 @@ def test_merge_preserves_third_party_incoming_edge(engine):
     assert after[0]["edge_type"] == "supports"
     assert after[0]["weight"] == 0.8, "weight 0.8, not the 0.5 default — this is D's declared row"
     assert after[0]["created"] == before[0]["created"], "the row was recreated, not preserved"
+
+
+def test_merge_retargets_neighbour_markdown_when_the_remap_is_skipped(engine):
+    """A neighbour's markdown must be retargeted even when its edge row already exists (#123).
+
+    Since #123, index_single(kept) no longer wipes the kept node's incoming edges. That means
+    a neighbour's edge into the kept node can already be present in the DB before the remap
+    loop runs, so the "edge already exists" check short-circuits that row and the INSERT is
+    skipped. affected_node_ids must still be recorded for that neighbour, or the markdown
+    rewrite pass never fires and the neighbour's connections keep pointing at the soft-deleted
+    removed node.
+    """
+    from ormah.models.node import Connection
+
+    original_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        id_a, _ = _create_node(
+            engine, title="Kept", content="This node will be kept because it is much longer"
+        )
+        id_b, _ = _create_node(engine, title="Removed", content="Short")
+        id_c, _ = _create_node(engine, title="Third", content="An unrelated third node entirely")
+    finally:
+        engine.settings.auto_link_similarity_threshold = original_threshold
+
+    # C declares C -> A and C -> B in its own markdown, so index_single(C) creates the A edge
+    # in the DB up front — the exact precondition that makes the "already exists" check fire
+    # for the remapped B -> A row during the merge.
+    node_c = engine.file_store.load(id_c)
+    node_c.connections.append(Connection(target=id_a, edge=EdgeType.supports, weight=0.8))
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.6))
+    engine.file_store.save(node_c)
+    engine.builder.index_single(engine.file_store._path_for(node_c))
+
+    engine.execute_merge(id_a, id_b)
+
+    after = engine.file_store.load(id_c)
+    targets = [c.target for c in after.connections]
+    assert id_b not in targets, "C's markdown still points at the removed node"
+    assert id_a in targets, "C's markdown should be retargeted at the kept node"

--- a/tests/test_engine/test_merge_undo.py
+++ b/tests/test_engine/test_merge_undo.py
@@ -299,3 +299,44 @@ def test_undo_missing_merge_returns_error(engine):
     """Undoing a non-existent merge returns an error string."""
     result = engine.undo_merge("nonexistent-id")
     assert "not found" in result
+
+
+def test_merge_preserves_third_party_incoming_edge(engine):
+    """A third node pointing AT the kept node must survive the merge (#123).
+
+    The merge path calls index_single(kept). Before #123 that destroyed every edge pointing
+    at kept, and merge_nodes hand-restored them. This test is what makes deleting that
+    workaround a proof rather than an assumption: no existing merge test creates D -> kept,
+    so the suite could stay green while exactly this edge was lost.
+    """
+    from ormah.models.node import Connection
+
+    id_a, _ = _create_node(engine, title="Kept", content="This node will be kept because longer")
+    id_b, _ = _create_node(engine, title="Removed", content="Shorter content")
+    id_d, _ = _create_node(engine, title="Third", content="An unrelated third node")
+
+    # D -> kept, declared in D's own markdown — the path index_single re-reads.
+    node_d = engine.file_store.load(id_d)
+    node_d.connections.append(
+        Connection(target=id_a, edge=EdgeType.supports, weight=0.8)
+    )
+    engine.file_store.save(node_d)
+    engine.builder.index_single(engine.file_store._path_for(node_d))
+
+    def third_party():
+        return engine.db.conn.execute(
+            "SELECT source_id, target_id, edge_type, weight, created FROM edges "
+            "WHERE source_id = ? AND target_id = ?",
+            (id_d, id_a),
+        ).fetchall()
+
+    before = third_party()
+    assert len(before) == 1, "sanity: D -> kept must exist before the merge"
+
+    engine.execute_merge(id_a, id_b)
+
+    after = third_party()
+    assert len(after) == 1, "merge destroyed the third-party incoming edge (#123)"
+    assert after[0]["edge_type"] == "supports"
+    assert after[0]["weight"] == 0.8, "weight 0.8, not the 0.5 default — this is D's declared row"
+    assert after[0]["created"] == before[0]["created"], "the row was recreated, not preserved"

--- a/tests/test_engine/test_merge_undo.py
+++ b/tests/test_engine/test_merge_undo.py
@@ -243,6 +243,96 @@ def test_undo_removes_remapped_edges(engine):
     assert len(after_undo) == 0
 
 
+def test_undo_does_not_delete_a_preexisting_collided_edge(engine):
+    """Undo must not delete an edge undo never created (Codex council finding, #123).
+
+    C declares BOTH C->A and C->B with the SAME edge_type in its own markdown. During the
+    merge, the remap loop for B->A skips the INSERT because C->A already exists (the
+    "already exists in either direction" check). undo_merge must not delete that
+    pre-existing C->A row just because it appears, remapped, in original_edges — it was
+    never inserted by execute_merge.
+    """
+    from ormah.models.node import Connection
+
+    original_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        id_a, _ = _create_node(
+            engine, title="Kept", content="This node is kept because its content is much longer"
+        )
+        id_b, _ = _create_node(engine, title="Removed", content="Short")
+        id_c, _ = _create_node(engine, title="Third", content="An unrelated third node entirely")
+    finally:
+        engine.settings.auto_link_similarity_threshold = original_threshold
+
+    # C -> A (weight 0.8) and C -> B (weight 0.6), same edge_type — the collision.
+    node_c = engine.file_store.load(id_c)
+    node_c.connections.append(Connection(target=id_a, edge=EdgeType.supports, weight=0.8))
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.6))
+    engine.file_store.save(node_c)
+    engine.builder.index_single(engine.file_store._path_for(node_c))
+
+    def c_to_a():
+        return engine.db.conn.execute(
+            "SELECT weight FROM edges WHERE source_id = ? AND target_id = ? "
+            "AND edge_type = 'supports'",
+            (id_c, id_a),
+        ).fetchall()
+
+    before = c_to_a()
+    assert len(before) == 1, "sanity: C -> A exists before the merge"
+
+    engine.execute_merge(id_a, id_b)
+    assert len(c_to_a()) == 1, "C -> A must survive the merge"
+
+    merge = engine.list_merges()[0]
+    engine.undo_merge(merge["id"])
+
+    after = c_to_a()
+    assert len(after) == 1, (
+        "undo deleted a pre-existing edge it never created: C -> A existed before the merge "
+        "and execute_merge skipped remapping it (already exists), but undo removed it anyway"
+    )
+    assert after[0]["weight"] == 0.8, "C -> A came back with the wrong weight"
+
+
+def test_undo_falls_back_when_remapped_edges_is_null(engine):
+    """Merge history rows written before this change (remapped_edges NULL) still undo
+    correctly: undo falls back to deriving the remapped key from original_edges."""
+    id_a, _ = _create_node(engine, title="A", content="Longer content for keeping")
+    id_b, _ = _create_node(engine, title="B", content="Short content")
+    id_c, _ = _create_node(engine, title="C", content="Neighbor node content")
+
+    # Create edge: B -> C (will be remapped to A -> C during merge)
+    engine.connect(ConnectRequest(
+        source_id=id_b, target_id=id_c, edge=EdgeType.supports, weight=0.8
+    ))
+
+    engine.execute_merge(id_a, id_b)
+
+    post_edges = engine.db.conn.execute(
+        "SELECT * FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = 'supports'",
+        (id_a, id_c),
+    ).fetchall()
+    assert len(post_edges) >= 1, "sanity: A -> C exists after merge (remapped)"
+
+    merge = engine.list_merges()[0]
+
+    # Simulate a merge_history row written before this change.
+    engine.db.conn.execute(
+        "UPDATE merge_history SET remapped_edges = NULL WHERE id = ?", (merge["id"],)
+    )
+    engine.db.conn.commit()
+
+    engine.undo_merge(merge["id"])
+
+    after_undo = engine.db.conn.execute(
+        "SELECT * FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = 'supports'",
+        (id_a, id_c),
+    ).fetchall()
+    assert len(after_undo) == 0, "fallback path must still remove the remapped edge"
+
+
 def test_undo_prefix_match(engine):
     """undo_merge supports prefix matching on merge IDs."""
     id_a, _ = _create_node(engine, title="A", content="Content A")

--- a/tests/test_engine/test_merge_undo.py
+++ b/tests/test_engine/test_merge_undo.py
@@ -574,3 +574,113 @@ def test_merge_retargets_a_neighbour_connection_whose_edge_type_does_not_collide
     ).fetchone()
     assert supports_row is not None and supports_row["weight"] == 0.8
     assert contradicts_row is not None and contradicts_row["weight"] == 0.6
+
+
+def test_merge_coalesces_duplicate_removed_connections_to_the_last_declaration(engine):
+    """When a neighbour declares the SAME edge type toward `removed` twice, the retarget must
+    keep the LAST declaration, matching what _index_file_edges makes effective (#123).
+
+    `_index_file_edges` writes edges with INSERT OR REPLACE on
+    (source_id, target_id, edge_type), so when a markdown file declares the same
+    (target, edge_type) pair twice, the LAST declaration wins at reindex time. C has no
+    connection to A at all here — only two declarations of C -> B, same edge type, different
+    weights — so the retargeted C -> A connection must carry the weight of the second
+    (last) one, not the first.
+    """
+    from ormah.models.node import Connection
+
+    original_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        id_a, _ = _create_node(
+            engine, title="Kept", content="This node will be kept because it is much longer"
+        )
+        id_b, _ = _create_node(engine, title="Removed", content="Short")
+        id_c, _ = _create_node(engine, title="Third", content="An unrelated third node entirely")
+    finally:
+        engine.settings.auto_link_similarity_threshold = original_threshold
+
+    # C declares C -> B (supports, 0.8) then C -> B (supports, 0.6) — same edge type, no
+    # connection to A at all. Last declaration (0.6) is the effective one.
+    node_c = engine.file_store.load(id_c)
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.8))
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.6))
+    engine.file_store.save(node_c)
+    engine.builder.index_single(engine.file_store._path_for(node_c))
+
+    engine.execute_merge(id_a, id_b)
+
+    # This is the step that surfaces the wrong winner in production: the 60s index updater
+    # reindexes any markdown file that changed, including C's rewritten markdown.
+    engine.builder.incremental_update()
+
+    after = engine.file_store.load(id_c)
+    a_connections = [c for c in after.connections if c.target == id_a]
+    assert len(a_connections) == 1, (
+        f"C's markdown should have exactly one connection to A, got {len(a_connections)}"
+    )
+    assert a_connections[0].weight == 0.6, (
+        f"C -> A should carry the LAST declaration's weight 0.6, got {a_connections[0].weight}"
+    )
+
+    row = engine.db.conn.execute(
+        "SELECT weight FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = ?",
+        (id_c, id_a, EdgeType.supports.value),
+    ).fetchone()
+    assert row is not None, "C -> A supports edge should exist"
+    assert row["weight"] == 0.6, (
+        f"C -> A supports edge should carry the last declaration's weight 0.6, got {row['weight']}"
+    )
+
+
+def test_merge_keeps_the_preexisting_declaration_when_duplicates_collide(engine):
+    """When a neighbour already declares the edge type toward `kept`, that pre-existing
+    declaration wins over BOTH duplicate declarations toward `removed`, no matter which of
+    the duplicates would otherwise be the last one (#123).
+
+    C declares C -> A (supports, 0.9) first, then two C -> B (supports) declarations. The
+    pre-existing C -> A connection must survive with its own weight 0.9; both C -> B
+    declarations are dropped entirely, not coalesced into a competing retarget.
+    """
+    from ormah.models.node import Connection
+
+    original_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        id_a, _ = _create_node(
+            engine, title="Kept", content="This node will be kept because it is much longer"
+        )
+        id_b, _ = _create_node(engine, title="Removed", content="Short")
+        id_c, _ = _create_node(engine, title="Third", content="An unrelated third node entirely")
+    finally:
+        engine.settings.auto_link_similarity_threshold = original_threshold
+
+    # C declares C -> A (supports, 0.9), then C -> B (supports, 0.8), then C -> B
+    # (supports, 0.6). The pre-existing C -> A declaration must win.
+    node_c = engine.file_store.load(id_c)
+    node_c.connections.append(Connection(target=id_a, edge=EdgeType.supports, weight=0.9))
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.8))
+    node_c.connections.append(Connection(target=id_b, edge=EdgeType.supports, weight=0.6))
+    engine.file_store.save(node_c)
+    engine.builder.index_single(engine.file_store._path_for(node_c))
+
+    engine.execute_merge(id_a, id_b)
+    engine.builder.incremental_update()
+
+    after = engine.file_store.load(id_c)
+    a_connections = [c for c in after.connections if c.target == id_a]
+    assert len(a_connections) == 1, (
+        f"C's markdown should have exactly one connection to A, got {len(a_connections)}"
+    )
+    assert a_connections[0].weight == 0.9, (
+        f"C -> A should keep its pre-existing weight 0.9, got {a_connections[0].weight}"
+    )
+
+    row = engine.db.conn.execute(
+        "SELECT weight FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = ?",
+        (id_c, id_a, EdgeType.supports.value),
+    ).fetchone()
+    assert row is not None, "C -> A supports edge should exist"
+    assert row["weight"] == 0.9, (
+        f"C -> A supports edge should keep the pre-existing weight 0.9, got {row['weight']}"
+    )

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -329,6 +329,11 @@ def test_reindex_keeps_the_incumbent_canonical_direction(engine):
     unrelated `related_to` B -> A edge (persisted into B's own markdown, same as any other
     connection) before this test ever declares its own `supports` connection -- a confound
     unrelated to the canonicalisation mechanism under test.
+
+    The weights are deliberately inverted against the outcome: A, indexed first, gets the
+    LOWER weight (0.2) and B gets the HIGHER weight (0.9), so A's row surviving can only be
+    explained by index order, not by a hypothetical "higher weight wins" rule -- there is no
+    weight comparison anywhere in `_index_file_edges` or `_clear_derived`.
     """
     from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
 
@@ -344,13 +349,13 @@ def test_reindex_keeps_the_incumbent_canonical_direction(engine):
 
     node_a = engine.file_store.load(id_a)
     node_a.connections.append(
-        Connection(target=id_b, edge=EdgeType.supports, weight=0.9)
+        Connection(target=id_b, edge=EdgeType.supports, weight=0.2)
     )
     engine.file_store.save(node_a)
 
     node_b = engine.file_store.load(id_b)
     node_b.connections.append(
-        Connection(target=id_a, edge=EdgeType.supports, weight=0.2)
+        Connection(target=id_a, edge=EdgeType.supports, weight=0.9)
     )
     engine.file_store.save(node_b)
 
@@ -366,4 +371,4 @@ def test_reindex_keeps_the_incumbent_canonical_direction(engine):
 
     assert len(rows) == 1, "the pair must be represented by exactly one canonical row"
     assert rows[0]["source_id"] == id_a, "reindexing B flipped the canonical direction"
-    assert rows[0]["weight"] == 0.9, "A's weight, not B's 0.2 — the incumbent's row is the one kept"
+    assert rows[0]["weight"] == 0.2, "A's weight, not B's 0.9 — the incumbent's row is the one kept"

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -199,10 +199,11 @@ def test_touch_updated_does_not_drop_incoming_edges(engine):
     and duplicate_merger all skip a pair already recorded in `auto_link_checked`. Nothing
     ever recreates the edge; the loss stands until a full rebuild.
 
-    Self-feeding on the Beta: the auto-linker touches the node before saving, so creating
-    any new link on a node destroys that node's own incoming edges. The same shape drives
-    the importance scorer, which touched 5,216 nodes in one pass on 2026-08-21 and cost
-    ~13,800 edges in 54 minutes.
+    Self-feeding: the auto-linker touches the node before saving, so creating any new link
+    on a node destroys that node's own incoming edges. Any job that rewrites a node's
+    markdown and calls `touch_updated()` — the auto-linker and the importance scorer both
+    do — drives this same reindex path, so the loss compounds across the whole store
+    rather than needing a user edit.
     """
     from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
 
@@ -238,9 +239,10 @@ def test_incremental_update_preserves_incoming_edges(engine):
     """The path production actually takes: the 60s index updater (#123).
 
     `index_single` is not the production trigger. `incremental_update` is — it walks the
-    store, sees B's file_hash changed, and calls `_remove_node(id, keep_vectors=True)` at
-    builder.py:104, a DIFFERENT call site from the one index_single uses (:122). A fix
-    applied only to index_single leaves this path destroying incoming edges once a minute.
+    store, sees B's file_hash changed, and calls `_clear_derived(node.id)` at builder.py:104
+    (before #123, this called `_remove_node(id, keep_vectors=True)`), a DIFFERENT call site
+    from the one index_single uses (:122). A fix applied only to index_single leaves this
+    path destroying incoming edges once a minute.
     """
     from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
 
@@ -348,7 +350,7 @@ def test_reindex_keeps_the_incumbent_canonical_direction(engine):
     """When both files declare the same link, the incumbent row wins — stably.
 
     `_index_file_edges` skips inserting A -> B when the reverse B -> A already exists with
-    the same edge type (builder.py:208-214). Before #123 was fixed, reindexing B destroyed both
+    the same edge type (builder.py:226-232). Before #123 was fixed, reindexing B destroyed both
     directions, so B's own declaration was reinserted and the surviving direction was
     whichever node happened to be reindexed last. Now the incumbent survives and B's
     declaration is skipped: deterministic, and NOT a regression.

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -150,3 +150,127 @@ def test_builder_never_takes_file_lock_inside_write_transaction(engine):
     assert engine.builder.incremental_update() == (0, 0)
 
     assert not violations, f"FileStore lock acquired inside db.transaction(): {violations}"
+
+
+def test_reindex_preserves_incoming_edges(engine):
+    """Reindexing a node must not destroy the edges that point AT it (#123).
+
+    The connection A -> B lives in A's markdown file. Reindexing B has no access to that
+    file and therefore no way to reconstruct the row, so it must not delete it.
+    """
+    from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
+
+    id_a, _ = engine.remember(
+        CreateNodeRequest(content="A fact.", type=NodeType.fact), agent_id="t")
+    id_b, _ = engine.remember(
+        CreateNodeRequest(content="Another fact.", type=NodeType.fact), agent_id="t")
+
+    node_a = engine.file_store.load(id_a)
+    node_a.connections.append(
+        Connection(target=id_b, edge=EdgeType.supports, weight=0.9)
+    )
+    engine.file_store.save(node_a)
+    engine.builder.index_single(engine.file_store._path_for(node_a))
+
+    def incoming():
+        return engine.db.conn.execute(
+            "SELECT source_id, edge_type, weight FROM edges WHERE target_id = ?", (id_b,)
+        ).fetchall()
+
+    assert len(incoming()) == 1, "sanity: the edge must exist before B is reindexed"
+
+    # Reindex the TARGET — what the index updater does after any change to B's own file.
+    node_b = engine.file_store.load(id_b)
+    engine.builder.index_single(engine.file_store._path_for(node_b))
+
+    rows = incoming()
+    assert len(rows) == 1, "incoming edge destroyed by reindexing the target (#123)"
+    assert rows[0]["source_id"] == id_a
+    assert rows[0]["edge_type"] == "supports"
+    assert rows[0]["weight"] == 0.9, "weight 0.9 (not the 0.5 default) proves this is A's row"
+
+
+def test_touch_updated_does_not_drop_incoming_edges(engine):
+    """The real-world trigger: file_hash changes, content fingerprint does not (#123).
+
+    `_invalidate_checked_pairs` only fires when the CONTENT fingerprint changes, but the
+    reindex fires on any file_hash change. `touch_updated()` moves only `updated`, so the
+    edge dies while the cached pair verdict survives — and auto_linker, conflict_detector
+    and duplicate_merger all skip a pair already recorded in `auto_link_checked`. Nothing
+    ever recreates the edge; the loss stands until a full rebuild.
+
+    Self-feeding on the Beta: the auto-linker touches the node before saving, so creating
+    any new link on a node destroys that node's own incoming edges. The same shape drives
+    the importance scorer, which touched 5,216 nodes in one pass on 2026-08-21 and cost
+    ~13,800 edges in 54 minutes.
+    """
+    from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
+
+    id_a, _ = engine.remember(
+        CreateNodeRequest(content="A fact.", type=NodeType.fact), agent_id="t")
+    id_b, _ = engine.remember(
+        CreateNodeRequest(content="Another fact.", type=NodeType.fact), agent_id="t")
+
+    node_a = engine.file_store.load(id_a)
+    node_a.connections.append(
+        Connection(target=id_b, edge=EdgeType.supports, weight=0.7)
+    )
+    engine.file_store.save(node_a)
+    engine.builder.index_single(engine.file_store._path_for(node_a))
+
+    def incoming_count():
+        return engine.db.conn.execute(
+            "SELECT COUNT(*) FROM edges WHERE target_id = ?", (id_b,)
+        ).fetchone()[0]
+
+    assert incoming_count() == 1, "sanity: the edge must exist before the touch"
+
+    # The only delta is `updated`: file_hash changes, content fingerprint does not.
+    node_b = engine.file_store.load(id_b)
+    node_b.touch_updated()
+    engine.file_store.save(node_b)
+    engine.builder.index_single(engine.file_store._path_for(node_b))
+
+    assert incoming_count() == 1, "touch_updated() destroyed the incoming edge (#123)"
+
+
+def test_incremental_update_preserves_incoming_edges(engine):
+    """The path production actually takes: the 60s index updater (#123).
+
+    `index_single` is not the production trigger. `incremental_update` is — it walks the
+    store, sees B's file_hash changed, and calls `_remove_node(id, keep_vectors=True)` at
+    builder.py:104, a DIFFERENT call site from the one index_single uses (:122). A fix
+    applied only to index_single leaves this path destroying incoming edges once a minute.
+    """
+    from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
+
+    id_a, _ = engine.remember(
+        CreateNodeRequest(content="A fact.", type=NodeType.fact), agent_id="t")
+    id_b, _ = engine.remember(
+        CreateNodeRequest(content="Another fact.", type=NodeType.fact), agent_id="t")
+
+    node_a = engine.file_store.load(id_a)
+    node_a.connections.append(
+        Connection(target=id_b, edge=EdgeType.supports, weight=0.6)
+    )
+    engine.file_store.save(node_a)
+    engine.builder.index_single(engine.file_store._path_for(node_a))
+
+    def incoming():
+        return engine.db.conn.execute(
+            "SELECT source_id, weight FROM edges WHERE target_id = ?", (id_b,)
+        ).fetchall()
+
+    assert len(incoming()) == 1, "sanity: the edge must exist before the updater runs"
+
+    # Change B's file so the updater sees a new file_hash, then run the REAL trigger.
+    node_b = engine.file_store.load(id_b)
+    node_b.touch_updated()
+    engine.file_store.save(node_b)
+    added, updated = engine.builder.incremental_update()
+
+    assert updated == 1, "sanity: the updater must have seen B as changed"
+    rows = incoming()
+    assert len(rows) == 1, "incremental_update destroyed the incoming edge (#123)"
+    assert rows[0]["source_id"] == id_a
+    assert rows[0]["weight"] == 0.6, "weight 0.6 (not the 0.5 default) proves this is A's row"

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -276,6 +276,36 @@ def test_incremental_update_preserves_incoming_edges(engine):
     assert rows[0]["weight"] == 0.6, "weight 0.6 (not the 0.5 default) proves this is A's row"
 
 
+def test_incremental_update_preserves_the_node_vector(engine):
+    """incremental_update must not drop the `node_vectors` row (#123).
+
+    `_clear_derived` takes `drop_vector` because `incremental_update` never re-embeds after
+    it — unlike `index_single`, whose callers always call `_index_embedding` afterwards. If
+    `incremental_update` ever passed `drop_vector=True`, the node would lose its embedding
+    and stay unsearchable by similarity until the next startup backfill picks it up.
+    """
+    from ormah.models.node import CreateNodeRequest, NodeType
+
+    node_id, _ = engine.remember(
+        CreateNodeRequest(content="A fact to embed.", type=NodeType.fact), agent_id="t")
+
+    def has_vector() -> bool:
+        return engine.db.conn.execute(
+            "SELECT 1 FROM node_vectors WHERE id = ?", (node_id,)
+        ).fetchone() is not None
+
+    assert has_vector(), "sanity: remember() must embed the node before the update runs"
+
+    # Change the node's file so the updater sees a new file_hash and reindexes it.
+    node = engine.file_store.load(node_id)
+    node.touch_updated()
+    engine.file_store.save(node)
+    added, updated = engine.builder.incremental_update()
+
+    assert updated == 1, "sanity: the updater must have seen the node as changed"
+    assert has_vector(), "incremental_update dropped the node_vectors row"
+
+
 def test_removing_a_node_still_drops_its_incoming_edges(engine):
     """When the file is really gone, incoming edges MUST die (the mirror of #123).
 

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -274,3 +274,96 @@ def test_incremental_update_preserves_incoming_edges(engine):
     assert len(rows) == 1, "incremental_update destroyed the incoming edge (#123)"
     assert rows[0]["source_id"] == id_a
     assert rows[0]["weight"] == 0.6, "weight 0.6 (not the 0.5 default) proves this is A's row"
+
+
+def test_removing_a_node_still_drops_its_incoming_edges(engine):
+    """When the file is really gone, incoming edges MUST die (the mirror of #123).
+
+    `edges.target_id` is `REFERENCES nodes(id) ON DELETE CASCADE`: an edge pointing at a
+    node that no longer exists is a foreign-key violation. A fix that simply never deleted
+    incoming edges would pass every other test in this file and leave orphan rows behind.
+    """
+    from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
+
+    id_a, _ = engine.remember(
+        CreateNodeRequest(content="A fact.", type=NodeType.fact), agent_id="t")
+    id_b, _ = engine.remember(
+        CreateNodeRequest(content="Another fact.", type=NodeType.fact), agent_id="t")
+
+    node_a = engine.file_store.load(id_a)
+    node_a.connections.append(
+        Connection(target=id_b, edge=EdgeType.supports, weight=0.9)
+    )
+    engine.file_store.save(node_a)
+    engine.builder.index_single(engine.file_store._path_for(node_a))
+
+    assert engine.db.conn.execute(
+        "SELECT COUNT(*) FROM edges WHERE target_id = ?", (id_b,)
+    ).fetchone()[0] == 1, "sanity: the edge must exist before B's file is deleted"
+
+    # B genuinely leaves the store: its markdown file is gone from disk.
+    path_b = engine.file_store._path_for(engine.file_store.load(id_b))
+    path_b.unlink()
+    engine.builder.incremental_update()
+
+    assert engine.db.conn.execute(
+        "SELECT COUNT(*) FROM nodes WHERE id = ?", (id_b,)
+    ).fetchone()[0] == 0, "the removed node must be gone from the index"
+    assert engine.db.conn.execute(
+        "SELECT COUNT(*) FROM edges WHERE target_id = ?", (id_b,)
+    ).fetchone()[0] == 0, "orphan edge survived the removal of its target"
+
+
+def test_reindex_keeps_the_incumbent_canonical_direction(engine):
+    """When both files declare the same link, the incumbent row wins — stably.
+
+    `_index_file_edges` skips inserting A -> B when the reverse B -> A already exists with
+    the same edge type (builder.py:208-214). Before #123 was fixed, reindexing B destroyed both
+    directions, so B's own declaration was reinserted and the surviving direction was
+    whichever node happened to be reindexed last. Now the incumbent survives and B's
+    declaration is skipped: deterministic, and NOT a regression.
+
+    Auto-linking is suppressed around `remember()` (same idiom as
+    `test_mutation_stamping.py`): "A fact." and "Another fact." are similar enough that the
+    real encoder crosses `auto_link_similarity_threshold`, which would otherwise plant an
+    unrelated `related_to` B -> A edge (persisted into B's own markdown, same as any other
+    connection) before this test ever declares its own `supports` connection -- a confound
+    unrelated to the canonicalisation mechanism under test.
+    """
+    from ormah.models.node import Connection, CreateNodeRequest, EdgeType, NodeType
+
+    original_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        id_a, _ = engine.remember(
+            CreateNodeRequest(content="A fact.", type=NodeType.fact), agent_id="t")
+        id_b, _ = engine.remember(
+            CreateNodeRequest(content="Another fact.", type=NodeType.fact), agent_id="t")
+    finally:
+        engine.settings.auto_link_similarity_threshold = original_threshold
+
+    node_a = engine.file_store.load(id_a)
+    node_a.connections.append(
+        Connection(target=id_b, edge=EdgeType.supports, weight=0.9)
+    )
+    engine.file_store.save(node_a)
+
+    node_b = engine.file_store.load(id_b)
+    node_b.connections.append(
+        Connection(target=id_a, edge=EdgeType.supports, weight=0.2)
+    )
+    engine.file_store.save(node_b)
+
+    # A is indexed first, so A -> B becomes the incumbent row.
+    engine.builder.index_single(engine.file_store._path_for(node_a))
+    engine.builder.index_single(engine.file_store._path_for(node_b))
+
+    rows = engine.db.conn.execute(
+        "SELECT source_id, weight FROM edges "
+        "WHERE (source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?)",
+        (id_a, id_b, id_b, id_a),
+    ).fetchall()
+
+    assert len(rows) == 1, "the pair must be represented by exactly one canonical row"
+    assert rows[0]["source_id"] == id_a, "reindexing B flipped the canonical direction"
+    assert rows[0]["weight"] == 0.9, "A's weight, not B's 0.2 — the incumbent's row is the one kept"


### PR DESCRIPTION
Fixes #123.

## The bug

A row in `edges` is owned by the markdown file of its **source** node. `edges.source_id` and
`edges.target_id` are both `REFERENCES nodes(id) ON DELETE CASCADE`, and `db.py` sets
`PRAGMA foreign_keys=ON`.

Reindexing a node destroyed every edge pointing **at** it, three separate ways:

| # | Statement | Effect |
|---|---|---|
| 1 | `DELETE FROM edges WHERE source_id = ? OR target_id = ?` | the explicit bidirectional delete |
| 2 | `DELETE FROM nodes WHERE id = ?` | `ON DELETE CASCADE` |
| 3 | `INSERT OR REPLACE INTO nodes` | REPLACE is a delete underneath — cascades again |

Measured against an existing incoming edge on sqlite 3.53: `INSERT OR REPLACE` 1 → 0,
`DELETE FROM nodes` 1 → 0, `INSERT … ON CONFLICT(id) DO UPDATE` 1 → **1**. Fixing fewer than all
three leaves the tests red.

Reindexing a node cannot read the *other* nodes' markdown, so it could never rebuild those rows.
The graph shrank silently between full rebuilds, and it compounds: any job that rewrites a node's
markdown and calls `touch_updated()` — the importance scorer and the auto-linker both do — drives
this path, so the loss spreads across the whole store without a single user edit.

## The fix

`_remove_node` is split in two:

- **`_clear_derived(node_id, *, drop_vector=False)`** — the reindex path. Leaves the `nodes` row
  alone and clears only `source_id` edges, which is exactly the set `_index_file_edges` reinserts
  from the node's own markdown.
- **`_remove_node(node_id)`** — genuine removal, where the cascade is correct.

The node write becomes a true `INSERT … ON CONFLICT(id) DO UPDATE`, so the cascade never fires on a
node that still exists. `keep_vectors` inverts into `drop_vector` rather than disappearing; both
call sites keep today's vector behaviour byte for byte (`incremental_update` never re-embeds, so it
keeps the vector; `index_single` already dropped it via the old default).

Removing the `merge_nodes` workaround is the second, independent proof: it captured the kept node's
incoming edges before `index_single` and hand-restored them afterwards, precisely because
`index_single` destroyed them. It no longer does, and the merge suite stays green through a path
that never mentions `_clear_derived`.

## A deliberate behaviour change, stated up front

`_index_file_edges` skips inserting `A → B` when the reverse `B → A` already exists with the same
`edge_type`. Under the old bidirectional delete that skip was **unreachable** on the reindex path.
It is reachable now. If both files declare the same pair with the same `edge_type`, reindexing A
drops `A → B` and the skip keeps it dropped, so A's declared weight is lost from the index while
the declaration stays in `A.md`. Connectivity survives — `graph.get_edges_for` is bidirectional and
the pair is one edge by design — but the direction and weight do not. The surviving direction moves
from "last reindexed wins" to "incumbent wins": deterministic instead of order-dependent.
`test_reindex_keeps_the_incumbent_canonical_direction` pins it.

## Fallout the fix exposed, fixed here

Making incoming edges survive made `execute_merge`'s duplicate-edge check reachable where it never
used to fire. Three consequences, each with a regression test written before the fix:

1. **`affected_node_ids` was recorded after the skip**, so a neighbour whose remap was skipped never
   had its markdown retargeted and kept pointing at the soft-deleted node. Markdown is the portable
   source of truth, so that dangling target resurrects a stale edge on a rebuild from disk.
2. **`undo_merge` deleted `(remapped_source, remapped_target, edge_type)` for every original edge**
   without checking whether the merge had inserted that row, destroying a pre-existing collided
   edge on rollback. `merge_history` gains a nullable `remapped_edges` column recording what the
   merge actually inserted; undo deletes only those. Rows written before this change have no
   provenance and cannot get any, so a NULL falls back to the previous behaviour — existing history
   rolls back exactly as it does today.
3. **The neighbour retarget was blind**, so a neighbour declaring both `C → kept` and `C → removed`
   with one `edge_type` ended up with two connections to `kept`; the next reindex's
   `INSERT OR REPLACE` let the last one win and overwrote the pre-existing row's `weight` and
   `created`. The retarget now drops a connection to `removed` when the neighbour already declares
   that `edge_type` toward `kept`, and coalesces duplicates to the **last** declaration, matching
   the index's own winner rule.

## Why no background job changes

`auto_linker`, `conflict_detector` and `duplicate_merger` all skip a pair already recorded in
`auto_link_checked`, and nothing invalidates those rows on this branch. That is why the loss was
permanent: the edge died on reindex and the cached verdict kept every job from re-proposing it.
Once nothing destroys the edges, nothing needs to recreate them. `consolidator` keys on
`consolidation_checked` by signature and is unaffected.

The fix stops the bleeding; it does not heal an already-damaged store. Recovery is `full_rebuild`,
which reconstructs edges from markdown — where every edge writer in the codebase does persist its
connection.

## Tests

Eight new tests, each written red first:

- three pinning the invariant, one per `_remove_node` call site that matters — `index_single`,
  `touch_updated` (the real-world trigger: `file_hash` changes, content does not), and
  `incremental_update`, the path the 60s index updater actually takes. Each was proved to have
  teeth by reverting its own call site alone.
- an over-correction guard: when a node's file is genuinely gone, its incoming edges must still die,
  or the foreign key is violated. Every other test here passes under a naive "never delete incoming
  edges" change; this one does not.
- the canonicalisation guard described above.
- `drop_vector=False` on the incremental path, so a future simplification of the two call sites
  into one cannot silently drop embeddings.
- the three merge/undo regressions above.

## Known and deferred

`undo_merge` never reverts neighbour markdown, on this branch or before it. It restores rows in
`edges` and nothing else, so after an undo the next reindex rebuilds the neighbour's outgoing edges
from a file that no longer declares the removed node. Fixing it needs pre-merge connection
snapshots persisted in `merge_history` and a reindex of affected nodes during undo — a separate
change, and measured identical to `main` on this branch.

Likewise, a `kept → kept` self-loop present in `edges` but not in the kept node's markdown is no
longer resurrected by the merge path. Everything else in the system treats a self-loop as garbage.
