### PR TITLE
fix(lifecycle): a restore onto an existing index re-evaluates the FSRS migration (#236)

### DIFF
--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -210,7 +210,8 @@ class MemoryEngine:
         full_rebuild logs and skips files it cannot hash, parse, or index, then
         returns a partial count, so "the rebuild finished" does not mean "the
         graph is whole". The check belongs here rather than on the caller: both
-        paths this issue is about — startup() and BackupService.rebuild_index —
+        paths this issue is about — startup() (including the start that
+        follows a CLI BackupService.restore) and MemoryEngine.rebuild_index —
         reach the migration without ever seeing the builder's bookkeeping.
 
         list_paths() globs nodes/*.md only, and soft-deleted files are moved to
@@ -1373,9 +1374,8 @@ class MemoryEngine:
         re-evaluated here; the seed's per-node predicate decides which restored
         nodes are genuinely pre-FSRS, and _migrate_fsrs itself withholds the
         version marker if the rebuild left the graph incomplete. Serialized
-        because the seed calls
-        file_store inside db.transaction(); holding the memory lock first keeps
-        the memory -> db order used by reinforcement.
+        because the seed calls file_store inside db.transaction(); holding the
+        memory lock first keeps the memory -> db order used by reinforcement.
         """
         count = self.builder.full_rebuild()
         self._reindex_all_embeddings()

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -168,17 +168,20 @@ class MemoryEngine:
 
     def _migrate_fsrs(self) -> None:
         """Seed FSRS stability once, and record the store's lifecycle-model version."""
+        # The seed runs on every call, gated by nothing (#236, council round 4,
+        # Codex high@0.98). A store-wide marker cannot decide a per-node
+        # question: a pre-FSRS node can arrive at any time — an external tool
+        # writes it into nodes/ and incremental_update indexes it — long after
+        # the store records the current version. Gating the seed on that marker
+        # stranded such a node at stability 1.0 forever. The per-node predicate
+        # inside the seed is what makes this cheap and safe: on a store with
+        # nothing to do it matches no rows, and a node it already seeded no
+        # longer qualifies.
+        self._seed_stability_from_access_count()
+
         version = self._lifecycle_model_version()
         if version >= LIFECYCLE_MODEL_VERSION:
             return
-
-        # Run the seed for every version below the current model, not only for
-        # a store-wide "pre-FSRS" verdict (#236, council round 1, Codex F2). A
-        # restored graph can mix externally authored pre-FSRS nodes with Ormah's
-        # own; the store-wide guard resolves such a graph as migrated and would
-        # skip all of them. The per-node predicate inside the seed is what keeps
-        # this safe — on a store with nothing to do it matches no rows.
-        self._seed_stability_from_access_count()
 
         if not self._graph_is_fully_indexed():
             # Recording a version over a partial graph is the one irreversible

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -172,8 +172,25 @@ class MemoryEngine:
         if version >= LIFECYCLE_MODEL_VERSION:
             return
 
-        if version == 0:
-            self._seed_stability_from_access_count()
+        # Run the seed for every version below the current model, not only for
+        # a store-wide "pre-FSRS" verdict (#236, council round 1, Codex F2). A
+        # restored graph can mix externally authored pre-FSRS nodes with Ormah's
+        # own; the store-wide guard resolves such a graph as migrated and would
+        # skip all of them. The per-node predicate inside the seed is what keeps
+        # this safe — on a store with nothing to do it matches no rows.
+        self._seed_stability_from_access_count()
+
+        if not self._graph_is_fully_indexed():
+            # Recording a version over a partial graph is the one irreversible
+            # mistake here (council round 2, Codex F2; round 3, Cursor F1): a
+            # pre-FSRS node that lands on a later incremental pass would sit
+            # behind the early return above forever. Seeding what IS indexed is
+            # safe and idempotent, so keep it and simply withhold the marker.
+            logger.warning(
+                "Lifecycle migration ran on an incomplete graph; withholding the "
+                "version marker so the next start re-evaluates it."
+            )
+            return
 
         with self.db.transaction() as conn:
             conn.execute(
@@ -186,6 +203,21 @@ class MemoryEngine:
             conn.execute(
                 "INSERT OR REPLACE INTO meta (key, value) VALUES ('fsrs_migrated', '1')"
             )
+
+    def _graph_is_fully_indexed(self) -> bool:
+        """True when every Markdown node file has a row in the index.
+
+        full_rebuild logs and skips files it cannot hash, parse, or index, then
+        returns a partial count, so "the rebuild finished" does not mean "the
+        graph is whole". The check belongs here rather than on the caller: both
+        paths this issue is about — startup() and BackupService.rebuild_index —
+        reach the migration without ever seeing the builder's bookkeeping.
+
+        list_paths() globs nodes/*.md only, and soft-deleted files are moved to
+        deleted/, so tombstones are absent from both sides of the comparison.
+        """
+        indexed = self.db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+        return len(self.file_store.list_paths()) == indexed
 
     def _lifecycle_model_version(self) -> int:
         """Read the store's lifecycle-model version, upgrading the legacy flag.
@@ -229,24 +261,36 @@ class MemoryEngine:
         return 1 if reviewed else 0
 
     def _seed_stability_from_access_count(self) -> None:
-        """Seed FSRS stability from access_count, updating both DB and markdown."""
+        """Seed FSRS stability from access_count, updating both DB and markdown.
+
+        Eligibility is per node, not per store (#236, council round 1). A node
+        qualifies only when it carries no evidence of its own lifecycle state:
+        no last_review, the default stability, and a real usage history. Any
+        other node — one Ormah reinforced, one seeded by an earlier run, one an
+        external tool wrote a real stability into — is left untouched in the DB
+        and on disk. Fail-closed, because the seed is destructive: skipping a
+        node leaves a default in place, seeding one destroys a real value.
+
+        This is also what makes the migration resumable. Markdown writes below
+        are not rolled back with the DB transaction, so a failed save leaves
+        earlier files rewritten; on the next run those nodes no longer qualify
+        and the ones not yet reached still do.
+        """
         rows = self.db.conn.execute(
-            "SELECT id, access_count, last_accessed FROM nodes"
+            "SELECT id, access_count, last_accessed FROM nodes "
+            "WHERE last_review IS NULL AND stability = 1.0 AND access_count > 0"
         ).fetchall()
 
         with self.db.transaction() as conn:
             for r in rows:
-                access_count = r["access_count"] or 0
-                stability = min(30.0, access_count * 2.0) if access_count > 0 else 1.0
+                stability = min(30.0, r["access_count"] * 2.0)
                 last_review = r["last_accessed"]
 
-                # Update DB
                 conn.execute(
                     "UPDATE nodes SET stability = ?, last_review = ? WHERE id = ?",
                     (stability, last_review, r["id"]),
                 )
 
-                # Update markdown file
                 node = self.file_store.load(r["id"])
                 if node is not None:
                     node.stability = stability
@@ -257,7 +301,7 @@ class MemoryEngine:
                             pass
                     self.file_store.save(node)
 
-        logger.info("FSRS data migration complete: seeded %d nodes from access_count", len(rows))
+        logger.info("FSRS data migration: seeded %d eligible nodes from access_count", len(rows))
 
     def _seed_initial_maintenance_grace_period(self) -> None:
         """Avoid firing agent-backed maintenance immediately on fresh installs."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -329,23 +329,51 @@ class MemoryEngine:
 
         with self.db.transaction() as conn:
             for r in rows:
+                node = self.file_store.load(r["id"])
+                if node is None:
+                    continue
+
                 stability = min(30.0, r["access_count"] * 2.0)
                 last_review = r["last_accessed"]
+                last_review_dt: datetime | None = None
+                if last_review:
+                    try:
+                        last_review_dt = datetime.fromisoformat(last_review)
+                    except (ValueError, TypeError):
+                        last_review_dt = None
+
+                # Re-check the predicate against the loaded node, not just the
+                # SQLite row that qualified it (council-pr, round 1: Codex
+                # high@0.99, Cursor high@0.90, converged independently).
+                # startup() with a non-empty index never refreshes it before
+                # _migrate_fsrs() runs, so the index can be stale relative to
+                # disk -- an external tool wrote a real stability into a node
+                # the index still shows as pre-FSRS. Writing unconditionally
+                # from the stale row would destroy that newer value on disk.
+                #
+                # A node this same seed already wrote in an earlier,
+                # interrupted attempt is not such a case: the formula is
+                # deterministic, so its disk state already equals what this
+                # pass would produce again. Recognizing that keeps the
+                # resumability this method's docstring promises (Codex F3) --
+                # a node the failed attempt had already (re)written still
+                # converges instead of being skipped as "someone else's value".
+                pre_fsrs = node.last_review is None and node.stability == 1.0
+                already_seeded = (
+                    node.stability == stability and node.last_review == last_review_dt
+                )
+                if not (pre_fsrs or already_seeded):
+                    continue
 
                 conn.execute(
                     "UPDATE nodes SET stability = ?, last_review = ? WHERE id = ?",
                     (stability, last_review, r["id"]),
                 )
 
-                node = self.file_store.load(r["id"])
-                if node is not None:
-                    node.stability = stability
-                    if last_review:
-                        try:
-                            node.last_review = datetime.fromisoformat(last_review)
-                        except (ValueError, TypeError):
-                            pass
-                    self.file_store.save(node)
+                node.stability = stability
+                if last_review_dt is not None:
+                    node.last_review = last_review_dt
+                self.file_store.save(node)
 
         logger.info("FSRS data migration: seeded %d eligible nodes from access_count", len(rows))
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1365,10 +1365,21 @@ class MemoryEngine:
             f"ID: {node.id} | valid_until: {node.valid_until.isoformat()}"
         )
 
+    @_serialized_memory_operation
     def rebuild_index(self) -> int:
-        """Full rebuild of the index from markdown files, including embeddings."""
+        """Full rebuild of the index from markdown files, including embeddings.
+
+        full_rebuild wipes the lifecycle markers (#236), so the migration is
+        re-evaluated here; the seed's per-node predicate decides which restored
+        nodes are genuinely pre-FSRS, and _migrate_fsrs itself withholds the
+        version marker if the rebuild left the graph incomplete. Serialized
+        because the seed calls
+        file_store inside db.transaction(); holding the memory lock first keeps
+        the memory -> db order used by reinforcement.
+        """
         count = self.builder.full_rebuild()
         self._reindex_all_embeddings()
+        self._migrate_fsrs()
         return count
 
     @_serialized_memory_operation
@@ -2085,10 +2096,12 @@ class MemoryEngine:
         opens db.transaction(), i.e. memory-lock -> db-lock. The inverse order
         (db-lock -> memory-lock, via file_store calls inside a transaction)
         exists in _seed_stability_from_access_count, _migrate_identity_tiers,
-        and _ensure_self_node, but all three run only from startup() before the
-        server serves, so the two orders never interleave today. Invariant this
-        depends on: never call file_store inside db.transaction() outside
-        startup().
+        and _ensure_self_node. They run from startup() before the server
+        serves, or — for the seed, via rebuild_index (#236) — under
+        _serialized_memory_operation, where the memory RLock is already held
+        and the order collapses to memory -> db. Invariant this depends on:
+        never call file_store inside db.transaction() outside startup() or a
+        _serialized_memory_operation.
         """
         node = self.file_store.load(node_id)
         if node is None:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -271,10 +271,12 @@ class MemoryEngine:
         and on disk. Fail-closed, because the seed is destructive: skipping a
         node leaves a default in place, seeding one destroys a real value.
 
-        This is also what makes the migration resumable. Markdown writes below
-        are not rolled back with the DB transaction, so a failed save leaves
-        earlier files rewritten; on the next run those nodes no longer qualify
-        and the ones not yet reached still do.
+        The whole loop below runs inside one DB transaction, so a mid-loop
+        failure rolls back every row already written to the DB while the
+        Markdown files already saved stay rewritten — the two stores diverge.
+        The retry is correct anyway: the seed formula is deterministic and the
+        write idempotent, so reseeding a node the interrupted run had already
+        written reproduces the same value, and the DB and Markdown reconverge.
         """
         rows = self.db.conn.execute(
             "SELECT id, access_count, last_accessed FROM nodes "

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -42,6 +42,7 @@ from ormah.models.node import (
     UpdateNodeRequest,
 )
 from ormah.store.file_store import FileStore
+from ormah.store.markdown import parse_node
 from ormah.text.tokens import STOP_WORDS
 
 logger = logging.getLogger(__name__)
@@ -217,11 +218,50 @@ class MemoryEngine:
         follows a CLI BackupService.restore) and MemoryEngine.rebuild_index —
         reach the migration without ever seeing the builder's bookkeeping.
 
+        Membership AND cardinality (#236, council rounds 4 and 5). Equal counts
+        do not establish that every file has its row: a file replaced externally
+        by a different node while the process was stopped leaves both sides at
+        the same count while the id sets diverge. Membership alone is not enough
+        either: a set discards multiplicity, so two files carrying the same id
+        collapse to one entry against SQLite's single row and would read as
+        complete (round 5, Codex high@0.99). Both checks are kept.
+
+        A file that fails to parse returns False before any comparison, and the
+        ordering is load-bearing. An unparseable file contributes no id, so it
+        would drop out of BOTH sets and a bare set equality would call such a
+        graph complete — the opposite of what this guard exists to say. Fail
+        closed on every edge: unreadable file, duplicate id, or sets unequal in
+        either direction.
+
         list_paths() globs nodes/*.md only, and soft-deleted files are moved to
         deleted/, so tombstones are absent from both sides of the comparison.
         """
-        indexed = self.db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
-        return len(self.file_store.list_paths()) == indexed
+        paths = self.file_store.list_paths()
+        on_disk: set[str] = set()
+        for path in paths:
+            try:
+                on_disk.add(parse_node(path.read_text(encoding="utf-8")).id)
+            except Exception:
+                logger.warning(
+                    "Lifecycle completeness check: cannot read %s; treating the "
+                    "graph as incomplete.",
+                    path,
+                )
+                return False
+
+        if len(on_disk) != len(paths):
+            logger.warning(
+                "Lifecycle completeness check: %d files carry only %d distinct "
+                "node ids; treating the graph as incomplete.",
+                len(paths),
+                len(on_disk),
+            )
+            return False
+
+        indexed = {
+            row["id"] for row in self.db.conn.execute("SELECT id FROM nodes").fetchall()
+        }
+        return on_disk == indexed
 
     def _lifecycle_model_version(self) -> int:
         """Read the store's lifecycle-model version, upgrading the legacy flag.

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -322,28 +322,35 @@ class MemoryEngine:
         write idempotent, so reseeding a node the interrupted run had already
         written reproduces the same value, and the DB and Markdown reconverge.
         """
-        rows = self.db.conn.execute(
-            "SELECT id, access_count, last_accessed FROM nodes "
-            "WHERE last_review IS NULL AND stability = 1.0 AND access_count > 0"
-        ).fetchall()
+        candidate_ids = [
+            r["id"]
+            for r in self.db.conn.execute(
+                "SELECT id FROM nodes "
+                "WHERE last_review IS NULL AND stability = 1.0 AND access_count > 0"
+            ).fetchall()
+        ]
 
+        seeded = 0
         with self.db.transaction() as conn:
-            for r in rows:
-                node = self.file_store.load(r["id"])
+            for node_id in candidate_ids:
+                node = self.file_store.load(node_id)
                 if node is None:
                     continue
 
-                stability = min(30.0, r["access_count"] * 2.0)
-                last_review = r["last_accessed"]
-                last_review_dt: datetime | None = None
-                if last_review:
-                    try:
-                        last_review_dt = datetime.fromisoformat(last_review)
-                    except (ValueError, TypeError):
-                        last_review_dt = None
+                # Compute strictly from the loaded node's own durable fields,
+                # never the SQLite row that made it a candidate (council-pr,
+                # round 1: Codex medium@0.97). The row only decides WHICH
+                # nodes are worth loading; using its access_count/last_accessed
+                # to compute the seeded VALUE reproduces whatever the index
+                # last saw, which can be older than disk -- an external tool
+                # can advance access_count on Markdown without the index (or
+                # this predicate's own stability=1.0/last_review=NULL shape)
+                # ever changing, so the row stays a "candidate" while it is
+                # already stale on the one input the formula actually uses.
+                stability = min(30.0, node.access_count * 2.0)
+                last_review_dt = node.last_accessed
 
-                # Re-check the predicate against the loaded node, not just the
-                # SQLite row that qualified it (council-pr, round 1: Codex
+                # Re-check the predicate against the loaded node too (Codex
                 # high@0.99, Cursor high@0.90, converged independently).
                 # startup() with a non-empty index never refreshes it before
                 # _migrate_fsrs() runs, so the index can be stale relative to
@@ -353,11 +360,12 @@ class MemoryEngine:
                 #
                 # A node this same seed already wrote in an earlier,
                 # interrupted attempt is not such a case: the formula is
-                # deterministic, so its disk state already equals what this
-                # pass would produce again. Recognizing that keeps the
-                # resumability this method's docstring promises (Codex F3) --
-                # a node the failed attempt had already (re)written still
-                # converges instead of being skipped as "someone else's value".
+                # deterministic over the node's own fields, so its disk state
+                # already equals what this pass would produce again.
+                # Recognizing that keeps the resumability this method's
+                # docstring promises (Codex F3) -- a node the failed attempt
+                # had already (re)written still converges instead of being
+                # skipped as "someone else's value".
                 pre_fsrs = node.last_review is None and node.stability == 1.0
                 already_seeded = (
                     node.stability == stability and node.last_review == last_review_dt
@@ -367,15 +375,15 @@ class MemoryEngine:
 
                 conn.execute(
                     "UPDATE nodes SET stability = ?, last_review = ? WHERE id = ?",
-                    (stability, last_review, r["id"]),
+                    (stability, last_review_dt.isoformat() if last_review_dt else None, node_id),
                 )
 
                 node.stability = stability
-                if last_review_dt is not None:
-                    node.last_review = last_review_dt
+                node.last_review = last_review_dt
                 self.file_store.save(node)
+                seeded += 1
 
-        logger.info("FSRS data migration: seeded %d eligible nodes from access_count", len(rows))
+        logger.info("FSRS data migration: seeded %d eligible nodes from access_count", seeded)
 
     def _seed_initial_maintenance_grace_period(self) -> None:
         """Avoid firing agent-backed maintenance immediately on fresh installs."""

--- a/src/ormah/index/builder.py
+++ b/src/ormah/index/builder.py
@@ -33,7 +33,13 @@ class IndexBuilder:
 
         # Mass reindex re-allocates seq from the durable counter; clear the watermark so the
         # rebuilt store is reprocessed even if the counter was also reset (wiped meta).
-        self.db.conn.execute("DELETE FROM meta WHERE key = 'auto_link_watermark'")
+        # The lifecycle markers are derived state too (#236): index.db is excluded from
+        # backups, so a restore onto an existing index must re-evaluate the FSRS migration
+        # instead of trusting a marker written for the previous graph.
+        self.db.conn.execute(
+            "DELETE FROM meta WHERE key IN "
+            "('auto_link_watermark', 'fsrs_migrated', 'lifecycle_model_version')"
+        )
 
         # Two-pass: nodes first, then edges (to satisfy FK constraints)
         paths = list(self.file_store.list_paths())

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -418,3 +418,132 @@ def test_cli_backup_status_explains_empty_memory_store(capsys):
     out = capsys.readouterr().out
     assert "Latest backup: none" in out
     assert "Backup due now: no (no memory nodes yet)" in out
+
+
+def test_restore_onto_existing_index_seeds_pre_fsrs_backup(tmp_path):
+    """#236, CLI path: a backup holding pre-FSRS Markdown (no last_review,
+    access_count > 0) is restored onto a memory dir whose index.db already
+    says 'migrated'. The next engine start must seed stability from
+    access_count instead of trusting the stale marker."""
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    memory_dir.mkdir()
+    (memory_dir / "nodes").mkdir()
+
+    # The backup: one pre-FSRS node, written straight to Markdown.
+    pre_fsrs = MemoryNode(
+        type=NodeType.fact,
+        title="Pre-FSRS",
+        content="Used five times before FSRS existed",
+        access_count=5,
+        stability=1.0,
+        last_review=None,
+    )
+    FileStore(memory_dir / "nodes").save(pre_fsrs)
+    service = _service(memory_dir, backup_dir)
+    backup = service.create(now=datetime(2026, 8, 25, 12, 0, 0, tzinfo=timezone.utc))
+
+    # The target: an engine that has already migrated a different graph.
+    for path in (memory_dir / "nodes").glob("*.md"):
+        path.unlink()
+    settings = Settings(memory_dir=memory_dir)
+    engine = MemoryEngine(settings)
+    engine.startup()
+    try:
+        row = engine.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"
+        ).fetchone()
+        assert row["value"] == "2"
+    finally:
+        engine.shutdown()
+
+    service.restore(backup.name)
+
+    engine = MemoryEngine(settings)
+    engine.startup()
+    try:
+        stability = engine.db.conn.execute(
+            "SELECT stability FROM nodes WHERE id = ?", (pre_fsrs.id,)
+        ).fetchone()["stability"]
+        assert stability == 10.0, "restore onto an existing index skipped the FSRS seed"
+        assert engine.file_store.load(pre_fsrs.id).stability == 10.0
+    finally:
+        engine.shutdown()
+
+
+def test_restore_withholds_the_version_while_a_file_cannot_be_indexed(tmp_path):
+    """Council round 3 (Cursor F1): the CLI restore path reaches the migration
+    through startup(), which never sees the builder's bookkeeping. If a version
+    were recorded over a partial graph, the node that only indexes on a later
+    pass would sit behind the early return forever.
+
+    The malformed file cannot be part of the backup itself: BackupService
+    refuses to create or restore a tree containing an unparseable node file
+    (backup.py:182), so the only reachable version of this scenario is a file
+    that becomes unindexable AFTER the restore, directly in the memory dir,
+    before the engine's first startup() ever sees it."""
+    memory_dir = tmp_path / "memory"
+    backup_dir = tmp_path / "backups"
+    memory_dir.mkdir()
+    (memory_dir / "nodes").mkdir()
+
+    pre_fsrs = MemoryNode(
+        type=NodeType.fact,
+        title="Pre-FSRS",
+        content="Used five times before FSRS existed",
+        access_count=5,
+        stability=1.0,
+        last_review=None,
+    )
+    FileStore(memory_dir / "nodes").save(pre_fsrs)
+    service = _service(memory_dir, backup_dir)
+    backup = service.create(now=datetime(2026, 8, 25, 13, 0, 0, tzinfo=timezone.utc))
+
+    for path in (memory_dir / "nodes").glob("*.md"):
+        path.unlink()
+    service.restore(backup.name)
+
+    # Only now, after the restore, does the tree become unindexable.
+    (memory_dir / "nodes" / "broken.md").write_text("not: [valid", encoding="utf-8")
+
+    settings = Settings(memory_dir=memory_dir)
+    engine = MemoryEngine(settings)
+    engine.startup()
+    try:
+        version = engine.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"
+        ).fetchone()
+        assert version is None, "a version was recorded while broken.md was unindexed"
+        stability = engine.db.conn.execute(
+            "SELECT stability FROM nodes WHERE id = ?", (pre_fsrs.id,)
+        ).fetchone()["stability"]
+        assert stability == 10.0, "the indexed node was not seeded"
+    finally:
+        engine.shutdown()
+
+    # Repair the file into a second pre-FSRS node; the next start completes.
+    repaired = MemoryNode(
+        type=NodeType.fact,
+        title="Repaired",
+        content="Also used five times",
+        access_count=5,
+        stability=1.0,
+        last_review=None,
+    )
+    (memory_dir / "nodes" / "broken.md").unlink()
+    FileStore(memory_dir / "nodes").save(repaired)
+
+    engine = MemoryEngine(settings)
+    engine.startup()
+    try:
+        engine.rebuild_index()
+        version = engine.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'lifecycle_model_version'"
+        ).fetchone()
+        assert version["value"] == "2"
+        stability = engine.db.conn.execute(
+            "SELECT stability FROM nodes WHERE id = ?", (repaired.id,)
+        ).fetchone()["stability"]
+        assert stability == 10.0, "the repaired node was stranded"
+    finally:
+        engine.shutdown()

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -505,3 +505,41 @@ def test_a_store_at_the_current_version_never_parses_the_graph(engine, monkeypat
         "a full-store Markdown parse"
     )
     assert _version(engine) == "2"
+
+
+def test_a_stale_index_row_does_not_overwrite_newer_markdown(engine):
+    """council-pr, round 1 (Codex high@0.99, Cursor high@0.90, converged
+    independently): eligibility comes from SQLite; the seed used to write to
+    the loaded Markdown unconditionally. If the index goes stale relative to
+    disk -- the server was stopped while an external tool wrote a real
+    stability into a node the index still shows as pre-FSRS -- startup() with
+    a non-empty index never refreshes before _migrate_fsrs() runs, so the
+    stale row destroyed the newer, earned value."""
+    node_id = _make_node(engine)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, last_review = NULL, access_count = 5 "
+        "WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+
+    # An external edit lands on disk with a real earned value while the index
+    # still reflects the pre-FSRS shape above.
+    node = engine.file_store.load(node_id)
+    node.stability = 42.0
+    node.last_review = None
+    engine.file_store.save(node)
+
+    engine._migrate_fsrs()
+
+    on_disk = engine.file_store.load(node_id)
+    assert on_disk.stability == 42.0, (
+        "a stale index row destroyed a newer Markdown value"
+    )
+    # The DB row is left stale at 1.0 here -- reconciling it to the disk value
+    # is the index refresh's job (incremental_update / index_updater), not the
+    # seed's. What must not happen is the seed fabricating a *third* value on
+    # either side, e.g. min(30, access_count * 2) = 10.0.
+    assert _stability(engine, node_id) != 10.0, (
+        "the seed wrote its own formula's value into the DB over a node it "
+        "correctly left alone on disk"
+    )

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -69,6 +69,14 @@ def test_a_legacy_store_is_backfilled_without_reseeding(engine):
 
 def test_an_unmigrated_store_still_gets_seeded(engine):
     node_id = _make_node(engine)
+    # The seed now computes from the loaded Markdown, not the SQLite row
+    # (council-pr, round 1, second pass: Codex medium@0.97) -- access_count has
+    # to be real on disk, or the fixture proves nothing but its own staleness.
+    node = engine.file_store.load(node_id)
+    node.access_count = 5
+    node.stability = 1.0
+    node.last_review = None
+    engine.file_store.save(node)
     engine.db.conn.execute("DELETE FROM meta WHERE key = 'lifecycle_model_version'")
     engine.db.conn.execute("DELETE FROM meta WHERE key = 'fsrs_migrated'")
     engine.db.conn.execute(
@@ -542,4 +550,32 @@ def test_a_stale_index_row_does_not_overwrite_newer_markdown(engine):
     assert _stability(engine, node_id) != 10.0, (
         "the seed wrote its own formula's value into the DB over a node it "
         "correctly left alone on disk"
+    )
+
+
+def test_stale_index_access_count_does_not_drive_the_formula(engine):
+    """council-pr, round 1, second pass (Codex medium@0.97): the earlier
+    re-check protects stability/last_review from being overwritten, but the
+    seed still computed its VALUE from the stale SQLite row's access_count.
+    An external tool that advances access_count on Markdown without touching
+    stability/last_review leaves the row eligible while the formula's input
+    is already wrong -- the write must come from the loaded node's own
+    access_count, not the row that only decided the node was worth loading."""
+    node_id = _make_node(engine)
+    engine.db.conn.execute(
+        "UPDATE nodes SET stability = 1.0, last_review = NULL, access_count = 5 "
+        "WHERE id = ?", (node_id,)
+    )
+    engine.db.conn.commit()
+
+    node = engine.file_store.load(node_id)
+    node.access_count = 10
+    engine.file_store.save(node)
+
+    engine._migrate_fsrs()
+
+    on_disk = engine.file_store.load(node_id)
+    assert on_disk.stability == 20.0, (
+        f"seeded from the stale SQLite access_count (would give 10.0) instead "
+        f"of the disk's own (20.0): got {on_disk.stability}"
     )

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -210,9 +210,10 @@ def test_a_node_with_no_usage_history_is_left_alone(engine):
 
 
 def test_an_interrupted_seed_resumes_on_the_next_run(engine):
-    """Codex F3: Markdown writes are not rolled back with the DB transaction.
-    The per-node predicate is what makes the retry correct — a node already
-    seeded no longer qualifies, one not yet reached still does."""
+    """Codex F3: an interrupted seed leaves no version marker behind, and a
+    subsequent run converges every eligible node on the correct stability.
+    The seed formula is deterministic and the write idempotent, so this holds
+    whether or not a node was already (re)written by the failed attempt."""
     first = _make_node(engine)
     second = _make_node(engine)
     for node_id in (first, second):

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -570,6 +570,12 @@ def test_stale_index_access_count_does_not_drive_the_formula(engine):
 
     node = engine.file_store.load(node_id)
     node.access_count = 10
+    # Set the pre-FSRS shape on disk explicitly rather than relying on the
+    # model default: fsrs_initial_stability is a settable knob, and a store
+    # whose remember() seeds a non-1.0 initial stability would make this
+    # fixture silently prove nothing.
+    node.stability = 1.0
+    node.last_review = None
     engine.file_store.save(node)
 
     engine._migrate_fsrs()

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 import pytest
 
 from ormah.engine.memory_engine import LIFECYCLE_MODEL_VERSION
-from ormah.models.node import CreateNodeRequest, NodeType, Tier
+from ormah.models.node import CreateNodeRequest, MemoryNode, NodeType, Tier
 
 
 def _version(engine) -> str | None:
@@ -373,3 +373,31 @@ def test_rebuild_index_holds_the_memory_lock_across_the_seeds_file_write(engine)
         "file_store.save() -- the db-transaction-then-file-write order is "
         "no longer wrapped in the engine's memory -> db -> file sequence"
     )
+
+
+def test_a_node_indexed_after_the_migration_is_still_seeded(engine):
+    """#236, council round 4 (Codex, high @ 0.98): the store-wide marker must
+    not gate the per-node seed. A pre-FSRS Markdown node dropped into nodes/ by
+    an external tool and picked up by incremental_update arrives AFTER the store
+    already records version 2. Under the old early return it kept stability 1.0
+    forever, so decay treated a well-used memory as brand new."""
+    assert _version(engine) == "2"
+
+    latecomer = MemoryNode(
+        type=NodeType.fact,
+        title="Latecomer",
+        content="Used five times before FSRS existed",
+        access_count=5,
+        stability=1.0,
+        last_review=None,
+    )
+    engine.file_store.save(latecomer)
+    engine.builder.incremental_update()
+
+    engine._migrate_fsrs()
+
+    assert _stability(engine, latecomer.id) == 10.0, (
+        "the store-wide version marker short-circuited the per-node seed"
+    )
+    assert engine.file_store.load(latecomer.id).stability == 10.0, "Markdown was not reseeded"
+    assert _version(engine) == "2", "the marker should be left exactly as it was"

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+
 from ormah.engine.memory_engine import LIFECYCLE_MODEL_VERSION
 from ormah.models.node import CreateNodeRequest, NodeType, Tier
 
@@ -136,3 +138,128 @@ def test_the_legacy_flag_is_written_alongside_the_version(engine):
         "SELECT value FROM meta WHERE key = 'fsrs_migrated'"
     ).fetchone()
     assert row is not None and row["value"] == "1"
+
+
+def _unmigrated_meta(engine) -> None:
+    """Put the store back to 'no lifecycle marker', the way full_rebuild does."""
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'lifecycle_model_version'")
+    engine.db.conn.execute("DELETE FROM meta WHERE key = 'fsrs_migrated'")
+    engine.db.conn.commit()
+
+
+def _write_lifecycle(engine, node_id: str, *, stability: float,
+                     access_count: int, last_review) -> None:
+    """Set a node's lifecycle fields in the DURABLE source, then reindex.
+
+    Council round 3, Cursor F3: a fixture that only UPDATEs SQLite proves
+    nothing about restore, because full_rebuild reindexes from Markdown and
+    throws the DB row away. Everything these tests assert about a restored
+    graph has to start on disk.
+    """
+    node = engine.file_store.load(node_id)
+    node.stability = stability
+    node.access_count = access_count
+    node.last_review = last_review
+    engine.file_store.save(node)
+    engine.builder.full_rebuild()
+
+
+def test_the_seed_never_overwrites_stability_it_did_not_produce(engine):
+    """Codex F1: externally authored Markdown may carry a real stability with
+    no last_review. The invariant that every Ormah writer stamps last_review
+    says nothing about such a file, so eligibility must be decided per node."""
+    node_id = _make_node(engine)
+    _write_lifecycle(engine, node_id, stability=42.0, access_count=5, last_review=None)
+    _unmigrated_meta(engine)
+
+    engine._migrate_fsrs()
+
+    assert _stability(engine, node_id) == 42.0, "the seed destroyed a stability it did not write"
+    assert _version(engine) == "2"
+
+
+def test_a_mixed_store_seeds_only_its_unreviewed_nodes(engine):
+    """Codex F2: one migrated node must not suppress the seed for the rest."""
+    reviewed = _make_node(engine)
+    unreviewed = _make_node(engine)
+    _write_lifecycle(engine, reviewed, stability=42.0, access_count=5,
+                     last_review=datetime.now(timezone.utc))
+    _write_lifecycle(engine, unreviewed, stability=1.0, access_count=5, last_review=None)
+    _unmigrated_meta(engine)
+
+    engine._migrate_fsrs()
+
+    assert _stability(engine, reviewed) == 42.0, "an earned value was reseeded"
+    assert _stability(engine, unreviewed) == 10.0, "a pre-FSRS node was skipped"
+
+
+def test_a_node_with_no_usage_history_is_left_alone(engine):
+    """access_count = 0 carries no signal, so the seed must not touch the node
+    — not its stability, and not its last_review."""
+    node_id = _make_node(engine)
+    _write_lifecycle(engine, node_id, stability=1.0, access_count=0, last_review=None)
+    _unmigrated_meta(engine)
+
+    engine._migrate_fsrs()
+
+    row = engine.db.conn.execute(
+        "SELECT stability, last_review FROM nodes WHERE id = ?", (node_id,)
+    ).fetchone()
+    assert row["stability"] == 1.0
+    assert row["last_review"] is None, "the seed stamped a node it did not change"
+
+
+def test_an_interrupted_seed_resumes_on_the_next_run(engine):
+    """Codex F3: Markdown writes are not rolled back with the DB transaction.
+    The per-node predicate is what makes the retry correct — a node already
+    seeded no longer qualifies, one not yet reached still does."""
+    first = _make_node(engine)
+    second = _make_node(engine)
+    for node_id in (first, second):
+        _write_lifecycle(engine, node_id, stability=1.0, access_count=5, last_review=None)
+    _unmigrated_meta(engine)
+
+    real_save = engine.file_store.save
+    saved: list[str] = []
+
+    def save_once_then_fail(node):
+        if saved:
+            raise OSError("disk full")
+        saved.append(node.id)
+        return real_save(node)
+
+    engine.file_store.save = save_once_then_fail
+    with pytest.raises(OSError):
+        engine._migrate_fsrs()
+    engine.file_store.save = real_save
+
+    assert _version(engine) is None, "a version was recorded over a failed seed"
+
+    engine._migrate_fsrs()
+
+    assert _stability(engine, first) == 10.0
+    assert _stability(engine, second) == 10.0
+    assert _version(engine) == "2"
+
+
+def test_no_version_is_recorded_while_a_file_is_missing_from_the_index(engine):
+    """Council round 2 (Codex F2) / round 3 (Cursor F1): recording version 2
+    over a graph that did not fully index strands every node that only lands on
+    a later incremental pass. The check has to live here, because startup() and
+    BackupService.rebuild_index call this method without consulting the builder."""
+    node_id = _make_node(engine)
+    _write_lifecycle(engine, node_id, stability=1.0, access_count=5, last_review=None)
+    _unmigrated_meta(engine)
+    # A file on disk that never made it into the index — exactly the shape
+    # full_rebuild leaves behind when a file fails to hash, parse, or index.
+    (engine.file_store.nodes_dir / "broken.md").write_text("not: [valid", encoding="utf-8")
+
+    engine._migrate_fsrs()
+
+    assert _version(engine) is None, "a version was recorded over an incomplete graph"
+    assert _stability(engine, node_id) == 10.0, "indexed nodes were not seeded"
+
+    (engine.file_store.nodes_dir / "broken.md").unlink()
+    engine._migrate_fsrs()
+
+    assert _version(engine) == "2"

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -99,13 +99,11 @@ def test_a_rebuilt_index_does_not_reseed_earned_stability(engine):
     The Markdown still carries stability and last_review, so the store is not a
     pre-FSRS one and must not be reseeded.
 
-    SCOPE, stated so nobody reads more into a green than it carries: this covers
-    the EMPTY-meta restore only. It deletes the keys by hand and calls
-    _migrate_fsrs directly — it goes through neither full_rebuild nor
-    reload_restored_graph. The same-device restore, where meta survives the
-    rebuild and _migrate_fsrs is never called, is a pre-existing defect tracked
-    outside this issue (see the scope boundary above). This test passing does
-    NOT mean restore is safe in general.
+    SCOPE: this covers the EMPTY-meta case at the _migrate_fsrs level only —
+    it deletes the keys by hand and never goes through full_rebuild or
+    reload_restored_graph. The same-device restore, where meta used to survive
+    the rebuild, is covered by test_a_restore_onto_an_existing_index_* below
+    (#236).
     """
     node_id = _make_node(engine)
     now = datetime.now(timezone.utc)
@@ -262,5 +260,57 @@ def test_no_version_is_recorded_while_a_file_is_missing_from_the_index(engine):
 
     (engine.file_store.nodes_dir / "broken.md").unlink()
     engine._migrate_fsrs()
+
+    assert _version(engine) == "2"
+
+
+def _rewrite_as_pre_fsrs(engine, node_id: str, access_count: int) -> None:
+    """Rewrite one node's Markdown the way a pre-FSRS store would have it:
+    no last_review, default stability, but a real usage history."""
+    node = engine.file_store.load(node_id)
+    node.last_review = None
+    node.stability = 1.0
+    node.access_count = access_count
+    engine.file_store.save(node)
+
+
+def test_a_restore_onto_an_existing_index_seeds_pre_fsrs_nodes(engine):
+    """#236: the store was already migrated (version 2 in meta), then the
+    Markdown is replaced by pre-FSRS nodes and the graph is reloaded. The
+    surviving marker must not short-circuit the seed."""
+    node_id = _make_node(engine)
+    assert _version(engine) == "2"
+    _rewrite_as_pre_fsrs(engine, node_id, access_count=5)
+
+    engine.reload_restored_graph()
+
+    assert _stability(engine, node_id) == 10.0, "min(30, access_count * 2) was not applied"
+    assert _version(engine) == "2"
+    assert engine.file_store.load(node_id).stability == 10.0, "Markdown was not reseeded"
+
+
+def test_a_restore_onto_an_existing_index_keeps_earned_stability(engine):
+    """The inverse of the case above: a store that carries last_review is not
+    pre-FSRS, so reloading must leave earned stability alone and simply
+    re-record the version."""
+    node_id = _make_node(engine)
+    node = engine.file_store.load(node_id)
+    node.stability = 42.0
+    node.access_count = 5
+    node.last_review = datetime.now(timezone.utc)
+    engine.file_store.save(node)
+
+    engine.reload_restored_graph()
+
+    assert _stability(engine, node_id) == 42.0, "the seed re-ran on a migrated store"
+    assert _version(engine) == "2"
+
+
+def test_an_admin_rebuild_re_records_the_version(engine):
+    """rebuild_index is also reachable from the admin route; it must leave the
+    store at the current version, not with the keys wiped by full_rebuild."""
+    _make_node(engine)
+
+    engine.rebuild_index()
 
     assert _version(engine) == "2"

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from datetime import datetime, timezone
 
 import pytest
@@ -314,3 +315,61 @@ def test_an_admin_rebuild_re_records_the_version(engine):
     engine.rebuild_index()
 
     assert _version(engine) == "2"
+
+
+def test_rebuild_index_holds_the_memory_lock_across_the_seeds_file_write(engine):
+    """#236: rebuild_index must hold _memory_operation_lock for its whole body.
+
+    _seed_stability_from_access_count writes to file_store.save() from INSIDE
+    engine.db.transaction() -- the inverse of the order every other memory job
+    uses (memory lock, then db transaction; see _record_confirmed_use's
+    docstring). @_serialized_memory_operation on rebuild_index is what turns
+    that inverted db -> file order back into memory -> db -> file, the same
+    order the rest of the engine relies on to avoid two operations taking the
+    two locks in opposite sequences and deadlocking. Remove the decorator and
+    the seed's file_store.save() runs with no outer lock held at all.
+
+    A reentrant lock is always acquirable from the thread that already holds
+    it, so testing "is the lock held" from the test's own thread would pass
+    vacuously regardless of whether rebuild_index acquired it. The only
+    reliable signal is a non-blocking acquire attempt from a different
+    thread: it succeeds iff nobody holds the lock.
+    """
+    node_id = _make_node(engine)
+    _write_lifecycle(engine, node_id, stability=1.0, access_count=5, last_review=None)
+    _unmigrated_meta(engine)
+
+    real_save = engine.file_store.save
+    calls: list[bool] = []
+
+    def probe_lock_held_by_another_thread() -> bool:
+        result: list[bool] = []
+
+        def attempt():
+            acquired = engine._memory_operation_lock.acquire(blocking=False)
+            if acquired:
+                engine._memory_operation_lock.release()
+            result.append(not acquired)
+
+        probe = threading.Thread(target=attempt)
+        probe.start()
+        probe.join(timeout=5.0)
+        assert not probe.is_alive(), "lock probe thread did not finish"
+        return result[0]
+
+    def save_and_record_lock_state(node):
+        calls.append(probe_lock_held_by_another_thread())
+        return real_save(node)
+
+    engine.file_store.save = save_and_record_lock_state
+    try:
+        engine.rebuild_index()
+    finally:
+        engine.file_store.save = real_save
+
+    assert calls, "file_store.save was never reached -- the test proves nothing"
+    assert all(calls), (
+        "rebuild_index's memory lock was not held while the seed wrote to "
+        "file_store.save() -- the db-transaction-then-file-write order is "
+        "no longer wrapped in the engine's memory -> db -> file sequence"
+    )

--- a/tests/test_engine/test_lifecycle_model_version.py
+++ b/tests/test_engine/test_lifecycle_model_version.py
@@ -7,8 +7,10 @@ from datetime import datetime, timezone
 
 import pytest
 
+from ormah.engine import memory_engine
 from ormah.engine.memory_engine import LIFECYCLE_MODEL_VERSION
 from ormah.models.node import CreateNodeRequest, MemoryNode, NodeType, Tier
+from ormah.store.markdown import parse_node, serialize_node
 
 
 def _version(engine) -> str | None:
@@ -401,3 +403,105 @@ def test_a_node_indexed_after_the_migration_is_still_seeded(engine):
     )
     assert engine.file_store.load(latecomer.id).stability == 10.0, "Markdown was not reseeded"
     assert _version(engine) == "2", "the marker should be left exactly as it was"
+
+
+def test_equal_counts_with_different_membership_withhold_the_version(engine):
+    """#236, council round 4 (Codex, high @ 0.97): len(list_paths()) ==
+    COUNT(*) proves cardinality, not membership. An indexed file replaced
+    externally by a different node while the process was stopped leaves both
+    sides at the same count while the id sets diverge. Recording the version
+    over that graph asserts a completed migration that never happened."""
+    node_id = _make_node(engine)
+    _unmigrated_meta(engine)
+
+    # Swap one indexed file for an unindexed stranger: one file out, one file
+    # in, so the counts stay identical and only the membership changes.
+    target = next(
+        path for path in engine.file_store.list_paths()
+        if parse_node(path.read_text(encoding="utf-8")).id == node_id
+    )
+    target.unlink()
+    stranger = MemoryNode(
+        type=NodeType.fact,
+        title="Stranger",
+        content="On disk, never indexed",
+    )
+    engine.file_store.save(stranger)
+
+    on_disk = len(engine.file_store.list_paths())
+    indexed = engine.db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    assert on_disk == indexed, "the fixture must keep the counts equal, or it proves nothing"
+
+    engine._migrate_fsrs()
+
+    assert _version(engine) is None, (
+        "a version was recorded over a graph whose membership does not match the index"
+    )
+
+
+def test_two_files_sharing_one_id_withhold_the_version(engine):
+    """#236, council round 5 (Codex, high @ 0.99): a set of parsed ids discards
+    multiplicity. Two Markdown files carrying the same node.id collapse to one
+    entry while SQLite holds one row, so bare set equality calls the graph
+    complete -- a case the cardinality check this task replaces used to reject."""
+    node_id = _make_node(engine)
+    _unmigrated_meta(engine)
+
+    # The store already holds the Self node, so assert against the baseline
+    # rather than absolute counts.
+    indexed = engine.db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0]
+    assert len(engine.file_store.list_paths()) == indexed, (
+        "the fixture must start from a balanced graph, or it proves nothing"
+    )
+
+    # A duplicate the way an external tool makes one: same id, different title,
+    # therefore a different filename, written straight to disk so FileStore's
+    # _path_for cannot reuse the existing file.
+    original = next(
+        path for path in engine.file_store.list_paths()
+        if parse_node(path.read_text(encoding="utf-8")).id == node_id
+    )
+    node = parse_node(original.read_text(encoding="utf-8"))
+    node.title = "Renamed by an external tool"
+    duplicate = original.parent / f"fact_renamed-by-an-external-tool_{node.short_id}.md"
+    duplicate.write_text(serialize_node(node), encoding="utf-8")
+
+    assert len(engine.file_store.list_paths()) == indexed + 1, (
+        "the duplicate must add one file and no row, or it proves nothing"
+    )
+    assert engine.db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0] == indexed
+
+    engine._migrate_fsrs()
+
+    assert _version(engine) is None, (
+        "a version was recorded over a graph holding two files for one id"
+    )
+
+
+def test_a_store_at_the_current_version_never_parses_the_graph(engine, monkeypatch):
+    """#236, council round 5 (Cursor, medium @ 0.93): the early return must sit
+    above the completeness guard. Nothing else pins that ordering -- the
+    latecomer test stays green either way -- and losing it puts a full-store
+    Markdown parse on every startup(), synchronous in the lifespan."""
+    assert _version(engine) == "2"
+
+    # Count calls rather than raise: _graph_is_fully_indexed wraps the parse in
+    # `except Exception`, which swallows AssertionError and fails closed, so a
+    # raising sentinel is invisible to the test and pins nothing.
+    calls: list[str] = []
+    real_parse = memory_engine.parse_node
+
+    def _spy(text):
+        calls.append(text)
+        return real_parse(text)
+
+    monkeypatch.setattr(memory_engine, "parse_node", _spy)
+
+    engine._migrate_fsrs()
+
+    assert not calls, (
+        "a store at the current version parsed the graph: the early return no "
+        "longer sits above the completeness guard, so every startup() now pays "
+        "a full-store Markdown parse"
+    )
+    assert _version(engine) == "2"

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -150,3 +150,34 @@ def test_builder_never_takes_file_lock_inside_write_transaction(engine):
     assert engine.builder.incremental_update() == (0, 0)
 
     assert not violations, f"FileStore lock acquired inside db.transaction(): {violations}"
+
+
+def test_full_rebuild_clears_lifecycle_keys(db, file_store):
+    """#236: the index is derived state, so a rebuild must invalidate the
+    lifecycle-migration markers the same way it already invalidates the
+    auto-link watermark. Otherwise a restore onto an existing index finds
+    'already migrated' and never seeds pre-FSRS nodes."""
+    with db.transaction() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('fsrs_migrated', '1')"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('lifecycle_model_version', '2')"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('auto_link_watermark', '7')"
+        )
+        # An unrelated key must survive: rebuild invalidates lifecycle state, not all of meta.
+        conn.execute(
+            "INSERT OR REPLACE INTO meta (key, value) VALUES ('user_node_id', 'keep-me')"
+        )
+
+    IndexBuilder(db, file_store).full_rebuild()
+
+    keys = {
+        row["key"] for row in db.conn.execute("SELECT key FROM meta").fetchall()
+    }
+    assert "fsrs_migrated" not in keys
+    assert "lifecycle_model_version" not in keys
+    assert "auto_link_watermark" not in keys
+    assert "user_node_id" in keys


### PR DESCRIPTION
Closes #236.

## Problem

Restoring a backup onto an installation whose SQLite index still exists never re-evaluated the FSRS migration, so restored nodes kept a default `stability` instead of being seeded from `access_count`. `full_rebuild` cleared most index tables but left `fsrs_migrated`/`lifecycle_model_version` alone, and `MemoryEngine.reload_restored_graph` never called `_migrate_fsrs()` at all.

## Fix

- `full_rebuild` now clears the lifecycle migration keys alongside `auto_link_watermark`.
- `rebuild_index()` (used by both `startup()` and `BackupService.restore`) calls `_migrate_fsrs()` after re-embedding, serialized under the engine's memory lock.
- The seed is decided **per node**, not per store: it runs on every `_migrate_fsrs()` call (not gated by a store-wide marker), touching only nodes whose loaded Markdown still matches `last_review IS NULL AND stability == 1.0 AND access_count > 0` — recomputed from the loaded node's own `access_count`/`last_accessed`, never from a possibly-stale SQLite row. That keeps a mixed graph (some nodes already migrated, some pre-FSRS) seeding correctly, keeps an externally authored Markdown's real stability from being overwritten even when the index hasn't caught up with it yet, and keeps an interrupted seed's retry idempotent.
- `_graph_is_fully_indexed()` (the guard that decides whether the store-wide version marker gets recorded) now compares **membership and cardinality**, not just file/row counts: it fails closed on any unparseable file and on any duplicate `node.id` across files, so a completed-looking count no longer masks a graph that is actually incomplete or ambiguous.

Known limit, stated rather than glossed: `parse_node` maps an absent `stability` and an explicit `stability: 1.0` to the same value, so a deliberately authored `1.0` with a usage history is indistinguishable from an unseeded node and will be seeded. That is exactly what #236 requires the seed to accept.

Second known limit, verified in this PR: `ormah restore --no-rebuild` (`BackupService.restore(rebuild_index=False)`) skips `rebuild_index()` entirely, and `rebuild_index()` is where `_migrate_fsrs()` now lives — so `#236` still reproduces on that specific flag. Filed as a follow-up rather than folded into this PR's scope.

Out of scope, filed separately: `rebuild_index()` holds the engine's memory lock across the whole embedding pass, not just the seed — #264.

## Tests

Unit: per-node eligibility, mixed store, no usage history, interrupted seed resume, incomplete/ambiguous graph (duplicate ids, unparseable files), restore seeds pre-FSRS nodes / keeps earned stability / survives an admin rebuild, a stale index not destroying or miscalculating a newer on-disk value. Builder: lifecycle keys cleared on `full_rebuild`. End-to-end via `BackupService.restore` + `startup()` for the happy path and the unindexable-file path.

Full suite: `3 failed, 1967 passed, 1 deselected` — the 3 failures are `tests/test_setup.py::TestConfigureCodexMcp`, pre-existing on `main` and unrelated to this change (they depend on whether the `codex` CLI is installed on the machine running the suite; zero commits in this branch touch `test_setup.py` or `setup.py`).

Reviewed by the Dev Council across multiple rounds, plan and PR — every accepted finding is carried in the commit messages with its origin (round + peer + confidence). Two data-integrity findings from the PR review (`council-pr`) were independently reproduced with standalone tests before being fixed: a stale index destroying a newer on-disk stability, and a stale index driving the seed's formula even after the first fix protected against overwriting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)