### PR TITLE
fix(signals): signals.strength becomes an ordinal evidence scale (#218)

### DIFF
--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -550,7 +550,9 @@ def _record_whisper_usage_signals(
                 "row": row,
                 "signal_type": signal_type,
                 "polarity": polarity,
-                "strength": confidence,
+                "strength": signal_strength.judge_strength(
+                    confidence, min_confidence, polarity
+                ),
                 "evidence": {
                     "detector": _LLM_JUDGE_SOURCE,
                     "verdict": verdict,

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -148,10 +148,16 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
     denominator = min(len(candidate_tokens), 12)
     overlap_ratio = (len(overlap) / denominator) if denominator else 0.0
     if len(overlap) >= 4 and overlap_ratio >= signal_strength.OVERLAP_GATE:
-        return True, signal_strength.token_overlap_strength(overlap_ratio), {
+        # Round ONCE, then use that same value for both the strength and the evidence.
+        # The #218 backfill recomputes strength from evidence, so a strength derived
+        # from a more precise ratio than the one recorded makes the recompute perturb
+        # a correct row instead of confirming it. The gate above still reads the raw
+        # ratio, so which responses count as referenced is unchanged.
+        recorded_ratio = round(overlap_ratio, 3)
+        return True, signal_strength.token_overlap_strength(recorded_ratio), {
             "match": "token_overlap",
             "overlap": overlap[:12],
-            "overlap_ratio": round(overlap_ratio, 3),
+            "overlap_ratio": recorded_ratio,
         }
 
     return False, 0.0, {

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -16,6 +16,7 @@ from threading import Event, Lock, Thread, Timer
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
+from ormah import signal_strength
 from ormah.engine.memory_engine import MemoryEngine
 from ormah.text.tokens import distinctive_tokens
 from ormah.transcript.parser import (
@@ -37,8 +38,8 @@ class IngestResult(Enum):
 
 _STATE_FILENAME = ".session_watcher_state"
 MAX_RECONCILE_RETRIES = 3
-_HEURISTIC_SOURCE = "transcript_watcher_heuristic"
-_LLM_JUDGE_SOURCE = "transcript_watcher_llm_judge"
+_HEURISTIC_SOURCE = signal_strength.HEURISTIC_SOURCE
+_LLM_JUDGE_SOURCE = signal_strength.LLM_JUDGE_SOURCE
 _HEURISTIC_AFFINITY_SOURCE = "auto_heuristic"
 _LLM_JUDGE_AFFINITY_SOURCE = "auto_llm_judge"
 _FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
@@ -116,13 +117,13 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
     node_id = row["node_id"]
     short_id = node_id[:8] if node_id else ""
     if short_id and short_id.lower() in response_text.lower():
-        return True, 1.0, {"match": "node_id", "short_id": short_id}
+        return True, signal_strength.VERBATIM_NODE_ID, {"match": "node_id", "short_id": short_id}
 
     title = row["title"] or ""
     title_tokens = distinctive_tokens(title, extra_stop_words={"memory", "ormah"})
     title_norm = _normalise_text(title)
     if len(title_tokens) >= 2 and len(title_norm) >= 12 and title_norm in response_norm:
-        return True, 0.95, {"match": "title", "title": title}
+        return True, signal_strength.VERBATIM_TITLE, {"match": "title", "title": title}
 
     content = row["content"] or ""
     for sentence in re.split(r"[\n.!?]+", content):
@@ -132,7 +133,10 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
         sentence_tokens = distinctive_tokens(sentence, extra_stop_words={"memory", "ormah"})
         sentence_norm = _normalise_text(sentence)
         if len(sentence_tokens) >= 4 and sentence_norm in response_norm:
-            return True, 0.9, {"match": "sentence", "text": sentence[:160]}
+            return True, signal_strength.VERBATIM_SENTENCE, {
+                "match": "sentence",
+                "text": sentence[:160],
+            }
 
     node_tokens = distinctive_tokens(
         f"{title} {content}",
@@ -143,8 +147,8 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
     overlap = sorted(candidate_tokens & response_tokens)
     denominator = min(len(candidate_tokens), 12)
     overlap_ratio = (len(overlap) / denominator) if denominator else 0.0
-    if len(overlap) >= 4 and overlap_ratio >= 0.5:
-        return True, min(0.85, 0.45 + overlap_ratio), {
+    if len(overlap) >= 4 and overlap_ratio >= signal_strength.OVERLAP_GATE:
+        return True, signal_strength.token_overlap_strength(overlap_ratio), {
             "match": "token_overlap",
             "overlap": overlap[:12],
             "overlap_ratio": round(overlap_ratio, 3),

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from ormah import lifecycle
+from ormah import signal_strength
 from ormah.config import Settings
 from ormah.embeddings.text import embedding_text as _embedding_text
 from ormah.engine.context_builder import ContextBuilder
@@ -2800,7 +2801,7 @@ class MemoryEngine:
                     resolved_node_id,
                     "feedback_submitted",
                     signal,
-                    1.0,
+                    signal_strength.feedback_strength(source, signal),
                     source,
                     session_id,
                     "submit_feedback",

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -172,32 +172,60 @@ class MemoryEngine:
         self._warmup_embedder()
         self._warmup_reranker()
 
-    def _migrate_signal_strength(self) -> None:
-        """Recompute signals.strength onto the #218 ordinal evidence ladder.
-
-        Exact rather than estimated: every row carries the evidence its own channel
-        needs, and the judge stamps the min_confidence in force when the row was
-        written -- so a row recomputes to what it would have stored had the ladder
-        existed then, not to what today's settings would produce.
-
-        Re-runnable by construction: evidence is never written, so a later revision
-        of the ladder recomputes from the same untouched source. Only strength moves.
-
-        No file_store call, so this does not take db-lock before memory-lock and
-        stays outside the ordering hazard documented on _record_confirmed_use.
-        """
-        stamp = self.db.conn.execute(
-            "SELECT value FROM meta WHERE key = 'signal_strength_ladder_version'"
-        ).fetchone()
+    def _meta_int(self, key: str) -> int:
+        """Read an integer meta value, treating absent or unparseable as 0."""
+        row = self.db.conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
         try:
-            version = int(stamp["value"]) if stamp else 0
+            return int(row["value"]) if row else 0
         except (TypeError, ValueError):
-            version = 0
-        if version >= SIGNAL_STRENGTH_LADDER_VERSION:
-            return
+            return 0
+
+    def _migrate_signal_strength(self) -> None:
+        """Normalise signals.strength onto the #218 ordinal evidence ladder.
+
+        Runs on every startup, not once. The first pass covers the whole table; every
+        later pass covers only rows that appeared since the previous one, tracked by a
+        cutoff on signals.id (AUTOINCREMENT, so ids are monotonic and never reused).
+
+        The rescan exists because a one-time stamp cannot repair what an OLD binary
+        writes AFTER the stamp is set -- a rollback then re-upgrade, or the second
+        unmanaged server process this project already knows about (#238). Those rows
+        would carry pre-ladder values forever on a table the stamp calls migrated, and
+        the column would silently mix incomparable scales.
+
+        Rescanning already-correct rows is safe because strength_from_evidence is a
+        pure function of (source, polarity, evidence) and every write site stores
+        exactly what it returns for what it recorded, so a row written by the current
+        code recomputes to itself. That property is what makes this a repair instead
+        of a drift, and it did not hold until evidence became a lossless record of the
+        overlap ratio.
+
+        The cutoff advances only to the highest id actually processed, never to
+        MAX(id): a row inserted between the SELECT and the stamp keeps an id above the
+        cutoff and is picked up on the next start rather than skipped.
+
+        Recompute is exact, not estimated: the judge stamps the min_confidence in
+        force when its row was written, so a row normalises to what it would have
+        stored had the ladder existed then, not to what today's settings would give.
+
+        No file_store call, so this does not take db-lock before memory-lock and stays
+        outside the ordering hazard documented on _record_confirmed_use.
+        """
+        version = self._meta_int("signal_strength_ladder_version")
+        # An unstamped store, or one stamped by a build that predates the cutoff, gets
+        # a full pass: 0 is the only lower bound that cannot skip a row.
+        lower_bound = (
+            self._meta_int("signal_strength_ladder_cutoff")
+            if version >= SIGNAL_STRENGTH_LADDER_VERSION
+            else 0
+        )
 
         with self.db.transaction() as conn:
-            rows = conn.execute("SELECT id, source, polarity, evidence FROM signals").fetchall()
+            rows = conn.execute(
+                "SELECT id, source, polarity, evidence FROM signals WHERE id > ?",
+                (lower_bound,),
+            ).fetchall()
+            processed_max = lower_bound
             for row in rows:
                 conn.execute(
                     "UPDATE signals SET strength = ? WHERE id = ?",
@@ -208,16 +236,24 @@ class MemoryEngine:
                         row["id"],
                     ),
                 )
+                processed_max = max(processed_max, row["id"])
             conn.execute(
                 "INSERT OR REPLACE INTO meta (key, value) VALUES "
                 "('signal_strength_ladder_version', ?)",
                 (str(SIGNAL_STRENGTH_LADDER_VERSION),),
             )
-        logger.info(
-            "Recomputed strength on %d signal rows (#218 ladder v%d)",
-            len(rows),
-            SIGNAL_STRENGTH_LADDER_VERSION,
-        )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                "('signal_strength_ladder_cutoff', ?)",
+                (str(processed_max),),
+            )
+        if rows:
+            logger.info(
+                "Normalised strength on %d signal rows above id %d (#218 ladder v%d)",
+                len(rows),
+                lower_bound,
+                SIGNAL_STRENGTH_LADDER_VERSION,
+            )
 
     def _migrate_fsrs(self) -> None:
         """Seed FSRS stability once, and record the store's lifecycle-model version."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -201,8 +201,11 @@ class MemoryEngine:
         overlap ratio.
 
         The cutoff advances only to the highest id actually processed, never to
-        MAX(id): a row inserted between the SELECT and the stamp keeps an id above the
-        cutoff and is picked up on the next start rather than skipped.
+        MAX(id). db.transaction() opens BEGIN IMMEDIATE, so no writer -- in this
+        process or any other -- can commit between the SELECT and the stamp, which
+        means that interleaving cannot occur as the code stands. Advancing by
+        processed id is therefore defence in depth against a future change to that
+        isolation, not a fix for a reachable race.
 
         Recompute is exact, not estimated: the judge stamps the min_confidence in
         force when its row was written, so a row normalises to what it would have

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -61,6 +61,10 @@ _CONFIRMED_USE_SOURCES = frozenset({"explicit", "implicit", "auto_llm_judge"})
 # so a future curve migration can tell which model produced the stored values.
 LIFECYCLE_MODEL_VERSION = 2
 
+# Evidence-ladder version for signals.strength (#218). Bump when the ladder's
+# values or mappings change, so a stamped store recomputes from its evidence.
+SIGNAL_STRENGTH_LADDER_VERSION = 1
+
 
 def _generate_title(content: str, max_chars: int = 60) -> str:
     """Generate a short title from the first line/sentence of content."""
@@ -160,12 +164,60 @@ class MemoryEngine:
 
         # One-time FSRS data migration: seed stability from access patterns
         self._migrate_fsrs()
+        self._migrate_signal_strength()
 
         self._ensure_self_node()
         self._migrate_identity_tiers()
         self._seed_initial_maintenance_grace_period()
         self._warmup_embedder()
         self._warmup_reranker()
+
+    def _migrate_signal_strength(self) -> None:
+        """Recompute signals.strength onto the #218 ordinal evidence ladder.
+
+        Exact rather than estimated: every row carries the evidence its own channel
+        needs, and the judge stamps the min_confidence in force when the row was
+        written -- so a row recomputes to what it would have stored had the ladder
+        existed then, not to what today's settings would produce.
+
+        Re-runnable by construction: evidence is never written, so a later revision
+        of the ladder recomputes from the same untouched source. Only strength moves.
+
+        No file_store call, so this does not take db-lock before memory-lock and
+        stays outside the ordering hazard documented on _record_confirmed_use.
+        """
+        stamp = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'signal_strength_ladder_version'"
+        ).fetchone()
+        try:
+            version = int(stamp["value"]) if stamp else 0
+        except (TypeError, ValueError):
+            version = 0
+        if version >= SIGNAL_STRENGTH_LADDER_VERSION:
+            return
+
+        with self.db.transaction() as conn:
+            rows = conn.execute("SELECT id, source, polarity, evidence FROM signals").fetchall()
+            for row in rows:
+                conn.execute(
+                    "UPDATE signals SET strength = ? WHERE id = ?",
+                    (
+                        signal_strength.strength_from_evidence(
+                            row["source"], row["polarity"], row["evidence"]
+                        ),
+                        row["id"],
+                    ),
+                )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                "('signal_strength_ladder_version', ?)",
+                (str(SIGNAL_STRENGTH_LADDER_VERSION),),
+            )
+        logger.info(
+            "Recomputed strength on %d signal rows (#218 ladder v%d)",
+            len(rows),
+            SIGNAL_STRENGTH_LADDER_VERSION,
+        )
 
     def _migrate_fsrs(self) -> None:
         """Seed FSRS stability once, and record the store's lifecycle-model version."""

--- a/src/ormah/signal_strength.py
+++ b/src/ormah/signal_strength.py
@@ -1,0 +1,159 @@
+"""The ordinal evidence-strength ladder behind ``signals.strength`` (issue #218).
+
+``strength`` is the strength of the evidence backing a signal row's polarity, on a
+single ordinal scale, comparable in RANK across channels. It is NOT a calibrated
+probability: 0.86 from the LLM judge and 0.86 from anywhere else mean "the same
+rung", not "the same likelihood".
+
+The load-bearing assertion is that the CHANNEL DOMINATES within-channel confidence.
+A verbatim match outranks any LLM judgment however confident; an LLM judgment
+outranks any agent self-report. Bands are therefore disjoint per channel, and native
+confidence modulates only WITHIN a band.
+
+    1.00         explicit ......... the user was actually asked
+    0.98         node_id .......... the short id was printed verbatim
+    0.94         title ............ the title was printed verbatim
+    0.92         sentence ......... a content sentence was printed verbatim
+    0.82 - 0.90  auto_llm_judge ... affine over [min_confidence, 1.0]
+    0.80         implicit ......... the agent's own self-assessment
+    0.40 - 0.78  token_overlap .... asymptotic in overlap_ratio
+    0.00         polarity == 0 .... a row that asserts nothing has no evidence
+
+A polarity-zero row asserts nothing, so it carries no evidence strength. Its native
+confidence still survives in ``signals.evidence``; nothing is lost.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+# Detector source labels. Owned here because this module maps them onto the ladder;
+# session_watcher imports them rather than repeating the literals.
+HEURISTIC_SOURCE = "transcript_watcher_heuristic"
+LLM_JUDGE_SOURCE = "transcript_watcher_llm_judge"
+
+EXPLICIT = 1.00
+VERBATIM_NODE_ID = 0.98
+VERBATIM_TITLE = 0.94
+VERBATIM_SENTENCE = 0.92
+JUDGE_LO = 0.82
+JUDGE_HI = 0.90
+IMPLICIT = 0.80
+
+# token_overlap: floored at the detector's own entry gate, asymptotic to FLOOR + SPAN.
+OVERLAP_GATE = 0.5
+OVERLAP_FLOOR = 0.40
+OVERLAP_SPAN = 0.38
+OVERLAP_K = 1.0
+
+# Bottom of the ladder. Unknown provenance is the weakest evidence there is.
+UNKNOWN = OVERLAP_FLOOR
+
+# (channel, band_low, band_high). Disjointness is the executable form of the
+# "channel dominates confidence" assertion; test_signal_strength.py pins it.
+BANDS = (
+    ("explicit", EXPLICIT, EXPLICIT),
+    ("node_id", VERBATIM_NODE_ID, VERBATIM_NODE_ID),
+    ("title", VERBATIM_TITLE, VERBATIM_TITLE),
+    ("sentence", VERBATIM_SENTENCE, VERBATIM_SENTENCE),
+    ("auto_llm_judge", JUDGE_LO, JUDGE_HI),
+    ("implicit", IMPLICIT, IMPLICIT),
+    ("token_overlap", OVERLAP_FLOOR, OVERLAP_FLOOR + OVERLAP_SPAN),
+)
+
+_FEEDBACK_LADDER = {
+    "explicit": EXPLICIT,
+    "implicit": IMPLICIT,
+    # submit_feedback carries no confidence, so a judge-sourced row arriving through
+    # it lands on the floor of the judge band rather than anywhere inside it.
+    "auto_llm_judge": JUDGE_LO,
+    "auto_heuristic": UNKNOWN,
+}
+
+
+def _as_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def token_overlap_strength(ratio: float) -> float:
+    """Map ``overlap_ratio`` onto the token_overlap band.
+
+    Asymptotic rather than clamped, because ``overlap_ratio`` is unbounded above --
+    its denominator is ``min(len(candidate_tokens), 12)`` while its numerator is not
+    capped. Any clamp ties every row above it, recreating the exact saturation defect
+    #218 reports; a clamp at 1.50 would tie 38% of the rows observed on a live store.
+
+    The supremum FLOOR + SPAN = 0.78 is strict in exact arithmetic but not in float64,
+    which reaches it around ratio 37 -- five times the 7.583 maximum observed.
+    """
+    return OVERLAP_FLOOR + OVERLAP_SPAN * (
+        1.0 - math.exp(-OVERLAP_K * max(ratio - OVERLAP_GATE, 0.0))
+    )
+
+
+def judge_strength(confidence: float, min_confidence: float, polarity: int) -> float:
+    """Map the judge's confidence onto its band, affine over [min_confidence, 1.0].
+
+    The domain is anchored on the caller's ``min_confidence`` rather than the literal
+    0.75, so the band re-anchors if the setting moves. That domain is sound because
+    the judge assigns a non-zero polarity only when ``confidence >= min_confidence``,
+    so no scoring row can sit below the band floor.
+    """
+    if polarity == 0:
+        return 0.0
+    if min_confidence >= 1.0:
+        return JUDGE_HI
+    span = (confidence - min_confidence) / (1.0 - min_confidence)
+    return JUDGE_LO + (JUDGE_HI - JUDGE_LO) * max(0.0, min(1.0, span))
+
+
+def feedback_strength(source: str, signal: int) -> float:
+    """Map a ``submit_feedback`` row onto the ladder.
+
+    Fail-closed: a source the ladder does not know lands on ``UNKNOWN``, the bottom
+    rung. ``submit_feedback`` validates ``signal`` only at its HTTP boundary
+    (``FeedbackRequest``), so a direct Python caller can still arrive here with 0.
+    """
+    if signal == 0:
+        return 0.0
+    return _FEEDBACK_LADDER.get(source, UNKNOWN)
+
+
+def strength_from_evidence(source: str, polarity: int, evidence_json: str | None) -> float:
+    """Recompute a stored row's strength from the ``evidence`` it already carries.
+
+    Used by the #218 backfill, and exact rather than estimated: each channel records
+    what its own mapping needs, and the judge stamps the ``min_confidence`` in force
+    when the row was written -- so the recompute uses that value, not today's.
+    """
+    if polarity == 0:
+        return 0.0
+    try:
+        evidence = json.loads(evidence_json) if evidence_json else {}
+    except (TypeError, ValueError):
+        evidence = {}
+    if not isinstance(evidence, dict):
+        evidence = {}
+
+    if source == HEURISTIC_SOURCE:
+        match = evidence.get("match")
+        if match == "node_id":
+            return VERBATIM_NODE_ID
+        if match == "title":
+            return VERBATIM_TITLE
+        if match == "sentence":
+            return VERBATIM_SENTENCE
+        if match == "token_overlap":
+            return token_overlap_strength(_as_float(evidence.get("overlap_ratio")))
+        return UNKNOWN
+    if source == LLM_JUDGE_SOURCE:
+        return judge_strength(
+            _as_float(evidence.get("confidence")),
+            _as_float(evidence.get("min_confidence"), default=0.75),
+            polarity,
+        )
+    return feedback_strength(source, polarity)

--- a/src/ormah/signal_strength.py
+++ b/src/ormah/signal_strength.py
@@ -73,10 +73,38 @@ _FEEDBACK_LADDER = {
 
 
 def _as_float(value: object, default: float = 0.0) -> float:
+    """Coerce a stored evidence value to a FINITE float, else *default*.
+
+    Both guards exist because the #218 migration runs on every startup and writes
+    into ``signals.strength``, which is ``REAL NOT NULL``:
+
+    - ``OverflowError`` is in the except tuple because ``json.loads`` returns an
+      unbounded Python ``int`` for a large integer literal, and ``float()`` of one
+      beyond the double range raises it -- not ``ValueError``.
+    - Non-finite results are rejected because ``json.loads`` accepts bare ``NaN``
+      and ``Infinity``, and SQLite stores a NaN REAL as NULL. Binding one would
+      raise ``IntegrityError`` inside the migration, and since the migration runs
+      at every boot, a single poisoned historical row would stop the server from
+      ever starting again.
+
+    Reported by the Codex peer, /council-pr of 2026-08-26.
+    """
     try:
-        return float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
         return default
+    return result if math.isfinite(result) else default
+
+
+def _finite(value: float) -> float:
+    """Last guard before a strength reaches the NOT NULL column.
+
+    ``_as_float`` already keeps non-finite values out of the inputs, so this cannot
+    fire today. It guards the OUTPUT side instead: a future change to one of the
+    band formulas could produce a non-finite result from finite inputs, and the
+    cost of that reaching the every-boot migration is a server that never starts.
+    """
+    return value if math.isfinite(value) else UNKNOWN
 
 
 def token_overlap_strength(ratio: float) -> float:
@@ -148,12 +176,14 @@ def strength_from_evidence(source: str, polarity: int, evidence_json: str | None
         if match == "sentence":
             return VERBATIM_SENTENCE
         if match == "token_overlap":
-            return token_overlap_strength(_as_float(evidence.get("overlap_ratio")))
+            return _finite(token_overlap_strength(_as_float(evidence.get("overlap_ratio"))))
         return UNKNOWN
     if source == LLM_JUDGE_SOURCE:
-        return judge_strength(
-            _as_float(evidence.get("confidence")),
-            _as_float(evidence.get("min_confidence"), default=0.75),
-            polarity,
+        return _finite(
+            judge_strength(
+                _as_float(evidence.get("confidence")),
+                _as_float(evidence.get("min_confidence"), default=0.75),
+                polarity,
+            )
         )
     return feedback_strength(source, polarity)

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ormah import signal_strength
 from ormah.background.session_watcher import (
     IngestResult,
     SessionHandler,
@@ -424,7 +425,10 @@ def test_llm_judge_promotes_used_verdict(engine, tmp_path):
     assert judge_signal is not None
     assert judge_signal["signal_type"] == "whisper_judged_used"
     assert judge_signal["polarity"] == 1
-    assert judge_signal["strength"] == 0.88
+    # #218: strength is the judge's band position now, not its raw confidence.
+    assert judge_signal["strength"] == pytest.approx(
+        signal_strength.judge_strength(0.88, engine.settings.feedback_llm_judge_min_confidence, 1)
+    )
 
     affinity = engine.db.conn.execute(
         "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)

--- a/tests/test_background/test_usage_signal_strength.py
+++ b/tests/test_background/test_usage_signal_strength.py
@@ -70,3 +70,75 @@ def test_every_heuristic_rung_sits_inside_its_band():
     """The verbatim rungs must stay above the judge band, the overlap rung below implicit."""
     assert ss.VERBATIM_SENTENCE > ss.JUDGE_HI
     assert ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN < ss.IMPLICIT
+
+
+import json  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+from ormah.background.session_watcher import _record_whisper_usage_signals  # noqa: E402
+from ormah.models.node import CreateNodeRequest  # noqa: E402
+from ormah.transcript.parser import parse_transcript  # noqa: E402
+from tests.test_background.test_session_watcher import (  # noqa: E402
+    _LLM_PATCH,
+    _insert_injected_whisper_log,
+    _write_turn_jsonl,
+)
+
+
+def _judged(engine, tmp_path, *, verdict, confidence, slug):
+    """Drive one whisper through the judge and return its stored signal row."""
+    prompt = "How should we handle the blue deployment rollback?"
+    response = "Nothing in particular comes to mind about that."
+    transcript_path = tmp_path / f"{slug}.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Roll back a blue deployment by repointing the load balancer first.",
+        type="fact",
+        title="Blue deployment rollback marker",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id=slug, prompt=prompt
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({"verdicts": [{
+        "whisper_log_id": whisper_log_id,
+        "verdict": verdict,
+        "confidence": confidence,
+        "reason": "fixture",
+    }]})
+    with patch(_LLM_PATCH, return_value=llm_response):
+        _record_whisper_usage_signals(engine, transcript)
+
+    return engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ? "
+        "AND source = 'transcript_watcher_llm_judge'",
+        (whisper_log_id,),
+    ).fetchone()
+
+
+def test_a_used_verdict_lands_inside_the_judge_band(engine, tmp_path):
+    """It used to store the raw confidence, which collides with other channels."""
+    signal = _judged(engine, tmp_path, verdict="used", confidence=0.88, slug="judge-band-used")
+    assert signal["polarity"] == 1
+    assert signal["strength"] != 0.88
+    assert ss.JUDGE_LO <= signal["strength"] <= ss.JUDGE_HI
+    assert signal["strength"] == pytest.approx(
+        ss.judge_strength(0.88, engine.settings.feedback_llm_judge_min_confidence, 1)
+    )
+
+
+def test_an_uncertain_verdict_carries_no_strength(engine, tmp_path):
+    """Below min_confidence the polarity is 0, so the row asserts nothing.
+
+    Its confidence is not lost: it stays in signals.evidence.
+    """
+    signal = _judged(
+        engine, tmp_path, verdict="used", confidence=0.35, slug="judge-band-uncertain"
+    )
+    assert signal["polarity"] == 0
+    assert signal["strength"] == 0.0
+    assert json.loads(signal["evidence"])["confidence"] == 0.35

--- a/tests/test_background/test_usage_signal_strength.py
+++ b/tests/test_background/test_usage_signal_strength.py
@@ -142,3 +142,24 @@ def test_an_uncertain_verdict_carries_no_strength(engine, tmp_path):
     assert signal["polarity"] == 0
     assert signal["strength"] == 0.0
     assert json.loads(signal["evidence"])["confidence"] == 0.35
+
+
+def test_recorded_evidence_reproduces_the_stored_strength():
+    """evidence must be a lossless record of what determined strength.
+
+    The #218 backfill recomputes strength from evidence. Deriving the stored strength
+    from a more precise ratio than the one recorded makes that recompute perturb a
+    correct row instead of confirming it — and makes any future rescan of new rows a
+    drift rather than a no-op.
+
+    4 overlaps over 6 candidates is 0.6666..., recorded as 0.667. That gap used to be
+    ~1e-04 of strength.
+    """
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="Q", content="quantum entanglement decoherence topology manifold curvature"),
+        "Consider decoherence, topology, the manifold and curvature when planning.",
+    )
+    assert referenced
+    assert evidence["match"] == "token_overlap"
+    assert evidence["overlap_ratio"] == pytest.approx(0.667)
+    assert strength == ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, json.dumps(evidence))

--- a/tests/test_background/test_usage_signal_strength.py
+++ b/tests/test_background/test_usage_signal_strength.py
@@ -1,0 +1,72 @@
+"""The heuristic detector places matches on the #218 ordinal ladder."""
+
+import pytest
+
+from ormah import signal_strength as ss
+from ormah.background.session_watcher import _node_usage_evidence
+
+
+def _row(node_id="a1b2c3d4-dead-beef-0000-000000000000", title="", content="", prompt_text=""):
+    """_node_usage_evidence reads its row purely by key, so a dict is a valid row."""
+    return {"node_id": node_id, "title": title, "content": content, "prompt_text": prompt_text}
+
+
+def test_node_id_match_takes_the_top_heuristic_rung():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(content="anything"), "As memory a1b2c3d4 records, we chose X."
+    )
+    assert referenced
+    assert evidence["match"] == "node_id"
+    assert strength == ss.VERBATIM_NODE_ID
+
+
+def test_title_match_takes_the_title_rung():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(
+            title="Transcript watcher mines feedback usage",
+            content="Some unrelated body text goes here.",
+        ),
+        "The transcript watcher mines feedback usage, as noted.",
+    )
+    assert referenced
+    assert evidence["match"] == "title"
+    assert strength == ss.VERBATIM_TITLE
+
+
+def test_sentence_match_takes_the_sentence_rung():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="T", content="The consolidator summarizes from full source content."),
+        "Recall that the consolidator summarizes from full source content today.",
+    )
+    assert referenced
+    assert evidence["match"] == "sentence"
+    assert strength == ss.VERBATIM_SENTENCE
+
+
+def test_token_overlap_varies_with_its_ratio():
+    """The defect #218 names: every token_overlap match used to report exactly 0.85."""
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="Q", content="quantum entanglement decoherence topology manifold"),
+        "We should consider decoherence, then topology, then the manifold, "
+        "and finally quantum entanglement in that order.",
+    )
+    assert referenced
+    assert evidence["match"] == "token_overlap"
+    assert evidence["overlap_ratio"] == pytest.approx(1.0)
+    assert strength == pytest.approx(ss.token_overlap_strength(1.0))
+    assert strength != 0.85
+
+
+def test_no_match_carries_no_strength():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="Z", content="alpha beta gamma delta"), "Completely unrelated prose here."
+    )
+    assert not referenced
+    assert evidence["match"] == "none"
+    assert strength == 0.0
+
+
+def test_every_heuristic_rung_sits_inside_its_band():
+    """The verbatim rungs must stay above the judge band, the overlap rung below implicit."""
+    assert ss.VERBATIM_SENTENCE > ss.JUDGE_HI
+    assert ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN < ss.IMPLICIT

