### PR TITLE
fix(#259): maintenance consolidation reads full content, bounded by an explicit budget

### DIFF
--- a/docs/12 - Configuration Reference.md
+++ b/docs/12 - Configuration Reference.md
@@ -295,6 +295,7 @@ backup taken before the upgrade.
 | `claude_maintenance_enabled` | `false` |
 | `claude_maintenance_interval_hours` | `24` |
 | `claude_maintenance_batch_size` | `25` |
+| `claude_maintenance_cluster_max_chars` | `24000` |
 
 ## Code Anchor
 

--- a/src/ormah/adapters/mcp_adapter.py
+++ b/src/ormah/adapters/mcp_adapter.py
@@ -180,7 +180,7 @@ def _format_maintenance_batches(batches: dict) -> str:
             for j, n in enumerate(cluster, 1):
                 lines.append(f"  {j}. [{n['type']}] {n['id']}  \"{n['title']}\"")
                 if n.get("content"):
-                    lines.append(f"     {n['content'][:200]}")
+                    lines.append(f"     {n['content']}")
             lines.append("")
 
     if not (link_candidates or conflict_candidates or merge_candidates or clusters):

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -37,7 +37,7 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
         return []
 
     rows = conn.execute(
-        "SELECT id, title, content, space FROM nodes WHERE tier = 'working'"
+        "SELECT id, title, content, space, type FROM nodes WHERE tier = 'working'"
     ).fetchall()
     if len(rows) < min_size:
         return []
@@ -75,7 +75,7 @@ def _find_consolidation_clusters(engine, limit: int = 4) -> list[list[dict]]:
             if match["similarity"] < threshold:
                 continue
             m_row = conn.execute(
-                "SELECT id, title, content, space, tier FROM nodes WHERE id = ?",
+                "SELECT id, title, content, space, tier, type FROM nodes WHERE id = ?",
                 (mid,),
             ).fetchone()
             if m_row is None or m_row["tier"] != "working":

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -291,6 +291,7 @@ class Settings(BaseSettings):
     claude_maintenance_enabled: bool = False
     claude_maintenance_interval_hours: int = 24  # hours between maintenance runs
     claude_maintenance_batch_size: int = 25  # candidates per type per run
+    claude_maintenance_cluster_max_chars: int = 24000  # serialized budget per cluster
 
     # --- Validators ---
 
@@ -644,6 +645,13 @@ class Settings(BaseSettings):
     def _enrichment_interval_positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError(f"interval must be >= 1 minute, got {v}")
+        return v
+
+    @field_validator("claude_maintenance_cluster_max_chars")
+    @classmethod
+    def _claude_maintenance_cluster_max_chars_min(cls, v: int) -> int:
+        if v < 1000:
+            raise ValueError(f"claude_maintenance_cluster_max_chars must be >= 1000, got {v}")
         return v
 
     @property

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -95,6 +95,64 @@ def _serialized_memory_operation(method):
     return locked
 
 
+def _select_cluster_within_budget(
+    cluster: list[dict], budget: int, min_size: int
+) -> list[dict]:
+    """Greedy seed-first selection of nodes whose serialized sizes fit `budget`.
+
+    The seed is always kept: it is the node the cluster was built around, and a
+    consolidation written without it is not a consolidation of that cluster. The
+    matches follow in descending similarity; a match that does not fit is
+    *skipped*, not a stop signal — stopping at the first oversized match would
+    hide every smaller match behind it, and because the finder rebuilds the same
+    ordered cluster every cycle, it would hide them permanently.
+
+    Nodes are never sliced. Returns [] when the seed alone exceeds the budget or
+    when fewer than `min_size` nodes fit.
+    """
+    if not cluster:
+        return []
+
+    seed, matches = cluster[0], cluster[1:]
+    seed_size = len(json.dumps(seed, ensure_ascii=False))
+    if seed_size > budget:
+        logger.warning(
+            "consolidation: seed %s serializes to %d chars, over the %d-char budget; "
+            "cluster dropped, its nodes stay in the working tier",
+            seed.get("id", "?"), seed_size, budget,
+        )
+        return []
+
+    selected = [seed]
+    used = seed_size
+    skipped: list[str] = []
+
+    for node in matches:
+        size = len(json.dumps(node, ensure_ascii=False))
+        if used + size > budget:
+            skipped.append(node.get("id", "?"))
+            continue
+        selected.append(node)
+        used += size
+
+    if len(selected) < min_size:
+        logger.warning(
+            "consolidation: only %d of %d nodes fit the %d-char budget (minimum %d); "
+            "cluster dropped, its nodes stay in the working tier",
+            len(selected), len(cluster), budget, min_size,
+        )
+        return []
+
+    if skipped:
+        logger.info(
+            "consolidation: cluster trimmed from %d to %d nodes to fit the %d-char budget "
+            "(skipped: %s)",
+            len(cluster), len(selected), budget, ", ".join(skipped),
+        )
+
+    return selected
+
+
 class MemoryEngine:
     """Main facade: remember(), recall(), connect(), context()."""
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -1877,13 +1877,14 @@ class MemoryEngine:
         merge_candidates = _find_merge_candidates(self, limit_per_batch)
         consolidation_clusters = _find_consolidation_clusters(self, limit=4)
 
-        def _norm(node: dict) -> dict:
+        def _norm(node: dict, content_limit: int | None = 400) -> dict:
+            content = node.get("content") or ""
             return {
                 "id": node.get("id", ""),
                 "title": node.get("title", ""),
                 "type": node.get("type", ""),
                 "space": node.get("space", ""),
-                "content": (node.get("content") or "")[:400],
+                "content": content if content_limit is None else content[:content_limit],
             }
 
         def _norm_pair(c: dict) -> dict:
@@ -1892,6 +1893,16 @@ class MemoryEngine:
                 "node_b": _norm(c["node_b"]),
                 "similarity": c.get("similarity", 0.0),
             }
