### PR TITLE
fix(consolidator): summarize from full source content, splitting oversized clusters instead of truncating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,3 +127,7 @@ ORMAH_WORKING_DECAY_DAYS=14
 
 # Memory consolidation (requires LLM)
 # ORMAH_CONSOLIDATION_INTERVAL_MINUTES=360
+# Prompt budget for one consolidation, in characters. Also sets the Ollama input window the
+# consolidation route requests (chars/2 + ORMAH_LLM_NUM_PREDICT). A cluster that does not fit is
+# split into smaller consolidations — sources are never truncated.
+# ORMAH_CONSOLIDATION_MAX_PROMPT_CHARS=24000

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -52,9 +52,14 @@ def _prompt_overhead_chars() -> int:
 
 
 def _render_item(node: dict) -> str:
-    """One source as it appears in the items block. FULL content -- never a slice (#192)."""
+    """One source as it appears in the items block. FULL content -- never a slice (#192).
+
+    ``or ""`` rather than ``get(key, "")``: ``nodes.content`` is nullable and the default only
+    applies to a MISSING key, so a present-but-NULL content would render as the literal string
+    "None" and teach the model that is the source's body. Same idiom as the audit log below.
+    """
     title = node.get("title") or "Untitled"
-    content = node.get("content", "")
+    content = node.get("content") or ""
     return f"- [{title}]: {content}"
 
 
@@ -363,6 +368,16 @@ def _consolidate_cluster(engine, cluster: list[dict]) -> None:
 
     raw = llm_generate(engine.settings, prompt, json_mode=True, route="consolidation")
     if raw is None:
+        # Without this the failure is invisible: llm_generate returns None on timeout, connect
+        # error or a disabled provider, the adapter's own warning names neither the job nor the
+        # cluster, and run_consolidation's closing report is guarded by `if consolidated_count:`.
+        # A run where every consolidation failed would emit nothing at all, so the daily job
+        # looks green while the working tier silently stops being curated.
+        logger.warning(
+            "consolidation produced no output for %d source(s) (prompt was %d chars); "
+            "sources left working: %s",
+            len(cluster), len(prompt), ",".join(str(n.get("id")) for n in cluster),
+        )
         return
 
     result = json.loads(extract_json(raw))

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -208,12 +208,17 @@ def _consolidate_cluster(engine, cluster: list[dict]) -> None:
     """Consolidate a single cluster using LLM summarization."""
     from ormah.background.llm_client import extract_json, llm_generate
 
-    # Build prompt
+    # Build prompt from FULL content, never a slice (#192). The prompt below tells the model its
+    # output "becomes the PRIMARY representation of this knowledge" and that it must "preserve
+    # every concrete detail" -- instructions that are meaningless about text the model was never
+    # shown, and destructive here because _apply_consolidation demotes every source to archival
+    # immediately afterwards. A cluster too large for the prompt is split upstream in
+    # run_consolidation; it is never trimmed.
     items = []
     for node in cluster:
         title = node.get("title") or "Untitled"
         content = node.get("content", "")