--- a/tests/test_engine/test_feedback_signal_strength.py
+++ b/tests/test_engine/test_feedback_signal_strength.py
@@ -1,0 +1,61 @@
+"""submit_feedback records a real strength, not a hardcoded 1.0 (#218)."""
+
+import pytest
+
+from ormah import signal_strength as ss
+from ormah.models.node import CreateNodeRequest
+
+
+def _node_with_whisper(engine, title):
+    """Create a node and a whisper_log row submit_feedback can resolve."""
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="caching architecture note for the strength ladder",
+        title=title,
+        type="fact",
+        tier="working",
+    ))
+    engine.recall_search("caching architecture", limit=10)
+    row = engine.db.conn.execute(
+        "SELECT id FROM whisper_log WHERE node_id = ? ORDER BY id DESC LIMIT 1",
+        (node_id,),
+    ).fetchone()
+    assert row is not None, "no whisper_log row was created — check the surface used"
+    return node_id, row["id"]
+
+
+def _stored_strength(engine, whisper_log_id):
+    return engine.db.conn.execute(
+        "SELECT strength FROM signals WHERE whisper_log_id = ? "
+        "AND signal_type = 'feedback_submitted'",
+        (whisper_log_id,),
+    ).fetchone()["strength"]
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("explicit", ss.EXPLICIT),
+        ("implicit", ss.IMPLICIT),
+        ("auto_heuristic", ss.UNKNOWN),
+    ],
+)
+def test_each_feedback_source_records_its_own_rung(engine, source, expected):
+    node_id, log_id = _node_with_whisper(engine, f"Caching {source}")
+    engine.submit_feedback(node_id, signal=1, source=source, whisper_log_id=log_id)
+    assert _stored_strength(engine, log_id) == expected
+
+
+def test_explicit_and_implicit_no_longer_collide(engine):
+    """Both used to store exactly 1.0, leaving source as the only discriminator."""
+    explicit_id, explicit_log = _node_with_whisper(engine, "Caching E")
+    implicit_id, implicit_log = _node_with_whisper(engine, "Caching I")
+    engine.submit_feedback(explicit_id, signal=1, source="explicit", whisper_log_id=explicit_log)
+    engine.submit_feedback(implicit_id, signal=1, source="implicit", whisper_log_id=implicit_log)
+    assert _stored_strength(engine, explicit_log) != _stored_strength(engine, implicit_log)
+
+
+def test_negative_feedback_keeps_its_channel_rung(engine):
+    """strength is the evidence for THIS row's polarity, so -1 is not weaker."""
+    node_id, log_id = _node_with_whisper(engine, "Caching N")
+    engine.submit_feedback(node_id, signal=-1, source="explicit", whisper_log_id=log_id)
+    assert _stored_strength(engine, log_id) == ss.EXPLICIT