+
+        cluster_budget = self.settings.claude_maintenance_cluster_max_chars
+        min_size = self.settings.consolidation_min_cluster_size
+        consolidation_clusters = [
+            trimmed
+            for cluster in consolidation_clusters
+            if (trimmed := _select_cluster_within_budget(
+                [_norm(n, content_limit=None) for n in cluster], cluster_budget, min_size
+            ))
+        ]
 
         parts = []
         if link_candidates:
@@ -1908,10 +1919,7 @@ class MemoryEngine:
             "link_candidates": [_norm_pair(c) for c in link_candidates],
             "conflict_candidates": [_norm_pair(c) for c in conflict_candidates],
             "merge_candidates": [_norm_pair(c) for c in merge_candidates],
-            "consolidation_clusters": [
-                [_norm(n) for n in cluster]
-                for cluster in consolidation_clusters
-            ],
+            "consolidation_clusters": consolidation_clusters,
             "summary": summary,
         }
 

--- a/tests/test_adapters/test_mcp_adapter.py
+++ b/tests/test_adapters/test_mcp_adapter.py
@@ -265,3 +265,50 @@ async def test_dispatch_polls_until_phase2_apply_completes(monkeypatch):
 
     assert '"status": "applied"' in text
     assert '"edges": 1' in text