-        items.append(f"- [{title}]: {content[:300]}")
+        items.append(f"- [{title}]: {content}")
     items_text = "\n".join(items)
 
     prompt = f"""\
@@ -260,4 +265,13 @@ Return a JSON object:
         return
 
     node_ids = [n["id"] for n in cluster]
-    _apply_consolidation(engine, node_ids, title, summary, node_type)
+    new_id = _apply_consolidation(engine, node_ids, title, summary, node_type)
+    # Audit trail (#192): the sources are demoted to archival by the call above, so this summary
+    # becomes what gets read instead of them. Recording both sizes makes a consolidation that
+    # shed too much visible in the logs without re-measuring the store by hand.
+    logger.info(
+        "consolidated %d sources into %s: source_chars=%d summary_chars=%d sources=%s",
+        len(node_ids), new_id,
+        sum(len(n.get("content") or "") for n in cluster), len(summary),
+        ",".join(node_ids),
+    )

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -361,7 +361,7 @@ def _consolidate_cluster(engine, cluster: list[dict]) -> None:
 
     prompt = _CONSOLIDATE_PROMPT.format(items_text=items_text)
 
-    raw = llm_generate(engine.settings, prompt, json_mode=True)
+    raw = llm_generate(engine.settings, prompt, json_mode=True, route="consolidation")
     if raw is None:
         return
 

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -294,16 +294,57 @@ def run_consolidation(engine) -> None:
     if not clusters:
         return
 
-    consolidated_count = 0
+    # A cluster whose sources do not fit the prompt is SPLIT, never truncated (#192).
+    budget = settings.consolidation_max_prompt_chars - _prompt_overhead_chars()
+    if budget <= 0:
+        # Checked ONCE per run, not once per cluster: _split_cluster_to_fit would emit the same
+        # line for every one of the (up to consolidation_max_clusters_per_run) clusters, turning
+        # a single operator misconfiguration into a wall of identical WARNINGs.
+        logger.warning(
+            "consolidation prompt budget is %d chars once the template's own overhead is "
+            "subtracted from ORMAH_CONSOLIDATION_MAX_PROMPT_CHARS (%d); nothing can be "
+            "consolidated this run -- raise the setting",
+            budget, settings.consolidation_max_prompt_chars,
+        )
+        return
+
+    min_size = settings.consolidation_min_cluster_size
+    queue: list[list[dict]] = []
+    dropped_nodes = 0
+
     for cluster in clusters:
+        parts = _split_cluster_to_fit(cluster, budget)
+        kept = [p for p in parts if len(p) >= min_size]
+        dropped_nodes += len(cluster) - sum(len(p) for p in kept)
+        queue.extend(kept)
+
+    # The cap bounds LLM CALLS, not discovery. Splitting can multiply one cluster into several,
+    # and a daily job silently costing 2.5x more is not what this setting promises. The excess is
+    # simply not processed, so it is rediscovered next run.
+    capped = queue[: settings.consolidation_max_clusters_per_run]
+    if len(queue) > len(capped):
+        logger.info(
+            "consolidation queue held %d sub-cluster(s) over the per-run cap; deferring to the "
+            "next run", len(queue) - len(capped),
+        )
+    if dropped_nodes:
+        logger.info(
+            "%d source(s) left working: too large for the prompt budget, or alone in a "
+            "sub-cluster after the split", dropped_nodes,
+        )
+
+    consolidated_count = 0
+    for sub in capped:
         try:
-            _consolidate_cluster(engine, cluster)
+            _consolidate_cluster(engine, sub)
             consolidated_count += 1
         except Exception as e:
             logger.warning("Failed to consolidate cluster: %s", e)
 
     if consolidated_count:
-        logger.info("Consolidated %d cluster(s)", consolidated_count)
+        logger.info(
+            "Consolidated %d sub-cluster(s) from %d cluster(s)", consolidated_count, len(clusters)
+        )
 
 
 def _consolidate_cluster(engine, cluster: list[dict]) -> None:

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -9,6 +9,108 @@ from ormah.background.memory_lock import serialized_memory_job
 
 logger = logging.getLogger(__name__)
 
+_CONSOLIDATE_PROMPT = """\
+You are consolidating a cluster of semantically similar memories into a single, richer memory. The consolidated memory will be stored as a new working-tier node, and the originals will be demoted to archival (still searchable but deprioritized). This means your output becomes the PRIMARY representation of this knowledge — it must be complete.
+
+Memories to consolidate:
+{items_text}
+
+## Your task
+
+Synthesize these into ONE memory that is better than any individual original. The result should read as a well-written knowledge base entry — not a list of bullet points stitched together, but a coherent narrative.
+
+## Rules
+
+1. **Preserve every concrete detail**: Names, versions, paths, numbers, dates, specific choices, file locations, command flags. If any original says "bge-base-en-v1.5" or "port 8787", the consolidated version must include it. Never generalize specifics — "chose SQLite" must stay "chose SQLite", not "chose a database".
+
+2. **Preserve all reasoning**: If any memory explains WHY something was decided, what alternative was rejected, or what constraint drove the design, that reasoning MUST appear. Reasoning is the most valuable part of memory — it prevents re-litigating decisions.
+
+3. **Eliminate only true redundancy**: If three memories all state "uses FastAPI", say it once. But if they say different things about FastAPI (routing patterns, middleware choices, deployment config), keep ALL of those distinct facts.
+
+4. **Choose the most valuable type**: Priority order: decision > procedure > observation > concept > fact. If the cluster contains a decision and supporting facts, the consolidated type should be "decision" because that's what makes the memory actionable.
+
+5. **Title for searchability**: Titles get 10x weight in full-text search. Make it specific and keyword-rich. BAD: "Project architecture". GOOD: "Ormah uses FastAPI + SQLite with hybrid FTS/vector search". The title should let someone find this memory by searching for any of its key topics.
+
+6. **Content length**: 3-8 sentences. Long enough to be self-contained, short enough to be scannable. This will be displayed to an AI assistant as context — it needs to absorb it quickly.
+
+Return a JSON object:
+{{
+  "title": "specific, keyword-rich title, 5-15 words",
+  "summary": "consolidated content as a coherent narrative, preserving all unique details",
+  "type": "fact|decision|preference|event|person|project|concept|procedure|goal|observation"
+}}"""
+
+
+def _prompt_overhead_chars() -> int:
+    """Chars the template costs around the items block.
+
+    Computed from the template itself so it cannot go stale when the prompt is edited -- this
+    number is subtracted from the operator's budget, so a hardcoded copy that drifted would
+    silently overrun the window the consolidation route asks for.
+    """
+    return len(_CONSOLIDATE_PROMPT.format(items_text=""))
+
+
+def _render_item(node: dict) -> str:
+    """One source as it appears in the items block. FULL content -- never a slice (#192)."""
+    title = node.get("title") or "Untitled"
+    content = node.get("content", "")
+    return f"- [{title}]: {content}"
+
+
+def _item_chars(node: dict) -> int:
+    """What one source costs in the prompt: its rendered line plus the newline that joins it."""
+    return len(_render_item(node)) + 1
+
+
+def _split_cluster_to_fit(cluster: list[dict], budget_chars: int) -> list[list[dict]]:
+    """Split *cluster* into sub-clusters whose rendered items fit within *budget_chars*.
+
+    Greedy, in the order given -- which is the order ``_find_consolidation_clusters`` produces
+    (seed first, then descending similarity), so the most similar sources stay together in the
+    first sub-cluster.
+
+    A source is NEVER truncated (#192): one that does not fit the remainder opens a new
+    sub-cluster, and one larger than the whole budget is dropped entirely and left where it is.
+    Losing a consolidation is recoverable -- the node stays working and keeps being whispered.
+    Summarizing from a partial view is not, because the sources are demoted to archival the
+    moment the summary is written.
+
+    Sub-clusters shorter than ``consolidation_min_cluster_size`` are NOT filtered here; that is
+    the caller's decision, which keeps this function pure and settings-free.
+    """
+    if budget_chars <= 0:
+        logger.warning(
+            "consolidation prompt budget is %d chars after the template's own overhead; "
+            "raise ORMAH_CONSOLIDATION_MAX_PROMPT_CHARS -- nothing can be consolidated",
+            budget_chars,
+        )
+        return []
+
+    parts: list[list[dict]] = []
+    current: list[dict] = []
+    used = 0
+
+    for node in cluster:
+        cost = _item_chars(node)
+        if cost > budget_chars:
+            logger.warning(
+                "consolidation source %s costs %d chars, more than the whole prompt budget "
+                "(%d); it stays put rather than being summarized from a partial view",
+                node.get("id"), cost, budget_chars,
+            )
+            continue
+        if current and used + cost > budget_chars:
+            parts.append(current)
+            current = []
+            used = 0
+        current.append(node)
+        used += cost
+
+    if current:
+        parts.append(current)
+    return parts
+
 
 def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
     """Find clusters of similar working-tier nodes for consolidation.
@@ -214,43 +316,9 @@ def _consolidate_cluster(engine, cluster: list[dict]) -> None:
     # shown, and destructive here because _apply_consolidation demotes every source to archival
     # immediately afterwards. A cluster too large for the prompt is split upstream in
     # run_consolidation; it is never trimmed.
-    items = []
-    for node in cluster:
-        title = node.get("title") or "Untitled"
-        content = node.get("content", "")
-        items.append(f"- [{title}]: {content}")
-    items_text = "\n".join(items)
+    items_text = "\n".join(_render_item(node) for node in cluster)
 
-    prompt = f"""\
-You are consolidating a cluster of semantically similar memories into a single, richer memory. The consolidated memory will be stored as a new working-tier node, and the originals will be demoted to archival (still searchable but deprioritized). This means your output becomes the PRIMARY representation of this knowledge — it must be complete.
-
-Memories to consolidate:
-{items_text}
-
-## Your task
-
-Synthesize these into ONE memory that is better than any individual original. The result should read as a well-written knowledge base entry — not a list of bullet points stitched together, but a coherent narrative.
-
-## Rules
-
-1. **Preserve every concrete detail**: Names, versions, paths, numbers, dates, specific choices, file locations, command flags. If any original says "bge-base-en-v1.5" or "port 8787", the consolidated version must include it. Never generalize specifics — "chose SQLite" must stay "chose SQLite", not "chose a database".
-
-2. **Preserve all reasoning**: If any memory explains WHY something was decided, what alternative was rejected, or what constraint drove the design, that reasoning MUST appear. Reasoning is the most valuable part of memory — it prevents re-litigating decisions.
-
-3. **Eliminate only true redundancy**: If three memories all state "uses FastAPI", say it once. But if they say different things about FastAPI (routing patterns, middleware choices, deployment config), keep ALL of those distinct facts.
-
-4. **Choose the most valuable type**: Priority order: decision > procedure > observation > concept > fact. If the cluster contains a decision and supporting facts, the consolidated type should be "decision" because that's what makes the memory actionable.
-
-5. **Title for searchability**: Titles get 10x weight in full-text search. Make it specific and keyword-rich. BAD: "Project architecture". GOOD: "Ormah uses FastAPI + SQLite with hybrid FTS/vector search". The title should let someone find this memory by searching for any of its key topics.
-
-6. **Content length**: 3-8 sentences. Long enough to be self-contained, short enough to be scannable. This will be displayed to an AI assistant as context — it needs to absorb it quickly.
-
-Return a JSON object:
-{{
-  "title": "specific, keyword-rich title, 5-15 words",
-  "summary": "consolidated content as a coherent narrative, preserving all unique details",
-  "type": "fact|decision|preference|event|person|project|concept|procedure|goal|observation"
-}}"""
+    prompt = _CONSOLIDATE_PROMPT.format(items_text=items_text)
 
     raw = llm_generate(engine.settings, prompt, json_mode=True)
     if raw is None:

--- a/src/ormah/background/llm/__init__.py
+++ b/src/ormah/background/llm/__init__.py
@@ -13,10 +13,15 @@ __all__ = [
 ]
 
 
-def get_adapter(settings) -> LLMAdapter | None:
+def get_adapter(settings, num_ctx: int | None = None) -> LLMAdapter | None:
     """Build an adapter from the application settings.
 
     Returns ``None`` when ``llm_provider`` is ``"none"``.
+
+    ``num_ctx`` is a parameter rather than a settings read on purpose: this factory builds the
+    adapter SHARED by every maintenance job, and wiring a large input window unconditionally
+    would give small pair-judging calls a large KV cache for no benefit. Only the consolidation
+    route opts in (#192).
     """
     provider = settings.llm_provider
     timeout = getattr(settings, "llm_timeout_seconds", 60)
@@ -29,6 +34,7 @@ def get_adapter(settings) -> LLMAdapter | None:
             base_url=settings.llm_base_url,
             timeout=timeout,
             num_predict=getattr(settings, "llm_num_predict", 4096),
+            num_ctx=num_ctx,
         )
 
     if provider == "litellm":

--- a/src/ormah/background/llm/ollama_adapter.py
+++ b/src/ormah/background/llm/ollama_adapter.py
@@ -16,11 +16,22 @@ class OllamaAdapter(LLMAdapter):
         base_url: str = "http://localhost:11434",
         timeout: int = 60,
         num_predict: int = 4096,
+        num_ctx: int | None = None,
     ) -> None:
         self.model = model
         self.base_url = base_url
         self.timeout = timeout
         self.num_predict = num_predict
+        # INPUT window. num_predict bounds the OUTPUT only; leaving num_ctx unset inherits the
+        # server's default, which we neither control nor version. A default below the payload
+        # truncates the prompt SILENTLY -- the HTTP call still returns 200 with a plausible
+        # answer, so nothing surfaces.
+        #
+        # None means OMIT the key, NOT "substitute a default of our own": a number invented here
+        # would silently NARROW every caller that today leaves the operator's server/Modelfile
+        # setting in charge. Only the consolidation route opts in (#192), because it is the one
+        # route whose prompt carries full source content.
+        self.num_ctx = num_ctx
 
     def generate(
         self,
@@ -34,6 +45,8 @@ class OllamaAdapter(LLMAdapter):
         import httpx
 
         options: dict = {"num_predict": max_tokens or self.num_predict}
+        if self.num_ctx is not None:
+            options["num_ctx"] = self.num_ctx
         if temperature is not None:
             options["temperature"] = temperature
 

--- a/src/ormah/background/llm_client.py
+++ b/src/ormah/background/llm_client.py
@@ -60,10 +60,19 @@ _adapter_initialised: bool = False
 _cached_consolidation_adapter: LLMAdapter | None = None
 _consolidation_adapter_initialised: bool = False
 
-# Chars per token assumed when converting a character budget into an input window. English prose
-# runs ~4 chars/token; 2.0 is a deliberate 2x safety margin, so a denser payload (hex digests,
-# base64, CJK) still fits the window we ask for. Erring large costs KV cache; erring small costs
-# a silently truncated prompt, which is the failure #192 exists to remove.
+# Chars per token assumed when converting a character budget into an input window. Latin-script
+# prose -- EN and PT-BR, which is what this store holds -- runs ~4 chars/token, so 2.0 asks for
+# roughly twice the tokens such a payload actually needs.
+#
+# That margin is NOT universal, and the direction matters: it only helps for content LESS dense
+# than 2 chars/token. A payload denser than that overruns the window we request. CJK is the known
+# case at ~1 char/token or worse -- a full 24000-char prompt is then ~24000 tokens against the
+# 16096 this asks for (24000/2 + llm_num_predict), and Ollama truncates the excess silently, which
+# is exactly the failure #192 exists to remove.
+#
+# A character budget cannot bound tokens; only the configured model's tokenizer can. This constant
+# buys headroom for the corpus ormah actually stores and is deliberately not a proof of fit.
+# Erring large costs KV cache; erring small costs a silently truncated prompt.
 _CHARS_PER_TOKEN = 2.0
 
 

--- a/src/ormah/background/llm_client.py
+++ b/src/ormah/background/llm_client.py
@@ -57,12 +57,24 @@ def extract_json(raw: str) -> str:
 _cached_adapter: LLMAdapter | None = None
 _adapter_initialised: bool = False
 
+_cached_consolidation_adapter: LLMAdapter | None = None
+_consolidation_adapter_initialised: bool = False
+
+# Chars per token assumed when converting a character budget into an input window. English prose
+# runs ~4 chars/token; 2.0 is a deliberate 2x safety margin, so a denser payload (hex digests,
+# base64, CJK) still fits the window we ask for. Erring large costs KV cache; erring small costs
+# a silently truncated prompt, which is the failure #192 exists to remove.
+_CHARS_PER_TOKEN = 2.0
+
 
 def reset_adapter() -> None:
-    """Clear the cached adapter (useful for test isolation)."""
+    """Clear the cached adapters (useful for test isolation)."""
     global _cached_adapter, _adapter_initialised
+    global _cached_consolidation_adapter, _consolidation_adapter_initialised
     _cached_adapter = None
     _adapter_initialised = False
+    _cached_consolidation_adapter = None
+    _consolidation_adapter_initialised = False
 
 
 def _get_or_create_adapter(settings) -> LLMAdapter | None:
@@ -73,6 +85,34 @@ def _get_or_create_adapter(settings) -> LLMAdapter | None:
     return _cached_adapter
 
 
+def _consolidation_num_ctx(settings) -> int:
+    """The input window the consolidation route needs, derived from the budget it packs against.
+
+    Both sides of the call use the same number: the splitter fills at most
+    ``consolidation_max_prompt_chars``, and this converts that to tokens, leaving room for the
+    model's own output budget.
+    """
+    return int(settings.consolidation_max_prompt_chars / _CHARS_PER_TOKEN) + (
+        settings.llm_num_predict
+    )
+
+
+def _get_or_create_consolidation_adapter(settings) -> LLMAdapter | None:
+    global _cached_consolidation_adapter, _consolidation_adapter_initialised
+    if not _consolidation_adapter_initialised:
+        # Consolidation is the ONE maintenance route whose prompt carries full source content
+        # (#192), and its output DISPLACES that content: every source is demoted to archival the
+        # moment the summary is written. Inheriting the operator's server default here would let
+        # Ollama truncate the prompt silently -- exactly the bug #192 fixes, one level down. The
+        # SHARED adapter above deliberately passes no num_ctx: auto_linker, conflict_detector and
+        # duplicate_merger judge small pairs and must not pay this KV cache.
+        _cached_consolidation_adapter = get_adapter(
+            settings, num_ctx=_consolidation_num_ctx(settings)
+        )
+        _consolidation_adapter_initialised = True
+    return _cached_consolidation_adapter
+
+
 def llm_generate(
     settings,
     prompt: str,
@@ -81,9 +121,18 @@ def llm_generate(
     response_format: dict | None = None,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    route: str = "maintenance",
 ) -> str | None:
-    """Call configured LLM. Returns raw response text, or None on failure."""
-    adapter = _get_or_create_adapter(settings)
+    """Call configured LLM. Returns raw response text, or None on failure.
+
+    ``route="consolidation"`` selects the adapter that pins its own input window (#192); every
+    other route shares the maintenance adapter, which leaves the window to the operator.
+    """
+    adapter = (
+        _get_or_create_consolidation_adapter(settings)
+        if route == "consolidation"
+        else _get_or_create_adapter(settings)
+    )
     if adapter is None:
         return None
     return adapter.generate(

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -286,6 +286,16 @@ class Settings(BaseSettings):
     consolidation_min_cluster_size: int = 2
     consolidation_cluster_threshold: float = 0.6
     consolidation_max_cluster_nodes: int = 5
+    # Budget for the WHOLE consolidation prompt, in characters. It governs two things at once:
+    # the cluster split (a cluster that does not fit is split, never truncated -- #192) and the
+    # Ollama input window the consolidation route pins on its own adapter. They must be the same
+    # number: a budget the provider never promised to honor is fiction, and an oversized prompt
+    # is then truncated by the Ollama server instead, silently.
+    # Sized from measurement (5,923 nodes / 301 real consolidation events): the worst real event
+    # builds a 12,961-char prompt and the largest single node is 5,513 chars, so this keeps 1.85x
+    # headroom over the worst case observed. At any value >= 16000 none of those 301 events would
+    # have been split -- the split is a tail safety net, not the common path.
+    consolidation_max_prompt_chars: int = 24000
 
     # Claude-in-the-loop maintenance
     claude_maintenance_enabled: bool = False
@@ -533,6 +543,16 @@ class Settings(BaseSettings):
                 f"consolidation_max_cluster_nodes ({v}) must be >= "
                 f"consolidation_min_cluster_size ({min_size})"
             )
+        return v
+
+    @field_validator("consolidation_max_prompt_chars")
+    @classmethod
+    def _consolidation_max_prompt_chars_floor(cls, v: int) -> int:
+        # The prompt template alone costs ~2,440 chars. Below 4000 there is no room left for two
+        # sources of any useful size, so no cluster could ever be consolidated -- reject the
+        # impossible config up front rather than emitting a silent no-op every run.
+        if v < 4000:
+            raise ValueError(f"consolidation_max_prompt_chars must be >= 4000, got {v}")
         return v
 
     @field_validator("activation_decay")

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -303,3 +303,204 @@ def test_prompt_items_are_rendered_by_the_same_function_the_split_budgets_with(m
         "the prompt does not go through _render_item — the split budgets against a different "
         "rendering than the one actually sent"
     )
+
+
+class TestRunConsolidationSplits:
+    """#192: run_consolidation splits oversized clusters and caps LLM calls, not discovery."""
+
+    @pytest.fixture(autouse=True)
+    def _fixed_overhead(self, monkeypatch):
+        """Pin the template overhead so these tests measure the SPLIT, not the prompt's prose.
+
+        With the real overhead the budgets below sit ~146 chars from their breaking point: an
+        unrelated edit to the prompt text would fail this class and point at the wrong code.
+        """
+        monkeypatch.setattr(consolidator, "_prompt_overhead_chars", lambda: 2_400)
+
+    @staticmethod
+    def _fat(nid: str, chars: int) -> dict:
+        return {"id": nid, "title": "t", "content": "x" * chars, "space": None}
+
+    def test_oversized_cluster_becomes_two_consolidations(self, monkeypatch, engine):
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_max_prompt_chars = 6_000
+        cluster = [self._fat(x, 1_500) for x in ("a", "b", "c", "d")]
+        monkeypatch.setattr(
+            consolidator, "_find_consolidation_clusters", lambda eng, limit: [cluster]
+        )
+        seen = []
+        monkeypatch.setattr(
+            consolidator, "_consolidate_cluster", lambda eng, sub: seen.append(sub)
+        )
+
+        consolidator.run_consolidation(engine)
+
+        assert [[n["id"] for n in sub] for sub in seen] == [["a", "b"], ["c", "d"]]
+
+    def test_oversized_node_is_never_sent_to_the_llm(self, monkeypatch, engine):
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_max_prompt_chars = 6_000
+        cluster = [self._fat("a", 800), self._fat("huge", 20_000), self._fat("b", 800)]
+        monkeypatch.setattr(
+            consolidator, "_find_consolidation_clusters", lambda eng, limit: [cluster]
+        )
+        seen = []
+        monkeypatch.setattr(
+            consolidator, "_consolidate_cluster", lambda eng, sub: seen.append(sub)
+        )
+
+        consolidator.run_consolidation(engine)
+
+        assert [[n["id"] for n in sub] for sub in seen] == [["a", "b"]]
+
+    def test_short_subcluster_is_dropped(self, monkeypatch, engine):
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_max_prompt_chars = 6_000
+        # a+b fill the budget; c lands alone in its sub-cluster with nothing to merge with
+        cluster = [self._fat("a", 1_700), self._fat("b", 1_700), self._fat("c", 1_700)]
+        monkeypatch.setattr(
+            consolidator, "_find_consolidation_clusters", lambda eng, limit: [cluster]
+        )
+        seen = []
+        monkeypatch.setattr(
+            consolidator, "_consolidate_cluster", lambda eng, sub: seen.append(sub)
+        )
+
+        consolidator.run_consolidation(engine)
+
+        assert [[n["id"] for n in sub] for sub in seen] == [["a", "b"]]
+
+    def test_cap_counts_subclusters_not_raw_clusters(self, monkeypatch, engine):
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_max_prompt_chars = 6_000
+        engine.settings.consolidation_max_clusters_per_run = 2
+        clusters = [
+            [self._fat(f"c{i}n{j}", 1_500) for j in range(4)] for i in range(3)
+        ]  # 3 raw clusters -> 6 sub-clusters of 2
+        monkeypatch.setattr(
+            consolidator, "_find_consolidation_clusters", lambda eng, limit: clusters
+        )
+        calls = {"n": 0}
+
+        def spy(eng, sub):
+            calls["n"] += 1
+
+        monkeypatch.setattr(consolidator, "_consolidate_cluster", spy)
+
+        consolidator.run_consolidation(engine)
+
+        assert calls["n"] == 2, "the cap must bound LLM calls, not discovery"
+
+    def test_exhausted_budget_warns_once_not_once_per_cluster(self, monkeypatch, engine, caplog):
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_max_prompt_chars = 4_000
+        monkeypatch.setattr(consolidator, "_prompt_overhead_chars", lambda: 4_000)
+        monkeypatch.setattr(
+            consolidator,
+            "_find_consolidation_clusters",
+            lambda eng, limit: [[self._fat("a", 10), self._fat("b", 10)] for _ in range(3)],
+        )
+        called = []
+        monkeypatch.setattr(
+            consolidator, "_consolidate_cluster", lambda eng, sub: called.append(sub)
+        )
+
+        with caplog.at_level("WARNING"):
+            consolidator.run_consolidation(engine)
+
+        assert called == []
+        budget_warnings = [
+            r for r in caplog.records
+            if r.levelname == "WARNING" and "budget" in r.getMessage().lower()
+        ]
+        assert len(budget_warnings) == 1, (
+            f"one warning per run, got {len(budget_warnings)}: "
+            f"{[r.getMessage() for r in budget_warnings]}"
+        )
+
+
+def test_split_produces_two_real_consolidations_and_demotes_every_source(
+    monkeypatch, consolidation_engine
+):
+    """#192 end-to-end: an oversized cluster yields TWO consolidated nodes, and all four
+    sources end up archival — none is left half-processed.
+
+    The count goes through the ``consolidated`` tag rather than the ``derived_from`` edges:
+    ``_apply_consolidation`` does create those edges, but ``update_node(tier=archival)`` on the
+    very next line re-indexes the source and ``IndexBuilder._remove_node`` deletes every row with
+    ``source_id = ? OR target_id = ?``, so an inbound ``derived_from`` never survives the demotion
+    that follows it. That is a pre-existing defect in a path this PR does not touch; counting
+    edges here would measure it instead of the split.
+    """
+    engine, ids = consolidation_engine
+    engine.settings.llm_provider = "ollama"
+    engine.settings.consolidation_max_prompt_chars = 6_000
+    cluster = [
+        {"id": nid, "title": f"src {i}", "content": "x" * 1_500, "space": "testproject"}
+        for i, nid in enumerate(ids)
+    ]
+    monkeypatch.setattr(
+        consolidator, "_find_consolidation_clusters", lambda eng, limit: [cluster]
+    )
+    monkeypatch.setattr(
+        "ormah.background.llm_client.llm_generate",
+        lambda settings, prompt, json_mode=True, **kw: json.dumps(
+            {"title": "merged", "summary": "merged body", "type": "fact"}
+        ),
+    )
+
+    consolidator.run_consolidation(engine)
+
+    tiers = {
+        nid: engine.db.conn.execute(
+            "SELECT tier FROM nodes WHERE id = ?", (nid,)
+        ).fetchone()["tier"]
+        for nid in ids
+    }
+    assert set(tiers.values()) == {"archival"}, tiers
+    created = engine.db.conn.execute(
+        "SELECT COUNT(*) AS n FROM node_tags WHERE tag = 'consolidated'"
+    ).fetchone()["n"]
+    assert created == 2, "each sub-cluster must produce its own consolidated node"
+
+
+def test_oversized_source_is_left_working_end_to_end(monkeypatch, consolidation_engine):
+    """The node the split refuses to pack must be left working while its neighbours merge.
+
+    The companion assertion is a consolidation count, not the absence of an inbound
+    ``derived_from`` edge: no such edge survives ``update_node``'s re-index (see the docstring
+    above), so asserting zero of them would pass even if the split had never run.
+    """
+    engine, ids = consolidation_engine
+    engine.settings.llm_provider = "ollama"
+    engine.settings.consolidation_max_prompt_chars = 6_000
+    huge, a, b = ids[0], ids[1], ids[2]
+    cluster = [
+        {"id": huge, "title": "huge", "content": "x" * 20_000, "space": "testproject"},
+        {"id": a, "title": "a", "content": "y" * 800, "space": "testproject"},
+        {"id": b, "title": "b", "content": "z" * 800, "space": "testproject"},
+    ]
+    monkeypatch.setattr(
+        consolidator, "_find_consolidation_clusters", lambda eng, limit: [cluster]
+    )
+    monkeypatch.setattr(
+        "ormah.background.llm_client.llm_generate",
+        lambda settings, prompt, json_mode=True, **kw: json.dumps(
+            {"title": "merged", "summary": "merged body", "type": "fact"}
+        ),
+    )
+
+    consolidator.run_consolidation(engine)
+
+    tier = engine.db.conn.execute(
+        "SELECT tier FROM nodes WHERE id = ?", (huge,)
+    ).fetchone()["tier"]
+    assert tier == "working"
+    consolidated = engine.db.conn.execute(
+        "SELECT COUNT(*) AS n FROM node_tags WHERE tag = 'consolidated'"
+    ).fetchone()["n"]
+    assert consolidated == 1, "a and b must still have been consolidated without the huge source"
+    for other in (a, b):
+        assert engine.db.conn.execute(
+            "SELECT tier FROM nodes WHERE id = ?", (other,)
+        ).fetchone()["tier"] == "archival"

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -214,3 +214,20 @@ def test_consolidation_logs_source_and_summary_sizes(monkeypatch, consolidation_
 
     assert "source_chars=1000" in caplog.text
     assert "summary_chars=120" in caplog.text
+
+
+def test_consolidation_max_prompt_chars_default(tmp_path):
+    s = Settings(memory_dir=tmp_path)
+    assert s.consolidation_max_prompt_chars == 24000
+
+
+def test_consolidation_max_prompt_chars_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORMAH_CONSOLIDATION_MAX_PROMPT_CHARS", "16000")
+    s = Settings(memory_dir=tmp_path)
+    assert s.consolidation_max_prompt_chars == 16000
+
+
+def test_consolidation_max_prompt_chars_rejects_below_floor(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORMAH_CONSOLIDATION_MAX_PROMPT_CHARS", "3999")
+    with pytest.raises(ValueError, match="consolidation_max_prompt_chars must be >= 4000"):
+        Settings(memory_dir=tmp_path)

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -197,6 +197,33 @@ def test_full_source_content_reaches_the_prompt(monkeypatch, consolidation_engin
     assert "A short one." in captured["prompt"]
 
 
+def test_consolidation_pins_the_llm_route(monkeypatch, consolidation_engine):
+    """The consolidation call must pin its own input window, not inherit the server default.
+
+    Without ``route="consolidation"`` the prompt falls back to whatever ``num_ctx`` the Ollama
+    server defaults to, and the full content this PR started sending is silently truncated by
+    the model instead of by us (#192).
+    """
+    engine, ids = consolidation_engine
+    cluster = [
+        {"id": ids[0], "title": "a", "content": "A body.", "space": None},
+        {"id": ids[1], "title": "b", "content": "B body.", "space": None},
+    ]
+    captured = {}
+
+    def spy(settings, prompt, json_mode=True, **kwargs):
+        captured.update(kwargs)
+        return json.dumps({"title": "t", "summary": "s", "type": "fact"})
+
+    monkeypatch.setattr("ormah.background.llm_client.llm_generate", spy)
+
+    consolidator._consolidate_cluster(engine, cluster)
+
+    assert captured.get("route") == "consolidation", (
+        f"the consolidation call did not pin its route: kwargs={captured}"
+    )
+
+
 def test_consolidation_logs_source_and_summary_sizes(monkeypatch, consolidation_engine, caplog):
     """A lossy consolidation must be detectable after the fact (#192)."""
     engine, ids = consolidation_engine
@@ -254,6 +281,23 @@ class TestSplitClusterToFit:
         assert flat == ["a", "b", "c", "d"]        # order preserved
         assert len(flat) == len(set(flat))          # no duplicates
 
+    def test_a_cluster_landing_exactly_on_the_budget_stays_whole(self):
+        """The boundary is inclusive: a cluster that fills the budget exactly is ONE call.
+
+        The budget comes from ``_item_chars`` rather than a magic number so it cannot rot when
+        the item rendering changes. Splitting here would cost a second LLM call and, worse, cut
+        apart sources that do fit together.
+        """
+        cluster = [self._node("a", 400), self._node("b", 400)]
+        exact = sum(consolidator._item_chars(n) for n in cluster)
+
+        parts = consolidator._split_cluster_to_fit(cluster, exact)
+        assert [[n["id"] for n in p] for p in parts] == [["a", "b"]]
+
+        # one char short is the other side of the same boundary
+        parts = consolidator._split_cluster_to_fit(cluster, exact - 1)
+        assert [[n["id"] for n in p] for p in parts] == [["a"], ["b"]]
+
     def test_node_larger_than_the_whole_budget_is_dropped_with_a_warning(self, caplog):
         cluster = [self._node("small", 100), self._node("huge", 5_000), self._node("s2", 100)]
         with caplog.at_level("WARNING"):
@@ -262,7 +306,13 @@ class TestSplitClusterToFit:
         assert [[n["id"] for n in p] for p in parts] == [["small", "s2"]]
         assert "huge" in caplog.text
 
-    def test_no_source_is_ever_truncated(self):
+    def test_split_does_not_mutate_source_content(self):
+        """The splitter hands back the input dicts untouched.
+
+        This guards the SPLITTER only -- it returns the dicts by reference, so it cannot catch
+        truncation in the renderer. That is what test_full_source_content_reaches_the_prompt is
+        for.
+        """
         cluster = [self._node("a", 400), self._node("b", 400)]
         parts = consolidator._split_cluster_to_fit(cluster, 500)
         for part in parts:
@@ -504,3 +554,43 @@ def test_oversized_source_is_left_working_end_to_end(monkeypatch, consolidation_
         assert engine.db.conn.execute(
             "SELECT tier FROM nodes WHERE id = ?", (other,)
         ).fetchone()["tier"] == "archival"
+
+
+def test_render_item_never_writes_the_literal_string_none():
+    """A NULL content column must render as empty, not as the four characters 'None'.
+
+    ``nodes.content`` is nullable, and ``dict.get(key, default)`` returns the stored ``None``
+    when the key is present -- the default only applies to a MISSING key. The audit log already
+    uses the ``or ""`` idiom; the renderer must match, or a node with NULL content teaches the
+    model that its body is the word "None".
+    """
+    assert consolidator._render_item({"id": "n", "title": "t", "content": None}) == "- [t]: "
+    assert "None" not in consolidator._render_item({"id": "n", "title": "t", "content": None})
+
+
+def test_a_failed_consolidation_is_logged_with_its_sources(monkeypatch, consolidation_engine,
+                                                           caplog):
+    """A consolidation the LLM never answered must not vanish silently (#192).
+
+    ``llm_generate`` returns None on timeout, connect error, or a disabled provider, and the
+    adapter's own warning names neither the job nor the cluster. run_consolidation's closing
+    report is guarded by ``if consolidated_count:``, so a run where EVERY consolidation failed
+    emits nothing at all: the daily job stays green while the working tier stops being curated.
+    """
+    engine, ids = consolidation_engine
+    cluster = [
+        {"id": ids[0], "title": "a", "content": "x" * 50, "space": None},
+        {"id": ids[1], "title": "b", "content": "y" * 50, "space": None},
+    ]
+    monkeypatch.setattr(
+        "ormah.background.llm_client.llm_generate",
+        lambda settings, prompt, json_mode=True, **kw: None,
+    )
+
+    with caplog.at_level("WARNING"):
+        consolidator._consolidate_cluster(engine, cluster)
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert warnings, "a consolidation that produced nothing left no trace"
+    text = " ".join(r.getMessage() for r in warnings)
+    assert ids[0] in text and ids[1] in text, f"the warning does not name the sources: {text}"

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -231,3 +232,74 @@ def test_consolidation_max_prompt_chars_rejects_below_floor(tmp_path, monkeypatc
     monkeypatch.setenv("ORMAH_CONSOLIDATION_MAX_PROMPT_CHARS", "3999")
     with pytest.raises(ValueError, match="consolidation_max_prompt_chars must be >= 4000"):
         Settings(memory_dir=tmp_path)
+
+
+class TestSplitClusterToFit:
+    """#192: a cluster that does not fit is SPLIT, never truncated."""
+
+    @staticmethod
+    def _node(nid: str, chars: int) -> dict:
+        return {"id": nid, "title": "t", "content": "x" * chars, "space": None}
+
+    def test_cluster_that_fits_is_returned_whole(self):
+        cluster = [self._node("a", 100), self._node("b", 100)]
+        assert consolidator._split_cluster_to_fit(cluster, 10_000) == [cluster]
+
+    def test_oversized_cluster_is_split_preserving_order(self):
+        cluster = [self._node(x, 400) for x in ("a", "b", "c", "d")]
+        parts = consolidator._split_cluster_to_fit(cluster, 900)
+
+        assert [[n["id"] for n in p] for p in parts] == [["a", "b"], ["c", "d"]]
+        flat = [n["id"] for p in parts for n in p]
+        assert flat == ["a", "b", "c", "d"]        # order preserved
+        assert len(flat) == len(set(flat))          # no duplicates
+
+    def test_node_larger_than_the_whole_budget_is_dropped_with_a_warning(self, caplog):
+        cluster = [self._node("small", 100), self._node("huge", 5_000), self._node("s2", 100)]
+        with caplog.at_level("WARNING"):
+            parts = consolidator._split_cluster_to_fit(cluster, 1_000)
+
+        assert [[n["id"] for n in p] for p in parts] == [["small", "s2"]]
+        assert "huge" in caplog.text
+
+    def test_no_source_is_ever_truncated(self):
+        cluster = [self._node("a", 400), self._node("b", 400)]
+        parts = consolidator._split_cluster_to_fit(cluster, 500)
+        for part in parts:
+            for node in part:
+                assert len(node["content"]) == 400
+
+    def test_exhausted_budget_returns_nothing_and_warns(self, caplog):
+        with caplog.at_level("WARNING"):
+            assert consolidator._split_cluster_to_fit([self._node("a", 10)], 0) == []
+        assert "budget" in caplog.text.lower()
+
+
+def test_prompt_overhead_is_computed_from_the_template():
+    overhead = consolidator._prompt_overhead_chars()
+    assert overhead == len(consolidator._CONSOLIDATE_PROMPT.format(items_text=""))
+    assert 1_000 < overhead < 10_000  # sanity: the template is real prose, not a stub
+
+
+def test_prompt_items_are_rendered_by_the_same_function_the_split_budgets_with(monkeypatch):
+    """The split's cost model and the prompt's rendering must be one function, or the budget
+    silently stops matching what is actually sent (#192)."""
+    engine = SimpleNamespace(settings=SimpleNamespace())
+    cluster = [{"id": "n1", "title": "T", "content": "C", "space": None}]
+    captured = {}
+
+    def spy(settings, prompt, json_mode=True, **kwargs):
+        captured["prompt"] = prompt
+        return None  # short-circuit: _consolidate_cluster returns before touching the engine
+
+    monkeypatch.setattr("ormah.background.llm_client.llm_generate", spy)
+    monkeypatch.setattr(
+        consolidator, "_render_item", lambda node: "SENTINEL-RENDER-" + node["id"]
+    )
+
+    consolidator._consolidate_cluster(engine, cluster)
+
+    assert "SENTINEL-RENDER-n1" in captured["prompt"], (
+        "the prompt does not go through _render_item — the split budgets against a different "
+        "rendering than the one actually sent"
+    )

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ormah.background import consolidator
 from ormah.config import Settings
 from ormah.models.node import CreateNodeRequest, NodeType, Tier
 
@@ -171,3 +172,45 @@ def test_inverted_cluster_bounds_returns_empty_and_warns(consolidation_engine, c
     assert "consolidation_max_cluster_nodes" in caplog.text
 
 
+def test_full_source_content_reaches_the_prompt(monkeypatch, consolidation_engine):
+    """The consolidator must never summarize from a partial view of a source (#192)."""
+    engine, ids = consolidation_engine
+    marker = "MARKER-BEYOND-THE-OLD-300-CHAR-CAP"
+    long_content = "padding. " * 600 + marker  # ~5400 chars, marker at the very end
+    cluster = [
+        {"id": ids[0], "title": "long source", "content": long_content, "space": None},
+        {"id": ids[1], "title": "short source", "content": "A short one.", "space": None},
+    ]
+    captured = {}
+
+    def spy(settings, prompt, json_mode=True, **kwargs):
+        captured["prompt"] = prompt
+        return json.dumps({"title": "t", "summary": "s", "type": "fact"})
+
+    monkeypatch.setattr("ormah.background.llm_client.llm_generate", spy)
+
+    consolidator._consolidate_cluster(engine, cluster)
+
+    assert marker in captured["prompt"], "content past char 300 never reached the model"
+    assert long_content in captured["prompt"]
+    assert "A short one." in captured["prompt"]
+
+
+def test_consolidation_logs_source_and_summary_sizes(monkeypatch, consolidation_engine, caplog):
+    """A lossy consolidation must be detectable after the fact (#192)."""
+    engine, ids = consolidation_engine
+    cluster = [
+        {"id": ids[0], "title": "a", "content": "x" * 400, "space": None},
+        {"id": ids[1], "title": "b", "content": "y" * 600, "space": None},
+    ]
+
+    def spy(settings, prompt, json_mode=True, **kwargs):
+        return json.dumps({"title": "t", "summary": "z" * 120, "type": "fact"})
+
+    monkeypatch.setattr("ormah.background.llm_client.llm_generate", spy)
+
+    with caplog.at_level("INFO"):
+        consolidator._consolidate_cluster(engine, cluster)
+
+    assert "source_chars=1000" in caplog.text
+    assert "summary_chars=120" in caplog.text

--- a/tests/test_background/test_llm_client.py
+++ b/tests/test_background/test_llm_client.py
@@ -65,7 +65,7 @@ class TestConsolidationRoute:
 class TestOllamaInputWindow:
     """num_ctx=None must OMIT the key, never substitute a default of our own."""
 
-    def test_num_ctx_is_absent_from_the_payload_when_unset(self):
+    def test_num_ctx_defaults_to_none(self):
         adapter = OllamaAdapter(model="m")
         assert adapter.num_ctx is None
 

--- a/tests/test_background/test_llm_client.py
+++ b/tests/test_background/test_llm_client.py
@@ -1,0 +1,95 @@
+"""Tests for the shared LLM facade — adapter routing and input windows."""
+
+from __future__ import annotations
+
+import pytest
+
+from ormah.background import llm_client
+from ormah.background.llm.ollama_adapter import OllamaAdapter
+
+
+class _StubAdapter:
+    def generate(self, prompt, **kwargs):
+        return "{}"
+
+
+@pytest.fixture
+def captured_num_ctx(monkeypatch):
+    """Capture the num_ctx get_adapter is called with, with a clean adapter cache."""
+    seen = {}
+
+    def fake_get_adapter(settings, num_ctx=None):
+        seen["num_ctx"] = num_ctx
+        return _StubAdapter()
+
+    monkeypatch.setattr(llm_client, "get_adapter", fake_get_adapter)
+    llm_client.reset_adapter()
+    yield seen
+    llm_client.reset_adapter()
+
+
+class TestConsolidationRoute:
+    """#192: only the consolidation route pins an input window it can prove."""
+
+    def test_consolidation_route_derives_num_ctx_from_the_budget(self, settings, captured_num_ctx):
+        settings.llm_provider = "ollama"
+        settings.consolidation_max_prompt_chars = 24000
+        settings.llm_num_predict = 4096
+
+        llm_client.llm_generate(settings, "prompt", route="consolidation")
+
+        assert captured_num_ctx["num_ctx"] == 16096  # 24000/2 chars-per-token + 4096 output
+
+    def test_shared_maintenance_adapter_still_omits_num_ctx(self, settings, captured_num_ctx):
+        """auto_linker, conflict_detector and duplicate_merger share this adapter and must not
+        pay the consolidation KV cache."""
+        settings.llm_provider = "ollama"
+
+        llm_client.llm_generate(settings, "prompt")
+
+        assert captured_num_ctx["num_ctx"] is None
+
+    def test_reset_adapter_clears_the_consolidation_cache(self, settings, captured_num_ctx):
+        settings.llm_provider = "ollama"
+        settings.consolidation_max_prompt_chars = 24000
+        settings.llm_num_predict = 4096
+        llm_client.llm_generate(settings, "prompt", route="consolidation")
+
+        llm_client.reset_adapter()
+        settings.consolidation_max_prompt_chars = 40000
+        llm_client.llm_generate(settings, "prompt", route="consolidation")
+
+        assert captured_num_ctx["num_ctx"] == 24096, "the cache was not rebuilt after reset"
+
+
+class TestOllamaInputWindow:
+    """num_ctx=None must OMIT the key, never substitute a default of our own."""
+
+    def test_num_ctx_is_absent_from_the_payload_when_unset(self):
+        adapter = OllamaAdapter(model="m")
+        assert adapter.num_ctx is None
+
+    def test_num_ctx_reaches_the_ollama_options(self, monkeypatch):
+        sent = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"response": "{}"}
+
+        def fake_post(url, json=None, timeout=None):
+            sent.update(json)
+            return _Resp()
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "post", fake_post)
+
+        OllamaAdapter(model="m", num_ctx=16096).generate("p")
+        assert sent["options"]["num_ctx"] == 16096
+
+        sent.clear()
+        OllamaAdapter(model="m").generate("p")
+        assert "num_ctx" not in sent["options"]


### PR DESCRIPTION
Fixes #192.

## The bug

`_consolidate_cluster` built its prompt with `content[:300]` per source, then
`_apply_consolidation` demoted every one of those sources to `archival`. The prompt itself
tells the model its output "becomes the PRIMARY representation of this knowledge" and that it
must "preserve every concrete detail" — instructions that are meaningless about text the model
was never shown, and destructive because the full sources stop being read the moment the
summary is written.

## The fix

1. **Full content, never a slice.** `_render_item` renders the whole `content`. `or ""` rather
   than `get(key, "")`, because `nodes.content` is nullable and a present-but-NULL value would
   otherwise render as the literal string `"None"`.
2. **Oversized clusters are split, not truncated.** `_split_cluster_to_fit` packs sources
   greedily in discovery order (seed first, then descending similarity) against
   `consolidation_max_prompt_chars` minus the template's own overhead, which is computed from
   the template so it cannot go stale. A source larger than the whole budget is **left where it
   is** rather than summarized from a partial view: losing a consolidation is recoverable, since
   the node stays `working` and keeps being surfaced; summarizing from a partial view is not.
3. **The per-run cap bounds LLM calls, not discovery.** Splitting can multiply one cluster into
   several, so the excess is deferred to the next run instead of silently costing more.
4. **Ollama gets an explicit input window.** `num_predict` bounds output only; leaving `num_ctx`
   unset inherits a server default we neither control nor version, and a default below the
   payload truncates the prompt silently — HTTP 200, plausible JSON. Only the consolidation
   route opts in; the shared maintenance adapter deliberately passes no `num_ctx`, so
   `auto_linker`, `conflict_detector` and `duplicate_merger` do not pay that KV cache for
   small pair judgements.
5. **Failure became observable.** A consolidation that produces no output now logs the source
   ids and the prompt size, and a successful one logs `source_chars` / `summary_chars`. Before,
   a run where every consolidation failed emitted nothing at all.

`consolidation_max_prompt_chars` defaults to `24000`, sized from the author's own store
(5,923 nodes / 301 real consolidation events): the worst real event builds a 12,961-char prompt
and the largest single node is 5,513 chars. At any value >= 16000 none of those 301 events would
have been split — **the split is a tail safety net, not the common path.** These numbers describe
one store's data, not a universal distribution.

## Known gaps — deliberately not fixed here

These were found while reviewing this branch and are limitations of *this* change, not
pre-existing upstream bugs. Flagging them rather than expanding the PR:

1. **The `litellm` adapter branch discards `num_ctx`.** A `litellm` provider pointing at an
   Ollama-backed model keeps the server's default window, so guarantee (4) above does not hold
   for that configuration. Closing it means either propagating the option through
   `LiteLLMAdapter` or refusing consolidation when the provider cannot promise the capacity.
2. **A character budget cannot bound tokens.** `_CHARS_PER_TOKEN = 2.0` asks for roughly twice
   the tokens Latin-script prose needs (~4 chars/token), but the margin only helps for content
   *less* dense than 2 chars/token. CJK runs ~1 char/token or worse, so a full 24000-char prompt
   would be ~24000 tokens against the 16096 requested. The real fix is tokenizer-based budgeting;
   the constant's comment now states this limit explicitly instead of claiming the opposite.
3. **`consolidation_max_prompt_chars` has a floor (4000) but no ceiling**, and it now sizes a KV
   cache allocation: `200000` asks for `num_ctx=104096`.

## Scope notes

- **#259 is the same defect on the other route.** The Claude-in-the-loop maintenance path
  summarizes from `content[:400]`. It is untouched here — one route per PR.
- **The E2E tests assert on `node_tags WHERE tag='consolidated'`, not on `derived_from` edges**,
  and the docstring says why: #123. `_apply_consolidation` creates the `derived_from` edge and
  the very next line calls `update_node(tier=archival)`, which reaches `IndexBuilder._remove_node`
  and its `DELETE FROM edges WHERE source_id = ? OR target_id = ?` — deleting the edge just
  created. Consolidated nodes on `main` therefore carry no provenance at all. That is #123's
  scope, not this PR's.
- **#258** (consolidation not idempotent under retry) is adjacent and also out of scope.
- **#261** was opened while reviewing this branch: a consolidated node stays `working` and
  re-clusters, so summaries get written from summaries. It is a pre-existing `main` bug that
  this PR neither causes nor fixes — discovery is untouched here.

## Verification

- `4 failed, 1976 passed`. The 4 failures live in `tests/test_setup.py` and
  `tests/test_adapters/test_space_detect.py` — files this branch does not touch — and are
  environment artifacts of running with a clean `HOME`.
- `ruff check src/ tests/` clean.
- Test power was checked by mutation rather than assumed. Two gaps it exposed are now covered by
  named tests: `test_a_cluster_landing_exactly_on_the_budget_stays_whole` pins the splitter's
  `>` / `>=` boundary (a cluster landing on exactly the budget, and one char over), and
  `test_consolidation_pins_the_llm_route` asserts `route == "consolidation"` at the call site —
  without it, deleting that argument left the whole suite green and turned the `num_ctx` commit
  into a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