--- a/tests/test_engine/test_signal_strength.py
+++ b/tests/test_engine/test_signal_strength.py
@@ -1,6 +1,7 @@
 """Unit tests for the #218 ordinal evidence ladder."""
 
 import json
+import math
 
 import pytest
 
@@ -127,3 +128,41 @@ def test_recompute_survives_malformed_evidence():
     assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, "not json") == ss.UNKNOWN
     assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, None) == ss.UNKNOWN
     assert ss.strength_from_evidence("implicit", 0, None) == 0.0
+
+
+# --- Non-finite and out-of-range evidence (#218, Codex peer 2026-08-26) ---------
+#
+# The migration runs on every startup. json.loads accepts NaN and Infinity by
+# default and returns an unbounded int for a large integer literal; SQLite stores a
+# NaN REAL as NULL and signals.strength is NOT NULL. So one poisoned historical row
+# would raise IntegrityError inside the migration and the server would never boot
+# again. These pin the coercion that prevents it.
+
+def test_as_float_survives_an_integer_beyond_the_double_range():
+    """float() of a huge int raises OverflowError, which is not a ValueError."""
+    assert ss._as_float(int("9" * 400)) == 0.0
+    assert ss._as_float(int("9" * 400), default=0.75) == 0.75
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_as_float_rejects_non_finite_values(value):
+    assert ss._as_float(value) == 0.0
+    assert ss._as_float(value, default=0.75) == 0.75
+
+
+@pytest.mark.parametrize(
+    "ratio", [float("nan"), float("inf"), float("-inf"), int("9" * 400)]
+)
+def test_recompute_stays_finite_and_in_band_for_poisoned_overlap_ratio(ratio):
+    evidence = json.dumps({"match": "token_overlap", "overlap_ratio": ratio})
+    result = ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, evidence)
+    assert math.isfinite(result)
+    assert ss.OVERLAP_FLOOR <= result <= ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN
+
+
+@pytest.mark.parametrize("confidence", [float("nan"), float("inf"), int("9" * 400)])
+def test_recompute_stays_finite_and_in_band_for_poisoned_confidence(confidence):
+    evidence = json.dumps({"confidence": confidence, "min_confidence": 0.75})
+    result = ss.strength_from_evidence(ss.LLM_JUDGE_SOURCE, 1, evidence)
+    assert math.isfinite(result)
+    assert ss.JUDGE_LO <= result <= ss.JUDGE_HI