+
+
+def _batches_with_cluster(content: str) -> dict:
+    node = {
+        "id": "n1",
+        "title": "Long node",
+        "type": "fact",
+        "space": "testproject",
+        "content": content,
+    }
+    other = dict(node, id="n2", title="Other node")
+    return {
+        "summary": "1 cluster(s)",
+        "link_candidates": [],
+        "conflict_candidates": [],
+        "merge_candidates": [],
+        "consolidation_clusters": [[node, other]],
+    }
+
+
+def test_formatter_emits_full_cluster_content():
+    """The agent must see the whole source, not the first 200 chars."""
+    content = "x" * 600
+    text = mcp_adapter._format_maintenance_batches(_batches_with_cluster(content))
+
+    assert content in text, "cluster content was truncated before reaching the agent"
+
+
+def test_formatter_still_truncates_screening_pairs():
+    """Screening stays a screening view — 300 chars, unchanged."""
+    long_content = "y" * 600
+    node_a = {
+        "id": "a", "title": "A", "type": "fact", "space": "s", "content": long_content,
+    }
+    node_b = dict(node_a, id="b", title="B")
+    batches = {
+        "summary": "1 link candidates",
+        "link_candidates": [{"node_a": node_a, "node_b": node_b, "similarity": 0.9}],
+        "conflict_candidates": [],
+        "merge_candidates": [],
+        "consolidation_clusters": [],
+    }
+
+    text = mcp_adapter._format_maintenance_batches(batches)
+
+    assert long_content not in text
+    assert long_content[:300] in text

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -171,3 +171,17 @@ def test_inverted_cluster_bounds_returns_empty_and_warns(consolidation_engine, c
     assert "consolidation_max_cluster_nodes" in caplog.text
 
 
+def test_clusters_carry_node_type(consolidation_engine):
+    """The agent picks the consolidated node's type — it must see the sources' type."""
+    from ormah.background.consolidator import _find_consolidation_clusters
+
+    engine, _ids = consolidation_engine
+    engine.settings.consolidation_cluster_threshold = 0.0
+    engine.settings.consolidation_min_cluster_size = 2
+
+    clusters = _find_consolidation_clusters(engine, limit=4)
+
+    assert clusters, "no cluster formed — the assertion below would never run"
+    for cluster in clusters:
+        for node in cluster:
+            assert node.get("type") == "fact"

--- a/tests/test_background/test_run_maintenance.py
+++ b/tests/test_background/test_run_maintenance.py
@@ -393,3 +393,159 @@ class TestSelectClusterWithinBudget:
             result = _select_cluster_within_budget(cluster, budget=5000, min_size=2)
 
         assert result == [], "the budget is measuring raw content, not the serialized node"
+
+
+def _seed_long_nodes(engine, n: int = 2, chars: int = 600) -> dict[str, str]:
+    """Create n nodes whose content is exactly `chars` long. Returns {id: content}.
+
+    auto_link is disabled during remember() so the pairs stay unchecked and remain
+    available as link candidates later.
+    """
+    base = "Python uses indentation to define code block scope. "
+    seeded: dict[str, str] = {}
+    orig_threshold = engine.settings.auto_link_similarity_threshold
+    engine.settings.auto_link_similarity_threshold = 999.0
+    try:
+        for i in range(n):
+            content = (f"{i} " + base * 40)[:chars]
+            assert len(content) == chars
+            req = CreateNodeRequest(
+                content=content,
+                type=NodeType.fact,
+                title=f"Python indentation {i}",
+                space="testproject",
+            )
+            nid, _ = engine.remember(req)
+            seeded[nid] = content
+    finally:
+        engine.settings.auto_link_similarity_threshold = orig_threshold
+    return seeded
+
+
+class TestConsolidationBatchFidelity:
+
+    def test_consolidation_cluster_carries_full_content(self, engine):
+        seeded = _seed_long_nodes(engine, n=2, chars=600)
+        engine.settings.consolidation_cluster_threshold = 0.0
+        engine.settings.consolidation_min_cluster_size = 2
+
+        batches = engine.get_maintenance_batches()
+
+        clusters = batches["consolidation_clusters"]
+        assert clusters, "no consolidation cluster produced — the fixture is not exercising the batch"
+        checked = 0
+        for cluster in clusters:
+            for node in cluster:
+                if node["id"] in seeded:
+                    assert node["content"] == seeded[node["id"]]
+                    assert len(node["content"]) == 600
+                    checked += 1
+        assert checked >= 2, "seeded nodes never appeared in a cluster"
+
+    def test_norm_truncates_screening_batches(self, engine, monkeypatch):
+        """The over-fix guard: it must fail if _norm stops truncating screening.
+
+        It monkeypatches the finder because the real one already slices to 400 in
+        `_node_dict` (auto_linker.py:154), so asserting on its output would stay
+        green even with _norm's limit removed. Both council peers found that.
+        """
+        import ormah.background.auto_linker as auto_linker
+
+        long_node = {
+            "id": "n1",
+            "title": "long",
+            "type": "fact",
+            "space": "testproject",
+            "content": "y" * 600,
+        }
+        other = dict(long_node, id="n2")
+        monkeypatch.setattr(
+            auto_linker,
+            "_find_link_candidates",
+            lambda engine, limit: [{"node_a": long_node, "node_b": other, "similarity": 0.9}],
+        )
+
+        batches = engine.get_maintenance_batches()
+
+        assert batches["link_candidates"], "monkeypatched finder produced nothing"
+        for candidate in batches["link_candidates"]:
+            for node in (candidate["node_a"], candidate["node_b"]):
+                assert len(node["content"]) == 400, "screening batches must stay truncated"
+
+    def test_oversized_cluster_is_trimmed_in_the_batch(self, engine, monkeypatch):
+        """A cluster over budget reaches the batch as a prefix, contents intact."""
+        import json
+
+        import ormah.background.consolidator as consolidator
+
+        nodes = [
+            {
+                "id": f"n{i}",
+                "title": f"node {i}",
+                "type": "fact",
+                "space": "testproject",
+                "content": "z" * 6000,
+            }
+            for i in range(5)
+        ]
+        monkeypatch.setattr(
+            consolidator, "_find_consolidation_clusters", lambda engine, limit: [nodes]
+        )
+        engine.settings.claude_maintenance_cluster_max_chars = 24000
+
+        batches = engine.get_maintenance_batches()
+
+        clusters = batches["consolidation_clusters"]
+        assert len(clusters) == 1, "a prefix is one cluster, never several"
+        kept = clusters[0]
+        assert [n["id"] for n in kept] == ["n0", "n1", "n2"], (
+            "three 6000-char nodes serialize to 18_258; a fourth reaches 24_344, over 24_000"
+        )
+        for node in kept:
+            assert len(node["content"]) == 6000, "trim must never slice a node"
+        assert len(json.dumps(kept, ensure_ascii=False)) <= 24000
+
+    def test_worst_case_cardinality_stays_bounded(self, engine, monkeypatch):
+        """Four max-size clusters of large nodes stay within `4 x budget`.
+
+        With one prefix per cluster the bound is exactly `n_clusters * budget` —
+        unlike v2's bin-packing, where the sub-cluster count was unbounded. Node
+        size is 6000 chars so the trim actually fires (3 of 5 survive), and
+        `assert clusters` keeps the test from passing by emitting nothing.
+        """
+        import json
+
+        import ormah.background.consolidator as consolidator
+
+        budget = engine.settings.claude_maintenance_cluster_max_chars
+        max_nodes = engine.settings.consolidation_max_cluster_nodes
+        big_clusters = [
+            [
+                {
+                    "id": f"c{c}n{i}",
+                    "title": f"node {c}-{i}",
+                    "type": "fact",
+                    "space": "testproject",
+                    "content": "w" * 6000,
+                }
+                for i in range(max_nodes)
+            ]
+            for c in range(4)
+        ]
+        monkeypatch.setattr(
+            consolidator, "_find_consolidation_clusters", lambda engine, limit: big_clusters
+        )
+
+        batches = engine.get_maintenance_batches()
+
+        clusters = batches["consolidation_clusters"]
+        assert clusters, "the trim dropped everything — the fixture proves nothing"
+        assert len(clusters) == 4, "one prefix per cluster"
+        for sub in clusters:
+            assert len(json.dumps(sub, ensure_ascii=False)) <= budget
+
+        payload = json.dumps(clusters, ensure_ascii=False)
+        bound = 4 * budget + 4096
+        assert len(payload) <= bound, (
+            f"consolidation batch is unbounded: {len(payload)} chars, bound {bound}"
+        )

--- a/tests/test_background/test_run_maintenance.py
+++ b/tests/test_background/test_run_maintenance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
 from ormah.models.node import CreateNodeRequest, NodeType
 
@@ -273,3 +275,121 @@ class TestWhisperSignal:
         text = engine.get_whisper_context(prompt="how does Python indexing work")
         assert MAINTENANCE_DUE_SIGNAL in text
         assert "continue the conversation without blocking the user" in text
+
+
+class TestSelectClusterWithinBudget:
+    """The per-node metadata overhead is ~77 chars for these fixtures; budgets below
+    are chosen with that measured overhead in mind, so each case exercises the
+    boundary it names."""
+
+    def _node(self, nid: str, chars: int, content: str | None = None) -> dict:
+        return {
+            "id": nid,
+            "title": f"t{nid}",
+            "type": "fact",
+            "space": "s",
+            "content": content if content is not None else "x" * chars,
+        }
+
+    def _size(self, node: dict) -> int:
+        return len(json.dumps(node, ensure_ascii=False))
+
+    def test_cluster_within_budget_is_returned_whole(self):
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node(f"n{i}", 400) for i in range(5)]
+        assert _select_cluster_within_budget(cluster, budget=24000, min_size=2) == cluster
+
+    def test_oversized_cluster_is_trimmed(self, caplog):
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node(f"n{i}", 500) for i in range(4)]
+        budget = self._size(cluster[0]) * 2 + 10  # exactly two nodes fit
+
+        with caplog.at_level("INFO"):
+            result = _select_cluster_within_budget(cluster, budget=budget, min_size=2)
+
+        assert [n["id"] for n in result] == ["n0", "n1"]
+        for node in result:
+            assert len(node["content"]) == 500, "trim must never slice a node"
+        assert "trimmed" in caplog.text
+
+    def test_an_oversized_match_does_not_hide_the_smaller_ones(self, caplog):
+        """The v3 defect: a strict prefix stopped here and lost seed + m2.
+
+        Sizes: seed 177, m1 24_073, m2 173 serialized. `seed + m1` is 24_250,
+        over budget; `seed + m2` is 350, well under. Stopping at m1 returns [].
+        """
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node("seed", 100), self._node("m1", 24000), self._node("m2", 100)]
+
+        with caplog.at_level("INFO"):
+            result = _select_cluster_within_budget(cluster, budget=24000, min_size=2)
+
+        assert [n["id"] for n in result] == ["seed", "m2"]
+        assert "m1" in caplog.text, "the skipped node must be named in the log"
+
+    def test_repeated_cycles_make_progress(self):
+        """No starvation: the finder rebuilds the same ordered cluster every cycle,
+        so a cluster that yields nothing once would yield nothing forever."""
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node("seed", 100), self._node("m1", 24000), self._node("m2", 100)]
+
+        results = [
+            _select_cluster_within_budget(cluster, budget=24000, min_size=2)
+            for _ in range(3)
+        ]
+
+        assert all(r for r in results), "a cycle produced nothing — this cluster is starved"
+        assert all([n["id"] for n in r] == ["seed", "m2"] for r in results)
+
+    def test_a_kept_cluster_always_contains_the_seed(self):
+        """The invariant next-fit violated: never consolidate without the seed."""
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node("seed", 600), self._node("m1", 400), self._node("m2", 400)]
+        budget = self._size(cluster[0]) + self._size(cluster[1]) + 10
+
+        result = _select_cluster_within_budget(cluster, budget=budget, min_size=2)
+
+        assert result, "this budget fits two nodes; the cluster should survive"
+        assert result[0]["id"] == "seed"
+
+    def test_cluster_below_min_size_after_trim_is_dropped_with_warning(self, caplog):
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node(f"n{i}", 12001) for i in range(5)]
+
+        with caplog.at_level("WARNING"):
+            result = _select_cluster_within_budget(cluster, budget=24000, min_size=2)
+
+        assert result == []
+        assert caplog.records, "a dropped cluster must never be silent"
+
+    def test_seed_larger_than_the_budget_drops_the_cluster(self, caplog):
+        """An oversized seed must not claim the cluster and starve its matches —
+        it drops the whole cluster, explicitly, with the seed named."""
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node("huge", 30000), self._node("a", 100), self._node("b", 100)]
+
+        with caplog.at_level("WARNING"):
+            result = _select_cluster_within_budget(cluster, budget=24000, min_size=2)
+
+        assert result == []
+        assert "huge" in caplog.text
+
+    def test_budget_counts_serialized_size_not_raw_content(self, caplog):
+        """3000 NUL chars are 3000 raw but 18_070 serialized — a len(content)
+        budget would keep this cluster; the serialized budget must drop it."""
+        from ormah.engine.memory_engine import _select_cluster_within_budget
+
+        cluster = [self._node("esc", 0, content="\x00" * 3000), self._node("a", 400)]
+        assert self._size(cluster[0]) > 5000 > len(cluster[0]["content"])
+
+        with caplog.at_level("WARNING"):
+            result = _select_cluster_within_budget(cluster, budget=5000, min_size=2)
+
+        assert result == [], "the budget is measuring raw content, not the serialized node"

