### PR TITLE
feat(lifecycle): reversible promotion and the seven-day initial lease (#223)

### DIFF
--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -163,7 +163,10 @@ def _apply_consolidation(
                         (new_id,),
                     )
 
-    # Create derived_from edges and demote originals to archival
+    # Create derived_from edges, record supersession, then demote originals to archival.
+    # Mark BEFORE demoting (#223): crashing between the two leaves the node working +
+    # marked, which is harmless because the marker only blocks automatic promotion.
+    # The reverse order would leave it archival + unmarked — a promotable node.
     for node_id in node_ids:
         try:
             engine.connect(ConnectRequest(
@@ -174,6 +177,7 @@ def _apply_consolidation(
             ))
         except Exception:
             pass
+        engine._mark_superseded(node_id, new_id)
         engine.update_node(node_id, UpdateNodeRequest(tier=Tier.archival))
 
     return new_id

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -88,7 +88,7 @@ class Settings(BaseSettings):
     working_decay_days: int = 14  # Deprecated: superseded by FSRS-based decay
 
     # FSRS spaced repetition decay
-    fsrs_initial_stability: float = 1.0    # days; starting stability for new nodes
+    fsrs_initial_stability: float = 5.814   # days; -7 / ln(0.3) — a seven-day unused lease
     fsrs_decay_threshold: float = 0.3      # R below this = decay candidate
     fsrs_max_stability: float = 365.0      # cap at 1 year
     # Bounded reinforcement (#221/#191): S' = S * (1 + g * S^-w * spacing).

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1560,6 +1560,32 @@ class MemoryEngine:
         ).fetchall()
         original_edges = [dict(r) for r in edge_rows]
 
+        # Second discovery route for the supersession redirect below, because the
+        # first one reads the index while the promotion gate reads the file, and the
+        # two can diverge: _mark_superseded saves the markdown first and writes the row
+        # second, so a crash in between leaves a marker only in the file. The
+        # consolidator writes the derived_from edge BEFORE calling _mark_superseded, so
+        # inside that window the edge is already there and names the source.
+        #
+        # derived_from on its own proves nothing — it is a general relationship, which
+        # is exactly why #223 narrowed the promotion gate off it. The marker in the file
+        # stays the criterion; the edge only says which files are worth opening, which
+        # keeps this bounded to the consolidation cluster instead of scanning the store.
+        # Read before the transaction: file I/O must not run holding the write lock.
+        marked_in_markdown: set[str] = set()
+        for edge in original_edges:
+            if edge["edge_type"] != EdgeType.derived_from.value:
+                continue
+            if edge["source_id"] != removed.id:
+                continue
+            # Full-id check: FileStore resolves ids through an eight-character filename
+            # prefix and can hand back an unrelated colliding node (#280).
+            candidate = self.file_store.load(edge["target_id"])
+            if candidate is None or candidate.id != edge["target_id"]:
+                continue
+            if candidate.superseded_by == removed.id:
+                marked_in_markdown.add(candidate.id)
+
         # Capture incoming edges for the kept node that aren't in its markdown.
         # index_single calls _remove_node which wipes ALL edges (including
         # incoming ones like self→kept "defines").  We need to restore these.
@@ -1637,18 +1663,26 @@ class MemoryEngine:
             # and after this merge the keeper is what represents them; left pointing at
             # the soft-deleted node it reads as dangling, and the next confirmed use
             # promotes a source back into the whisper-eligible tier (#223, PR #257).
+            #
+            # Union of both routes: the index, and the files named by the derived_from
+            # edges read above. A source found only by the second route has a row whose
+            # marker never landed, so the per-id UPDATE heals that row as it redirects.
             # The keeper is excluded — its own marker was already cleared above.
-            redirected_sources = [
-                r["id"]
-                for r in conn.execute(
-                    "SELECT id FROM nodes WHERE superseded_by = ? AND id != ?",
-                    (removed.id, kept.id),
-                ).fetchall()
-            ]
-            conn.execute(
-                "UPDATE nodes SET superseded_by = ? WHERE superseded_by = ? AND id != ?",
-                (kept.id, removed.id, kept.id),
+            redirected_sources = sorted(
+                {
+                    r["id"]
+                    for r in conn.execute(
+                        "SELECT id FROM nodes WHERE superseded_by = ?", (removed.id,)
+                    ).fetchall()
+                }
+                | marked_in_markdown
+                - {kept.id}
             )
+            for source_id in redirected_sources:
+                conn.execute(
+                    "UPDATE nodes SET superseded_by = ? WHERE id = ?",
+                    (kept.id, source_id),
+                )
 
             # Clean up auto-linker checked pairs:
             # - removed node: delete all (node is gone)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2098,11 +2098,21 @@ class MemoryEngine:
         # the next confirmed use un-buries it. The marker itself is NOT cleared —
         # it is the provenance record, and only the block is lifted. The extra load
         # is cheap and rare: it runs only for an archival node that carries a marker.
+        #
+        # The id is compared in full, not merely tested for None: FileStore resolves
+        # an id through the eight-character prefix in the filename and returns the
+        # first match without re-checking what it loaded (#280), so a deleted
+        # replacement whose prefix collides with an unrelated node comes back as that
+        # node. `is not None` would read that as live and bury this memory forever.
         promoted = False
         if node.tier is Tier.archival:
+            replacement = (
+                self.file_store.load(node.superseded_by)
+                if node.superseded_by is not None
+                else None
+            )
             superseded_by_live = (
-                node.superseded_by is not None
-                and self.file_store.load(node.superseded_by) is not None
+                replacement is not None and replacement.id == node.superseded_by
             )
             if not superseded_by_live:
                 node.stability = lifecycle.promotion_floor(

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -200,6 +200,12 @@ class MemoryEngine:
         defaults in place; running an unneeded one destroys real values. Only
         the total absence of any signal — no version key, no legacy flag, and
         no node carrying last_review — returns 0.
+
+        #223 deliberately does not bump this. The version records which
+        reinforcement model wrote a store's stability values; #223 changes a
+        creation default and adds a column, not the model. A bump would not
+        help either way — this is a store-level flag, and a real store spans
+        both eras of nodes.
         """
         row = self.db.conn.execute(
             "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1714,8 +1714,6 @@ class MemoryEngine:
                 ),
             )
 
-        self.file_store.soft_delete(removed.id)
-
         # Update markdown files: rewrite connections from removed→kept
         for node_id in affected_node_ids:
             neighbor = self.file_store.load(node_id)
@@ -1752,6 +1750,15 @@ class MemoryEngine:
                 reload_kept.connections = pruned
                 reload_kept.touch_updated()
                 self.file_store.save(reload_kept)
+
+        # Delete the old replacement last. The promotion gate reads superseded_by
+        # from source markdown, not from the index: deleting the removed node before
+        # the redirects above creates a crash window where the row points at the
+        # keeper but the file still points at the now-missing node, so confirmed use
+        # promotes the source even though the keeper represents it. While the
+        # removed node remains live, either the old or new marker safely blocks
+        # promotion.
+        self.file_store.soft_delete(removed.id)
 
         kept_title = kept.title or kept.content[:60]
         removed_title = removed.title or removed.content[:60]

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -569,6 +569,7 @@ class MemoryEngine:
             title=title,
             content=req.content,
             confidence=req.confidence,
+            stability=self.settings.fsrs_initial_stability,
         )
 
         # Mark and promote identity nodes

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2126,6 +2126,30 @@ class MemoryEngine:
                 detail=json.dumps({"from": "archival", "to": "working"}),
             )
 
+    @_serialized_memory_operation
+    def _mark_superseded(self, source_id: str, consolidation_id: str) -> None:
+        """Record that *source_id* was replaced by *consolidation_id* (#223).
+
+        Written here rather than through update_node because superseded_by is
+        deliberately absent from UpdateNodeRequest: it is policy state, and no
+        agent sets it. Serialized for the same reason _record_confirmed_use is —
+        this is a load-modify-save pair.
+
+        `updated` is intentionally NOT advanced here: the consolidator's
+        update_node(tier=archival) on the next line already does it, and
+        touch_updated is reserved for content mutations.
+        """
+        node = self.file_store.load(source_id)
+        if node is None:
+            return
+        node.superseded_by = consolidation_id
+        self.file_store.save(node)
+        with self.db.transaction() as conn:
+            conn.execute(
+                "UPDATE nodes SET superseded_by = ? WHERE id = ?",
+                (consolidation_id, source_id),
+            )
+
     # --- Private helpers ---
 
     def _supplement_temporal(

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2091,17 +2091,29 @@ class MemoryEngine:
         # superseded_by blocks ONLY consolidation sources. A generic derived_from
         # target promotes, which is the narrowing #191 asked for over the originally
         # proposed blanket exclusion.
+        #
+        # And it blocks only while the consolidation node it points at still exists:
+        # a dangling marker (the replacement was deleted — the #192 scenario) would
+        # otherwise bury this memory forever with nothing left standing in for it, so
+        # the next confirmed use un-buries it. The marker itself is NOT cleared —
+        # it is the provenance record, and only the block is lifted. The extra load
+        # is cheap and rare: it runs only for an archival node that carries a marker.
         promoted = False
-        if node.tier is Tier.archival and node.superseded_by is None:
-            node.stability = lifecycle.promotion_floor(
-                node.stability, self.settings.fsrs_initial_stability
+        if node.tier is Tier.archival:
+            superseded_by_live = (
+                node.superseded_by is not None
+                and self.file_store.load(node.superseded_by) is not None
             )
-            # Goes through TierManager.promote(), not `node.tier = ...`: this gives
-            # #223's root cause its first production caller and brings the tier-ordering
-            # guard along. promote() calls touch_updated(), so `updated` advances — that
-            # is correct, the tier genuinely changed, and `updated` feeds LWW sync; not
-            # advancing it would let a stale remote copy win and silently re-archive.
-            promoted = self.tier_manager.promote(node, Tier.working)
+            if not superseded_by_live:
+                node.stability = lifecycle.promotion_floor(
+                    node.stability, self.settings.fsrs_initial_stability
+                )
+                # Goes through TierManager.promote(), not `node.tier = ...`: this gives
+                # #223's root cause its first production caller and brings the tier-ordering
+                # guard along. promote() calls touch_updated(), so `updated` advances — that
+                # is correct, the tier genuinely changed, and `updated` feeds LWW sync; not
+                # advancing it would let a stale remote copy win and silently re-archive.
+                promoted = self.tier_manager.promote(node, Tier.working)
 
         # Standard access tracking
         node.last_accessed = now

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2074,6 +2074,29 @@ class MemoryEngine:
             )
             node.last_review = now
 
+        # Reversible promotion (#223, decided in #191). Deliberately AFTER the
+        # cooldown block: the bounded update runs on the OLD stability first, then
+        # the floor lifts the result. The floor also runs when the cooldown blocked
+        # the numeric update — otherwise a second confirmed use in one day promotes
+        # with S=1, buying a ~29 h lease that the next decay run immediately revokes.
+        # promotion_floor is max() against a constant, so running it on every
+        # promotion cannot push stability past one initial lease.
+        #
+        # superseded_by blocks ONLY consolidation sources. A generic derived_from
+        # target promotes, which is the narrowing #191 asked for over the originally
+        # proposed blanket exclusion.
+        promoted = False
+        if node.tier is Tier.archival and node.superseded_by is None:
+            node.stability = lifecycle.promotion_floor(
+                node.stability, self.settings.fsrs_initial_stability
+            )
+            # Goes through TierManager.promote(), not `node.tier = ...`: this gives
+            # #223's root cause its first production caller and brings the tier-ordering
+            # guard along. promote() calls touch_updated(), so `updated` advances — that
+            # is correct, the tier genuinely changed, and `updated` feeds LWW sync; not
+            # advancing it would let a stale remote copy win and silently re-archive.
+            promoted = self.tier_manager.promote(node, Tier.working)
+
         # Standard access tracking
         node.last_accessed = now
         node.access_count += 1
@@ -2082,14 +2105,25 @@ class MemoryEngine:
         with self.db.transaction() as conn:
             conn.execute(
                 "UPDATE nodes SET access_count = ?, last_accessed = ?, stability = ?, "
-                "last_review = ? WHERE id = ?",
+                "last_review = ?, tier = ?, updated = ? WHERE id = ?",
                 (
                     node.access_count,
                     node.last_accessed.isoformat(),
                     node.stability,
                     node.last_review.isoformat() if node.last_review else None,
+                    node.tier.value,
+                    node.updated.isoformat(),
                     node_id,
                 ),
+            )
+
+        if promoted:
+            # After the transaction: _write_audit_log opens its own, so it cannot
+            # sit inside. Same position update_node places its own audit call.
+            self._write_audit_log(
+                operation="promote",
+                node_id=node_id,
+                detail=json.dumps({"from": "archival", "to": "working"}),
             )
 
     # --- Private helpers ---

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1541,6 +1541,14 @@ class MemoryEngine:
         if merged_title is not None:
             kept.title = merged_title
 
+        # If the keeper was itself marked superseded by the node it is now absorbing,
+        # the marker has nothing left to point at: redirecting it would write
+        # kept.superseded_by == kept.id, a marker that always resolves live and buries
+        # the node forever. Absorbing the replacement means nothing supersedes it (#223).
+        # Cleared before save/index_single so markdown and the row agree from the start.
+        if kept.superseded_by == removed.id:
+            kept.superseded_by = None
+
         # Snapshot removed node before deletion
         snapshot = removed.model_dump(mode="json")
 
@@ -1624,6 +1632,24 @@ class MemoryEngine:
                          edge["weight"], edge["created"]),
                     )
 
+            # Consolidation sources marked superseded_by the removed node must follow
+            # it into the keeper. The marker is what blocks their automatic promotion,
+            # and after this merge the keeper is what represents them; left pointing at
+            # the soft-deleted node it reads as dangling, and the next confirmed use
+            # promotes a source back into the whisper-eligible tier (#223, PR #257).
+            # The keeper is excluded — its own marker was already cleared above.
+            redirected_sources = [
+                r["id"]
+                for r in conn.execute(
+                    "SELECT id FROM nodes WHERE superseded_by = ? AND id != ?",
+                    (removed.id, kept.id),
+                ).fetchall()
+            ]
+            conn.execute(
+                "UPDATE nodes SET superseded_by = ? WHERE superseded_by = ? AND id != ?",
+                (kept.id, removed.id, kept.id),
+            )
+
             # Clean up auto-linker checked pairs:
             # - removed node: delete all (node is gone)
             # - kept node: invalidate if content changed (merged_content applied)
@@ -1669,6 +1695,20 @@ class MemoryEngine:
             if updated:
                 neighbor.touch_updated()
                 self.file_store.save(neighbor)
+
+        # Markdown side of the supersession redirect: the promotion gate reads the
+        # file, so the row alone is not enough. `updated` advances — unlike
+        # _mark_superseded, nothing else in this path stamps it, and the marker feeds
+        # LWW sync: a stale remote copy would otherwise win and restore the dead pointer.
+        for node_id in redirected_sources:
+            source = self.file_store.load(node_id)
+            # Full-id check: FileStore resolves ids through an eight-character filename
+            # prefix and can hand back an unrelated colliding node (#280).
+            if source is None or source.id != node_id:
+                continue
+            source.superseded_by = kept.id
+            source.touch_updated()
+            self.file_store.save(source)
 
         # Also fix the kept node's own connections that pointed to removed
         reload_kept = self.file_store.load(kept.id)

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -138,9 +138,9 @@ class IndexBuilder:
             INSERT OR REPLACE INTO nodes
             (id, type, tier, source, space, title, content, created, updated,
              last_accessed, access_count, confidence, importance,
-             valid_until, stability, last_review, file_path, file_hash)
+             valid_until, stability, last_review, superseded_by, file_path, file_hash)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?)
+                    ?, ?, ?, ?, ?, ?)
             """,
             (
                 node.id,
@@ -159,6 +159,7 @@ class IndexBuilder:
                 node.valid_until.isoformat() if node.valid_until else None,
                 node.stability,
                 node.last_review.isoformat() if node.last_review else None,
+                node.superseded_by,
                 str(path),
                 file_hash,
             ),

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -141,6 +141,7 @@ class Database:
                 ("valid_until", "ALTER TABLE nodes ADD COLUMN valid_until TEXT"),
                 ("stability", "ALTER TABLE nodes ADD COLUMN stability REAL DEFAULT 1.0"),
                 ("last_review", "ALTER TABLE nodes ADD COLUMN last_review TEXT"),
+                ("superseded_by", "ALTER TABLE nodes ADD COLUMN superseded_by TEXT"),
             ]
             for col_name, ddl in enrichment_migrations:
                 if col_name not in node_cols:

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS nodes (
     valid_until TEXT,
     stability REAL DEFAULT 1.0,
     last_review TEXT,
+    superseded_by TEXT,
     file_path TEXT NOT NULL,
     file_hash TEXT NOT NULL,
     seq INTEGER NOT NULL DEFAULT 0

--- a/src/ormah/lifecycle.py
+++ b/src/ormah/lifecycle.py
@@ -90,3 +90,13 @@ def reinforcement_due(
     if last_review is None:
         return True
     return (now - last_review) >= timedelta(days=cooldown_days)
+
+
+def promotion_floor(stability: float, initial_stability: float) -> float:
+    """``max(S, initial)`` — the lease a promoted node restarts from.
+
+    ``max``, never a sum: a node promoted twice in one cooldown window must end
+    at one initial lease, not two, and a node whose stability already exceeds the
+    initial value must not be pulled down to it.
+    """
+    return max(stability, initial_stability)

--- a/src/ormah/models/node.py
+++ b/src/ormah/models/node.py
@@ -60,6 +60,7 @@ class MemoryNode(BaseModel):
     last_review: datetime | None = None  # last stability update (distinct from last_accessed)
     valid_until: datetime | None = None
     deleted_at: datetime | None = None  # tombstone stamp; ordering for sync merges uses this, never `updated`
+    superseded_by: str | None = None  # id of the consolidation node that replaced this one; blocks automatic promotion (#223)
     space: str | None = None
     tags: list[str] = Field(default_factory=list)
     connections: list[Connection] = Field(default_factory=list)

--- a/src/ormah/store/markdown.py
+++ b/src/ormah/store/markdown.py
@@ -45,6 +45,7 @@ def parse_node(text: str) -> MemoryNode:
         last_review=_parse_dt(meta["last_review"]) if meta.get("last_review") else None,
         valid_until=valid_until,
         deleted_at=deleted_at,
+        superseded_by=meta.get("superseded_by"),
         space=meta.get("space"),
         tags=meta.get("tags", []),
         connections=connections,
@@ -75,6 +76,8 @@ def serialize_node(node: MemoryNode) -> str:
         meta["valid_until"] = _format_dt(node.valid_until)
     if node.deleted_at is not None:
         meta["deleted_at"] = _format_dt(node.deleted_at)
+    if node.superseded_by is not None:
+        meta["superseded_by"] = node.superseded_by
     if node.title:
         meta["title"] = node.title
     if node.space:

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -237,5 +237,3 @@ def test_marking_precedes_demotion_so_a_crash_leaves_working_plus_marked(engine,
     node = engine.file_store.load(a)
     assert node.tier is Tier.working
     assert node.superseded_by is not None
-
-

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -171,3 +171,71 @@ def test_inverted_cluster_bounds_returns_empty_and_warns(consolidation_engine, c
     assert "consolidation_max_cluster_nodes" in caplog.text
 
 
+def test_consolidation_marks_sources_as_superseded(engine):
+    from ormah.background.consolidator import _apply_consolidation
+    from ormah.models.node import CreateNodeRequest, Tier
+
+    a, _ = engine.remember(CreateNodeRequest(content="source one about pytest fixtures"))
+    b, _ = engine.remember(CreateNodeRequest(content="source two about pytest fixtures"))
+
+    new_id = _apply_consolidation(engine, [a, b], "Pytest fixtures", "merged body", "fact")
+
+    for source_id in (a, b):
+        node = engine.file_store.load(source_id)
+        assert node.tier is Tier.archival
+        assert node.superseded_by == new_id
+
+
+def test_the_marker_survives_in_the_index_after_consolidation(engine):
+    """Regression for the INSERT OR REPLACE column drop (Task 3): update_node
+    re-indexes the file one line after the marker is written."""
+    from ormah.background.consolidator import _apply_consolidation
+    from ormah.models.node import CreateNodeRequest
+
+    a, _ = engine.remember(CreateNodeRequest(content="source one about ruff config"))
+    b, _ = engine.remember(CreateNodeRequest(content="source two about ruff config"))
+
+    new_id = _apply_consolidation(engine, [a, b], "Ruff config", "merged body", "fact")
+
+    row = engine.db.conn.execute(
+        "SELECT superseded_by FROM nodes WHERE id = ?", (a,)
+    ).fetchone()
+    assert row["superseded_by"] == new_id
+
+
+def test_a_superseded_source_does_not_come_back_on_confirmed_use(engine):
+    """The end-to-end point of #223's exception: consolidation sources stay buried."""
+    from ormah.background.consolidator import _apply_consolidation
+    from ormah.models.node import CreateNodeRequest, Tier
+
+    a, _ = engine.remember(CreateNodeRequest(content="source one about sqlite vec"))
+    b, _ = engine.remember(CreateNodeRequest(content="source two about sqlite vec"))
+    _apply_consolidation(engine, [a, b], "sqlite-vec", "merged body", "fact")
+
+    engine._record_confirmed_use(a)
+
+    assert engine.file_store.load(a).tier is Tier.archival
+
+
+def test_marking_precedes_demotion_so_a_crash_leaves_working_plus_marked(engine, monkeypatch):
+    """Inject a demotion failure and assert the node ended working + marked,
+    NOT archival + unmarked — the promotable node we must never create."""
+    from ormah.background.consolidator import _apply_consolidation
+    from ormah.models.node import CreateNodeRequest, Tier
+
+    a, _ = engine.remember(CreateNodeRequest(content="source one about apscheduler"))
+    b, _ = engine.remember(CreateNodeRequest(content="source two about apscheduler"))
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("demotion failed")
+
+    monkeypatch.setattr(engine, "update_node", boom)
+
+    with pytest.raises(RuntimeError):
+        _apply_consolidation(engine, [a, b], "APScheduler", "merged body", "fact")
+
+    node = engine.file_store.load(a)
+    assert node.tier is Tier.working
+    assert node.superseded_by is not None
+
+

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -424,7 +424,6 @@ def test_a_seven_day_lease_survives_six_and_a_half_days_and_decays_after_seven(e
     def _age_it(days: float) -> None:
         node = engine.file_store.load(node_id)
         node.stability = 5.814            # Task 4 makes remember() do this; pinned here on purpose
-        node.importance = 0.0             # under decay_importance_threshold (0.5), gate is `>=`
         node.last_accessed = now - timedelta(days=days)
         engine.builder.index_single(engine.file_store.save(node))
 

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -416,6 +416,27 @@ def test_a_node_used_today_is_not_decayed_while_its_review_lags(engine):
     assert _get_tier(engine, node_id) == "working"
 
 
+def test_a_seven_day_lease_survives_six_and_a_half_days_and_decays_after_seven(engine):
+    """Drives run_decay, not the formula: the seven-day lease must reach the job."""
+    now = datetime.now(timezone.utc)
+    node_id, _ = engine.remember(CreateNodeRequest(content="a fresh working memory"))
+
+    def _age_it(days: float) -> None:
+        node = engine.file_store.load(node_id)
+        node.stability = 5.814            # Task 4 makes remember() do this; pinned here on purpose
+        node.importance = 0.0             # under decay_importance_threshold (0.5), gate is `>=`
+        node.last_accessed = now - timedelta(days=days)
+        engine.builder.index_single(engine.file_store.save(node))
+
+    _age_it(6.5)
+    run_decay(engine)
+    assert _get_tier(engine, node_id) == Tier.working.value
+
+    _age_it(7.5)
+    run_decay(engine)
+    assert _get_tier(engine, node_id) == Tier.archival.value
+
+
 def test_zero_stability_decays_on_the_configured_initial_stability(engine, monkeypatch):
     """Decay must use the same zero fallback reinforcement uses (council round 3, I3).
 

--- a/tests/test_engine/test_audit_log.py
+++ b/tests/test_engine/test_audit_log.py
@@ -136,3 +136,25 @@ def test_delete_node_soft_deletes_file(engine):
 
     # Node should no longer be loadable from store
     assert engine.file_store.load(node_id) is None
+
+
+def test_promotion_writes_one_promote_audit_entry(engine):
+    from ormah.models.node import Tier
+
+    node_id, _ = engine.remember(CreateNodeRequest(content="about to be promoted"))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    engine.builder.index_single(engine.file_store.save(node))
+
+    engine._record_confirmed_use(node_id)
+
+    entries = engine.list_audit_log(node_id=node_id, operation="promote")
+    assert len(entries) == 1
+
+
+def test_a_non_promoting_confirmed_use_writes_no_promote_entry(engine):
+    node_id, _ = engine.remember(CreateNodeRequest(content="already working"))
+
+    engine._record_confirmed_use(node_id)
+
+    assert engine.list_audit_log(node_id=node_id, operation="promote") == []

--- a/tests/test_engine/test_audit_log.py
+++ b/tests/test_engine/test_audit_log.py
@@ -151,6 +151,9 @@ def test_promotion_writes_one_promote_audit_entry(engine):
     entries = engine.list_audit_log(node_id=node_id, operation="promote")
     assert len(entries) == 1
 
+    detail = json.loads(entries[0]["detail"])
+    assert detail == {"from": "archival", "to": "working"}
+
 
 def test_a_non_promoting_confirmed_use_writes_no_promote_entry(engine):
     node_id, _ = engine.remember(CreateNodeRequest(content="already working"))

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -271,6 +271,43 @@ def test_negative_feedback_never_confirms(engine, source):
     )
 
 
+@pytest.mark.parametrize(
+    "signal,source,was_injected,should_promote",
+    [
+        (1, "explicit", 1, True),
+        (1, "auto_heuristic", 1, False),
+        (-1, "explicit", 1, False),
+        (1, "explicit", 0, False),
+    ],
+)
+def test_only_qualified_positives_promote(engine, signal, source, was_injected, should_promote):
+    """#223: promotion needs a qualified positive on an event the agent actually saw."""
+    from ormah.models.node import Tier
+
+    node_id = _make_nodes(engine, count=1)[0]
+
+    # Seed the whisper-log event BEFORE demoting: _seed_whisper_log goes through
+    # recall_search, and an archival node scores below the relevance floor, so no
+    # row would be created. The matrix is about signal/source/was_injected, not
+    # about ranking — seeding first keeps the event identical either way.
+    if was_injected:
+        whisper_log_id = _seed_whisper_log(engine, node_id)
+    else:
+        whisper_log_id = _seed_held_back_whisper_log(engine, node_id)
+
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    engine.builder.index_single(engine.file_store.save(node))
+
+    engine.submit_feedback(node_id, signal=signal, source=source, whisper_log_id=whisper_log_id)
+
+    expected = Tier.working if should_promote else Tier.archival
+    assert engine.file_store.load(node_id).tier is expected, (
+        f"signal={signal} source={source} was_injected={was_injected}: "
+        f"expected {expected}, got {engine.file_store.load(node_id).tier}"
+    )
+
+
 # --- Idempotency contracts (second council round: the latch, not affinity) ---
 
 def test_replaying_the_same_positive_feedback_confirms_once(engine):

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -136,3 +136,17 @@ def test_the_legacy_flag_is_written_alongside_the_version(engine):
         "SELECT value FROM meta WHERE key = 'fsrs_migrated'"
     ).fetchone()
     assert row is not None and row["value"] == "1"
+
+
+def test_223_does_not_bump_the_lifecycle_model_version(engine):
+    """#223 changes a creation default and adds a column; it does not change the
+    reinforcement model, which is what this version records."""
+    from ormah.models.node import CreateNodeRequest, Tier
+
+    node_id, _ = engine.remember(CreateNodeRequest(content="written under #223"))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    engine.builder.index_single(engine.file_store.save(node))
+    engine._record_confirmed_use(node_id)
+
+    assert engine._lifecycle_model_version() == 2

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -695,3 +695,28 @@ def test_memory_restore_lock_excludes_live_remember(engine):
     thread.join(timeout=2)
     assert finished.is_set()
     assert engine.file_store.load(result[0]) is not None
+
+
+def test_remember_uses_the_configured_initial_stability(engine):
+    """Set a NON-default value: testing with 5.814 would pass by accident if
+    someone also changed MemoryNode.stability's model default."""
+    from ormah.models.node import CreateNodeRequest
+
+    engine.settings.fsrs_initial_stability = 9.0
+
+    node_id, _ = engine.remember(CreateNodeRequest(content="a brand new memory"))
+
+    assert engine.file_store.load(node_id).stability == 9.0
+
+
+def test_remember_writes_the_initial_stability_to_the_index(engine):
+    from ormah.models.node import CreateNodeRequest
+
+    engine.settings.fsrs_initial_stability = 9.0
+
+    node_id, _ = engine.remember(CreateNodeRequest(content="a brand new memory"))
+
+    row = engine.db.conn.execute(
+        "SELECT stability FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    assert row["stability"] == 9.0

--- a/tests/test_engine/test_recall_concurrency.py
+++ b/tests/test_engine/test_recall_concurrency.py
@@ -65,3 +65,46 @@ def test_concurrent_recall_does_not_raise(engine):
         t.join()
 
     assert not errors, f"concurrent recall raised: {errors[:3]}"
+
+
+def test_decay_and_promotion_leave_disk_and_index_agreeing(engine):
+    """"Did not raise" does not catch divergence — this compares disk against index.
+
+    run_decay holds _memory_operation_lock for its whole run (serialized_memory_job
+    -> engine.memory_operation()), and _record_confirmed_use takes the same RLock,
+    so the two cannot interleave in-process.
+    """
+    from ormah.background.decay_manager import run_decay
+    from ormah.models.node import Tier
+
+    node_id, _ = engine.remember(CreateNodeRequest(content="contended node"))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    engine.builder.index_single(engine.file_store.save(node))
+
+    errors: list[BaseException] = []
+
+    def decay():
+        try:
+            run_decay(engine)
+        except BaseException as e:  # noqa: BLE001 - recorded and re-raised below
+            errors.append(e)
+
+    def promote():
+        try:
+            engine._record_confirmed_use(node_id)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=decay), threading.Thread(target=promote)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    on_disk = engine.file_store.load(node_id).tier.value
+    in_index = engine.db.conn.execute(
+        "SELECT tier FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()["tier"]
+    assert on_disk == in_index

--- a/tests/test_engine/test_recall_concurrency.py
+++ b/tests/test_engine/test_recall_concurrency.py
@@ -106,7 +106,7 @@ def test_decay_and_promotion_leave_disk_and_index_agreeing(engine):
     def decay():
         try:
             run_decay(engine)
-        except BaseException as e:  # noqa: BLE001 - recorded and re-raised below
+        except BaseException as e:  # noqa: BLE001 - recorded and asserted empty below
             errors.append(e)
 
     def promote():

--- a/tests/test_engine/test_recall_concurrency.py
+++ b/tests/test_engine/test_recall_concurrency.py
@@ -68,18 +68,37 @@ def test_concurrent_recall_does_not_raise(engine):
 
 
 def test_decay_and_promotion_leave_disk_and_index_agreeing(engine):
-    """"Did not raise" does not catch divergence — this compares disk against index.
+    """Decay and confirmed use race over one node; only two outcomes are legal.
 
-    run_decay holds _memory_operation_lock for its whole run (serialized_memory_job
-    -> engine.memory_operation()), and _record_confirmed_use takes the same RLock,
-    so the two cannot interleave in-process.
+    What this proves: run_decay holds _memory_operation_lock for its whole run
+    (serialized_memory_job -> engine.memory_operation()) and _record_confirmed_use
+    takes the same RLock, so the two cannot interleave in-process. Whichever wins
+    the lock, disk and index end up agreeing and the final state is one of the two
+    serializations enumerated below — no torn half-demoted/half-promoted state.
+
+    What it cannot prove: nothing about cross-process safety. _memory_operation_lock
+    is an in-process threading.RLock; a second OS process running the sleep cycle
+    against the same store is not covered by this test at all.
+
+    The node is seeded as a genuine decay candidate (tier=working, stability=1.0,
+    last_accessed 30 days back => R = exp(-30) << fsrs_decay_threshold=0.3), so the
+    decay thread really does have work to do rather than being a silent no-op.
+    run_decay swallows its own exceptions, so `errors` can only ever fail on the
+    promotion side — the outcome assertions below are what actually covers decay.
     """
+    from datetime import datetime, timedelta, timezone
+
     from ormah.background.decay_manager import run_decay
     from ormah.models.node import Tier
 
     node_id, _ = engine.remember(CreateNodeRequest(content="contended node"))
     node = engine.file_store.load(node_id)
-    node.tier = Tier.archival
+    stale = datetime.now(timezone.utc) - timedelta(days=30)
+    node.tier = Tier.working
+    node.stability = 1.0
+    node.last_accessed = stale
+    node.last_review = stale
+    node.importance = 0.0
     engine.builder.index_single(engine.file_store.save(node))
 
     errors: list[BaseException] = []
@@ -103,8 +122,25 @@ def test_decay_and_promotion_leave_disk_and_index_agreeing(engine):
         t.join()
 
     assert errors == []
-    on_disk = engine.file_store.load(node_id).tier.value
+
+    final = engine.file_store.load(node_id)
     in_index = engine.db.conn.execute(
         "SELECT tier FROM nodes WHERE id = ?", (node_id,)
     ).fetchone()["tier"]
-    assert on_disk == in_index
+    assert final.tier.value == in_index
+
+    # Both legal serializations end on `working`:
+    #   decay first  -> demoted to archival, then confirmed use reinforces
+    #                   (S=1, 30d -> 2.0) and the archival branch applies the
+    #                   promotion floor max(2.0, fsrs_initial_stability=5.814)
+    #                   -> back to working with S=5.814 and ONE promote entry.
+    #   promotion first -> node is still `working`, so no promotion happens:
+    #                   only the bounded reinforcement (S=1, 30d -> 2.0), and
+    #                   last_accessed=now makes decay skip it -> working, 0 entries.
+    assert final.tier is Tier.working
+    assert in_index == Tier.working.value
+    assert final.stability in (5.814, 2.0), final.stability
+
+    promotes = engine.list_audit_log(node_id=node_id, operation="promote")
+    expected_promotes = 1 if final.stability == 5.814 else 0
+    assert len(promotes) == expected_promotes, (final.stability, promotes)

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -219,3 +219,60 @@ def test_concurrent_touches_run_reinforcement_once(engine, monkeypatch):
         f"cooldown ran reinforcement {len(reinforcements)} times under concurrency"
     )
     assert _row(engine, node_id)["access_count"] == 4, "every touch must still be counted"
+
+
+# --- Interaction with reversible promotion (#223) ---------------------------
+
+def test_bounded_update_runs_before_the_floor(engine):
+    """Archival, S=1, last used 30d ago -> 5.814.
+
+    The bounded update gives 1 -> 2.0 (spacing saturates at cap 2.0); the floor
+    then lifts 2.0 -> 5.814. The INVERTED order would give ~8.23
+    (5.814 * (1 + 0.5 * 5.814**-0.5 * 2.0)), so equality at 5.814 catches it.
+    Since e13d733 the spacing anchor is last_accessed (last_review only opens
+    the cooldown gate), so both are backdated.
+    """
+    node_id, _ = engine.remember(CreateNodeRequest(content="an old archived memory"))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    node.stability = 1.0
+    node.last_accessed = node.last_review = datetime.now(timezone.utc) - timedelta(days=30)
+    engine.builder.index_single(engine.file_store.save(node))
+
+    engine._record_confirmed_use(node_id)
+
+    promoted = engine.file_store.load(node_id)
+    assert promoted.stability == 5.814
+    assert promoted.tier is Tier.working
+
+
+def test_floor_applies_even_when_the_cooldown_blocked_the_numeric_update(engine):
+    """Asserting only tier == working passes WITH the bug — and the node would
+    re-archive in ~29 h on S=1. The stability assertion is the real gate."""
+    node_id, _ = engine.remember(CreateNodeRequest(content="recently reviewed, archived"))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    node.stability = 1.0
+    node.last_review = datetime.now(timezone.utc)   # on cooldown
+    engine.builder.index_single(engine.file_store.save(node))
+
+    engine._record_confirmed_use(node_id)
+
+    promoted = engine.file_store.load(node_id)
+    assert promoted.tier is Tier.working
+    assert promoted.stability == 5.814
+
+
+def test_the_floor_does_not_stack_across_two_uses_in_one_day(engine):
+    """Two confirmed uses in one day -> 5.814, not 11.628 and not 6.814."""
+    node_id, _ = engine.remember(CreateNodeRequest(content="used twice today"))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    node.stability = 1.0
+    node.last_review = datetime.now(timezone.utc)
+    engine.builder.index_single(engine.file_store.save(node))
+
+    engine._record_confirmed_use(node_id)
+    engine._record_confirmed_use(node_id)
+
+    assert engine.file_store.load(node_id).stability == 5.814

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -264,7 +264,11 @@ def test_floor_applies_even_when_the_cooldown_blocked_the_numeric_update(engine)
 
 
 def test_the_floor_does_not_stack_across_two_uses_in_one_day(engine):
-    """Two confirmed uses in one day -> 5.814, not 11.628 and not 6.814."""
+    """The first call is the load-bearing one: with a `+` instead of `max` it
+    would land at 6.814 instead of 5.814. After that call the node is
+    already `working`, so the second call never reaches the archival-only
+    floor branch at all -- stacking is structurally impossible here, since
+    promotion_floor is `max()` against a constant, not an accumulator."""
     node_id, _ = engine.remember(CreateNodeRequest(content="used twice today"))
     node = engine.file_store.load(node_id)
     node.tier = Tier.archival

--- a/tests/test_engine/test_reversible_promotion.py
+++ b/tests/test_engine/test_reversible_promotion.py
@@ -30,9 +30,16 @@ def test_recall_node_promotes_exactly_the_requested_node(engine):
 
 def test_a_generic_derived_from_target_still_promotes(engine):
     """derived_from is a general relationship; only marked sources are blocked.
-    Testing only the marked node misses the block-everything bug the issue names."""
+    Testing only the marked node misses the block-everything bug the issue names.
+    Both `plain` and `marked` are genuine derived_from targets (each has an
+    incoming derived_from edge from a parent); only the superseded_by marker
+    tells them apart, so a gate that keys off the edge instead of the marker
+    would block both and fail this test."""
+    parent = _archive(engine, "a parent that derives both nodes below")
     plain = _archive(engine, "a derived_from target that was never superseded")
     marked = _archive(engine, "a genuinely superseded source", superseded_by="some-consolidation-id")
+    engine.connect(ConnectRequest(source_id=parent, target_id=plain, edge=EdgeType.derived_from))
+    engine.connect(ConnectRequest(source_id=parent, target_id=marked, edge=EdgeType.derived_from))
 
     engine._record_confirmed_use(plain)
     engine._record_confirmed_use(marked)
@@ -56,7 +63,6 @@ def test_a_superseded_node_is_not_promoted_but_still_tracks_access(engine):
 def test_a_working_node_is_left_alone(engine):
     """promote() guards tier ordering; a working node must not be touched by the branch."""
     node_id, _ = engine.remember(CreateNodeRequest(content="already working"))
-    engine.file_store.load(node_id)
 
     engine._record_confirmed_use(node_id)
 

--- a/tests/test_engine/test_reversible_promotion.py
+++ b/tests/test_engine/test_reversible_promotion.py
@@ -34,10 +34,14 @@ def test_a_generic_derived_from_target_still_promotes(engine):
     Both `plain` and `marked` are genuine derived_from targets (each has an
     incoming derived_from edge from a parent); only the superseded_by marker
     tells them apart, so a gate that keys off the edge instead of the marker
-    would block both and fail this test."""
+    would block both and fail this test.
+
+    The marker must point at a node that really exists: a dangling marker no longer
+    blocks (see test_a_dangling_superseded_by_no_longer_blocks_promotion)."""
     parent = _archive(engine, "a parent that derives both nodes below")
     plain = _archive(engine, "a derived_from target that was never superseded")
-    marked = _archive(engine, "a genuinely superseded source", superseded_by="some-consolidation-id")
+    replacement, _ = engine.remember(CreateNodeRequest(content="the consolidation node"))
+    marked = _archive(engine, "a genuinely superseded source", superseded_by=replacement)
     engine.connect(ConnectRequest(source_id=parent, target_id=plain, edge=EdgeType.derived_from))
     engine.connect(ConnectRequest(source_id=parent, target_id=marked, edge=EdgeType.derived_from))
 
@@ -50,7 +54,8 @@ def test_a_generic_derived_from_target_still_promotes(engine):
 
 def test_a_superseded_node_is_not_promoted_but_still_tracks_access(engine):
     """Blocking promotion must not silently swallow the access bookkeeping."""
-    marked = _archive(engine, "superseded but still read", superseded_by="some-consolidation-id")
+    replacement, _ = engine.remember(CreateNodeRequest(content="the consolidation node"))
+    marked = _archive(engine, "superseded but still read", superseded_by=replacement)
     before = engine.file_store.load(marked).access_count
 
     engine._record_confirmed_use(marked)
@@ -67,6 +72,32 @@ def test_a_working_node_is_left_alone(engine):
     engine._record_confirmed_use(node_id)
 
     assert engine.file_store.load(node_id).tier is Tier.working
+
+
+def test_a_dangling_superseded_by_no_longer_blocks_promotion(engine):
+    """Self-healing against permanent burial (#192 scenario): the consolidation node
+    the marker points at was deleted, so nothing is left to represent this memory.
+    The block is lifted on the next confirmed use — but the marker itself stays,
+    because it is the provenance record, not the lock."""
+    dangling = "00000000-0000-0000-0000-000000000000"
+    marked = _archive(engine, "superseded by a node that no longer exists", superseded_by=dangling)
+
+    engine._record_confirmed_use(marked)
+
+    after = engine.file_store.load(marked)
+    assert after.tier is Tier.working
+    assert after.superseded_by == dangling
+
+
+def test_a_live_superseded_by_still_blocks_promotion(engine):
+    """The discriminator is whether the consolidation node is still loadable, pinned
+    directly next to the dangling case: same marker field, opposite outcome."""
+    replacement, _ = engine.remember(CreateNodeRequest(content="the live consolidation node"))
+    marked = _archive(engine, "a genuinely superseded source", superseded_by=replacement)
+
+    engine._record_confirmed_use(marked)
+
+    assert engine.file_store.load(marked).tier is Tier.archival
 
 
 def test_promotion_is_written_to_the_index_too(engine):

--- a/tests/test_engine/test_reversible_promotion.py
+++ b/tests/test_engine/test_reversible_promotion.py
@@ -1,0 +1,74 @@
+"""Reversible promotion: archival nodes return to working on confirmed use (#223)."""
+
+from __future__ import annotations
+
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, Tier
+
+
+def _archive(engine, content: str, superseded_by: str | None = None) -> str:
+    node_id, _ = engine.remember(CreateNodeRequest(content=content))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    node.superseded_by = superseded_by
+    engine.builder.index_single(engine.file_store.save(node))
+    return node_id
+
+
+def test_recall_node_promotes_exactly_the_requested_node(engine):
+    """The archival NEIGHBOUR is the point: without it, an implementation that
+    promotes every id in whisper_log_ids passes — and recall_node DOES create
+    whisper_log rows for neighbours, in _log_feedback_candidates."""
+    a = _archive(engine, "the node actually recalled")
+    b = _archive(engine, "a connected neighbour that must stay archival")
+    engine.connect(ConnectRequest(source_id=a, target_id=b, edge=EdgeType.related_to))
+
+    engine.recall_node(a)
+
+    assert engine.file_store.load(a).tier is Tier.working
+    assert engine.file_store.load(b).tier is Tier.archival
+
+
+def test_a_generic_derived_from_target_still_promotes(engine):
+    """derived_from is a general relationship; only marked sources are blocked.
+    Testing only the marked node misses the block-everything bug the issue names."""
+    plain = _archive(engine, "a derived_from target that was never superseded")
+    marked = _archive(engine, "a genuinely superseded source", superseded_by="some-consolidation-id")
+
+    engine._record_confirmed_use(plain)
+    engine._record_confirmed_use(marked)
+
+    assert engine.file_store.load(plain).tier is Tier.working
+    assert engine.file_store.load(marked).tier is Tier.archival
+
+
+def test_a_superseded_node_is_not_promoted_but_still_tracks_access(engine):
+    """Blocking promotion must not silently swallow the access bookkeeping."""
+    marked = _archive(engine, "superseded but still read", superseded_by="some-consolidation-id")
+    before = engine.file_store.load(marked).access_count
+
+    engine._record_confirmed_use(marked)
+
+    after = engine.file_store.load(marked)
+    assert after.tier is Tier.archival
+    assert after.access_count == before + 1
+
+
+def test_a_working_node_is_left_alone(engine):
+    """promote() guards tier ordering; a working node must not be touched by the branch."""
+    node_id, _ = engine.remember(CreateNodeRequest(content="already working"))
+    engine.file_store.load(node_id)
+
+    engine._record_confirmed_use(node_id)
+
+    assert engine.file_store.load(node_id).tier is Tier.working
+
+
+def test_promotion_is_written_to_the_index_too(engine):
+    node_id = _archive(engine, "must land in SQL as well")
+
+    engine._record_confirmed_use(node_id)
+
+    row = engine.db.conn.execute(
+        "SELECT tier FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    assert row["tier"] == "working"

--- a/tests/test_engine/test_reversible_promotion.py
+++ b/tests/test_engine/test_reversible_promotion.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, Tier
+from ormah.models.node import (
+    ConnectRequest,
+    CreateNodeRequest,
+    EdgeType,
+    MemoryNode,
+    NodeType,
+    Tier,
+)
 
 
 def _archive(engine, content: str, superseded_by: str | None = None) -> str:
@@ -98,6 +105,38 @@ def test_a_live_superseded_by_still_blocks_promotion(engine):
     engine._record_confirmed_use(marked)
 
     assert engine.file_store.load(marked).tier is Tier.archival
+
+
+def test_a_prefix_collision_is_not_mistaken_for_a_live_replacement(engine):
+    """`load(marker) is not None` is not the same question as "the replacement exists".
+
+    FileStore._find_file resolves an id through the 8-character prefix in the
+    filename and returns the first match without checking the id it loaded (#280),
+    so a deleted replacement whose prefix collides with an unrelated node comes
+    back as that node.  The marker then reads as live, the block never lifts, and
+    the memory is buried forever — the failure the dangling-marker branch exists
+    to prevent.  The liveness check has to confirm the complete id."""
+    collider = MemoryNode(
+        id="deadbeef-0000-0000-0000-00000000000b",
+        type=NodeType.fact,
+        content="an unrelated node that happens to share the first eight characters",
+    )
+    engine.builder.index_single(engine.file_store.save(collider))
+
+    gone = "deadbeef-0000-0000-0000-00000000000a"
+    collision = engine.file_store.load(gone)
+    assert collision is not None and collision.id != gone, (
+        "precondition: this test needs load() to resolve the prefix to the collider; "
+        "drop this assertion once #280 makes the lookup exact"
+    )
+
+    marked = _archive(engine, "superseded by a node that no longer exists", superseded_by=gone)
+
+    engine._record_confirmed_use(marked)
+
+    after = engine.file_store.load(marked)
+    assert after.tier is Tier.working
+    assert after.superseded_by == gone
 
 
 def test_promotion_is_written_to_the_index_too(engine):

--- a/tests/test_engine/test_supersession_merge_redirect.py
+++ b/tests/test_engine/test_supersession_merge_redirect.py
@@ -1,0 +1,116 @@
+"""Merging a consolidation node carries its sources' supersession markers (#223).
+
+Consolidation writes A/B -> C.  If C is later merged into D, ``execute_merge``
+soft-deletes C while A and B still point at it: the marker then reads as
+*dangling*, and the next confirmed use promotes A or B even though D still
+represents them.  Reported on PR #257 by the maintainer.
+"""
+
+from __future__ import annotations
+
+from ormah.models.node import CreateNodeRequest, Tier
+
+
+def _live(engine, content: str, title: str) -> str:
+    node_id, _ = engine.remember(CreateNodeRequest(content=content, title=title))
+    return node_id
+
+
+def _superseded_source(engine, content: str, replacement: str) -> str:
+    """An archival source carrying the marker the consolidator writes."""
+    node_id, _ = engine.remember(CreateNodeRequest(content=content))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    node.superseded_by = replacement
+    engine.builder.index_single(engine.file_store.save(node))
+    return node_id
+
+
+def _sql_marker(engine, node_id: str) -> str | None:
+    row = engine.db.conn.execute(
+        "SELECT superseded_by FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    return None if row is None else row["superseded_by"]
+
+
+def _consolidation_then_merge(engine):
+    """A/B -> C, then C merged into D.  Returns (a, b, c, d).
+
+    D wins ``_pick_keeper`` deterministically: same tier, strictly longer content.
+    """
+    c = _live(engine, "the consolidation node", "C")
+    a = _superseded_source(engine, "source A folded into C", c)
+    b = _superseded_source(engine, "source B folded into C", c)
+    d = _live(
+        engine,
+        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
+        "D",
+    )
+    engine.execute_merge(c, d)
+    return a, b, c, d
+
+
+def test_merging_the_replacement_redirects_every_source(engine):
+    a, b, c, d = _consolidation_then_merge(engine)
+
+    assert engine.file_store.load(c) is None, "precondition: C was soft-deleted"
+    assert engine.file_store.load(a).superseded_by == d
+    assert engine.file_store.load(b).superseded_by == d
+
+
+def test_the_redirect_reaches_sqlite_too(engine):
+    """Markdown and index must not disagree: the promotion gate reads the file,
+    but a reindex rebuilds the file's value into the row and sync reads the row."""
+    a, b, _c, d = _consolidation_then_merge(engine)
+
+    assert _sql_marker(engine, a) == d
+    assert _sql_marker(engine, b) == d
+
+
+def test_a_redirected_source_still_blocks_promotion(engine):
+    """The point of the redirect.  With the stale pointer the marker reads as
+    dangling (C is gone), the self-healing branch lifts the block, and A promotes
+    into the whisper-eligible tier even though D represents it."""
+    a, _b, _c, _d = _consolidation_then_merge(engine)
+
+    engine._record_confirmed_use(a)
+
+    assert engine.file_store.load(a).tier is Tier.archival
+
+
+def test_a_marker_pointing_elsewhere_is_left_alone(engine):
+    """The UPDATE is keyed on the removed node, not on 'has a marker'."""
+    other = _live(engine, "an unrelated consolidation node", "other")
+    bystander = _superseded_source(engine, "superseded by something else entirely", other)
+
+    _consolidation_then_merge(engine)
+
+    assert engine.file_store.load(bystander).superseded_by == other
+    assert _sql_marker(engine, bystander) == other
+
+
+def test_the_kept_node_never_supersedes_itself(engine):
+    """If the kept node is the one carrying the marker, a blind redirect writes
+    ``kept.superseded_by = kept.id`` — a marker that always resolves live and buries
+    the node forever, the exact failure the dangling-marker branch exists to prevent.
+    Absorbing the removed node means nothing supersedes the keeper any more."""
+    replacement = _live(engine, "short", "R")
+    keeper = engine.file_store.load(replacement)
+    keeper.tier = Tier.archival
+    engine.builder.index_single(engine.file_store.save(keeper))
+
+    marked = _superseded_source(
+        engine,
+        "the source, longer than its own replacement so _pick_keeper keeps it",
+        replacement,
+    )
+
+    engine.execute_merge(marked, replacement)
+
+    assert engine.file_store.load(marked) is not None, "precondition: the marked node is the keeper"
+    assert engine.file_store.load(marked).superseded_by is None
+    assert _sql_marker(engine, marked) is None
+
+    engine._record_confirmed_use(marked)
+
+    assert engine.file_store.load(marked).tier is Tier.working

--- a/tests/test_engine/test_supersession_merge_redirect.py
+++ b/tests/test_engine/test_supersession_merge_redirect.py
@@ -114,3 +114,105 @@ def test_the_kept_node_never_supersedes_itself(engine):
     engine._record_confirmed_use(marked)
 
     assert engine.file_store.load(marked).tier is Tier.working
+
+
+# --- Where the redirect gets its list of sources -----------------------------
+#
+# The redirect discovers sources with `SELECT id FROM nodes WHERE superseded_by = ?`
+# — it reads the index, not the files.  The three tests below pin what that costs
+# and what it does not, because the markdown file is the authority the promotion
+# gate reads, and the two can diverge: `_mark_superseded` saves the file first and
+# writes the row second, so a crash in between leaves a marker only in markdown.
+
+
+def _marker_in_markdown_only(engine, content: str, replacement: str) -> str:
+    """A source whose marker reached the file but not the row — the crash window
+    inside _mark_superseded, reproduced by saving without re-indexing."""
+    node_id, _ = engine.remember(CreateNodeRequest(content=content))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    node.superseded_by = replacement
+    engine.file_store.save(node)  # deliberately NOT index_single
+    assert _sql_marker(engine, node_id) is None, "precondition: the row never saw the marker"
+    return node_id
+
+
+def test_a_marker_that_never_reached_the_index_is_missed(engine):
+    """Characterisation, not an endorsement: the redirect is exactly as
+    index-trusting as the code around it — `execute_merge` already reads the
+    edges it remaps out of SQLite in the same way, so a stale index mis-remaps
+    edges long before it mis-redirects a marker.  Pinning the boundary here means
+    a future change that widens it has to edit this test on purpose."""
+    c = _live(engine, "the consolidation node", "C")
+    orphan = _marker_in_markdown_only(engine, "marked in the file, absent from the row", c)
+    d = _live(
+        engine,
+        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
+        "D",
+    )
+
+    engine.execute_merge(c, d)
+
+    assert engine.file_store.load(orphan).superseded_by == c, "still pointing at the dead node"
+    assert _sql_marker(engine, orphan) is None
+
+
+def test_the_missed_marker_lets_the_source_promote(engine):
+    """The consequence, spelled out: C is gone, so the stale marker reads as
+    dangling and the self-healing branch lifts the block."""
+    c = _live(engine, "the consolidation node", "C")
+    orphan = _marker_in_markdown_only(engine, "marked in the file, absent from the row", c)
+    d = _live(
+        engine,
+        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
+        "D",
+    )
+    engine.execute_merge(c, d)
+
+    engine._record_confirmed_use(orphan)
+
+    assert engine.file_store.load(orphan).tier is Tier.working
+
+
+def test_a_reindex_closes_the_gap_before_the_merge(engine):
+    """The divergence is not durable: the index is derived from the files, so
+    re-indexing the source restores the row and the redirect finds it."""
+    c = _live(engine, "the consolidation node", "C")
+    orphan = _marker_in_markdown_only(engine, "marked in the file, absent from the row", c)
+    engine.builder.index_single(engine.file_store._find_file(orphan))
+    assert _sql_marker(engine, orphan) == c, "precondition: the reindex restored the row"
+    d = _live(
+        engine,
+        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
+        "D",
+    )
+
+    engine.execute_merge(c, d)
+
+    assert engine.file_store.load(orphan).superseded_by == d
+    assert _sql_marker(engine, orphan) == d
+
+
+def test_the_opposite_divergence_heals_instead_of_breaking(engine):
+    """Marker in the row, absent from the file — the mirror image.  SQL discovery
+    finds it, and the markdown pass writes the keeper into the file, so the merge
+    leaves the two agreeing.  This is why the SQL-first read is the safe half of
+    the pair: it over-reaches into repair, never under-reaches into loss."""
+    c = _live(engine, "the consolidation node", "C")
+    node_id, _ = engine.remember(CreateNodeRequest(content="marked in the row, absent from the file"))
+    node = engine.file_store.load(node_id)
+    node.tier = Tier.archival
+    engine.builder.index_single(engine.file_store.save(node))
+    engine.db.conn.execute("UPDATE nodes SET superseded_by = ? WHERE id = ?", (c, node_id))
+    engine.db.conn.commit()
+    assert engine.file_store.load(node_id).superseded_by is None, "precondition: file has no marker"
+
+    d = _live(
+        engine,
+        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
+        "D",
+    )
+    engine.execute_merge(c, d)
+
+    assert _sql_marker(engine, node_id) == d
+    assert engine.file_store.load(node_id).superseded_by == d, "the markdown pass healed the file"

--- a/tests/test_engine/test_supersession_merge_redirect.py
+++ b/tests/test_engine/test_supersession_merge_redirect.py
@@ -8,7 +8,7 @@ represents them.  Reported on PR #257 by the maintainer.
 
 from __future__ import annotations
 
-from ormah.models.node import CreateNodeRequest, Tier
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, Tier
 
 
 def _live(engine, content: str, title: str) -> str:
@@ -118,17 +118,28 @@ def test_the_kept_node_never_supersedes_itself(engine):
 
 # --- Where the redirect gets its list of sources -----------------------------
 #
-# The redirect discovers sources with `SELECT id FROM nodes WHERE superseded_by = ?`
-# — it reads the index, not the files.  The three tests below pin what that costs
-# and what it does not, because the markdown file is the authority the promotion
-# gate reads, and the two can diverge: `_mark_superseded` saves the file first and
-# writes the row second, so a crash in between leaves a marker only in markdown.
+# Two routes, because they answer slightly different questions.  Route 1 reads
+# `nodes.superseded_by` out of the index; route 2 opens the files named by the
+# derived_from edges leaving the removed node.  The gate reads the *file*, and the
+# two can diverge: `_mark_superseded` saves the markdown first and writes the row
+# second, so a crash in between leaves a marker only in markdown.  The consolidator
+# writes the derived_from edge before that call, so route 2 covers the window.
 
 
-def _marker_in_markdown_only(engine, content: str, replacement: str) -> str:
+def _marker_in_markdown_only(engine, content: str, replacement: str, *, edge: bool) -> str:
     """A source whose marker reached the file but not the row — the crash window
-    inside _mark_superseded, reproduced by saving without re-indexing."""
+    inside _mark_superseded.  *edge* replays the derived_from link the consolidator
+    writes one line earlier; without it there is nothing pointing at this file."""
     node_id, _ = engine.remember(CreateNodeRequest(content=content))
+    if edge:
+        # Created BEFORE the unindexed save: connect() re-indexes, which would
+        # otherwise hand the row the very marker this fixture must withhold.
+        engine.connect(ConnectRequest(
+            source_id=replacement,
+            target_id=node_id,
+            edge=EdgeType.derived_from,
+            weight=1.0,
+        ))
     node = engine.file_store.load(node_id)
     node.tier = Tier.archival
     node.superseded_by = replacement
@@ -137,67 +148,113 @@ def _marker_in_markdown_only(engine, content: str, replacement: str) -> str:
     return node_id
 
 
-def test_a_marker_that_never_reached_the_index_is_missed(engine):
-    """Characterisation, not an endorsement: the redirect is exactly as
-    index-trusting as the code around it — `execute_merge` already reads the
-    edges it remaps out of SQLite in the same way, so a stale index mis-remaps
-    edges long before it mis-redirects a marker.  Pinning the boundary here means
-    a future change that widens it has to edit this test on purpose."""
-    c = _live(engine, "the consolidation node", "C")
-    orphan = _marker_in_markdown_only(engine, "marked in the file, absent from the row", c)
-    d = _live(
-        engine,
-        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
-        "D",
-    )
-
-    engine.execute_merge(c, d)
-
-    assert engine.file_store.load(orphan).superseded_by == c, "still pointing at the dead node"
-    assert _sql_marker(engine, orphan) is None
-
-
-def test_the_missed_marker_lets_the_source_promote(engine):
-    """The consequence, spelled out: C is gone, so the stale marker reads as
-    dangling and the self-healing branch lifts the block."""
-    c = _live(engine, "the consolidation node", "C")
-    orphan = _marker_in_markdown_only(engine, "marked in the file, absent from the row", c)
+def _merge_into_d(engine, c: str) -> str:
     d = _live(
         engine,
         "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
         "D",
     )
     engine.execute_merge(c, d)
-
-    engine._record_confirmed_use(orphan)
-
-    assert engine.file_store.load(orphan).tier is Tier.working
+    return d
 
 
-def test_a_reindex_closes_the_gap_before_the_merge(engine):
-    """The divergence is not durable: the index is derived from the files, so
-    re-indexing the source restores the row and the redirect finds it."""
+def test_a_marker_only_in_markdown_is_found_through_the_derived_from_edge(engine):
+    """The crash window inside _mark_superseded, reproduced end to end: the row
+    never got the marker, so route 1 cannot see this source at all."""
     c = _live(engine, "the consolidation node", "C")
-    orphan = _marker_in_markdown_only(engine, "marked in the file, absent from the row", c)
-    engine.builder.index_single(engine.file_store._find_file(orphan))
-    assert _sql_marker(engine, orphan) == c, "precondition: the reindex restored the row"
-    d = _live(
-        engine,
-        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
-        "D",
-    )
+    orphan = _marker_in_markdown_only(engine, "marked in the file only", c, edge=True)
 
-    engine.execute_merge(c, d)
+    d = _merge_into_d(engine, c)
 
     assert engine.file_store.load(orphan).superseded_by == d
+
+
+def test_the_row_is_healed_while_it_is_redirected(engine):
+    """Route 2 finds a source whose row is still NULL, so the per-id UPDATE has to
+    write the marker rather than merely change it — a `WHERE superseded_by = ?`
+    update would match nothing and leave the row behind the file forever."""
+    c = _live(engine, "the consolidation node", "C")
+    orphan = _marker_in_markdown_only(engine, "marked in the file only", c, edge=True)
+
+    d = _merge_into_d(engine, c)
+
     assert _sql_marker(engine, orphan) == d
 
 
+def test_the_recovered_source_stays_blocked(engine):
+    """The point of covering the window: without route 2 the stale marker reads as
+    dangling once C is gone, and the source promotes back into the whisper tier."""
+    c = _live(engine, "the consolidation node", "C")
+    orphan = _marker_in_markdown_only(engine, "marked in the file only", c, edge=True)
+    _merge_into_d(engine, c)
+
+    engine._record_confirmed_use(orphan)
+
+    assert engine.file_store.load(orphan).tier is Tier.archival
+
+
+def test_a_derived_from_target_without_a_marker_is_not_redirected(engine):
+    """derived_from is a general relationship — the same reason #223 refused to gate
+    promotion on it.  Route 2 opens the file to read the marker; the edge only
+    decides which files are worth opening.  Without this, every derived_from target
+    of the removed node would be marked superseded by the keeper."""
+    c = _live(engine, "the consolidation node", "C")
+    plain, _ = engine.remember(CreateNodeRequest(content="derived from C, never superseded"))
+    engine.connect(ConnectRequest(
+        source_id=c, target_id=plain, edge=EdgeType.derived_from, weight=1.0,
+    ))
+
+    _merge_into_d(engine, c)
+
+    assert engine.file_store.load(plain).superseded_by is None
+    assert _sql_marker(engine, plain) is None
+
+
+def test_a_derived_from_target_marked_by_someone_else_is_not_redirected(engine):
+    """Reachable by the edge, but its marker names a different node.  The criterion
+    is the marker's value, not merely that the file carries one."""
+    c = _live(engine, "the consolidation node", "C")
+    other = _live(engine, "an unrelated consolidation node", "other")
+    node_id, _ = engine.remember(CreateNodeRequest(content="derived from C, superseded by other"))
+    node = engine.file_store.load(node_id)
+    node.superseded_by = other
+    engine.builder.index_single(engine.file_store.save(node))
+    # The edge is created LAST: index_single wipes every edge touching this node,
+    # so building it first would leave the node unreachable by route 2 and this
+    # test would pass with the marker check removed.
+    engine.connect(ConnectRequest(
+        source_id=c, target_id=node_id, edge=EdgeType.derived_from, weight=1.0,
+    ))
+    assert engine.db.conn.execute(
+        "SELECT 1 FROM edges WHERE source_id = ? AND target_id = ? AND edge_type = 'derived_from'",
+        (c, node_id),
+    ).fetchone(), "precondition: route 2 can actually reach this node"
+
+    _merge_into_d(engine, c)
+
+    assert engine.file_store.load(node_id).superseded_by == other
+    assert _sql_marker(engine, node_id) == other
+
+
+def test_a_marker_with_neither_a_row_nor_an_edge_is_still_missed(engine):
+    """The residual boundary, pinned on purpose.  Both routes need *some* trace of
+    the source; a marker written outside the consolidator, into the file alone, has
+    none.  Nothing in this repository writes one that way — the consolidator is the
+    only producer, and it always writes the edge first — so closing this last case
+    would cost a full store scan on every merge for a state no code can reach.  A
+    change that widens the redirect has to edit this test on purpose."""
+    c = _live(engine, "the consolidation node", "C")
+    orphan = _marker_in_markdown_only(engine, "no row, no edge", c, edge=False)
+
+    _merge_into_d(engine, c)
+
+    assert engine.file_store.load(orphan).superseded_by == c, "still pointing at the dead node"
+
+
 def test_the_opposite_divergence_heals_instead_of_breaking(engine):
-    """Marker in the row, absent from the file — the mirror image.  SQL discovery
-    finds it, and the markdown pass writes the keeper into the file, so the merge
-    leaves the two agreeing.  This is why the SQL-first read is the safe half of
-    the pair: it over-reaches into repair, never under-reaches into loss."""
+    """Marker in the row, absent from the file — the mirror image.  Route 1 finds
+    it, and the markdown pass writes the keeper into the file, so the merge leaves
+    the two agreeing."""
     c = _live(engine, "the consolidation node", "C")
     node_id, _ = engine.remember(CreateNodeRequest(content="marked in the row, absent from the file"))
     node = engine.file_store.load(node_id)
@@ -207,12 +264,7 @@ def test_the_opposite_divergence_heals_instead_of_breaking(engine):
     engine.db.conn.commit()
     assert engine.file_store.load(node_id).superseded_by is None, "precondition: file has no marker"
 
-    d = _live(
-        engine,
-        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
-        "D",
-    )
-    engine.execute_merge(c, d)
+    d = _merge_into_d(engine, c)
 
     assert _sql_marker(engine, node_id) == d
     assert engine.file_store.load(node_id).superseded_by == d, "the markdown pass healed the file"

--- a/tests/test_engine/test_supersession_merge_redirect.py
+++ b/tests/test_engine/test_supersession_merge_redirect.py
@@ -8,6 +8,8 @@ represents them.  Reported on PR #257 by the maintainer.
 
 from __future__ import annotations
 
+import pytest
+
 from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, Tier
 
 
@@ -72,6 +74,39 @@ def test_a_redirected_source_still_blocks_promotion(engine):
     dangling (C is gone), the self-healing branch lifts the block, and A promotes
     into the whisper-eligible tier even though D represents it."""
     a, _b, _c, _d = _consolidation_then_merge(engine)
+
+    engine._record_confirmed_use(a)
+
+    assert engine.file_store.load(a).tier is Tier.archival
+
+
+def test_a_crash_after_deleting_the_replacement_cannot_reopen_its_source(
+    engine, monkeypatch
+):
+    """Deletion is the final filesystem mutation. If the process dies immediately
+    after C is removed, A's markdown must already point at D; otherwise confirmed
+    use reads a dangling C marker and promotes A despite D still representing it."""
+    c = _live(engine, "the consolidation node", "C")
+    a = _superseded_source(engine, "source A folded into C", c)
+    d = _live(
+        engine,
+        "the node C is merged into, deliberately much longer so _pick_keeper keeps it",
+        "D",
+    )
+    original_soft_delete = engine.file_store.soft_delete
+
+    def crash_after_soft_delete(node_id: str) -> bool:
+        original_soft_delete(node_id)
+        raise RuntimeError("simulated process crash after C is removed")
+
+    monkeypatch.setattr(engine.file_store, "soft_delete", crash_after_soft_delete)
+
+    with pytest.raises(RuntimeError, match="simulated process crash"):
+        engine.execute_merge(c, d)
+
+    assert engine.file_store.load(c) is None, "precondition: C was removed"
+    assert engine.file_store.load(a).superseded_by == d
+    assert _sql_marker(engine, a) == d
 
     engine._record_confirmed_use(a)
 

--- a/tests/test_engine/test_tier_manager.py
+++ b/tests/test_engine/test_tier_manager.py
@@ -41,3 +41,15 @@ def test_enforce_core_cap_demotes_least_important():
     assert len(demoted) == 1
     assert demoted[0].id == "node-low"
     assert demoted[0].tier == Tier.working
+
+
+def test_promote_returns_true_upward_and_false_sideways():
+    """#223 relies on this guard: a working node must not be re-promoted."""
+    manager = TierManager()
+
+    node = MemoryNode(type=NodeType.fact, content="c", tier=Tier.archival)
+    assert manager.promote(node, Tier.working) is True
+    assert node.tier is Tier.working
+
+    assert manager.promote(node, Tier.working) is False
+    assert node.tier is Tier.working

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -150,3 +150,20 @@ def test_builder_never_takes_file_lock_inside_write_transaction(engine):
     assert engine.builder.incremental_update() == (0, 0)
 
     assert not violations, f"FileStore lock acquired inside db.transaction(): {violations}"
+
+
+def test_reindex_preserves_superseded_by(engine):
+    """INSERT OR REPLACE drops omitted columns to their DEFAULT — the marker must be
+    in the column list, or the consolidator's own update_node wipes it (#223)."""
+    from ormah.models.node import CreateNodeRequest
+
+    node_id, _ = engine.remember(CreateNodeRequest(content="a source about to be superseded"))
+
+    node = engine.file_store.load(node_id)
+    node.superseded_by = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    engine.builder.index_single(engine.file_store.save(node))
+
+    row = engine.db.conn.execute(
+        "SELECT superseded_by FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    assert row["superseded_by"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"

--- a/tests/test_index/test_migration_superseded.py
+++ b/tests/test_index/test_migration_superseded.py
@@ -1,0 +1,45 @@
+"""Tests for the nodes.superseded_by column migration (#223)."""
+
+from __future__ import annotations
+
+
+def test_migration_adds_superseded_by_and_leaves_existing_rows_null(tmp_path):
+    from ormah.index.db import Database
+
+    db = Database(tmp_path / "legacy.db")
+    try:
+        with db.transaction() as conn:
+            conn.execute(
+                "CREATE TABLE nodes (id TEXT PRIMARY KEY, type TEXT, tier TEXT, space TEXT, "
+                "title TEXT, content TEXT, created TEXT NOT NULL)"
+            )
+            conn.execute("CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            conn.execute(
+                "INSERT INTO nodes (id, type, tier, space, title, content, created) "
+                "VALUES ('old', 'fact', 'working', NULL, 't', 'c', '2020-01-01')"
+            )
+
+        db.init_schema()  # must not raise
+
+        cols = [r[1] for r in db.conn.execute("PRAGMA table_info(nodes)").fetchall()]
+        assert "superseded_by" in cols
+        row = db.conn.execute(
+            "SELECT superseded_by FROM nodes WHERE id = 'old'"
+        ).fetchone()
+        assert row[0] is None
+    finally:
+        db.close()
+
+
+def test_migration_is_idempotent(tmp_path):
+    """PRAGMA-guarded: running init_schema twice must not raise 'duplicate column'."""
+    from ormah.index.db import Database
+
+    db = Database(tmp_path / "twice.db")
+    try:
+        db.init_schema()
+        db.init_schema()
+        cols = [r[1] for r in db.conn.execute("PRAGMA table_info(nodes)").fetchall()]
+        assert cols.count("superseded_by") == 1
+    finally:
+        db.close()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -115,3 +115,37 @@ def test_reinforcement_is_due_once_the_cooldown_elapses():
 def test_a_zero_cooldown_always_allows_reinforcement():
     now = datetime.now(timezone.utc)
     assert lifecycle.reinforcement_due(now, now, 0.0) is True
+
+
+def test_default_initial_stability_gives_a_seven_day_unused_lease():
+    """-7/ln(0.3) = 5.8140852, rounded to 5.814 in config."""
+    from ormah.config import Settings
+
+    initial = Settings().fsrs_initial_stability
+    assert initial == 5.814
+    # 6.5 days unused: still retrievable. 7.5 days: a decay candidate.
+    assert lifecycle.retrievability(6.5, initial) > 0.3
+    assert lifecycle.retrievability(7.5, initial) < 0.3
+
+
+def test_rounded_default_crosses_threshold_just_under_seven_days():
+    """5.814 x 1.2039728 = 6.99990 days, ~8.8 s before the 7-day mark.
+
+    Pinned deliberately: an assertion of `> 0.3` at t = 7.0 would FAIL.
+    """
+    assert lifecycle.retrievability(7.0, 5.814) < 0.3
+    assert lifecycle.retrievability(6.99, 5.814) > 0.3
+
+
+def test_promotion_floor_never_reduces_stability():
+    """Equality at 50.0, not `>= 5.814` — with `>=` a min/max swap passes."""
+    assert lifecycle.promotion_floor(50.0, 5.814) == 50.0
+
+
+def test_promotion_floor_lifts_a_below_floor_stability():
+    assert lifecycle.promotion_floor(2.0, 5.814) == 5.814
+
+
+def test_promotion_floor_is_idempotent():
+    once = lifecycle.promotion_floor(1.0, 5.814)
+    assert lifecycle.promotion_floor(once, 5.814) == once

--- a/tests/test_store/test_markdown.py
+++ b/tests/test_store/test_markdown.py
@@ -74,3 +74,51 @@ def test_deleted_at_omitted_when_none():
     node = MemoryNode(type=NodeType.fact, source="agent:test", content="Live fact.")
     text = serialize_node(node)
     assert "deleted_at" not in text
+
+
+def test_superseded_by_survives_a_markdown_roundtrip():
+    node = MemoryNode(type=NodeType.fact, content="a superseded source")
+    node.superseded_by = "11111111-2222-3333-4444-555555555555"
+
+    parsed = parse_node(serialize_node(node))
+
+    assert parsed.superseded_by == "11111111-2222-3333-4444-555555555555"
+
+
+def test_superseded_by_is_absent_from_frontmatter_when_none():
+    """Without this assertion, writing `superseded_by: null` pollutes every node file."""
+    node = MemoryNode(type=NodeType.fact, content="an ordinary node")
+
+    text = serialize_node(node)
+
+    assert "superseded_by" not in text
+    assert parse_node(text).superseded_by is None
+
+
+def test_a_file_written_before_223_parses_to_none():
+    node = MemoryNode(type=NodeType.fact, content="written by an older build")
+    text = serialize_node(node)
+    assert parse_node(text).superseded_by is None
+
+
+def test_stability_is_not_retroactively_rescaled():
+    """#191 forbids rescaling values that predate the new default."""
+    node = MemoryNode(type=NodeType.fact, content="an old node", stability=1.0)
+    assert parse_node(serialize_node(node)).stability == 1.0
+
+
+def test_a_file_with_no_stability_key_parses_to_one_not_the_new_default():
+    """parse_node's `meta.get("stability", 1.0)` fallback must stay 1.0."""
+    text = (
+        "---\n"
+        "id: 99999999-8888-7777-6666-555555555555\n"
+        "type: fact\n"
+        "tier: working\n"
+        "source: agent:test\n"
+        "created: 2026-01-01T00:00:00Z\n"
+        "updated: 2026-01-01T00:00:00Z\n"
+        "last_accessed: 2026-01-01T00:00:00Z\n"
+        "---\n"
+        "a node from before FSRS\n"
+    )
+    assert parse_node(text).stability == 1.0


### PR DESCRIPTION
## Problem

Archival was a one-way transition: `TierManager.promote()` had no production caller, so a node
deliberately recalled after archiving could never return to the whisper-eligible working tier.

New nodes also took `stability=1.0` from the model default, ignoring the configured and validated
`fsrs_initial_stability`. At the default threshold `R=0.3`, `S=1` crosses into decay candidacy
after about 29 hours.

And the exclusion originally proposed for promotion — every `derived_from` target — was too broad.
`derived_from` is a general relationship; it does not mean the target was superseded.

## Solution

Implements the decision recorded in #191.

### Seven-day initial lease

- `fsrs_initial_stability` default becomes `5.814` (`-7 / ln(0.3)`), a mathematical seven-day
  unused working window (`config.py`).
- `remember()` creates nodes at that configured stability instead of the model default
  (`memory_engine.py`).
- `lifecycle.promotion_floor(S, initial) -> max(S, initial)` — `max`, never a sum, so a node
  promoted twice in one cooldown window ends at one lease, not two, and a node already above
  the initial value is never pulled down to it.

### Reversible promotion

`_record_confirmed_use` promotes `archival -> working` on confirmed use, as one atomic lifecycle
operation with the bounded update:

- The bounded update runs on the **old** stability first, then the floor lifts the result
  (`1 -> 2 -> 5.814`), exactly as #191 specifies.
- The floor also runs when the per-day cooldown blocked the numeric update — otherwise a second
  confirmed use in one day promotes with `S=1` and buys a ~29 h lease the next decay run revokes.
- Promotion goes through `TierManager.promote()` rather than assigning `node.tier`, which gives
  the root cause its first production caller and brings the tier-ordering guard along. `updated`
  advances (the tier genuinely changed, and `updated` feeds LWW sync — not advancing it would let
  a stale remote copy silently re-archive the node).
- Tier and `updated` now travel in the same `UPDATE` as the rest of the access tracking, so
  markdown and index cannot disagree under concurrent promotion/decay. The `promote` audit entry
  is written after that transaction, where `update_node` places its own.

### Explicit supersession provenance

- New `superseded_by: str | None` on `MemoryNode`, with markdown (de)serialization, a
  `schema.sql` column, and an additive `ALTER TABLE` migration alongside the other enrichment
  columns; `IndexBuilder` persists it and it survives a reindex.
- The consolidator records supersession via `_mark_superseded` **before** demoting sources.
  Crashing between the two leaves a node working + marked, which is harmless because the marker
  only blocks automatic promotion. The reverse order would leave it archival + unmarked — a
  promotable node.
- `superseded_by` is written outside `UpdateNodeRequest` deliberately: it is policy state, not
  something an agent sets.
- Only an explicitly superseded consolidation source is blocked from automatic promotion. A
  generic `derived_from` target promotes — the narrowing #191 asked for.
- A **dangling** marker does not bury a node forever: the gate re-checks that the consolidation
  node still exists (`file_store.load`), so if the replacement was deleted (the #192 scenario)
  the next confirmed use un-buries the source. The marker itself is never cleared — it is the
  provenance record; only the block is lifted. The extra load runs only for an archival node
  that carries a marker.

## Notes for the reviewer

- **`fsrs_initial_stability` is also the `stability=0` fallback.** `decay_manager` passes it as
  `fallback_stability` and `reinforced_stability` uses it as `effective_stability` when the
  stored value is falsy. Changing the default therefore also moves the lease of `S=0` nodes from
  ~29 h to ~7 days. That is consistent with the intent, but it is a wider blast radius than the
  creation path alone.
- **Soft-deleting a consolidation node un-buries its sources.** Consequence of the dangling-marker
  self-heal above — a deliberate decision, not an oversight: burying a memory behind a replacement
  that no longer exists is the worse failure.
- **Consolidation is not idempotent under retry** — a failure after marking but before demotion
  leaves a working node carrying a marker, and the cluster query filters only on `tier='working'`,
  so a retry can produce a second consolidation. This is **pre-existing behaviour of the
  consolidator**, verified against the base (`git show <base>:src/ormah/background/consolidator.py`),
  not introduced here. Happy to open a follow-up issue for making the marking compare-and-set and
  excluding marked working nodes from new clusters.
- **`lifecycle_model_version` is deliberately not bumped.** The version records which
  reinforcement model wrote a store's stability values; this PR changes a creation default and
  adds a column, not the model. Reasoning is recorded in a comment at the version helper.
- **No stability rescale.** Existing values are left alone, as #191 requires.
- Product docs are intentionally out of this branch, following the precedent in `f8cb685`.

## Testing

10 commits, TDD throughout — 14 test files against 9 source files. New/extended coverage:

- `test_engine/test_reversible_promotion.py` — promotion on `recall_node`, qualified positive
  feedback, negative/unqualified sources not promoting, promotion never reducing stability, the
  floor not amplifying one event past a single lease, the `superseded_by` block, and the
  dangling-marker self-heal.
- `test_engine/test_recall_concurrency.py` — concurrent promotion/decay leaves markdown and index
  consistent.
- `test_index/test_migration_superseded.py`, `test_index/test_builder.py` — migration on an
  existing database and reindex survival.
- `test_store/test_markdown.py` — round-trip of the new front-matter field.
- `test_background/test_consolidator.py` — mark-before-demote ordering and provenance.
- `test_lifecycle.py`, `test_engine/test_reinforcement_cooldown.py`, `test_audit_log.py`,
  `test_tier_manager.py`, `test_decay_manager.py`, `test_lifecycle_model_version.py` — the floor
  helper, the cooldown interaction, the `promote` audit payload, and the unchanged version.

Closes #223.