--- a/tests/test_engine/test_signal_strength.py
+++ b/tests/test_engine/test_signal_strength.py
@@ -1,0 +1,129 @@
+"""Unit tests for the #218 ordinal evidence ladder."""
+
+import json
+
+import pytest
+
+from ormah import signal_strength as ss
+
+
+def test_bands_are_disjoint_and_ordered():
+    """The ladder's central assertion: channel dominates within-channel confidence."""
+    ordered = sorted(ss.BANDS, key=lambda band: -band[1])
+    assert [band[0] for band in ordered] == [
+        "explicit",
+        "node_id",
+        "title",
+        "sentence",
+        "auto_llm_judge",
+        "implicit",
+        "token_overlap",
+    ]
+    for (upper, upper_lo, _), (lower, _, lower_hi) in zip(ordered, ordered[1:]):
+        assert lower_hi < upper_lo, f"{lower} band overlaps {upper}"
+
+
+def test_token_overlap_starts_at_the_band_floor():
+    assert ss.token_overlap_strength(ss.OVERLAP_GATE) == pytest.approx(ss.OVERLAP_FLOOR)
+
+
+def test_token_overlap_separates_the_observed_domain():
+    """0.5..7.583 is the range measured on a live store; no two ratios may tie."""
+    values = [ss.token_overlap_strength(r) for r in (0.5, 0.55, 1.167, 1.5, 3.0, 7.583)]
+    assert values == sorted(values)
+    assert len(set(values)) == len(values)
+    assert values[-1] < ss.IMPLICIT
+
+
+def test_token_overlap_fixes_the_defect_218_names():
+    """Today min(0.85, 0.45 + ratio) returns exactly 0.85 for both of these."""
+    assert ss.token_overlap_strength(0.5) != ss.token_overlap_strength(1.8)
+
+
+def test_token_overlap_never_exceeds_its_band():
+    """The supremum is strict in exact arithmetic, not in float64.
+
+    float64 reaches it around ratio 37 — five times above the 7.583 maximum observed
+    on a live store. That crossover is libm-dependent, so it is documented here and
+    not asserted; what is asserted is that the band is never exceeded.
+    """
+    supremum = ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN
+    assert all(ss.token_overlap_strength(n / 10) <= supremum for n in range(5, 1000))
+    assert supremum < ss.IMPLICIT
+
+
+@pytest.mark.parametrize("min_confidence", [0.75, 0.80])
+def test_judge_band_is_affine_over_the_callers_min_confidence(min_confidence):
+    assert ss.judge_strength(min_confidence, min_confidence, 1) == pytest.approx(ss.JUDGE_LO)
+    assert ss.judge_strength(1.0, min_confidence, 1) == pytest.approx(ss.JUDGE_HI)
+    midpoint = (min_confidence + 1.0) / 2
+    assert ss.judge_strength(midpoint, min_confidence, 1) == pytest.approx(
+        (ss.JUDGE_LO + ss.JUDGE_HI) / 2
+    )
+
+
+def test_judge_zero_polarity_carries_no_strength():
+    """An uncertain verdict asserts nothing. Its confidence survives in evidence."""
+    assert ss.judge_strength(0.35, 0.75, 0) == 0.0
+    assert ss.judge_strength(0.99, 0.75, 0) == 0.0
+
+
+def test_judge_negative_polarity_uses_the_same_band():
+    """A confident 'irrelevant' is strong evidence for its own polarity."""
+    assert ss.judge_strength(1.0, 0.75, -1) == pytest.approx(ss.JUDGE_HI)
+
+
+def test_judge_degenerate_min_confidence_does_not_divide_by_zero():
+    assert ss.judge_strength(1.0, 1.0, 1) == ss.JUDGE_HI
+
+
+def test_explicit_and_implicit_no_longer_share_a_strength():
+    """Today submit_feedback hardcodes 1.0 for both."""
+    assert ss.feedback_strength("explicit", 1) == ss.EXPLICIT
+    assert ss.feedback_strength("implicit", 1) == ss.IMPLICIT
+    assert ss.feedback_strength("explicit", 1) != ss.feedback_strength("implicit", 1)
+
+
+def test_feedback_zero_signal_carries_no_strength():
+    """Unreachable through the HTTP surface; reachable from a direct Python caller."""
+    assert ss.feedback_strength("explicit", 0) == 0.0
+
+
+def test_unknown_source_fails_closed_to_the_bottom_rung():
+    assert ss.feedback_strength("something_new", 1) == ss.UNKNOWN
+    assert ss.feedback_strength("auto_heuristic", -1) == ss.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "match,expected",
+    [
+        ("node_id", ss.VERBATIM_NODE_ID),
+        ("title", ss.VERBATIM_TITLE),
+        ("sentence", ss.VERBATIM_SENTENCE),
+    ],
+)
+def test_recompute_reads_the_heuristic_match_kind(match, expected):
+    evidence = json.dumps({"match": match})
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, evidence) == expected
+
+
+def test_recompute_reads_the_overlap_ratio():
+    evidence = json.dumps({"match": "token_overlap", "overlap_ratio": 1.167})
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, evidence) == pytest.approx(
+        ss.token_overlap_strength(1.167)
+    )
+
+
+def test_recompute_uses_the_rows_own_min_confidence():
+    """Not today's setting: the judge stamps min_confidence on every row it writes."""
+    lenient = json.dumps({"confidence": 0.80, "min_confidence": 0.75})
+    strict = json.dumps({"confidence": 0.80, "min_confidence": 0.80})
+    assert ss.strength_from_evidence(
+        ss.LLM_JUDGE_SOURCE, 1, lenient
+    ) > ss.strength_from_evidence(ss.LLM_JUDGE_SOURCE, 1, strict)
+
+
+def test_recompute_survives_malformed_evidence():
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, "not json") == ss.UNKNOWN
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, None) == ss.UNKNOWN
+    assert ss.strength_from_evidence("implicit", 0, None) == 0.0