--- a/tests/test_background/test_run_maintenance.py
+++ b/tests/test_background/test_run_maintenance.py
@@ -549,3 +549,20 @@ class TestConsolidationBatchFidelity:
         assert len(payload) <= bound, (
             f"consolidation batch is unbounded: {len(payload)} chars, bound {bound}"
         )
+
+    def test_consolidation_cluster_carries_type(self, engine):
+        seeded = _seed_long_nodes(engine, n=2, chars=600)
+        engine.settings.consolidation_cluster_threshold = 0.0
+        engine.settings.consolidation_min_cluster_size = 2
+
+        batches = engine.get_maintenance_batches()
+
+        clusters = batches["consolidation_clusters"]
+        assert clusters, "no consolidation cluster produced — the assertion below would never run"
+        checked = 0
+        for cluster in clusters:
+            for node in cluster:
+                if node["id"] in seeded:
+                    assert node["type"] == "fact"
+                    checked += 1
+        assert checked >= 2, "seeded nodes never appeared in a cluster"


### PR DESCRIPTION
Closes #259.

## The problem

The Claude-in-the-loop maintenance path handed consolidation clusters to the agent **truncated at
two independent cut points**, then archived the source nodes. The agent was writing a summary from
a partial view, and the originals it replaced were the full ones.

