### PR TITLE
fix(background): consolidated nodes are terminal for cluster discovery

### DIFF
--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -9,10 +9,18 @@ from ormah.background.memory_lock import serialized_memory_job
 
 logger = logging.getLogger(__name__)
 
+# A consolidated node is terminal for discovery: never a seed, never a member. Feeding a
+# summary back into consolidation writes a summary from summaries while the real sources sit
+# in archival, unread (#261). The predicate is applied to both queries below.
+_NOT_CONSOLIDATED = (
+    "NOT EXISTS (SELECT 1 FROM node_tags WHERE node_id = nodes.id AND tag = 'consolidated')"
+)
+
 
 def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
     """Find clusters of similar working-tier nodes for consolidation.
 
+    Nodes tagged ``consolidated`` are terminal and are excluded as seed and as member (#261).
     Returns up to *limit* clusters, each a list of node dicts (max
     ``engine.settings.consolidation_max_cluster_nodes`` nodes).
     Does NOT call the LLM — pure similarity-based clustering.
@@ -37,7 +45,8 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
         return []
 
     rows = conn.execute(
-        "SELECT id, title, content, space FROM nodes WHERE tier = 'working'"
+        "SELECT id, title, content, space FROM nodes "
+        f"WHERE tier = 'working' AND {_NOT_CONSOLIDATED}"
     ).fetchall()
     if len(rows) < min_size:
         return []
@@ -75,7 +84,8 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
             if match["similarity"] < threshold:
                 continue
             m_row = conn.execute(
-                "SELECT id, title, content, space, tier FROM nodes WHERE id = ?",
+                "SELECT id, title, content, space, tier FROM nodes "
+                f"WHERE id = ? AND {_NOT_CONSOLIDATED}",
                 (mid,),
             ).fetchone()
             if m_row is None or m_row["tier"] != "working":

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -246,3 +246,24 @@ def test_two_summaries_are_not_summarised_again(monkeypatch, engine):
         ).fetchall()
     }
     assert tiers == {"working"}
+
+
+def test_consolidated_seed_never_recruits_raw_neighbours(engine):
+    """Seed-side exclusion, proven independently of the member check (#261).
+
+    Discovery scans working nodes in insertion order, so the summaries go in FIRST: without
+    the seed predicate the first summary seeds a cluster and recruits the raw pair, which the
+    member predicate alone cannot prevent.
+    """
+    from ormah.background.consolidator import _find_consolidation_clusters
+
+    summaries = [
+        _remember(engine, _SAME_TEXT, f"Summary {i}", tags=["consolidated"]) for i in range(2)
+    ]
+    raw = [_remember(engine, _SAME_TEXT, f"Raw {i}") for i in range(2)]
+
+    clusters = _find_consolidation_clusters(engine)
+    ids_in_clusters = {n["id"] for cluster in clusters for n in cluster}
+
+    assert ids_in_clusters.isdisjoint(summaries), "a consolidated node seeded a cluster"
+    assert set(raw) <= ids_in_clusters, "the raw pair should still cluster"

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -171,3 +171,78 @@ def test_inverted_cluster_bounds_returns_empty_and_warns(consolidation_engine, c
     assert "consolidation_max_cluster_nodes" in caplog.text
 
 
+def _remember(engine, content: str, title: str, tags: list[str] | None = None) -> str:
+    req = CreateNodeRequest(
+        content=content, type=NodeType.fact, title=title, space="testproject", tags=tags or []
+    )
+    nid, _ = engine.remember(req)
+    return nid
+
+
+_SAME_TEXT = "Python uses indentation to define code blocks"
+
+
+def test_consolidated_nodes_are_never_seed_nor_member(engine):
+    """A summary is terminal: discovery must not pick it as seed or member (#261)."""
+    from ormah.background.consolidator import _find_consolidation_clusters
+
+    raw = [_remember(engine, _SAME_TEXT, f"Raw {i}") for i in range(2)]
+    summaries = [
+        _remember(engine, _SAME_TEXT, f"Summary {i}", tags=["consolidated"]) for i in range(2)
+    ]
+    # Fixture check: the tag reached the index, otherwise the test proves nothing.
+    tagged = {
+        r[0]
+        for r in engine.db.conn.execute(
+            "SELECT node_id FROM node_tags WHERE tag = 'consolidated'"
+        ).fetchall()
+    }
+    assert set(summaries) <= tagged
+
+    clusters = _find_consolidation_clusters(engine)
+    ids_in_clusters = {n["id"] for cluster in clusters for n in cluster}
+
+    assert ids_in_clusters.isdisjoint(summaries), "a consolidated node entered a cluster"
+    assert set(raw) <= ids_in_clusters, "the raw pair should still cluster"
+
+
+def test_two_summaries_are_not_summarised_again(monkeypatch, engine):
+    """Issue #261's scenario: run 1 yields N1 and N2, run 2 must leave them alone."""
+    from ormah.background import consolidator
+
+    engine.settings.llm_provider = "ollama"  # default is "none", which skips the job
+    engine.settings.consolidation_max_cluster_nodes = 2  # four sources -> two clusters
+    for i in range(4):
+        _remember(engine, _SAME_TEXT, f"Source {i}")
+
+    prompts: list[str] = []
+
+    def fake_llm(settings, prompt, json_mode=True, **kwargs):
+        prompts.append(prompt)
+        return json.dumps(
+            {"title": "Python indentation rules", "summary": "Blocks by indentation.", "type": "fact"}
+        )
+
+    monkeypatch.setattr("ormah.background.llm_client.llm_generate", fake_llm)
+
+    def consolidated_ids() -> list[str]:
+        rows = engine.db.conn.execute(
+            "SELECT node_id FROM node_tags WHERE tag = 'consolidated'"
+        ).fetchall()
+        return sorted(r[0] for r in rows)
+
+    consolidator.run_consolidation(engine)
+    first = consolidated_ids()
+    assert len(first) == 2 and len(prompts) == 2
+
+    consolidator.run_consolidation(engine)
+
+    assert consolidated_ids() == first, "run 2 created a summary of summaries"
+    assert len(prompts) == 2, "run 2 asked the LLM again"
+    tiers = {
+        r[0]
+        for r in engine.db.conn.execute(
+            "SELECT tier FROM nodes WHERE id IN (?, ?)", first
+        ).fetchall()
+    }
+    assert tiers == {"working"}


### PR DESCRIPTION
Fixes #261.

## The bug

`_find_consolidation_clusters` selected any `tier = 'working'` node. A consolidation summary is
itself written to the working tier and tagged `consolidated`, so on the next sleep cycle it was
picked up again — as a seed, and as a cluster member. The LLM then wrote a summary whose input was
a summary, while the real sources sat in archival, already demoted and unread. Every pass
compounded the loss.

## The change

One predicate, applied to both entry points into a cluster:

```python
_NOT_CONSOLIDATED = (
    "NOT EXISTS (SELECT 1 FROM node_tags WHERE node_id = nodes.id AND tag = 'consolidated')"
)
```

- seed query (`consolidator.py:47-49`)
- member lookup (`consolidator.py:86-92`)

A consolidated node is terminal for discovery: never a seed, never a member. No schema change, no
change to `_apply_consolidation`, to the prompt, or to the LLM route.

The design rationale and the alternatives considered are recorded in
`docs/superpowers/specs/2026-08-25-issue-261-consolidated-nodes-terminal-design.md` — that file is
local tooling and is deliberately not part of this diff.

## Second caller

`_find_consolidation_clusters` has a second caller besides the sleep-cycle job:
`MemoryEngine.get_maintenance_batches` (`src/ormah/engine/memory_engine.py:1820`), the
Claude-in-the-loop maintenance route. It is fixed by the same predicate.

## Accepted trade-off

New memories related to an existing summary form a **second** summary beside it, rather than being
folded into the first. This is deliberate: the alternative — letting a raw seed recruit one
existing summary and archiving the superseded one — still writes a summary from a summary, which
is the defect this closes.

Convergence of sibling summaries is the `duplicate_merger`'s job and already works:
`_find_merge_candidates` scans `SELECT id, content, title, type FROM nodes` with no tag filter and
no tier filter, so summaries are ordinary merge candidates.

A working node left over from a cluster stays working, indexed and searchable; with
`consolidation_min_cluster_size` defaulting to 2 it simply waits for a second related node, exactly
like any freshly remembered singleton.

## Known sharp edge

`consolidated` is a user-writable tag. A `remember(tags=["consolidated"])` makes that node terminal
for discovery, silently. Left as is — narrowing it would need a provenance marker that does not
exist yet.

## Follow-up, out of scope here

Re-consolidating from the **original sources** (rather than from summaries) needs the provenance
that #258 is about. Recorded there, not attempted here.

## Overlap with #260

#260 also touches `consolidator.py`, in the import region (`@@ -9,6`), in `run_consolidation`
(`@@ -192`) and at `@@ -260`. It does **not** touch either of the two discovery `SELECT`s this PR
changes (around lines 37 and 84). Both PRs insert a module constant after the imports, so whichever
merges second gets a trivial header conflict there and nothing else.

## Tests

Three new tests in `tests/test_background/test_consolidator.py`:

1. a consolidated node is not recruited as a cluster **member**;
2. a consolidated node inserted **first** does not act as a seed and recruit raw neighbours — this
   one proves the seed-side exclusion independently of the member check, so a partial revert of
   either predicate fails a test;
3. the issue's two-run scenario: the second sleep cycle does not call the LLM again.

Reviewer shortcut — reproduce the pre-fix behaviour without touching the tree:

```python
monkeypatch.setattr(consolidator, "_NOT_CONSOLIDATED", "1=1")
```

`tests/test_background/test_consolidator.py`: 13 passed.

Full suite: 1952 passed, 3 failed. The 3 failures are
`tests/test_setup.py::TestConfigureCodexMcp`, which fail on any machine with `codex` installed
(the code resolves `/opt/homebrew/bin/codex` by absolute path rather than through `PATH`, so the
mock never intercepts). They are unrelated to this change: `tests/test_setup.py` and
`src/ormah/setup.py` are byte-identical to `main` here (blob `c01e71a1`), and this PR touches only
`consolidator.py` and its test file.