--- a/tests/test_engine/test_signal_strength_backfill.py
+++ b/tests/test_engine/test_signal_strength_backfill.py
@@ -202,3 +202,36 @@ def test_the_cutoff_advances_after_a_repair(engine):
     engine._migrate_signal_strength()
 
     assert _row(engine, legacy)["strength"] == 0.123, "the cutoff did not advance"
+
+
+def test_a_poisoned_evidence_row_cannot_block_startup(engine):
+    """One malformed historical value must not stop the server from ever booting.
+
+    The migration runs at every startup and writes into signals.strength, which is
+    REAL NOT NULL. SQLite stores a NaN REAL as NULL, so binding one raises
+    IntegrityError — and with an every-boot migration that failure is permanent,
+    not a one-time hiccup. Codex peer finding, /council-pr of 2026-08-26.
+    """
+    poisoned = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": float("nan")},
+    )
+    huge = _seed(
+        engine,
+        source=ss.LLM_JUDGE_SOURCE,
+        polarity=1,
+        evidence={"confidence": int("9" * 400), "min_confidence": 0.75},
+    )
+
+    _rerun(engine)          # must not raise
+    engine._migrate_signal_strength()   # and the next boot must not raise either
+
+    for signal_id, lo, hi in (
+        (poisoned, ss.OVERLAP_FLOOR, ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN),
+        (huge, ss.JUDGE_LO, ss.JUDGE_HI),
+    ):
+        strength = _row(engine, signal_id)["strength"]
+        assert strength is not None
+        assert lo <= strength <= hi

