### PR TITLE
fix(concurrency): scope L_mem to each apply step instead of the whole job run (#240)

### DIFF
--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -48,10 +48,19 @@ def run_auto_cluster(engine, epoch: int) -> None:
             # Update markdown file
             with engine.memory_operation_at(epoch):
                 node = engine.file_store.load(node_id)
-                if node:
-                    node.space = most_common
-                    node.touch_updated()
-                    engine.file_store.save(node)
+                if node is None:
+                    continue
+                # Revalidate: the candidate query said this node had no space, but that was
+                # read outside the lock. A space assigned since is the user's, not ours (#240).
+                if node.space:
+                    logger.debug(
+                        "Auto-cluster left %s alone: a space was assigned since the scan",
+                        node_id[:8])
+                    updates.pop()
+                    continue
+                node.space = most_common
+                node.touch_updated()
+                engine.file_store.save(node)
 
             assigned += 1
 

--- a/src/ormah/background/auto_cluster.py
+++ b/src/ormah/background/auto_cluster.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import logging
 from collections import Counter
 
-from ormah.background.memory_lock import serialized_memory_job
+from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
 
 logger = logging.getLogger(__name__)
 
 
-@serialized_memory_job
-def run_auto_cluster(engine) -> None:
+@restore_aware_job
+def run_auto_cluster(engine, epoch: int) -> None:
     """Assign unassigned nodes to spaces based on their connections."""
     try:
         unassigned = engine.db.conn.execute(
@@ -46,24 +46,28 @@ def run_auto_cluster(engine) -> None:
             updates.append((most_common, node_id))
 
             # Update markdown file
-            node = engine.file_store.load(node_id)
-            if node:
-                node.space = most_common
-                node.touch_updated()
-                engine.file_store.save(node)
+            with engine.memory_operation_at(epoch):
+                node = engine.file_store.load(node_id)
+                if node:
+                    node.space = most_common
+                    node.touch_updated()
+                    engine.file_store.save(node)
 
             assigned += 1
 
         if updates:
             chunk_size = 100
             for i in range(0, len(updates), chunk_size):
-                with engine.db.transaction() as conn:
-                    for space_val, node_id in updates[i : i + chunk_size]:
-                        conn.execute(
-                            "UPDATE nodes SET space = ? WHERE id = ?", (space_val, node_id)
-                        )
+                with engine.memory_operation_at(epoch):
+                    with engine.db.transaction() as conn:
+                        for space_val, node_id in updates[i : i + chunk_size]:
+                            conn.execute(
+                                "UPDATE nodes SET space = ? WHERE id = ?", (space_val, node_id)
+                            )
         if assigned:
             logger.info("Auto-cluster assigned %d nodes to spaces", assigned)
 
+    except RestoredUnderfoot:
+        raise
     except Exception as e:
         logger.warning("Auto-cluster failed: %s", e)

--- a/src/ormah/background/auto_linker.py
+++ b/src/ormah/background/auto_linker.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime, timezone
 
 from ormah.background.llm import normalize_link_type
-from ormah.background.memory_lock import serialized_memory_job
+from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
 
 logger = logging.getLogger(__name__)
 
@@ -273,48 +273,59 @@ def _apply_edge(
     edge_type: str,
     reason: str,
     similarity: float = 0.0,
+    *,
+    epoch: int | None = None,
 ) -> None:
     """Record a link decision: write to auto_link_checked and optionally create an edge.
 
     ``edge_type="none"`` records the pair as checked without creating an edge.
+
+    *epoch* is the caller's restore epoch. Background jobs pass it so the whole
+    apply step is exclusive and aborts if a restore landed (#240);
+    ``apply_maintenance_results`` passes nothing because it already holds L_mem.
     """
+    from contextlib import nullcontext
+
     from ormah.models.node import Connection, EdgeType
 
     pair = tuple(sorted([node_a_id, node_b_id]))
     now = datetime.now(timezone.utc).isoformat()
 
-    with engine.db.transaction() as conn:
-        conn.execute(
-            "INSERT OR IGNORE INTO auto_link_checked (node_a, node_b, result, checked_at) "
-            "VALUES (?, ?, ?, ?)",
-            (*pair, edge_type, now),
-        )
-
-        if edge_type not in ("none", "error"):
+    guard = engine.memory_operation_at(epoch) if epoch is not None else nullcontext()
+    with guard:
+        with engine.db.transaction() as conn:
             conn.execute(
-                "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (node_a_id, node_b_id, edge_type, round(similarity, 3), now, reason),
+                "INSERT OR IGNORE INTO auto_link_checked (node_a, node_b, result, checked_at) "
+                "VALUES (?, ?, ?, ?)",
+                (*pair, edge_type, now),
             )
 
-    if edge_type not in ("none", "error"):
-        try:
-            mem_node = engine.file_store.load(node_a_id)
-            if mem_node is not None:
-                md_conn = Connection(
-                    target=node_b_id,
-                    edge=EdgeType(edge_type),
-                    weight=round(similarity, 2),
+            if edge_type not in ("none", "error"):
+                conn.execute(
+                    "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (node_a_id, node_b_id, edge_type, round(similarity, 3), now, reason),
                 )
-                mem_node.connections.append(md_conn)
-                mem_node.touch_updated()
-                engine.file_store.save(mem_node)
-        except Exception as e:
-            logger.debug("Failed to persist connection to markdown for %s: %s", node_a_id[:8], e)
+
+        if edge_type not in ("none", "error"):
+            try:
+                mem_node = engine.file_store.load(node_a_id)
+                if mem_node is not None:
+                    md_conn = Connection(
+                        target=node_b_id,
+                        edge=EdgeType(edge_type),
+                        weight=round(similarity, 2),
+                    )
+                    mem_node.connections.append(md_conn)
+                    mem_node.touch_updated()
+                    engine.file_store.save(mem_node)
+            except Exception as e:
+                logger.debug("Failed to persist connection to markdown for %s: %s",
+                             node_a_id[:8], e)
 
 
-@serialized_memory_job
-def run_auto_linker(engine) -> None:
+@restore_aware_job
+def run_auto_linker(engine, epoch: int) -> None:
     """Incrementally link nodes with seq above the watermark; advance only past
     fully-resolved nodes."""
     try:
@@ -402,7 +413,7 @@ def run_auto_linker(engine) -> None:
                     relationship = llm_result["relationship"]  # may be 'error' (invalid output)
                     _apply_edge(
                         engine, node["id"], match["id"], relationship,
-                        llm_result.get("reason", ""), similarity,
+                        llm_result.get("reason", ""), similarity, epoch=epoch,
                     )
                     # 'error' (poison content) is recorded in auto_link_checked by _apply_edge
                     # and the node still counts as resolved → watermark advances (council v2 crit#2).
@@ -414,9 +425,12 @@ def run_auto_linker(engine) -> None:
             last_complete = node["seq"]
 
         if last_complete is not None:
-            _set_watermark(engine, last_complete)
+            with engine.memory_operation_at(epoch):
+                _set_watermark(engine, last_complete)
         if created:
             logger.info("Auto-linker created %d edges", created)
 
+    except RestoredUnderfoot:
+        raise
     except Exception as e:
         logger.warning("Auto-linker failed: %s", e)

--- a/src/ormah/background/conflict_detector.py
+++ b/src/ormah/background/conflict_detector.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime, timezone
 
 from ormah.background.llm import normalize_conflict_type
-from ormah.background.memory_lock import serialized_memory_job
+from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
 from ormah.models.node import Connection, EdgeType
 
 logger = logging.getLogger(__name__)
@@ -213,8 +213,8 @@ def _find_conflict_candidates(engine, limit: int = 8) -> list[dict]:
         return []
 
 
-@serialized_memory_job
-def run_conflict_detection(engine) -> None:
+@restore_aware_job
+def run_conflict_detection(engine, epoch: int) -> None:
     """Find potentially contradicting nodes and create edges."""
     try:
         settings = engine.settings
@@ -243,29 +243,30 @@ def run_conflict_detection(engine) -> None:
             now = datetime.now(timezone.utc).isoformat()
             conflict_type = llm_result.get("type", "tension")
 
-            with engine.db.transaction() as db_conn:
-                if conflict_type == "evolution":
-                    evolved = llm_result.get("evolved_node", "b")
-                    if evolved == "a":
-                        newer_id, older_id = node_a["id"], node_b["id"]
-                    else:
-                        newer_id, older_id = node_b["id"], node_a["id"]
+            with engine.memory_operation_at(epoch):
+                with engine.db.transaction() as db_conn:
+                    if conflict_type == "evolution":
+                        evolved = llm_result.get("evolved_node", "b")
+                        if evolved == "a":
+                            newer_id, older_id = node_a["id"], node_b["id"]
+                        else:
+                            newer_id, older_id = node_b["id"], node_a["id"]
 
-                    db_conn.execute(
-                        "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
-                        "VALUES (?, ?, 'evolved_from', 0.9, ?, ?)",
-                        (newer_id, older_id, now, explanation),
-                    )
-                    edge_type_str = "evolved_from"
-                    source_id, target_id = newer_id, older_id
-                else:
-                    db_conn.execute(
-                        "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
-                        "VALUES (?, ?, 'contradicts', 0.9, ?, ?)",
-                        (node_a["id"], node_b["id"], now, explanation),
-                    )
-                    edge_type_str = "contradicts"
-                    source_id, target_id = node_a["id"], node_b["id"]
+                        db_conn.execute(
+                            "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+                            "VALUES (?, ?, 'evolved_from', 0.9, ?, ?)",
+                            (newer_id, older_id, now, explanation),
+                        )
+                        edge_type_str = "evolved_from"
+                        source_id, target_id = newer_id, older_id
+                    else:
+                        db_conn.execute(
+                            "INSERT INTO edges (source_id, target_id, edge_type, weight, created, reason) "
+                            "VALUES (?, ?, 'contradicts', 0.9, ?, ?)",
+                            (node_a["id"], node_b["id"], now, explanation),
+                        )
+                        edge_type_str = "contradicts"
+                        source_id, target_id = node_a["id"], node_b["id"]
 
             md_conn = Connection(
                 target=target_id,
@@ -277,18 +278,22 @@ def run_conflict_detection(engine) -> None:
 
         # Persist new connections to markdown files
         for nid, new_connections in dirty_nodes.items():
-            try:
-                mem_node = engine.file_store.load(nid)
-                if mem_node is None:
-                    continue
-                mem_node.connections.extend(new_connections)
-                mem_node.touch_updated()
-                engine.file_store.save(mem_node)
-            except Exception as e:
-                logger.debug("Failed to persist conflict edge to markdown for %s: %s", nid[:8], e)
+            with engine.memory_operation_at(epoch):
+                try:
+                    mem_node = engine.file_store.load(nid)
+                    if mem_node is None:
+                        continue
+                    mem_node.connections.extend(new_connections)
+                    mem_node.touch_updated()
+                    engine.file_store.save(mem_node)
+                except Exception as e:
+                    logger.debug(
+                        "Failed to persist conflict edge to markdown for %s: %s", nid[:8], e)
 
         if edges_created:
             logger.info("Conflict detector created %d edges", edges_created)
 
+    except RestoredUnderfoot:
+        raise
     except Exception as e:
         logger.warning("Conflict detection failed: %s", e)

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -183,6 +183,16 @@ def _apply_consolidation(
                 ))
             except Exception:
                 pass
+            # Revalidate before demoting: node_ids was snapshotted before the LLM call,
+            # so a foreground promotion may have landed since. Skip the item, do not abort
+            # the run — one node changing invalidates that node, not the whole cluster (#240).
+            current = conn.execute(
+                "SELECT tier FROM nodes WHERE id = ?", (node_id,)
+            ).fetchone()
+            if current is None or current["tier"] != "working":
+                logger.debug(
+                    "Consolidation left %s alone: tier changed since the snapshot", node_id[:8])
+                continue
             engine.update_node(node_id, UpdateNodeRequest(tier=Tier.archival))
 
         return new_id

--- a/src/ormah/background/consolidator.py
+++ b/src/ormah/background/consolidator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
-from ormah.background.memory_lock import serialized_memory_job
+from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
 
 logger = logging.getLogger(__name__)
 
@@ -95,11 +95,18 @@ def _apply_consolidation(
     title: str,
     content: str,
     node_type: str,
+    *,
+    epoch: int | None = None,
 ) -> str:
     """Create a consolidated node, link originals, and demote them to archival.
 
-    Returns the new node's ID.
+    Returns the new node's ID. When *epoch* is given the whole operation is one
+    exclusive apply step (#240): a restore landing mid-consolidation must not be
+    able to observe the new node without the originals demoted, or vice versa.
+    ``apply_maintenance_results`` passes no epoch — it already holds L_mem.
     """
+    from contextlib import nullcontext
+
     from ormah.models.node import (
         ConnectRequest,
         CreateNodeRequest,
@@ -108,79 +115,81 @@ def _apply_consolidation(
         UpdateNodeRequest,
     )
 
-    conn = engine.db.conn
-    placeholders = ",".join("?" * len(node_ids))
+    guard = engine.memory_operation_at(epoch) if epoch is not None else nullcontext()
+    with guard:
+        conn = engine.db.conn
+        placeholders = ",".join("?" * len(node_ids))
 
-    # Fetch cluster nodes for space determination and identity transfer
-    cluster_rows = conn.execute(
-        f"SELECT id, space FROM nodes WHERE id IN ({placeholders})",
-        node_ids,
-    ).fetchall()
-    cluster = [dict(r) for r in cluster_rows]
+        # Fetch cluster nodes for space determination and identity transfer
+        cluster_rows = conn.execute(
+            f"SELECT id, space FROM nodes WHERE id IN ({placeholders})",
+            node_ids,
+        ).fetchall()
+        cluster = [dict(r) for r in cluster_rows]
 
-    # Determine space by majority vote
-    space_counts: dict[str | None, int] = {}
-    for node in cluster:
-        sp = node.get("space")
-        space_counts[sp] = space_counts.get(sp, 0) + 1
-    space = max(space_counts, key=space_counts.get)  # type: ignore[arg-type]
+        # Determine space by majority vote
+        space_counts: dict[str | None, int] = {}
+        for node in cluster:
+            sp = node.get("space")
+            space_counts[sp] = space_counts.get(sp, 0) + 1
+        space = max(space_counts, key=space_counts.get)  # type: ignore[arg-type]
 
-    # Create consolidated node
-    req = CreateNodeRequest(
-        content=content,
-        type=node_type,
-        title=title,
-        space=space,
-        tags=["consolidated"],
-    )
-    new_id, _ = engine.remember(req, agent_id="consolidator")
+        # Create consolidated node
+        req = CreateNodeRequest(
+            content=content,
+            type=node_type,
+            title=title,
+            space=space,
+            tags=["consolidated"],
+        )
+        new_id, _ = engine.remember(req, agent_id="consolidator")
 
-    # Transfer identity edges
-    if engine.user_node_id:
-        has_identity = conn.execute(
-            f"SELECT 1 FROM edges WHERE source_id = ? AND edge_type = 'defines' "
-            f"AND target_id IN ({placeholders}) LIMIT 1",
-            [engine.user_node_id] + node_ids,
-        ).fetchone()
-        if has_identity:
+        # Transfer identity edges
+        if engine.user_node_id:
+            has_identity = conn.execute(
+                f"SELECT 1 FROM edges WHERE source_id = ? AND edge_type = 'defines' "
+                f"AND target_id IN ({placeholders}) LIMIT 1",
+                [engine.user_node_id] + node_ids,
+            ).fetchone()
+            if has_identity:
+                try:
+                    engine.connect(ConnectRequest(
+                        source_id=engine.user_node_id,
+                        target_id=new_id,
+                        edge=EdgeType.defines,
+                        weight=1.0,
+                    ))
+                except Exception:
+                    pass
+                new_node = engine.file_store.load(new_id)
+                if new_node and "about_self" not in new_node.tags:
+                    new_node.tags.append("about_self")
+                    new_node.touch_updated()
+                    engine.file_store.save(new_node)
+                    with engine.db.transaction() as tx_conn:
+                        tx_conn.execute(
+                            "INSERT OR IGNORE INTO node_tags (node_id, tag) VALUES (?, 'about_self')",
+                            (new_id,),
+                        )
+
+        # Create derived_from edges and demote originals to archival
+        for node_id in node_ids:
             try:
                 engine.connect(ConnectRequest(
-                    source_id=engine.user_node_id,
-                    target_id=new_id,
-                    edge=EdgeType.defines,
+                    source_id=new_id,
+                    target_id=node_id,
+                    edge=EdgeType.derived_from,
                     weight=1.0,
                 ))
             except Exception:
                 pass
-            new_node = engine.file_store.load(new_id)
-            if new_node and "about_self" not in new_node.tags:
-                new_node.tags.append("about_self")
-                new_node.touch_updated()
-                engine.file_store.save(new_node)
-                with engine.db.transaction() as tx_conn:
-                    tx_conn.execute(
-                        "INSERT OR IGNORE INTO node_tags (node_id, tag) VALUES (?, 'about_self')",
-                        (new_id,),
-                    )
+            engine.update_node(node_id, UpdateNodeRequest(tier=Tier.archival))
 
-    # Create derived_from edges and demote originals to archival
-    for node_id in node_ids:
-        try:
-            engine.connect(ConnectRequest(
-                source_id=new_id,
-                target_id=node_id,
-                edge=EdgeType.derived_from,
-                weight=1.0,
-            ))
-        except Exception:
-            pass
-        engine.update_node(node_id, UpdateNodeRequest(tier=Tier.archival))
-
-    return new_id
+        return new_id
 
 
-@serialized_memory_job
-def run_consolidation(engine) -> None:
+@restore_aware_job
+def run_consolidation(engine, epoch: int) -> None:
     """Find clusters of similar working memories and consolidate via LLM."""
     settings = engine.settings
     if not settings.llm_enabled:
@@ -195,8 +204,10 @@ def run_consolidation(engine) -> None:
     consolidated_count = 0
     for cluster in clusters:
         try:
-            _consolidate_cluster(engine, cluster)
+            _consolidate_cluster(engine, cluster, epoch)
             consolidated_count += 1
+        except RestoredUnderfoot:
+            raise
         except Exception as e:
             logger.warning("Failed to consolidate cluster: %s", e)
 
@@ -204,7 +215,7 @@ def run_consolidation(engine) -> None:
         logger.info("Consolidated %d cluster(s)", consolidated_count)
 
 
-def _consolidate_cluster(engine, cluster: list[dict]) -> None:
+def _consolidate_cluster(engine, cluster: list[dict], epoch: int) -> None:
     """Consolidate a single cluster using LLM summarization."""
     from ormah.background.llm_client import extract_json, llm_generate
 
@@ -260,4 +271,4 @@ Return a JSON object:
         return
 
     node_ids = [n["id"] for n in cluster]
-    _apply_consolidation(engine, node_ids, title, summary, node_type)
+    _apply_consolidation(engine, node_ids, title, summary, node_type, epoch=epoch)

--- a/src/ormah/background/decay_manager.py
+++ b/src/ormah/background/decay_manager.py
@@ -6,30 +6,63 @@ import logging
 from datetime import datetime, timezone
 
 from ormah import lifecycle
-from ormah.background.memory_lock import serialized_memory_job
+from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
 from ormah.models.node import Tier, UpdateNodeRequest
 
 logger = logging.getLogger(__name__)
 
 
-@serialized_memory_job
-def run_decay(engine) -> None:
+def _still_decays(engine, node_id: str, now, settings) -> bool:
+    """Re-read the row and recompute retrievability inside the apply step.
+
+    L_mem no longer spans the run, so a promotion can land between the snapshot
+    query and this demotion. Re-reading here — under the same lock that will
+    write — is what keeps a freshly-used node in working (#223/#240).
+    """
+    row = engine.db.conn.execute(
+        "SELECT tier, stability, last_review, last_accessed FROM nodes WHERE id = ?",
+        (node_id,),
+    ).fetchone()
+    if row is None or row["tier"] != "working":
+        return False
+
+    anchor_str = row["last_accessed"] or row["last_review"]
+    try:
+        anchor = datetime.fromisoformat(anchor_str)
+        days_since = max((now - anchor).total_seconds() / 86400, 0.001)
+    except (ValueError, TypeError):
+        return False
+
+    retrievability = lifecycle.retrievability(
+        days_since,
+        row["stability"],
+        fallback_stability=settings.fsrs_initial_stability,
+    )
+    return retrievability < settings.fsrs_decay_threshold
+
+
+@restore_aware_job
+def run_decay(engine, epoch: int) -> None:
     """Auto-demote working nodes whose FSRS retrievability drops below threshold.
 
     Retrievability alone decides (#222/#191). Importance is deliberately not a
     pre-gate: cumulative access and edge counts could push it permanently above
     any threshold, pinning a stale node to working forever. Identity (the self
     node) and core stay protected — core never enters this query.
+
+    The candidate scan runs unlocked; each demotion takes L_mem for itself and
+    revalidates the node first (#240).
     """
     try:
         settings = engine.settings
         now = datetime.now(timezone.utc)
 
         # One-time cleanup: remove legacy pending decay proposals
-        with engine.db.transaction() as conn:
-            conn.execute(
-                "DELETE FROM proposals WHERE type = 'decay' AND status = 'pending'"
-            )
+        with engine.memory_operation_at(epoch):
+            with engine.db.transaction() as conn:
+                conn.execute(
+                    "DELETE FROM proposals WHERE type = 'decay' AND status = 'pending'"
+                )
 
         rows = engine.db.conn.execute(
             "SELECT id, stability, last_review, last_accessed "
@@ -75,12 +108,17 @@ def run_decay(engine) -> None:
             if retrievability >= r_threshold:
                 continue
 
-            result = engine.update_node(row["id"], UpdateNodeRequest(tier=Tier.archival))
-            if result:
-                demoted += 1
+            with engine.memory_operation_at(epoch):
+                if not _still_decays(engine, row["id"], datetime.now(timezone.utc), settings):
+                    continue
+                result = engine.update_node(row["id"], UpdateNodeRequest(tier=Tier.archival))
+                if result:
+                    demoted += 1
 
         if demoted:
             logger.info("Decay manager demoted %d nodes to archival", demoted)
 
+    except RestoredUnderfoot:
+        raise  # restore_aware_job ends the run; never swallowed as a generic failure
     except Exception as e:
         logger.warning("Decay manager failed: %s", e)

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -339,6 +339,23 @@ def run_duplicate_detection(engine, epoch: int) -> None:
                 merged = False
                 if score >= engine.settings.auto_merge_threshold:
                     with engine.memory_operation_at(epoch):
+                        # Revalidate: merged_content was written by the LLM from the content
+                        # snapshotted before the call. Applying it over an edit made since would
+                        # silently discard that edit. Skip the pair; the next run re-checks it
+                        # against the new content (#240).
+                        fresh = engine.db.conn.execute(
+                            "SELECT id, content FROM nodes WHERE id IN (?, ?)",
+                            (node["id"], match["id"]),
+                        ).fetchall()
+                        current = {r["id"]: r["content"] for r in fresh}
+                        if (
+                            current.get(node["id"]) != node["content"]
+                            or current.get(match["id"]) != other["content"]
+                        ):
+                            logger.debug(
+                                "Auto-merge skipped %s / %s: content changed since the snapshot",
+                                node["id"][:8], match["id"][:8])
+                            continue
                         try:
                             result = engine.execute_merge(
                                 node["id"], match["id"],

--- a/src/ormah/background/duplicate_merger.py
+++ b/src/ormah/background/duplicate_merger.py
@@ -7,7 +7,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from ormah.background.memory_lock import serialized_memory_job
+from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
 
 logger = logging.getLogger(__name__)
 
@@ -239,8 +239,8 @@ def _find_merge_candidates(engine, limit: int = 8) -> list[dict]:
         return []
 
 
-@serialized_memory_job
-def run_duplicate_detection(engine) -> None:
+@restore_aware_job
+def run_duplicate_detection(engine, epoch: int) -> None:
     """Find near-duplicate nodes and create merge proposals.
 
     Uses a multi-signal approach: embedding similarity (primary),
@@ -336,19 +336,24 @@ def run_duplicate_detection(engine) -> None:
                 reason += f" (score={score:.3f}, embed={embedding_sim:.2f}, title={title_sim:.2f}, token={token_sim:.2f})"
 
                 # Auto-merge for high-confidence duplicates
+                merged = False
                 if score >= engine.settings.auto_merge_threshold:
-                    try:
-                        result = engine.execute_merge(
-                            node["id"], match["id"],
-                            merged_content=merged_content,
-                            merged_title=merged_title,
-                        )
-                        logger.info("Auto-merged: %s", result)
-                        proposals_created += 1
+                    with engine.memory_operation_at(epoch):
+                        try:
+                            result = engine.execute_merge(
+                                node["id"], match["id"],
+                                merged_content=merged_content,
+                                merged_title=merged_title,
+                            )
+                            logger.info("Auto-merged: %s", result)
+                            proposals_created += 1
+                            merged = True
+                        except Exception as e:
+                            logger.warning("Auto-merge failed for %s / %s: %s",
+                                           node["id"][:8], match["id"][:8], e)
+                            merged = False
+                    if merged:
                         continue
-                    except Exception as e:
-                        logger.warning("Auto-merge failed for %s / %s: %s",
-                                       node["id"][:8], match["id"][:8], e)
 
                 # Check no existing merge proposal
                 existing = engine.db.conn.execute(
@@ -369,21 +374,25 @@ def run_duplicate_detection(engine) -> None:
                     )
 
                 proposal_id = str(uuid.uuid4())
-                with engine.db.transaction() as conn:
-                    conn.execute(
-                        "INSERT INTO proposals (id, type, status, source_nodes, proposed_action, reason, created) "
-                        "VALUES (?, 'merge', 'pending', ?, ?, ?, ?)",
-                        (
-                            proposal_id,
-                            json.dumps([node["id"], match["id"]]),
-                            proposed_action,
-                            reason,
-                            datetime.now(timezone.utc).isoformat(),
-                        ),
-                    )
+                with engine.memory_operation_at(epoch):
+                    with engine.db.transaction() as conn:
+                        conn.execute(
+                            "INSERT INTO proposals (id, type, status, source_nodes, "
+                            "proposed_action, reason, created) "
+                            "VALUES (?, 'merge', 'pending', ?, ?, ?, ?)",
+                            (
+                                proposal_id,
+                                json.dumps([node["id"], match["id"]]),
+                                proposed_action,
+                                reason,
+                                datetime.now(timezone.utc).isoformat(),
+                            ),
+                        )
                 proposals_created += 1
         if proposals_created:
             logger.info("Duplicate merger created %d proposals/auto-merges", proposals_created)
 
+    except RestoredUnderfoot:
+        raise
     except Exception as e:
         logger.warning("Duplicate detection failed: %s", e)

--- a/src/ormah/background/importance_scorer.py
+++ b/src/ormah/background/importance_scorer.py
@@ -6,7 +6,7 @@ import logging
 import math
 from datetime import datetime, timezone
 
-from ormah.background.memory_lock import serialized_memory_job
+from ormah.background.memory_lock import restore_aware_job
 
 logger = logging.getLogger(__name__)
 
@@ -29,20 +29,29 @@ def _recency_signal(days_ago: float, half_life_days: float) -> float:
     return math.exp(-math.log(2) * days_ago / half_life_days)
 
 
-def _commit_updates_chunked(db, updates, chunk_size: int = 100) -> None:
+def _commit_updates_chunked(db, updates, chunk_size: int = 100, *, engine=None, epoch=None) -> None:
     """Apply (importance, node_id) updates in bounded write transactions so a
-    full-store batch never holds the write lock long enough to stall foreground writes."""
+    full-store batch never holds the write lock long enough to stall foreground writes.
+
+    When *engine* and *epoch* are given, each chunk also takes L_mem for itself and
+    revalidates the restore epoch (#240) — the care this function already took for
+    L_db, extended to the lock that was being held for the whole run.
+    """
+    from contextlib import nullcontext
+
     for i in range(0, len(updates), chunk_size):
-        with db.transaction() as conn:
-            for importance_val, nid in updates[i : i + chunk_size]:
-                conn.execute(
-                    "UPDATE nodes SET importance = ? WHERE id = ?",
-                    (importance_val, nid),
-                )
+        guard = engine.memory_operation_at(epoch) if engine is not None else nullcontext()
+        with guard:
+            with db.transaction() as conn:
+                for importance_val, nid in updates[i : i + chunk_size]:
+                    conn.execute(
+                        "UPDATE nodes SET importance = ? WHERE id = ?",
+                        (importance_val, nid),
+                    )
 
 
-@serialized_memory_job
-def run_importance_scoring(engine) -> None:
+@restore_aware_job
+def run_importance_scoring(engine, epoch: int) -> None:
     """Iterate all nodes, compute weighted importance, persist changes."""
     settings = engine.settings
     conn = engine.db.conn
@@ -127,15 +136,16 @@ def run_importance_scoring(engine) -> None:
         updates.append((round(importance, 4), nid))
 
         # Update markdown file
-        node = engine.file_store.load(nid)
-        if node is not None:
-            node.importance = round(importance, 4)
-            node.touch_updated()
-            engine.file_store.save(node)
+        with engine.memory_operation_at(epoch):
+            node = engine.file_store.load(nid)
+            if node is not None:
+                node.importance = round(importance, 4)
+                node.touch_updated()
+                engine.file_store.save(node)
 
         updated += 1
 
     if updates:
-        _commit_updates_chunked(engine.db, updates)
+        _commit_updates_chunked(engine.db, updates, engine=engine, epoch=epoch)
     if updated:
         logger.info("Importance scorer: updated %d/%d nodes", updated, len(rows))

--- a/src/ormah/background/memory_lock.py
+++ b/src/ormah/background/memory_lock.py
@@ -1,10 +1,55 @@
-"""In-process exclusion for jobs that mutate the live memory graph."""
+"""Restore-awareness for jobs that mutate the live memory graph.
 
+``L_mem`` buys background jobs exactly one thing: a mutation must not interleave
+with a full graph restore. It does *not* provide per-operation atomicity — every
+primitive a job mutates through already locks at its own granularity
+(``engine.remember``/``connect``/``update_node``/``execute_merge`` and
+``engine.file_store.save`` take ``L_mem`` per call; ``engine.db.transaction()``
+takes ``L_db`` with ``BEGIN IMMEDIATE``).
+
+So a job reads the restore epoch once, on entry, and takes ``L_mem`` only around
+each apply step, via ``engine.memory_operation_at(epoch)``. If a restore lands
+mid-run the job's whole snapshot is stale, not one row of it: the next apply step
+raises :class:`RestoredUnderfoot`, the run ends, and the job returns at its next
+interval.
+"""
+
+from __future__ import annotations
+
+import logging
 from functools import wraps
+
+logger = logging.getLogger(__name__)
+
+
+class RestoredUnderfoot(Exception):
+    """A full graph restore landed while this run was computing its snapshot."""
+
+
+def restore_aware_job(job):
+    """Supply the entry-time restore epoch; end the run cleanly if it moves.
+
+    The wrapped job body takes ``(engine, epoch, *args, **kwargs)``. Callers keep
+    calling ``run_x(engine)``.
+    """
+
+    @wraps(job)
+    def wrapper(engine, *args, **kwargs):
+        epoch = engine.restore_epoch
+        try:
+            return job(engine, epoch, *args, **kwargs)
+        except RestoredUnderfoot:
+            logger.info(
+                "%s aborted: a graph restore landed mid-run; it will retry next interval",
+                job.__name__,
+            )
+            return None
+
+    return wrapper
 
 
 def serialized_memory_job(job):
-    """Keep a background mutation from overlapping a full graph restore."""
+    """Deprecated: whole-run exclusion. Being replaced by restore_aware_job (#240)."""
 
     @wraps(job)
     def locked(engine, *args, **kwargs):

--- a/src/ormah/background/memory_lock.py
+++ b/src/ormah/background/memory_lock.py
@@ -47,13 +47,3 @@ def restore_aware_job(job):
 
     return wrapper
 
-
-def serialized_memory_job(job):
-    """Deprecated: whole-run exclusion. Being replaced by restore_aware_job (#240)."""
-
-    @wraps(job)
-    def locked(engine, *args, **kwargs):
-        with engine.memory_operation():
-            return job(engine, *args, **kwargs)
-
-    return locked

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from ormah import lifecycle
+from ormah.background.memory_lock import RestoredUnderfoot
 from ormah.config import Settings
 from ormah.embeddings.text import embedding_text as _embedding_text
 from ormah.engine.context_builder import ContextBuilder
@@ -101,6 +102,7 @@ class MemoryEngine:
     def __init__(self, settings: Settings) -> None:
         self.settings = settings
         self._memory_operation_lock = threading.RLock()
+        self._restore_epoch = 0
         self.file_store = FileStore(settings.nodes_dir, self._memory_operation_lock)
         self.db = Database(settings.db_path)
         self.db.init_schema()
@@ -550,6 +552,28 @@ class MemoryEngine:
         """Exclude a live graph mutation while a full restore is swapping files."""
 
         with self._memory_operation_lock:
+            yield
+
+    @property
+    def restore_epoch(self) -> int:
+        """Monotonic counter; every completed full restore bumps it."""
+        return self._restore_epoch
+
+    @contextmanager
+    def memory_operation_at(self, epoch: int):
+        """One exclusive apply step, valid only if no restore landed since *epoch*.
+
+        The epoch check happens *inside* ``L_mem`` on purpose: a loose ``if``
+        before the mutation would let a restore land between the check and the
+        write, and a write landing between the file swap and
+        ``rebuild_index()`` is silently overwritten, not corrupted (spec §2).
+        """
+
+        with self._memory_operation_lock:
+            if self._restore_epoch != epoch:
+                raise RestoredUnderfoot(
+                    f"restore epoch moved {epoch} -> {self._restore_epoch}"
+                )
             yield
 
     @_serialized_memory_operation
@@ -1328,6 +1352,11 @@ class MemoryEngine:
     @_serialized_memory_operation
     def reload_restored_graph(self) -> int:
         """Reload file, identity, and search state after a full memory restore."""
+
+        # Bump first: this method is exclusive under L_mem, and the file swap has
+        # already happened. Any job that computed against the pre-swap graph must
+        # abort even if the rebuild below raises.
+        self._restore_epoch += 1
 
         self.file_store = FileStore(self.settings.nodes_dir, self._memory_operation_lock)
         self.builder = IndexBuilder(self.db, self.file_store)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2430,7 +2430,6 @@ class MemoryEngine:
 
     # --- Conversation ingestion ---
 
-    @_serialized_memory_operation
     def ingest_conversation(
         self,
         content: str,
@@ -2467,12 +2466,6 @@ class MemoryEngine:
             if not mem_content:
                 continue
 
-            # Dedup: check if a very similar memory already exists (skip in dry_run)
-            if not dry_run and self._is_duplicate_memory(mem_content):
-                logger.debug("Skipping duplicate: %s", mem.get("title", mem_content[:40]))
-                skipped += 1
-                continue
-
             try:
                 node_type = NodeType(mem.get("type", "fact"))
             except ValueError:
@@ -2486,6 +2479,11 @@ class MemoryEngine:
             tags = mem.get("tags", []) + ["auto-ingested"] + (extra_tags or [])
 
             if dry_run:
+                # Dry run never writes, so a loose pre-check is fine here — there is
+                # no race to revalidate against.
+                if self._is_duplicate_memory(mem_content):
+                    skipped += 1
+                    continue
                 created.append({
                     "title": mem_title,
                     "content": mem_content,
@@ -2496,16 +2494,26 @@ class MemoryEngine:
                 })
                 continue
 
-            req = CreateNodeRequest(
-                content=mem_content,
-                type=node_type,
-                title=mem_title,
-                tags=tags,
-                space=space,
-                about_self=mem.get("about_self", False),
-                confidence=confidence,
-            )
-            node_id, _ = self.remember(req, agent_id=agent_id or "ingester")
+            # Dedup check and store must be one exclusive step: extraction ran
+            # unlocked, so another concurrent ingest could have written the same
+            # content since. Re-checking outside this lock would race the same
+            # way the old whole-call lock accidentally prevented (#240).
+            with self.memory_operation():
+                if self._is_duplicate_memory(mem_content):
+                    logger.debug("Skipping duplicate: %s", mem.get("title", mem_content[:40]))
+                    skipped += 1
+                    continue
+
+                req = CreateNodeRequest(
+                    content=mem_content,
+                    type=node_type,
+                    title=mem_title,
+                    tags=tags,
+                    space=space,
+                    about_self=mem.get("about_self", False),
+                    confidence=confidence,
+                )
+                node_id, _ = self.remember(req, agent_id=agent_id or "ingester")
             created.append({
                 "node_id": node_id,
                 "title": mem_title,

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2479,11 +2479,6 @@ class MemoryEngine:
             tags = mem.get("tags", []) + ["auto-ingested"] + (extra_tags or [])
 
             if dry_run:
-                # Dry run never writes, so a loose pre-check is fine here — there is
-                # no race to revalidate against.
-                if self._is_duplicate_memory(mem_content):
-                    skipped += 1
-                    continue
                 created.append({
                     "title": mem_title,
                     "content": mem_content,

--- a/tests/test_background/lock_probe.py
+++ b/tests/test_background/lock_probe.py
@@ -1,0 +1,67 @@
+"""Count real L_mem acquisitions, ignoring RLock re-entries.
+
+L_mem is an RLock and every engine mutator is decorated with it, so a job that
+holds it and calls engine.remember() re-enters. Only a per-thread 0 -> 1
+transition is a hold a foreground writer would have waited on.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class LockProbe:
+    """Drop-in wrapper around the engine's L_mem RLock."""
+
+    def __init__(self, real_lock) -> None:
+        self._real = real_lock
+        self._local = threading.local()
+        self._counter_lock = threading.Lock()
+        self.acquisitions = 0
+
+    @property
+    def _depth(self) -> int:
+        return getattr(self._local, "depth", 0)
+
+    @_depth.setter
+    def _depth(self, value: int) -> None:
+        self._local.depth = value
+
+    @property
+    def held(self) -> bool:
+        """Is the calling thread currently inside L_mem?"""
+        return self._depth > 0
+
+    def __enter__(self):
+        if self._depth == 0:
+            with self._counter_lock:
+                self.acquisitions += 1
+        self._depth += 1
+        return self._real.__enter__()
+
+    def __exit__(self, *args):
+        self._depth -= 1
+        return self._real.__exit__(*args)
+
+    # FileStore and the engine only ever use `with`, but keep the RLock surface
+    # intact so an unexpected direct call does not silently bypass the probe.
+    def acquire(self, *args, **kwargs):
+        acquired = self._real.acquire(*args, **kwargs)
+        if acquired:
+            if self._depth == 0:
+                with self._counter_lock:
+                    self.acquisitions += 1
+            self._depth += 1
+        return acquired
+
+    def release(self):
+        self._depth -= 1
+        return self._real.release()
+
+
+def install_probe(engine) -> LockProbe:
+    """Swap a LockProbe into both references to L_mem and return it."""
+    probe = LockProbe(engine._memory_operation_lock)
+    engine._memory_operation_lock = probe
+    engine.file_store._operation_lock = probe
+    return probe

--- a/tests/test_background/test_auto_cluster.py
+++ b/tests/test_background/test_auto_cluster.py
@@ -1,0 +1,66 @@
+"""Auto-cluster: another no-LLM job that held L_mem for its whole run."""
+
+from __future__ import annotations
+
+from ormah.background.auto_cluster import run_auto_cluster
+from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType
+
+from tests.test_background.lock_probe import install_probe
+
+
+def _unassign(engine, node_id: str) -> None:
+    engine.db.conn.execute("UPDATE nodes SET space = NULL WHERE id = ?", (node_id,))
+    engine.db.conn.commit()
+
+
+def _space_of(engine, node_id: str) -> str | None:
+    row = engine.db.conn.execute(
+        "SELECT space FROM nodes WHERE id = ?", (node_id,)).fetchone()
+    return row["space"] if row else None
+
+
+def _seeded_pair(engine, i: int) -> str:
+    """One spaced anchor plus one unassigned neighbour edged to it."""
+    anchor, _ = engine.remember(CreateNodeRequest(
+        content=f"anchor {i}", type=NodeType.fact, title=f"anchor {i}", space="proj"))
+    orphan, _ = engine.remember(CreateNodeRequest(
+        content=f"orphan {i}", type=NodeType.fact, title=f"orphan {i}"))
+    _unassign(engine, orphan)
+    engine.connect(ConnectRequest(
+        source_id=orphan, target_id=anchor, edge=EdgeType.related_to, weight=1.0))
+    return orphan
+
+
+def test_auto_cluster_assigns_from_neighbours(engine):
+    orphan = _seeded_pair(engine, 0)
+    run_auto_cluster(engine)
+    assert _space_of(engine, orphan) == "proj"
+
+
+def test_auto_cluster_takes_the_lock_per_node_not_once_per_run(engine):
+    orphans = [_seeded_pair(engine, i) for i in range(3)]
+    probe = install_probe(engine)
+    run_auto_cluster(engine)
+
+    assert all(_space_of(engine, o) == "proj" for o in orphans)
+    # Before the fix: exactly 1, whatever the node count.
+    assert probe.acquisitions >= 3
+
+
+def test_auto_cluster_aborts_when_a_restore_lands_mid_run(engine):
+    orphans = [_seeded_pair(engine, i) for i in range(3)]
+    real_save = engine.file_store.save
+    saves = {"count": 0}
+
+    def bump_after_first(node):
+        path = real_save(node)
+        saves["count"] += 1
+        if saves["count"] == 1:
+            engine._restore_epoch += 1
+        return path
+
+    engine.file_store.save = bump_after_first
+    run_auto_cluster(engine)  # returns cleanly
+
+    assert saves["count"] == 1
+    assert sum(_space_of(engine, o) == "proj" for o in orphans) == 0

--- a/tests/test_background/test_auto_cluster.py
+++ b/tests/test_background/test_auto_cluster.py
@@ -64,3 +64,33 @@ def test_auto_cluster_aborts_when_a_restore_lands_mid_run(engine):
 
     assert saves["count"] == 1
     assert sum(_space_of(engine, o) == "proj" for o in orphans) == 0
+
+
+def test_a_space_assigned_after_the_scan_is_not_overwritten(engine):
+    """auto_cluster's candidate query says 'no space'; revalidate before writing one."""
+    orphan = _seeded_pair(engine, 0)
+    assigned_by_user = {"done": False}
+
+    real_load = engine.file_store.load
+
+    def assign_then_load(node_id):
+        """file_store.load is the first thing the apply step does; the user write lands
+        just before it, standing in for one that arrived after the candidate query."""
+        if not assigned_by_user["done"] and node_id == orphan:
+            assigned_by_user["done"] = True
+            node = real_load(node_id)
+            node.space = "chosen-by-user"
+            node.touch_updated()
+            real_save(node)
+            engine.db.conn.execute(
+                "UPDATE nodes SET space = 'chosen-by-user' WHERE id = ?", (orphan,))
+            engine.db.conn.commit()
+        return real_load(node_id)
+
+    real_save = engine.file_store.save
+    engine.file_store.load = assign_then_load
+
+    run_auto_cluster(engine)
+
+    assert assigned_by_user["done"], "the apply step never ran — the fixture stopped exercising the job"
+    assert _space_of(engine, orphan) == "chosen-by-user"

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -411,3 +411,96 @@ def test_checked_pairs_invalidated_on_update(engine):
         run_auto_linker(engine)
 
     assert mock_llm.call_count >= 1  # LLM was called again for this pair
+
+
+def test_lock_is_not_held_across_the_llm_call(engine):
+    """The bug, stated as an assertion (#240)."""
+    from tests.test_background.lock_probe import install_probe
+
+    _create_pair(engine)
+    _create_pair(engine, title_a="Ruby language", content_a="Ruby is a programming language.",
+                 title_b="Ruby lang", content_b="Ruby is a popular programming language.")
+
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    _reset_adapter()
+
+    probe = install_probe(engine)
+    lock_held_at_call: list[bool] = []
+
+    def fake_llm(*args, **kwargs):
+        lock_held_at_call.append(probe.held)
+        return json.dumps({"relationship": "supports", "reason": "same topic"})
+
+    with patch(_LLM_PATCH, side_effect=fake_llm):
+        from ormah.background.auto_linker import run_auto_linker
+        run_auto_linker(engine)
+
+    assert lock_held_at_call, "the fake LLM was never called — the fixture stopped exercising the job"
+    assert not any(lock_held_at_call)
+    assert probe.acquisitions >= len(lock_held_at_call)
+
+
+def test_a_foreground_write_completes_while_the_job_is_inside_the_llm(engine):
+    """The 25-minute symptom. No sleeps: the fake LLM blocks until the write lands."""
+    import threading
+
+    _create_pair(engine)
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    _reset_adapter()
+
+    job_is_inside_llm = threading.Event()
+    foreground_write_done = threading.Event()
+
+    def blocking_llm(*args, **kwargs):
+        job_is_inside_llm.set()
+        # Deadlocks the test only if L_mem is held here — which is the bug.
+        assert foreground_write_done.wait(timeout=10.0), "foreground write never completed"
+        return json.dumps({"relationship": "supports", "reason": "same topic"})
+
+    def foreground_write():
+        assert job_is_inside_llm.wait(timeout=10.0)
+        engine.remember(CreateNodeRequest(
+            content="a user memory written while the linker is thinking",
+            type=NodeType.fact, title="foreground"))
+        foreground_write_done.set()
+
+    writer = threading.Thread(target=foreground_write, daemon=True)
+    writer.start()
+
+    with patch(_LLM_PATCH, side_effect=blocking_llm):
+        from ormah.background.auto_linker import run_auto_linker
+        job_thread = threading.Thread(target=run_auto_linker, args=(engine,), daemon=True)
+        job_thread.start()
+        job_thread.join(timeout=20.0)
+
+    writer.join(timeout=5.0)
+    assert foreground_write_done.is_set(), "L_mem was held across the LLM call"
+    assert not job_thread.is_alive()
+
+
+def test_auto_linker_aborts_when_a_restore_lands_mid_run(engine):
+    """Abort the run, and leave nothing written after the bump."""
+    _create_pair(engine)
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_link_similarity_threshold = 0.0
+    _reset_adapter()
+
+    # The bump must land AFTER the job read its entry epoch, not before: restore_aware_job
+    # reads engine.restore_epoch at call time, so bumping first would just hand the job the
+    # new value and there would be no mismatch to detect. Bumping inside the fake LLM puts
+    # it exactly where a real restore lands — between the unlocked LLM call and the apply
+    # step that follows it.
+    def fake_llm(*args, **kwargs):
+        engine._restore_epoch += 1
+        return json.dumps({"relationship": "supports", "reason": "same topic"})
+
+    edges_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+
+    with patch(_LLM_PATCH, side_effect=fake_llm):
+        from ormah.background.auto_linker import run_auto_linker
+        run_auto_linker(engine)  # returns cleanly, no raise
+
+    edges_after = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+    assert edges_after == edges_before

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -452,11 +452,16 @@ def test_a_foreground_write_completes_while_the_job_is_inside_the_llm(engine):
 
     job_is_inside_llm = threading.Event()
     foreground_write_done = threading.Event()
+    llm_saw_the_write = []
 
     def blocking_llm(*args, **kwargs):
         job_is_inside_llm.set()
-        # Deadlocks the test only if L_mem is held here — which is the bug.
-        assert foreground_write_done.wait(timeout=10.0), "foreground write never completed"
+        # Record the wait's outcome instead of asserting on it. An assert raised here
+        # would be swallowed by run_auto_linker's own blanket `except Exception`, which
+        # then releases L_mem — the writer would unblock, both outer assertions would
+        # still read true, and a reintroduced whole-run lock would show up as a ~10s
+        # slow pass instead of a red test. Carrying the value out makes it a hard failure.
+        llm_saw_the_write.append(foreground_write_done.wait(timeout=10.0))
         return json.dumps({"relationship": "supports", "reason": "same topic"})
 
     def foreground_write():
@@ -476,7 +481,9 @@ def test_a_foreground_write_completes_while_the_job_is_inside_the_llm(engine):
         job_thread.join(timeout=20.0)
 
     writer.join(timeout=5.0)
-    assert foreground_write_done.is_set(), "L_mem was held across the LLM call"
+    assert llm_saw_the_write, "the fake LLM was never called — the fixture stopped exercising the job"
+    assert all(llm_saw_the_write), "L_mem was held across the LLM call"
+    assert foreground_write_done.is_set()
     assert not job_thread.is_alive()
 
 

--- a/tests/test_background/test_auto_linker.py
+++ b/tests/test_background/test_auto_linker.py
@@ -504,10 +504,14 @@ def test_auto_linker_aborts_when_a_restore_lands_mid_run(engine):
         return json.dumps({"relationship": "supports", "reason": "same topic"})
 
     edges_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+    epoch_before = engine.restore_epoch
 
     with patch(_LLM_PATCH, side_effect=fake_llm):
         from ormah.background.auto_linker import run_auto_linker
         run_auto_linker(engine)  # returns cleanly, no raise
+
+    assert engine.restore_epoch > epoch_before, \
+        "the fake LLM was never called — the fixture stopped exercising the job"
 
     edges_after = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
     assert edges_after == edges_before

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -283,3 +283,59 @@ def test_project_scoped_nodes_skipped_by_default(engine):
 
     # LLM should never be called since project-scoped nodes are skipped
     mock_llm.assert_not_called()
+
+
+def test_conflict_detection_does_not_hold_the_lock_across_the_llm_call(engine):
+    """Same bug as auto_linker: the LLM runs under L_mem today (#240)."""
+    import json
+    from unittest.mock import patch
+
+    from tests.test_background.lock_probe import install_probe
+
+    id_a, id_b = _create_pair(engine, node_type=NodeType.fact)
+    engine.settings.llm_provider = "ollama"
+
+    probe = install_probe(engine)
+    lock_held_at_call: list[bool] = []
+
+    def fake_llm(*args, **kwargs):
+        lock_held_at_call.append(probe.held)
+        return json.dumps({
+            "same_subject": True, "conflict": True, "type": "tension",
+            "explanation": "they disagree",
+        })
+
+    with patch("ormah.background.llm_client.llm_generate", side_effect=fake_llm):
+        from ormah.background.conflict_detector import run_conflict_detection
+        run_conflict_detection(engine)
+
+    assert lock_held_at_call, "the fake LLM was never called — the fixture stopped exercising the job"
+    assert not any(lock_held_at_call)
+
+
+def test_conflict_detection_aborts_when_a_restore_lands_mid_run(engine):
+    import json
+    from unittest.mock import patch
+
+    id_a, id_b = _create_pair(engine, node_type=NodeType.fact)
+    engine.settings.llm_provider = "ollama"
+
+    edges_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+
+    # The bump must land AFTER the job read its entry epoch: restore_aware_job reads
+    # engine.restore_epoch at call time, so bumping before the call would hand the job the
+    # new value and leave no mismatch to detect. Inside the fake LLM is where a real restore
+    # lands — between the unlocked LLM call and the apply step that follows it.
+    def fake_llm(*args, **kwargs):
+        engine._restore_epoch += 1
+        return json.dumps({
+            "same_subject": True, "conflict": True, "type": "tension",
+            "explanation": "they disagree",
+        })
+
+    with patch("ormah.background.llm_client.llm_generate", side_effect=fake_llm):
+        from ormah.background.conflict_detector import run_conflict_detection
+        run_conflict_detection(engine)  # returns cleanly
+
+    edges_after = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+    assert edges_after == edges_before

--- a/tests/test_background/test_conflict_detector.py
+++ b/tests/test_background/test_conflict_detector.py
@@ -321,6 +321,7 @@ def test_conflict_detection_aborts_when_a_restore_lands_mid_run(engine):
     engine.settings.llm_provider = "ollama"
 
     edges_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+    epoch_before = engine.restore_epoch
 
     # The bump must land AFTER the job read its entry epoch: restore_aware_job reads
     # engine.restore_epoch at call time, so bumping before the call would hand the job the
@@ -336,6 +337,9 @@ def test_conflict_detection_aborts_when_a_restore_lands_mid_run(engine):
     with patch("ormah.background.llm_client.llm_generate", side_effect=fake_llm):
         from ormah.background.conflict_detector import run_conflict_detection
         run_conflict_detection(engine)  # returns cleanly
+
+    assert engine.restore_epoch > epoch_before, \
+        "the fake LLM was never called — the fixture stopped exercising the job"
 
     edges_after = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
     assert edges_after == edges_before

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -187,6 +187,39 @@ class TestConsolidation:
         nodes_after = engine.db.conn.execute("SELECT COUNT(*) AS c FROM nodes").fetchone()["c"]
         assert nodes_after == nodes_before
 
+    @patch("ormah.background.llm_client.llm_generate")
+    def test_a_node_promoted_during_the_llm_call_is_not_demoted(self, mock_llm, consolidation_engine):
+        """The #257 canary, in the consolidator: revalidate tier inside the apply step."""
+        from ormah.models.node import Tier, UpdateNodeRequest
+
+        engine, ids = consolidation_engine
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_min_cluster_size = 2
+
+        promoted_id = ids[0]
+        promoted = {"done": False}
+
+        def promote_then_answer(*args, **kwargs):
+            """The LLM call is the unlocked phase: a foreground promotion lands here."""
+            if not promoted["done"]:
+                promoted["done"] = True
+                engine.update_node(promoted_id, UpdateNodeRequest(tier=Tier.core))
+            return json.dumps({
+                "title": "Python uses indentation",
+                "summary": "Python blocks are delimited by indentation.",
+                "type": "fact",
+            })
+
+        mock_llm.side_effect = promote_then_answer
+
+        from ormah.background.consolidator import run_consolidation
+        run_consolidation(engine)
+
+        assert promoted["done"], "the fake LLM was never called — the fixture stopped exercising the job"
+        row = engine.db.conn.execute(
+            "SELECT tier FROM nodes WHERE id = ?", (promoted_id,)).fetchone()
+        assert row["tier"] == "core", "consolidation demoted a node promoted after the snapshot"
+
 
 def test_consolidation_settings_defaults(tmp_path):
     s = Settings(memory_dir=tmp_path)

--- a/tests/test_background/test_consolidator.py
+++ b/tests/test_background/test_consolidator.py
@@ -126,6 +126,67 @@ class TestConsolidation:
         run_consolidation(engine)
         # Completes without error
 
+    @patch("ormah.background.llm_client.llm_generate")
+    def test_lock_is_not_held_across_the_llm_call(self, mock_llm, consolidation_engine):
+        from tests.test_background.lock_probe import install_probe
+
+        engine, ids = consolidation_engine
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_min_cluster_size = 2
+
+        probe = install_probe(engine)
+        lock_held_at_call = []
+
+        def fake_llm(*args, **kwargs):
+            lock_held_at_call.append(probe.held)
+            return json.dumps({
+                "title": "Python uses indentation",
+                "summary": "Python blocks are delimited by indentation.",
+                "type": "fact",
+            })
+
+        mock_llm.side_effect = fake_llm
+
+        from ormah.background.consolidator import run_consolidation
+        run_consolidation(engine)
+
+        assert lock_held_at_call, "the fake LLM was never called — the fixture stopped exercising the job"
+        assert not any(lock_held_at_call)
+
+    @patch("ormah.background.llm_client.llm_generate")
+    def test_aborts_when_a_restore_lands_mid_run(self, mock_llm, consolidation_engine):
+        engine, ids = consolidation_engine
+        engine.settings.llm_provider = "ollama"
+        engine.settings.consolidation_min_cluster_size = 2
+
+        nodes_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM nodes").fetchone()["c"]
+        epoch_before = engine.restore_epoch
+
+        # The bump must land AFTER the job read its entry epoch: restore_aware_job reads
+        # engine.restore_epoch at call time, so bumping before the call would hand the job
+        # the new value and leave no mismatch to detect. Inside the fake LLM is where a real
+        # restore lands — between the unlocked LLM call and the apply step that follows it.
+        def fake_llm(*args, **kwargs):
+            engine._restore_epoch += 1
+            return json.dumps({
+                "title": "Python uses indentation",
+                "summary": "Python blocks are delimited by indentation.",
+                "type": "fact",
+            })
+
+        mock_llm.side_effect = fake_llm
+
+        from ormah.background.consolidator import run_consolidation
+        run_consolidation(engine)  # returns cleanly
+
+        # Guard against silent vacuousness: the assertion below holds trivially if the job
+        # never reached an apply step (no clusters found, min cluster size unmet). Since the
+        # bump lives inside the fake LLM, a moved epoch is proof the job actually got there.
+        assert engine.restore_epoch > epoch_before, \
+            "the fake LLM was never called — the fixture stopped exercising the job"
+        nodes_after = engine.db.conn.execute("SELECT COUNT(*) AS c FROM nodes").fetchone()["c"]
+        assert nodes_after == nodes_before
+
 
 def test_consolidation_settings_defaults(tmp_path):
     s = Settings(memory_dir=tmp_path)

--- a/tests/test_background/test_decay_manager.py
+++ b/tests/test_background/test_decay_manager.py
@@ -444,3 +444,97 @@ def test_zero_stability_decays_on_the_configured_initial_stability(engine, monke
     run_decay(engine)
 
     assert _get_tier(engine, node_id) == "working"
+
+
+def test_decay_takes_the_lock_once_per_demoted_node_not_once_per_run(engine):
+    """The default-install bug: no LLM anywhere, yet L_mem is held for the whole run."""
+    from tests.test_background.lock_probe import install_probe
+
+    ids = []
+    for i in range(3):
+        nid, _ = engine.remember(CreateNodeRequest(
+            content=f"stale node {i}", type=NodeType.fact, tier=Tier.working,
+            title=f"stale {i}"))
+        _make_stale(engine, nid)
+        ids.append(nid)
+
+    probe = install_probe(engine)
+    run_decay(engine)
+
+    assert all(_get_tier(engine, nid) == "archival" for nid in ids)
+    # Before the fix: exactly 1, whatever the node count. After: one per demotion.
+    assert probe.acquisitions >= 3
+
+
+def test_decay_does_not_demote_a_node_promoted_after_the_snapshot(engine):
+    """#257's canary, written here: revalidate tier inside the apply step.
+
+    Decay snapshots the node as a stale 'working' candidate. Between that snapshot
+    and the locked apply step, a foreground promotion refreshes it. Without
+    per-apply-step revalidation the demotion would land anyway and silently undo
+    the promotion.
+
+    The hook point matters: it must land the promotion between the unlocked outer
+    scan and the locked `_still_decays` re-check — not between `_still_decays` and
+    `update_node`, which are both inside the same `memory_operation_at(epoch)` and
+    so can never observe an interleaved write (every engine mutator takes the same
+    lock). `lifecycle.retrievability` runs in the outer scan, once per candidate
+    row, which makes it the right seam: patching it fires exactly once, before
+    that node's locked apply step, and does not touch `_still_decays` or
+    `update_node` — the code under test.
+    """
+    from ormah import lifecycle
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="about to be promoted", type=NodeType.fact, tier=Tier.working,
+        title="promoted"))
+    _make_stale(engine, node_id)
+
+    real_retrievability = lifecycle.retrievability
+    promoted = {"done": False}
+
+    def promote_then_compute(days_since, stability, **kwargs):
+        """Stand in for a concurrent foreground promotion landing right after the
+        outer scan snapshots this node as a stale candidate."""
+        if not promoted["done"]:
+            promoted["done"] = True
+            fresh = datetime.now(timezone.utc).isoformat()
+            engine.db.conn.execute(
+                "UPDATE nodes SET last_accessed = ?, last_review = ?, tier = 'working' "
+                "WHERE id = ?", (fresh, fresh, node_id))
+            engine.db.conn.commit()
+        return real_retrievability(days_since, stability, **kwargs)
+
+    lifecycle.retrievability = promote_then_compute
+    try:
+        run_decay(engine)
+    finally:
+        lifecycle.retrievability = real_retrievability
+
+    assert _get_tier(engine, node_id) == "working"
+
+
+def test_decay_aborts_the_run_when_a_restore_lands_mid_run(engine):
+    """Abort, do not skip: the whole snapshot is stale, and nothing may be written."""
+    ids = []
+    for i in range(3):
+        nid, _ = engine.remember(CreateNodeRequest(
+            content=f"stale {i}", type=NodeType.fact, tier=Tier.working, title=f"s{i}"))
+        _make_stale(engine, nid)
+        ids.append(nid)
+
+    real_update = engine.update_node
+    demotions = {"count": 0}
+
+    def bump_after_first(nid, req, *args, **kwargs):
+        result = real_update(nid, req, *args, **kwargs)
+        demotions["count"] += 1
+        if demotions["count"] == 1:
+            engine._restore_epoch += 1
+        return result
+
+    engine.update_node = bump_after_first
+    run_decay(engine)  # returns cleanly, does not raise
+
+    assert demotions["count"] == 1
+    assert sum(_get_tier(engine, nid) == "archival" for nid in ids) == 1

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -156,3 +156,70 @@ def test_merged_content_stored_in_proposal(engine):
     assert "Python Programming Language" in proposal["proposed_action"]
     assert "Python is a popular programming language used widely." in proposal["proposed_action"]
     assert "Both describe Python" in proposal["reason"]
+
+
+def test_duplicate_detection_does_not_hold_the_lock_across_the_llm_call(engine):
+    from tests.test_background.lock_probe import install_probe
+
+    id_a, id_b = _create_pair(engine)
+    # Force the auto-merge branch (the one wrapping engine.execute_merge, itself
+    # lock-decorated) so the probe also exercises the nested-lock path.
+    engine.settings.auto_merge_threshold = 0.0
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    probe = install_probe(engine)
+    lock_held_at_call: list[bool] = []
+
+    def fake_llm(*args, **kwargs):
+        lock_held_at_call.append(probe.held)
+        return json.dumps({
+            "is_duplicate": True, "reason": "same fact",
+            "merged_title": "merged", "merged_content": "merged content",
+        })
+
+    with patch(_LLM_PATCH, side_effect=fake_llm):
+        from ormah.background.duplicate_merger import run_duplicate_detection
+        run_duplicate_detection(engine)
+
+    assert lock_held_at_call, "the fake LLM was never called — the fixture stopped exercising the job"
+    assert not any(lock_held_at_call)
+
+
+def test_duplicate_detection_aborts_when_a_restore_lands_mid_run(engine):
+    id_a, id_b = _create_pair(engine)
+    # Force the auto-merge branch so the node-count assertion below actually
+    # proves that path aborted too, not only the (mutually exclusive) proposal path.
+    engine.settings.auto_merge_threshold = 0.0
+    engine.settings.llm_provider = "ollama"
+    _reset_adapter()
+
+    proposals_before = engine.db.conn.execute(
+        "SELECT COUNT(*) AS c FROM proposals").fetchone()["c"]
+    nodes_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM nodes").fetchone()["c"]
+    epoch_before = engine.restore_epoch
+
+    # The bump must land AFTER the job read its entry epoch: restore_aware_job reads
+    # engine.restore_epoch at call time, so bumping before the call would hand the job the
+    # new value and leave no mismatch to detect. Inside the fake LLM is where a real restore
+    # lands — between the unlocked LLM call and the apply step that follows it.
+    def fake_llm(*args, **kwargs):
+        engine._restore_epoch += 1
+        return json.dumps({
+            "is_duplicate": True, "reason": "same fact",
+            "merged_title": "merged", "merged_content": "merged content",
+        })
+
+    with patch(_LLM_PATCH, side_effect=fake_llm):
+        from ormah.background.duplicate_merger import run_duplicate_detection
+        run_duplicate_detection(engine)  # returns cleanly
+
+    # Guard against silent vacuousness: the abort assertions below hold trivially if the
+    # job never reached an apply step at all. Since the bump lives inside the fake LLM, a
+    # moved epoch is proof the job actually got there.
+    assert engine.restore_epoch > epoch_before, \
+        "the fake LLM was never called — the fixture stopped exercising the job"
+    assert engine.db.conn.execute(
+        "SELECT COUNT(*) AS c FROM proposals").fetchone()["c"] == proposals_before
+    assert engine.db.conn.execute(
+        "SELECT COUNT(*) AS c FROM nodes").fetchone()["c"] == nodes_before

--- a/tests/test_background/test_duplicate_merger.py
+++ b/tests/test_background/test_duplicate_merger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import patch, MagicMock
 
-from ormah.models.node import CreateNodeRequest, NodeType
+from ormah.models.node import CreateNodeRequest, NodeType, UpdateNodeRequest
 
 _LLM_PATCH = "ormah.background.llm_client.llm_generate"
 
@@ -221,5 +221,42 @@ def test_duplicate_detection_aborts_when_a_restore_lands_mid_run(engine):
         "the fake LLM was never called — the fixture stopped exercising the job"
     assert engine.db.conn.execute(
         "SELECT COUNT(*) AS c FROM proposals").fetchone()["c"] == proposals_before
+    assert engine.db.conn.execute(
+        "SELECT COUNT(*) AS c FROM nodes").fetchone()["c"] == nodes_before
+
+
+def test_a_node_edited_during_the_llm_call_is_not_merged_over(engine):
+    """The merged text was written from pre-edit content; do not apply it to edited nodes."""
+    import json
+    from unittest.mock import patch
+
+    id_a, id_b = _create_pair(engine)
+    engine.settings.llm_provider = "ollama"
+    engine.settings.auto_merge_threshold = 0.0
+
+    edited = {"done": False}
+
+    def edit_then_answer(*args, **kwargs):
+        """The LLM call is the unlocked phase: a foreground edit lands here."""
+        if not edited["done"]:
+            edited["done"] = True
+            engine.update_node(id_a, UpdateNodeRequest(
+                content="the user rewrote this node while the merger was thinking"))
+        return json.dumps({
+            "is_duplicate": True, "reason": "same fact",
+            "merged_title": "merged", "merged_content": "merged content",
+        })
+
+    nodes_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM nodes").fetchone()["c"]
+
+    with patch("ormah.background.llm_client.llm_generate", side_effect=edit_then_answer):
+        from ormah.background.duplicate_merger import run_duplicate_detection
+        run_duplicate_detection(engine)
+
+    assert edited["done"], "the fake LLM was never called — the fixture stopped exercising the job"
+    row = engine.db.conn.execute(
+        "SELECT content FROM nodes WHERE id = ?", (id_a,)).fetchone()
+    assert row is not None, "the edited node was merged away"
+    assert "the user rewrote this node" in row["content"], "the stale merged text overwrote a fresh edit"
     assert engine.db.conn.execute(
         "SELECT COUNT(*) AS c FROM nodes").fetchone()["c"] == nodes_before

--- a/tests/test_background/test_importance_scorer.py
+++ b/tests/test_background/test_importance_scorer.py
@@ -531,3 +531,49 @@ def test_importance_recency_is_independent_of_stability(engine):
     assert low_imp == pytest.approx(high_imp), (
         f"stability must not affect importance recency: {low_imp} vs {high_imp}"
     )
+
+
+def test_importance_scoring_takes_the_lock_per_node_and_per_chunk(engine):
+    """No LLM in this job at all — the hold is pure whole-run retention."""
+    from tests.test_background.lock_probe import install_probe
+
+    for i in range(4):
+        nid, _ = engine.remember(CreateNodeRequest(
+            content=f"node {i} with enough content to score", type=NodeType.fact,
+            title=f"node {i}"))
+        engine.db.conn.execute(
+            "UPDATE nodes SET access_count = ?, importance = 0.0 WHERE id = ?", (i * 5, nid))
+    engine.db.conn.commit()
+
+    probe = install_probe(engine)
+    run_importance_scoring(engine)
+
+    # Before the fix: exactly 1 for any node count.
+    assert probe.acquisitions >= 4
+
+
+def test_importance_scoring_aborts_when_a_restore_lands_mid_run(engine):
+    from ormah.background.memory_lock import RestoredUnderfoot  # noqa: F401  (documents intent)
+
+    for i in range(4):
+        nid, _ = engine.remember(CreateNodeRequest(
+            content=f"node {i} with enough content to score", type=NodeType.fact,
+            title=f"node {i}"))
+        engine.db.conn.execute(
+            "UPDATE nodes SET access_count = ?, importance = 0.0 WHERE id = ?", (i * 5, nid))
+    engine.db.conn.commit()
+
+    real_save = engine.file_store.save
+    saves = {"count": 0}
+
+    def bump_after_first(node):
+        path = real_save(node)
+        saves["count"] += 1
+        if saves["count"] == 1:
+            engine._restore_epoch += 1
+        return path
+
+    engine.file_store.save = bump_after_first
+    run_importance_scoring(engine)  # returns cleanly
+
+    assert saves["count"] == 1

--- a/tests/test_background/test_lock_probe.py
+++ b/tests/test_background/test_lock_probe.py
@@ -1,0 +1,54 @@
+"""The probe itself: re-entrancy must not inflate the count."""
+
+from __future__ import annotations
+
+import threading
+
+from ormah.models.node import CreateNodeRequest, NodeType
+
+from tests.test_background.lock_probe import install_probe
+
+
+def test_reentrant_acquisition_counts_once(engine):
+    probe = install_probe(engine)
+    with engine.memory_operation():
+        with engine.memory_operation():
+            pass
+    assert probe.acquisitions == 1
+
+
+def test_sequential_acquisitions_count_separately(engine):
+    probe = install_probe(engine)
+    with engine.memory_operation():
+        pass
+    with engine.memory_operation():
+        pass
+    assert probe.acquisitions == 2
+
+
+def test_held_reports_the_calling_thread_only(engine):
+    probe = install_probe(engine)
+    inside = threading.Event()
+    other_thread_saw = []
+
+    def observer():
+        inside.wait(timeout=5.0)
+        other_thread_saw.append(probe.held)
+
+    t = threading.Thread(target=observer, daemon=True)
+    t.start()
+    with engine.memory_operation():
+        assert probe.held is True
+        inside.set()
+        t.join(timeout=5.0)
+    assert probe.held is False
+    assert other_thread_saw == [False]
+
+
+def test_probe_covers_file_store_writes(engine):
+    """FileStore keeps its own reference to L_mem; the probe must reach it."""
+    probe = install_probe(engine)
+    engine.remember(CreateNodeRequest(
+        content="probe reaches the file store", type=NodeType.fact, title="probe"))
+    assert probe.acquisitions >= 1
+    assert probe.held is False

--- a/tests/test_background/test_memory_lock.py
+++ b/tests/test_background/test_memory_lock.py
@@ -1,0 +1,71 @@
+"""The restore epoch: apply steps are valid only against the graph they were computed on."""
+
+from __future__ import annotations
+
+import pytest
+
+from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
+
+
+def test_memory_operation_at_yields_while_the_epoch_holds(engine):
+    epoch = engine.restore_epoch
+    with engine.memory_operation_at(epoch):
+        pass  # no raise
+
+
+def test_memory_operation_at_raises_once_the_epoch_moves(engine):
+    epoch = engine.restore_epoch
+    engine._restore_epoch += 1
+    with pytest.raises(RestoredUnderfoot):
+        with engine.memory_operation_at(epoch):
+            pass
+
+
+def test_memory_operation_at_holds_l_mem_while_it_yields(engine):
+    """The check and the mutation must be atomic w.r.t. the restore (spec §2)."""
+    epoch = engine.restore_epoch
+    with engine.memory_operation_at(epoch):
+        assert engine._memory_operation_lock.acquire(blocking=False) is True
+        engine._memory_operation_lock.release()
+
+
+def test_reload_restored_graph_bumps_the_epoch(engine):
+    before = engine.restore_epoch
+    engine.reload_restored_graph()
+    assert engine.restore_epoch == before + 1
+
+
+def test_restore_aware_job_passes_the_entry_epoch_to_the_job(engine):
+    seen = []
+
+    @restore_aware_job
+    def job(eng, epoch):
+        seen.append(epoch)
+
+    job(engine)
+    assert seen == [engine.restore_epoch]
+
+
+def test_restore_aware_job_ends_the_run_instead_of_raising(engine, caplog):
+    """APScheduler must not see the abort as a job crash."""
+
+    @restore_aware_job
+    def job(eng, epoch):
+        eng._restore_epoch += 1
+        with eng.memory_operation_at(epoch):
+            pass
+
+    with caplog.at_level("INFO"):
+        assert job(engine) is None
+    assert "restore" in caplog.text.lower()
+
+
+def test_restore_aware_job_forwards_extra_arguments(engine):
+    seen = {}
+
+    @restore_aware_job
+    def job(eng, epoch, limit, *, dry_run=False):
+        seen.update(limit=limit, dry_run=dry_run)
+
+    job(engine, 7, dry_run=True)
+    assert seen == {"limit": 7, "dry_run": True}

--- a/tests/test_background/test_memory_lock.py
+++ b/tests/test_background/test_memory_lock.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from ormah.background.memory_lock import RestoredUnderfoot, restore_aware_job
@@ -22,11 +24,40 @@ def test_memory_operation_at_raises_once_the_epoch_moves(engine):
 
 
 def test_memory_operation_at_holds_l_mem_while_it_yields(engine):
-    """The check and the mutation must be atomic w.r.t. the restore (spec §2)."""
+    """The check and the mutation must be atomic w.r.t. the restore (spec §2).
+
+    A same-thread ``acquire(blocking=False)`` can't tell "lock held by me" from
+    "lock free" because ``_memory_operation_lock`` is reentrant. Use a second
+    thread instead: it can only acquire the lock when nobody else holds it.
+    """
     epoch = engine.restore_epoch
+    entered = threading.Event()
+    probe_done = threading.Event()
+    result = {}
+
+    def probe_from_other_thread():
+        entered.wait(timeout=5)
+        acquired = engine._memory_operation_lock.acquire(timeout=0.2)
+        if acquired:
+            engine._memory_operation_lock.release()
+        result["acquired_while_held"] = acquired
+        probe_done.set()
+
+    prober = threading.Thread(target=probe_from_other_thread)
+    prober.start()
     with engine.memory_operation_at(epoch):
-        assert engine._memory_operation_lock.acquire(blocking=False) is True
-        engine._memory_operation_lock.release()
+        entered.set()
+        # Hold the context open until the other thread has actually tried
+        # and failed to acquire the lock, so the exclusion window is real.
+        assert probe_done.wait(timeout=5), "probe thread never reported back"
+    prober.join(timeout=5)
+
+    assert result.get("acquired_while_held") is False
+
+    # And the lock must be free again once the context manager has exited.
+    released = engine._memory_operation_lock.acquire(timeout=1)
+    assert released is True
+    engine._memory_operation_lock.release()
 
 
 def test_reload_restored_graph_bumps_the_epoch(engine):

--- a/tests/test_engine/test_ingest.py
+++ b/tests/test_engine/test_ingest.py
@@ -173,3 +173,98 @@ class TestIngestTruncation:
         prompt = captured_prompt["prompt"]
         marker_count = prompt.count(marker)
         assert marker_count == 500
+
+
+def test_extraction_runs_unlocked_and_dedup_stores_under_one_acquisition(engine):
+    """The change, stated structurally: the LLM extraction stops holding L_mem, and the
+    dedup check moves inside the same acquisition as the write it guards (#240)."""
+    from tests.test_background.lock_probe import install_probe
+
+    fake_llm_response = json.dumps({
+        "memories": [{
+            "content": "The team standardized on FastAPI for every new backend service",
+            "type": "fact",
+            "title": "FastAPI standard",
+            "tags": [],
+            "about_self": False,
+        }]
+    })
+
+    probe = install_probe(engine)
+    lock_held_during_extract = []
+    lock_held_during_dedup = []
+
+    real_extract = engine._extract_memories_llm
+    real_is_duplicate = engine._is_duplicate_memory
+
+    def watched_extract(content):
+        lock_held_during_extract.append(probe.held)
+        return real_extract(content)
+
+    def watched_is_duplicate(content):
+        lock_held_during_dedup.append(probe.held)
+        return real_is_duplicate(content)
+
+    engine._extract_memories_llm = watched_extract
+    engine._is_duplicate_memory = watched_is_duplicate
+
+    with patch(_LLM_PATCH, return_value=fake_llm_response):
+        created = engine.ingest_conversation(
+            content="A long enough conversation about backend architecture." * 5)
+
+    assert created, "nothing was ingested — the fixture stopped exercising the store path"
+    assert lock_held_during_extract == [False], "L_mem was held across the LLM extraction"
+    assert lock_held_during_dedup, "the dedup check never ran"
+    assert all(lock_held_during_dedup), "the dedup check ran outside the lock that guards the write"
+
+
+def test_concurrent_ingests_of_the_same_content_create_one_node(engine):
+    """Two ingests racing on the same content must still produce one node (#240).
+
+    The barrier sits in the *extraction* phase, which this change makes unlocked, so both
+    threads finish extracting before either reaches its apply step. That is the window the
+    in-lock dedup revalidation has to close.
+    """
+    import threading
+
+    fake_llm_response = json.dumps({
+        "memories": [{
+            "content": "The team standardized on FastAPI for every new backend service",
+            "type": "fact",
+            "title": "FastAPI standard",
+            "tags": [],
+            "about_self": False,
+        }]
+    })
+
+    barrier = threading.Barrier(2)
+    real_extract = engine._extract_memories_llm
+
+    def synced_extract(content):
+        result = real_extract(content)
+        barrier.wait(timeout=10.0)  # both threads leave extraction together
+        return result
+
+    engine._extract_memories_llm = synced_extract
+    errors: list[BaseException] = []
+
+    def run():
+        try:
+            with patch(_LLM_PATCH, return_value=fake_llm_response):
+                engine.ingest_conversation(
+                    content="A long enough conversation about backend architecture." * 5)
+        except BaseException as exc:  # noqa: BLE001 — the test asserts on what was raised
+            errors.append(exc)
+
+    threads = [threading.Thread(target=run) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=20.0)
+
+    assert not errors, f"an ingest raised: {errors}"
+    assert not any(t.is_alive() for t in threads)
+    rows = engine.db.conn.execute(
+        "SELECT COUNT(*) AS c FROM nodes WHERE title = 'FastAPI standard'"
+    ).fetchone()
+    assert rows["c"] == 1

--- a/tests/test_engine/test_memory_engine.py
+++ b/tests/test_engine/test_memory_engine.py
@@ -695,3 +695,84 @@ def test_memory_restore_lock_excludes_live_remember(engine):
     thread.join(timeout=2)
     assert finished.is_set()
     assert engine.file_store.load(result[0]) is not None
+
+
+def test_a_restore_mid_run_aborts_every_job_without_partial_writes(engine):
+    """#210 acceptance criterion, exercised across the real scheduler entry points."""
+    import json
+    from datetime import datetime, timedelta, timezone
+    from unittest.mock import patch
+
+    from ormah.background.auto_linker import run_auto_linker
+    from ormah.background.decay_manager import run_decay
+    from ormah.models.node import CreateNodeRequest, NodeType, Tier
+
+    # remember() auto-links similar nodes at creation time; disable that for the
+    # second node below so it stays unlinked to `stale_id` -- otherwise
+    # auto_linker would find zero candidates and its bump would never fire,
+    # making the epoch_before + 2 guard below vacuous rather than a real check.
+    stale_id, _ = engine.remember(CreateNodeRequest(
+        content="a stale working node", type=NodeType.fact, tier=Tier.working,
+        title="stale"))
+    real_auto_link = engine._auto_link_node
+    engine._auto_link_node = lambda node: []
+    engine.remember(CreateNodeRequest(
+        content="a stale working node", type=NodeType.fact, title="stale twin"))
+    engine._auto_link_node = real_auto_link
+    # A bare SQL `datetime('now', '-30 days')` literal produces a naive,
+    # space-separated string; decay_manager's anchor parse still succeeds on it
+    # (fromisoformat accepts the space), but the later `now - anchor` then mixes
+    # a tz-aware `now` with a naive anchor, raises TypeError, and the node is
+    # silently skipped -- vacuous for this test. Use the same tz-aware ISO
+    # string tests/test_background/test_decay_manager.py's _make_stale uses.
+    stale_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_accessed = ? WHERE id = ?", (stale_date, stale_id))
+    engine.db.conn.commit()
+
+    edges_before = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+    epoch_before = engine.restore_epoch
+
+    # The bump must land AFTER the job read its entry epoch, never before the call:
+    # restore_aware_job reads engine.restore_epoch at call time, so a pre-call bump would
+    # simply hand the job the new value and there would be no mismatch to detect. Each job
+    # below gets the bump at the point where a real restore would land in its own run.
+    from ormah import lifecycle
+
+    real_retrievability = lifecycle.retrievability
+    bumped = {"done": False}
+
+    def bump_then_compute(days_since, stability, **kwargs):
+        """decay's seam: fires once per candidate in the unlocked outer scan."""
+        if not bumped["done"]:
+            bumped["done"] = True
+            engine._restore_epoch += 1
+        return real_retrievability(days_since, stability, **kwargs)
+
+    lifecycle.retrievability = bump_then_compute
+    try:
+        run_decay(engine)  # returns cleanly
+    finally:
+        lifecycle.retrievability = real_retrievability
+
+    row = engine.db.conn.execute(
+        "SELECT tier FROM nodes WHERE id = ?", (stale_id,)).fetchone()
+    assert row["tier"] == "working"  # not demoted
+
+    engine.settings.llm_provider = "ollama"
+
+    def bump_then_link(*args, **kwargs):
+        """auto_linker's seam: the unlocked LLM call, right before its apply step."""
+        engine._restore_epoch += 1
+        return json.dumps({"relationship": "supports", "reason": "x"})
+
+    with patch("ormah.background.llm_client.llm_generate", side_effect=bump_then_link):
+        run_auto_linker(engine)  # also returns cleanly
+
+    # Guard against silent vacuousness: both assertions hold trivially if neither job ever
+    # reached an apply step. Each bump lives inside that job's own seam, so an epoch that
+    # moved twice is proof both jobs actually got there.
+    assert engine.restore_epoch == epoch_before + 2, \
+        "a job never reached its apply step — the fixture stopped exercising it"
+    edges_after = engine.db.conn.execute("SELECT COUNT(*) AS c FROM edges").fetchone()["c"]
+    assert edges_after == edges_before

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -160,6 +160,7 @@ def test_no_background_job_takes_l_mem_inside_a_write_transaction(engine):
     above — that test covers the builder's own entry points, not the seven jobs.
     """
     import json
+    from datetime import datetime, timedelta, timezone
     from unittest.mock import patch
 
     from ormah.background.auto_cluster import run_auto_cluster
@@ -169,7 +170,13 @@ def test_no_background_job_takes_l_mem_inside_a_write_transaction(engine):
     from ormah.background.decay_manager import run_decay
     from ormah.background.duplicate_merger import run_duplicate_detection
     from ormah.background.importance_scorer import run_importance_scoring
-    from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType
+    from ormah.models.node import (
+        ConnectRequest,
+        CreateNodeRequest,
+        EdgeType,
+        NodeType,
+        UpdateNodeRequest,
+    )
 
     real_lock = engine._memory_operation_lock
     violations: list[int] = []
@@ -219,11 +226,26 @@ def test_no_background_job_takes_l_mem_inside_a_write_transaction(engine):
     # linked, above-threshold pairs to classify.
     engine.connect(ConnectRequest(
         source_id=ids[0], target_id=ids[4], edge=EdgeType.related_to, weight=1.0))
-    engine.db.conn.execute("UPDATE nodes SET space = 'architecture' WHERE id = ?", (ids[0],))
-    engine.db.conn.execute("UPDATE nodes SET space = NULL WHERE id = ?", (ids[4],))
+    # ids[4] is already space=None from creation -- nothing to set there.
+    # ids[0]'s space must go through update_node, not a raw SQL UPDATE: the
+    # markdown file (loaded by file_store) is the source of truth, and any later
+    # engine.update_node call (decay's own demotion, right below) reloads from
+    # the file and re-persists it -- silently reverting a DB-only `space` back
+    # to None and starving auto_cluster of a spaced neighbor to vote from.
+    engine.update_node(ids[0], UpdateNodeRequest(space="architecture"))
+    # A bare SQL `datetime('now', '-30 days')` literal produces a naive,
+    # space-separated string; decay_manager's anchor parse then mixes it with a
+    # tz-aware `now`, raises TypeError, and silently skips the node -- vacuous.
+    # Use the same tz-aware ISO string test_decay_manager.py's _make_stale uses.
+    # last_accessed is read straight from the SQLite index by decay's own
+    # candidate scan and revalidation, so a raw SQL UPDATE (unlike space above)
+    # is exactly what's needed here -- and update_node's later reload/resave for
+    # the tier demotion doesn't touch it since UpdateNodeRequest carries no
+    # last_accessed field.
+    stale_date = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
     engine.db.conn.execute(
-        "UPDATE nodes SET last_accessed = datetime('now', '-30 days'), tier = 'working' "
-        "WHERE id = ?", (ids[0],))
+        "UPDATE nodes SET last_accessed = ?, tier = 'working' WHERE id = ?",
+        (stale_date, ids[0]))
     engine.db.conn.commit()
 
     engine.settings.llm_provider = "ollama"
@@ -273,8 +295,22 @@ def test_no_background_job_takes_l_mem_inside_a_write_transaction(engine):
 
     try:
         with patch("ormah.background.llm_client.llm_generate", side_effect=fake_llm):
+            # decay gets its own check instead of the shared acquisitions-count guard:
+            # run_decay unconditionally opens L_mem once at the top of every call to
+            # clear stale proposals (decay_manager.py's one-time cleanup), before it
+            # ever scans for demotion candidates. That means acquisitions["n"] > before
+            # would hold even if decay found nothing to demote -- it doesn't prove the
+            # apply step (the actual tier demotion) ran. Assert the observable effect
+            # instead: the seeded stale node (ids[0]) really moved to archival.
+            run_decay(engine)
+            tier_row = engine.db.conn.execute(
+                "SELECT tier FROM nodes WHERE id = ?", (ids[0],)).fetchone()
+            assert tier_row is not None and tier_row["tier"] == "archival", (
+                "decay never demoted the seeded stale node -- its apply step was "
+                "never reached, so this net covers nothing for it"
+            )
+
             for name, run_job in [
-                ("decay", run_decay),
                 ("importance_scoring", run_importance_scoring),
                 ("auto_cluster", run_auto_cluster),
                 ("auto_linker", run_auto_linker),

--- a/tests/test_index/test_builder.py
+++ b/tests/test_index/test_builder.py
@@ -65,7 +65,7 @@ def test_incremental_update_does_not_deadlock_against_a_memory_job(engine):
     The restore-exclusion lock decorates 8 FileStore methods with the engine's own RLock
     (L_mem) -- MemoryEngine passes it in: FileStore(nodes_dir, self._memory_operation_lock).
     incremental_update opens the write txn (L_db) and only then calls file_store.list_paths /
-    file_hash: L_db -> L_mem. Every @serialized_memory_job background job goes L_mem -> L_db.
+    file_hash: L_db -> L_mem. Every background job apply step goes L_mem -> L_db (#240).
     Opposite orders on two locks = deadlock, and index_updater runs every 60s.
     """
     engine.remember(CreateNodeRequest(
@@ -86,7 +86,7 @@ def test_incremental_update_does_not_deadlock_against_a_memory_job(engine):
     engine.file_store.list_paths = instrumented_list_paths
 
     def memory_job():
-        """What @serialized_memory_job + a write txn do on every background job: L_mem, L_db."""
+        """What every background job's apply step does: L_mem, then a write txn (#240)."""
         builder_reached_file_store.wait(timeout=5.0)
         with engine._memory_operation_lock:
             job_holds_mem.set()
@@ -150,3 +150,145 @@ def test_builder_never_takes_file_lock_inside_write_transaction(engine):
     assert engine.builder.incremental_update() == (0, 0)
 
     assert not violations, f"FileStore lock acquired inside db.transaction(): {violations}"
+
+
+def test_no_background_job_takes_l_mem_inside_a_write_transaction(engine):
+    """Cross-cutting net for #240: the inversion #207 fixed must not come back.
+
+    Every job now acquires and releases L_mem repeatedly instead of once, so this
+    is not redundant with test_builder_never_takes_file_lock_inside_write_transaction
+    above — that test covers the builder's own entry points, not the seven jobs.
+    """
+    import json
+    from unittest.mock import patch
+
+    from ormah.background.auto_cluster import run_auto_cluster
+    from ormah.background.auto_linker import run_auto_linker
+    from ormah.background.conflict_detector import run_conflict_detection
+    from ormah.background.consolidator import run_consolidation
+    from ormah.background.decay_manager import run_decay
+    from ormah.background.duplicate_merger import run_duplicate_detection
+    from ormah.background.importance_scorer import run_importance_scoring
+    from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType
+
+    real_lock = engine._memory_operation_lock
+    violations: list[int] = []
+
+    class OrderProbe:
+        def __enter__(self):
+            tx_depth = getattr(engine.db._local, "tx_depth", 0)
+            if tx_depth > 0:
+                violations.append(tx_depth)
+            return real_lock.__enter__()
+
+        def __exit__(self, *args):
+            return real_lock.__exit__(*args)
+
+    engine._memory_operation_lock = OrderProbe()
+    engine.file_store._operation_lock = engine._memory_operation_lock
+
+    # Count L_mem acquisitions per job so a job that quietly finds zero candidates
+    # (and so never reaches an apply step) fails loudly instead of the assertion
+    # below passing vacuously for it. OrderProbe.__enter__ already runs on every
+    # acquisition, so piggyback the count there instead of a second wrapper.
+    acquisitions = {"n": 0}
+    real_enter = OrderProbe.__enter__
+
+    def counting_enter(self):
+        acquisitions["n"] += 1
+        return real_enter(self)
+
+    OrderProbe.__enter__ = counting_enter
+
+    # remember() auto-links highly-similar nodes at creation time via the same
+    # similarity threshold the background auto_linker job uses -- if left on, the
+    # 5 near-identical seed nodes below end up fully pairwise-linked before the job
+    # ever runs, so it would find zero candidates. Disable it for the seeding only.
+    real_auto_link = engine._auto_link_node
+    engine._auto_link_node = lambda node: []
+    ids = []
+    for i in range(5):
+        nid, _ = engine.remember(CreateNodeRequest(
+            content=f"seed node {i} about project architecture", type=NodeType.fact,
+            title=f"seed {i}"))
+        ids.append(nid)
+    engine._auto_link_node = real_auto_link
+
+    # ids[0] <-> ids[4] manually connected so auto_cluster has a spaced neighbor to
+    # vote from; ids[1..3] stay unconnected so auto_linker has real, not-already-
+    # linked, above-threshold pairs to classify.
+    engine.connect(ConnectRequest(
+        source_id=ids[0], target_id=ids[4], edge=EdgeType.related_to, weight=1.0))
+    engine.db.conn.execute("UPDATE nodes SET space = 'architecture' WHERE id = ?", (ids[0],))
+    engine.db.conn.execute("UPDATE nodes SET space = NULL WHERE id = ?", (ids[4],))
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_accessed = datetime('now', '-30 days'), tier = 'working' "
+        "WHERE id = ?", (ids[0],))
+    engine.db.conn.commit()
+
+    engine.settings.llm_provider = "ollama"
+    engine.settings.consolidation_min_cluster_size = 2
+    # Cap the linker's source scan so it doesn't mark every pair as auto_link_checked
+    # before conflict/duplicate detection run -- those two also skip already-checked
+    # pairs, and with an unbounded scan the linker would starve them of candidates.
+    engine.settings.auto_link_max_nodes_per_run = 2
+
+    fake_link = json.dumps({"relationship": "supports", "reason": "same topic"})
+    fake_conflict_true = json.dumps({
+        "same_subject": True, "conflict": True, "type": "tension", "explanation": "x"})
+    fake_conflict_false = json.dumps({
+        "same_subject": True, "conflict": False, "type": "none", "explanation": "n/a"})
+    fake_dup_true = json.dumps({
+        "is_duplicate": True, "merged_title": "merged", "merged_content": "merged content"})
+    fake_dup_false = json.dumps({"is_duplicate": False, "reason": "distinct"})
+    fake_consolidate = json.dumps({
+        "title": "merged", "summary": "merged content", "type": "fact"})
+
+    # conflict_detection and duplicate_detection only reach their apply step (the
+    # engine.memory_operation_at block) on a positive verdict -- a fixed "false"
+    # response (as consolidation and auto_linker's "none"/"supports" pattern might
+    # suggest) would leave those two jobs' apply steps completely unexercised. Flip
+    # to positive for the first candidate of each type only, so exactly one real
+    # apply happens per job instead of a cascade of merges/edges eating the fixture.
+    done = {"conflict": False, "dup": False}
+
+    def fake_llm(*args, **kwargs):
+        prompt = args[1] if len(args) > 1 else kwargs.get("prompt", "")
+        # Match on phrases unique to each job's prompt -- "contradict" alone also
+        # appears inside the auto_linker prompt's "contradicts" edge-type option,
+        # which would misroute every linker call into the conflict branch.
+        if "duplicates that should be merged" in prompt:
+            if not done["dup"]:
+                done["dup"] = True
+                return fake_dup_true
+            return fake_dup_false
+        if "contradict each other" in prompt:
+            if not done["conflict"]:
+                done["conflict"] = True
+                return fake_conflict_true
+            return fake_conflict_false
+        if "consolidating a cluster" in prompt:
+            return fake_consolidate
+        return fake_link
+
+    try:
+        with patch("ormah.background.llm_client.llm_generate", side_effect=fake_llm):
+            for name, run_job in [
+                ("decay", run_decay),
+                ("importance_scoring", run_importance_scoring),
+                ("auto_cluster", run_auto_cluster),
+                ("auto_linker", run_auto_linker),
+                ("conflict_detection", run_conflict_detection),
+                ("duplicate_detection", run_duplicate_detection),
+                ("consolidation", run_consolidation),
+            ]:
+                before = acquisitions["n"]
+                run_job(engine)
+                assert acquisitions["n"] > before, (
+                    f"{name} never acquired L_mem -- its apply step was never "
+                    "reached, so this net covers nothing for it"
+                )
+    finally:
+        OrderProbe.__enter__ = real_enter
+
+    assert not violations, f"L_mem acquired inside db.transaction(): depths {violations}"


### PR DESCRIPTION
## What this does

`@serialized_memory_job` held `L_mem` (`MemoryEngine._memory_operation_lock`) for the entire
duration of a background job. The same `RLock` guards every foreground mutator and every
`FileStore` call, so one long maintenance run made the whole write side unanswerable — a real
`POST /agent/remember` parked behind a 30 min 43 s `auto_linker` run took **25 min 3 s**, and a
synthetic probe got no response at all after 600 s.

This PR replaces run-scoped locking with **per-apply-step, epoch-guarded acquisition**:

- All seven background jobs lose `@serialized_memory_job` and take `L_mem` only around their
  apply step, never across an LLM call.
- A new `restore_epoch` on the engine, plus `memory_operation_at()`, lets a job detect that a
  restore happened mid-run and abort instead of applying stale state.
- Every job that snapshots state outside the lock **revalidates it inside the apply step**
  (`decay_manager`, `consolidator`, `auto_cluster`, `duplicate_merger`) — this is debt the
  change itself creates, and it is paid here rather than documented as an accepted window.
- `ingest_conversation` splits extraction (unlocked) from apply (short lock), with dedup
  revalidated atomically with the write. Its `dry_run` behaviour is unchanged.

The `L_mem → L_db` lock hierarchy from #211 is preserved, and made *more* load-bearing, since
jobs now acquire and release repeatedly. #211 stays open.

## What this does NOT do — #240 stays partially open

**This PR does not fix the default-install baseline.** The `index_updater` / `FileStore` scan is
deliberately out of scope: ~495 ms every 60 s steady-state and **34,5 s on a cold scan** over
3 303 node files, with `llm_provider=none` — i.e. a default install carries a smaller version of
the same contention with no LLM involved at all, scaling with file count.

It was left out because #207's fix deliberately hoisted that scan above the write transaction for
lock-order reasons (`index/builder.py:79-81`). Touching it means changing `FileStore` locking,
which is shared with all eleven engine mutators, and reopens the lock-order question #207 closed.
That deserves its own issue and its own lock-order review, not a ride on a job-semantics change.

Two further findings surfaced during this work and are **not** addressed here — different root
causes, each needing its own change. Both are now filed:

1. **#270 — task pause does not survive restart.** `background/scheduler.py` uses APScheduler's
   default `MemoryJobStore`, while `routes_admin.py` derives `paused` from `job.next_run_time`,
   so a pause is silently lost on the next boot.
2. **#271 — `SIGTERM` cannot stop a running maintenance job.** `main.py` shuts down with
   `scheduler.shutdown(wait=True)` and no job checks a stop flag, while `server_manager.py`
   escalates to `SIGKILL` after a 15 s graceful window — against the 30 min 43 s `auto_linker`
   run measured above.

   This PR and #271 are complementary, not alternatives. Scoping `L_mem` to each apply step
   shortens the exposure — a `SIGKILL` now lands either between apply steps or inside a short
   one — but it does not close it, and `SIGKILL` runs neither `finally` nor the compensation
   blocks that keep markdown and the index from diverging. Cooperative cancellation is what
   actually makes a shutdown graceful.

#238 (cross-process exclusion) is untouched and nothing here forecloses it.

## Testing

`1983 passed` on the full suite. Four failures are pre-existing and environmental (a `/tmp`
symlink vs `realpath` in `test_space_detect`, and a real `codex` binary on `PATH` leaking into
three mocked `TestConfigureCodexMcp` tests); they are unrelated to any file in this diff.
`ruff check src/ tests/` is clean.

New coverage asserts *structure*, not latency: that the lock is not held across the LLM call,
that abort-on-epoch-change actually fires, and that `memory_operation_at` grants real
cross-thread exclusivity. Several tests carry explicit anti-vacuousness guards
(`assert engine.restore_epoch > epoch_before`, or an assertion that the apply step was reached)
because early drafts passed while testing nothing.

## What stays inferred

**No latency measurement was taken against the fixed code.** The claim that one acquisition per
pair / cluster / node is short enough is *inferred* — short because no LLM call sits inside it —
but the original probe was not re-run against this branch. The consolidator's per-cluster hold is
the longest apply step here (up to ~6 embedding operations under one continuous acquisition) and
is likewise inferred, not measured.

Closes part of #240.