The two cut points:

1. `MemoryEngine._norm` sliced every node's content to 400 chars when building the batch.
2. `_format_maintenance_batches` sliced it again to 200 chars when rendering it for the agent.

Both applied to consolidation clusters, where the agent is asked to *synthesize* — not to screen.

## The fix

Consolidation clusters now carry **full content**, bounded by an explicit budget instead of a
blind slice. Screening batches (link / conflict / merge candidates) keep their truncation: those
are a screening view by design, and a guard test pins that.

- **New setting** `claude_maintenance_cluster_max_chars` (default `24000`, validator enforces
  `>= 1000`) — a serialized budget per cluster.
- **`_select_cluster_within_budget`** — greedy seed-first selection. The seed is always kept (a
  consolidation written without the node the cluster was built around is not a consolidation of
  that cluster). Matches follow in descending similarity; a match that does not fit is **skipped,
  not a stop signal**. **Nodes are never sliced.** A cluster that falls below
  `consolidation_min_cluster_size` after trimming is dropped with a warning, and its nodes stay in
  the working tier.
- **Consolidation clusters carry `type`** — the agent picks the consolidated node's type, so it
  has to see the sources' type. Additive change to two `SELECT`s.
- Payload stays bounded: one prefix per cluster, at most 4 clusters, so the worst case is
  `4 x budget` — pinned by `test_worst_case_cardinality_stays_bounded`.