--- a/tests/test_engine/test_signal_strength_backfill.py
+++ b/tests/test_engine/test_signal_strength_backfill.py
@@ -25,9 +25,10 @@ def _seed(engine, *, source, polarity, evidence, strength=0.85):
 
 
 def _rerun(engine):
-    """Clear the version stamp so the guarded migration runs again."""
+    """Clear both markers so the migration makes a full pass over the table."""
     engine.db.conn.execute(
-        "DELETE FROM meta WHERE key = 'signal_strength_ladder_version'"
+        "DELETE FROM meta WHERE key IN "
+        "('signal_strength_ladder_version', 'signal_strength_ladder_cutoff')"
     )
     engine.db.conn.commit()
     engine._migrate_signal_strength()
@@ -130,8 +131,8 @@ def test_backfill_is_idempotent(engine):
     assert once == twice
 
 
-def test_backfill_does_not_rerun_once_stamped(engine):
-    """The version guard, not the recompute, is what makes the second boot free."""
+def test_rows_at_or_below_the_cutoff_are_not_rescanned(engine):
+    """The cutoff, not the recompute, is what keeps a later start cheap."""
     signal_id = _seed(
         engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence={"match": "node_id"}
     )
@@ -142,3 +143,62 @@ def test_backfill_does_not_rerun_once_stamped(engine):
     engine._migrate_signal_strength()
 
     assert _row(engine, signal_id)["strength"] == 0.123
+
+
+def test_rescan_repairs_a_legacy_row_written_after_the_stamp(engine):
+    """A one-time stamp cannot repair what an old binary writes after it.
+
+    A rollback then re-upgrade, or the second unmanaged server process this project
+    already knows about (#238), inserts pre-ladder values into a table the stamp
+    declares migrated. Council peer finding, /council-pr of 2026-08-26.
+    """
+    _rerun(engine)
+
+    legacy = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "node_id"},
+        strength=1.0,
+    )
+    engine._migrate_signal_strength()
+
+    assert _row(engine, legacy)["strength"] == ss.VERBATIM_NODE_ID
+
+
+def test_rescan_leaves_an_already_correct_row_untouched(engine):
+    """The repair is a repair only because a current-code row recomputes to itself.
+
+    strength_from_evidence is a pure function of (source, polarity, evidence), and
+    every write site stores exactly what it returns for what it recorded. Without
+    that, rescanning would drift correct rows instead of confirming them.
+    """
+    _rerun(engine)
+
+    correct = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": 0.667},
+        strength=ss.token_overlap_strength(0.667),
+    )
+    before = _row(engine, correct)["strength"]
+    engine._migrate_signal_strength()
+
+    assert _row(engine, correct)["strength"] == before
+
+
+def test_the_cutoff_advances_after_a_repair(engine):
+    """Each start covers only what arrived since the last one."""
+    _rerun(engine)
+    legacy = _seed(
+        engine, source="implicit", polarity=1, evidence={"source": "implicit"}, strength=1.0
+    )
+    engine._migrate_signal_strength()
+    assert _row(engine, legacy)["strength"] == ss.IMPLICIT
+
+    engine.db.conn.execute("UPDATE signals SET strength = 0.123 WHERE id = ?", (legacy,))
+    engine.db.conn.commit()
+    engine._migrate_signal_strength()
+
+    assert _row(engine, legacy)["strength"] == 0.123, "the cutoff did not advance"

--- a/tests/test_engine/test_signal_strength_backfill.py
+++ b/tests/test_engine/test_signal_strength_backfill.py
@@ -1,0 +1,144 @@
+"""The #218 backfill recomputes historical strength exactly, and only once."""
+
+import json
+
+import pytest
+
+from ormah import signal_strength as ss
+
+
+def _seed(engine, *, source, polarity, evidence, strength=0.85):
+    """Insert a signals row with a stale strength.
+
+    whisper_log_id stays NULL: the unique index on
+    (whisper_log_id, signal_type, source) is partial on whisper_log_id IS NOT NULL,
+    so NULL rows never collide however many are seeded.
+    """
+    cursor = engine.db.conn.execute(
+        "INSERT INTO signals "
+        "(whisper_log_id, node_id, signal_type, polarity, strength, source, evidence, created) "
+        "VALUES (NULL, 'seed-node', 'seeded', ?, ?, ?, ?, datetime('now'))",
+        (polarity, strength, source, json.dumps(evidence) if evidence is not None else None),
+    )
+    engine.db.conn.commit()
+    return cursor.lastrowid
+
+
+def _rerun(engine):
+    """Clear the version stamp so the guarded migration runs again."""
+    engine.db.conn.execute(
+        "DELETE FROM meta WHERE key = 'signal_strength_ladder_version'"
+    )
+    engine.db.conn.commit()
+    engine._migrate_signal_strength()
+
+
+def _row(engine, signal_id):
+    return engine.db.conn.execute(
+        "SELECT strength, polarity, evidence FROM signals WHERE id = ?", (signal_id,)
+    ).fetchone()
+
+
+def test_backfill_recomputes_each_channel_exactly(engine):
+    verbatim = _seed(
+        engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence={"match": "node_id"}
+    )
+    overlap = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": 1.167},
+    )
+    judged = _seed(
+        engine,
+        source=ss.LLM_JUDGE_SOURCE,
+        polarity=1,
+        evidence={"confidence": 0.88, "min_confidence": 0.75},
+    )
+    implicit = _seed(engine, source="implicit", polarity=1, evidence={"source": "implicit"},
+                     strength=1.0)
+
+    _rerun(engine)
+
+    assert _row(engine, verbatim)["strength"] == ss.VERBATIM_NODE_ID
+    assert _row(engine, overlap)["strength"] == pytest.approx(ss.token_overlap_strength(1.167))
+    assert _row(engine, judged)["strength"] == pytest.approx(ss.judge_strength(0.88, 0.75, 1))
+    assert _row(engine, implicit)["strength"] == ss.IMPLICIT
+
+
+def test_backfill_uses_the_rows_own_min_confidence(engine):
+    """Not today's setting — the judge stamped it on the row when it wrote it."""
+    lenient = _seed(
+        engine, source=ss.LLM_JUDGE_SOURCE, polarity=1,
+        evidence={"confidence": 0.80, "min_confidence": 0.75},
+    )
+    strict = _seed(
+        engine, source=ss.LLM_JUDGE_SOURCE, polarity=1,
+        evidence={"confidence": 0.80, "min_confidence": 0.80},
+    )
+
+    _rerun(engine)
+
+    assert _row(engine, lenient)["strength"] > _row(engine, strict)["strength"]
+
+
+def test_backfill_zeroes_rows_that_assert_nothing(engine):
+    uncertain = _seed(
+        engine, source=ss.LLM_JUDGE_SOURCE, polarity=0,
+        evidence={"confidence": 0.35, "min_confidence": 0.75},
+    )
+
+    _rerun(engine)
+
+    assert _row(engine, uncertain)["strength"] == 0.0
+
+
+def test_backfill_survives_missing_evidence(engine):
+    orphan = _seed(engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence=None)
+
+    _rerun(engine)
+
+    assert _row(engine, orphan)["strength"] == ss.UNKNOWN
+
+
+def test_backfill_leaves_evidence_and_polarity_untouched(engine):
+    evidence = {"match": "token_overlap", "overlap_ratio": 1.167}
+    signal_id = _seed(engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence=evidence)
+    before = _row(engine, signal_id)
+
+    _rerun(engine)
+
+    after = _row(engine, signal_id)
+    assert after["evidence"] == before["evidence"]
+    assert after["polarity"] == before["polarity"]
+    assert after["strength"] != before["strength"]
+
+
+def test_backfill_is_idempotent(engine):
+    signal_id = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": 1.167},
+    )
+
+    _rerun(engine)
+    once = _row(engine, signal_id)["strength"]
+    _rerun(engine)
+    twice = _row(engine, signal_id)["strength"]
+
+    assert once == twice
+
+
+def test_backfill_does_not_rerun_once_stamped(engine):
+    """The version guard, not the recompute, is what makes the second boot free."""
+    signal_id = _seed(
+        engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence={"match": "node_id"}
+    )
+    _rerun(engine)
+
+    engine.db.conn.execute("UPDATE signals SET strength = 0.123 WHERE id = ?", (signal_id,))
+    engine.db.conn.commit()
+    engine._migrate_signal_strength()
+
+    assert _row(engine, signal_id)["strength"] == 0.123