### Why skip-not-stop rather than a strict prefix

A strict prefix (break at the first oversized match) starves. With
`cluster = [seed(177), m1(24_073), m2(173)]` at budget `24_000`, it keeps only the seed, falls
below `min_size`, and returns `[]`. Because `_find_consolidation_clusters` rebuilds the same
cluster in the same order every cycle, that is not a deferral — it is **permanent**. Pinned by
`test_an_oversized_match_does_not_hide_the_smaller_ones` and `test_repeated_cycles_make_progress`.

## Review

Reviewed by an adversarial two-peer council over two rounds, finishing with **zero criticals**.
One peer approved outright; the other opened with a critical on prompt injection through the
now-uncapped formatter and **withdrew it in round two** as pre-existing and out of scope for this
diff: the interpolation was already unescaped at 200 chars (200 is ample for a forged cluster
header), `_pair_block` is untouched, and `apply_maintenance_results` does not appear in this diff.
That gap is tracked separately in #265.

Test suite: **1964 passed**. Four failures are environmental and pre-existing — verified by running
the same tests on a detached worktree at this branch's base commit (`90c431e`, none of this
branch's code), where they fail identically. Three are `tests/test_setup.py::TestConfigureCodexMcp`
picking up a real `codex` CLI; one is `test_detect_returns_none_for_home`, an artifact of the
synthetic `HOME` the suite needs for isolation on this machine. Lint clean.

## Known limitation (not a regression, filed as follow-up)

The council surfaced one genuine issue that this PR does **not** fix, confirmed by reading the
source rather than taken on the reviewer's word:

When the **seed alone** exceeds the budget, `_select_cluster_within_budget` drops the whole
cluster — but `_find_consolidation_clusters` has already added every match to `clustered_ids`
*before* the trim runs, and its `SELECT` has no `ORDER BY`, so scan order is stable across cycles.
The same oversized seed is found first again, claims the same matches again, and the cluster is
dropped again: the matches are **permanently starved**, not deferred. A single memory larger than
the budget can keep all its smaller related memories from ever consolidating.

`test_seed_larger_than_the_budget_drops_the_cluster` only asserts that one invocation returns `[]`,
so it does not catch this. The fix belongs in the finder (make it budget-aware so a rejected seed
does not claim its matches, or exclude only the seed and let eligible matches form another
cluster), plus a repeated-cycle end-to-end test — which is why it is not folded into this PR.

## Merge-order note for the maintainer

**#263** (issue #261, open) edits the exact same two `SELECT` lines in `consolidator.py` that this
PR touches, adding a `_NOT_CONSOLIDATED` filter. If **#263 merges first, this branch's `type`
column must be rebased alongside that filter, not in place of it.** #260 (issue #192) also touches
`consolidator.py` but not these lines — no line-level collision there.