### PR DESCRIPTION
Closes #218.

## The problem

`signals.strength` is documented as a per-event confidence score. In practice it is a tier label stored as a float:

- `submit_feedback` declares `strength` in its INSERT column list and then passes the literal `1.0`, so an explicit user confirmation and an implicit agent self-assessment are stored identically — `source` is the only discriminator.
- Three heuristic match kinds return fixed constants.
- `token_overlap` computes `min(0.85, 0.45 + ratio)` behind an entry gate of `ratio >= 0.5`. The `min()` saturates at `ratio >= 0.40`, so **every match that reaches the branch is already at the ceiling**.

Measured on a live store (read-only snapshot, 6,355 nodes), positive heuristic pairs on injected whispers:

| match | pairs | share |
|---|---|---|
| `token_overlap` | 1,587 | 97.4% |
| `node_id` | 29 | 1.8% |
| `sentence` | 13 | 0.8% |
| `title` | 0 | 0% |

`overlap_ratio` across those 1,587 rows ranges **0.50 to 7.583** (mean 1.452, median 1.167, with 38% at ≥ 1.50) — and all 1,587 report exactly `0.85`. Three distinct strength values across the whole positive heuristic channel.

## The design decision to review

**`strength` becomes the strength of the evidence backing a row's polarity, on a single ordinal scale, comparable in rank across channels.** It is explicitly *not* a calibrated probability, and the module docstring says so.

The load-bearing assertion — and the thing worth attacking first — is that **the channel dominates within-channel confidence**. A verbatim match outranks any LLM judgment however confident; an LLM judgment outranks any agent self-report. This is #218's own argument (*"a judge reading the finished response is stronger evidence than a model's in-flight claim about its own retrieval"*) carried to its conclusion. Bands are therefore disjoint per channel:

| band | channel | mapping |
|---|---|---|
| `1.00` | `explicit` | constant |
| `0.98` | heuristic `node_id` | constant |
| `0.94` | heuristic `title` | constant |
| `0.92` | heuristic `sentence` | constant |
| `0.82–0.90` | `auto_llm_judge` | affine over `[min_confidence, 1.0]` |
| `0.80` | `implicit` | constant |
| `0.40–0.78` | heuristic `token_overlap` | asymptotic in `overlap_ratio` |
| `0.00` | any row with `polarity = 0` | convention |

If you reject that ordering rule, the design collapses back to per-source thresholds — so it is the one premise to push on.

Two notes on the mapping:

- **`token_overlap` is asymptotic, not clamped.** `overlap_ratio = len(overlap) / min(len(candidate_tokens), 12)` is unbounded above, so any linear map needs an arbitrary clamp and every clamp recreates the saturation defect. A clamp at 1.50 would tie 38% of observed rows. `0.40 + 0.38·(1 − e^−(r−0.5))` gives variance across the whole domain; the supremum 0.78 sits below `implicit = 0.80` by construction. On real data this takes the channel from **3 distinct values to 59** — injective over the 57 distinct stored ratios.
- **`polarity = 0` stores `0.00`.** The judge previously wrote its confidence on rows that assert nothing. Its raw confidence still lives in `signals.evidence`. This is safe because the judge assigns non-zero polarity only when `confidence >= min_confidence`, so no scoring row can fall below its band floor.

## Backfill

Historical rows would otherwise keep pre-ladder values, and the 1,587 `token_overlap` rows pinned at `0.85` land **inside the new judge band** — the column would go on lying, now about which channel produced the row.

The recompute is exact, not estimated: no `signals` row in the measured store lacks `evidence`, heuristic rows carry `match` and `overlap_ratio`, and judge rows carry the `min_confidence` in force **when they were written**, so a row normalises to what it would have stored had the ladder existed then. Only `strength` is written; `evidence` and `polarity` are untouched, which makes a later ladder revision re-runnable from the same source.

## What no reader means

`signals.strength` has **no readers**. A sweep of `src/`, `ui/`, `schema.sql` and `db.py` finds only write paths and unrelated homonyms (`belief strength` in `tool_schemas.py`, a force-simulation local in `GraphView.tsx`). This PR therefore produces **no observable behaviour change**, and `tests/test_engine/test_confirmed_use_contract.py` staying green is the intended proof. If you find a reader I missed, that invalidates the risk assessment.

## Review history

Two adversarial review rounds ran before this PR, and both found real defects:

1. A one-time migration stamp could not repair rows an older binary writes *after* the stamp — a rollback then re-upgrade, or the second unmanaged server process this project already documents. The migration now runs at every startup, bounded by a cutoff on `signals.id`. Rescanning is a repair rather than a drift only because `strength_from_evidence` is pure and every write site stores exactly what it returns: recomputing over all 5,354 rows of a real store changes **0** rows.
2. Fixing (1) surfaced a second issue: `json.loads` accepts bare `NaN`/`Infinity` and returns an unbounded `int` for a large integer literal, `float()` of which raises `OverflowError` rather than `ValueError`. SQLite stores a NaN REAL as NULL and `signals.strength` is `NOT NULL` — so with an every-boot migration, one malformed historical row would stop the server from **ever** starting again. `_as_float` now catches `OverflowError` and rejects non-finite results.

A third defect was found in between: the detector computed `token_overlap` strength from the full-precision ratio while recording `round(ratio, 3)` in `evidence`, so the migration's own recompute disagreed with what the write site stored (`0.45833694` vs `0.45844415`). It now rounds once and uses that value for both. **The admission gate still reads the raw ratio**, so which responses count as referenced is deliberately unchanged.

## Testing

39+12 = 51 new tests. Local baseline on an untouched `upstream/main` checkout is **1948 passed, 4 failed**; with this branch, **2003 passed, the same 4 failed**. Those 4 are pre-existing and unrelated to this change — three in `tests/test_setup.py::TestConfigureCodexMcp` (the test patches `shutil.which`, but `_find_binary` falls past it to hardcoded paths including `/opt/homebrew/bin/codex`, which exists on my machine) and one `test_detect_returns_none_for_home` artifact of running with an isolated `HOME`. Both look worth their own issue; neither is touched here.

`ruff check src/ tests/` is clean.

## Out of scope

Admitting `auto_heuristic` into `_CONFIRMED_USE_SOURCES`, calling `_claim_confirmed_use` from the heuristic commit block, and the judge suppression at `if llm_judge_enabled and not has_llm_judge and not referenced`. Those are **#272**, which this PR unblocks — the #220 design deferred `auto_heuristic` admission explicitly "until #218 provides signal calibration", and Contract 9 still pins the exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
