### PR TITLE
fix(feedback): the heuristic detector claims confirmed use (#272)

### DIFF
--- a/src/ormah/api/routes_admin.py
+++ b/src/ormah/api/routes_admin.py
@@ -28,6 +28,7 @@ _TASK_RUNNERS = {
     "memory_backup": ("ormah.backup", "run_auto_backup"),
     "cloud_backup": ("ormah.cloud.jobs", "run_cloud_backup"),
     "restore_verification": ("ormah.cloud.jobs", "run_restore_verification"),
+    "reinforcement_retry": ("ormah.background.reinforcement_retry", "run_reinforcement_retry"),
 }
 
 _TASK_DESCRIPTIONS = {
@@ -43,6 +44,7 @@ _TASK_DESCRIPTIONS = {
     "memory_backup": "Creates a local backup of memory source files when one is due.",
     "cloud_backup": "Encrypts and uploads a due cloud backup without changing the sync head.",
     "restore_verification": "Downloads, decrypts, rebuilds, and searches the latest cloud backup.",
+    "reinforcement_retry": "Re-applies confirmed-use reinforcements whose claim committed but whose write never landed.",
 }
 
 # Order for sleep cycle (full maintenance pass)
@@ -55,6 +57,7 @@ _SLEEP_CYCLE_ORDER = [
     "auto_cluster",
     "consolidator",
     "decay_manager",
+    "reinforcement_retry",
     "memory_backup",
 ]
 

--- a/src/ormah/background/reinforcement_retry.py
+++ b/src/ormah/background/reinforcement_retry.py
@@ -1,0 +1,100 @@
+"""Retry confirmed-use reinforcements whose claim committed but never landed (#272).
+
+_claim_confirmed_use takes a monotonic latch inside the caller's transaction, and
+_record_confirmed_use runs after that transaction commits with its exception isolated.
+Before #272 a transient failure there was permanent: the claim was taken, so nothing
+retried. The claim now carries a state, and this job sweeps the rows still 'pending'.
+
+'legacy_unknown' (written before the state column existed, or by a binary that predates
+it) and 'orphaned' (the node is gone) are terminal and never swept.
+
+Each attempt stamps last_attempt_at, and an attempted row is ineligible until the
+backoff expires. That is what stops a wall of permanently-failing claims from filling
+every batch and starving every newer claim.
+
+Not LLM-gated, so it keeps working under ORMAH_LLM_PROVIDER=none.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# A claim taken seconds ago may still have its reinforcement in flight — the mutator
+# runs after the claiming transaction commits. Matches the interval
+# session_watcher_reconcile_interval_minutes uses for the equivalent reason.
+_GRACE_MINUTES = 5
+
+# Deliberately smaller than whisper_log_cleanup_batch_size (1000): every row here does
+# file I/O under the memory lock, while that job is pure SQL.
+_BATCH_SIZE = 200
+
+# How long an attempted-and-still-pending claim steps out of the eligible set.
+#
+# Without this the job starves: `ORDER BY claimed_at ASC LIMIT _BATCH_SIZE` with no
+# record of attempts lets _BATCH_SIZE permanently-failing claims fill every batch
+# forever, so a claim taken today is never tried once. Per-row exception isolation
+# does not help — it saves the rest of THIS batch, and the next run selects the same
+# rows. Deliberately longer than the hourly interval so a broken row is retried at
+# most once per couple of runs rather than every run.
+_RETRY_BACKOFF_MINUTES = 180
+
+
+def run_reinforcement_retry(engine) -> None:
+    """Re-apply reinforcements for claims left unapplied."""
+    try:
+        rows = engine.db.conn.execute(
+            """
+            SELECT whisper_log_id, node_id
+            FROM confirmed_use_claims
+            WHERE state = 'pending'
+              AND claimed_at < datetime('now', ?)
+              AND (last_attempt_at IS NULL OR last_attempt_at < datetime('now', ?))
+            ORDER BY COALESCE(last_attempt_at, claimed_at) ASC
+            LIMIT ?
+            """,
+            (
+                f"-{_GRACE_MINUTES} minutes",
+                f"-{_RETRY_BACKOFF_MINUTES} minutes",
+                _BATCH_SIZE,
+            ),
+        ).fetchall()
+
+        if not rows:
+            return
+
+        # Stamped BEFORE the loop, in its own committed transaction, for two reasons.
+        # A row whose reinforcement raises would otherwise never record the attempt —
+        # the mutator rolls its own transaction back — and a process killed mid-batch
+        # would leave no trace either. Both cases would reopen the starvation this
+        # column exists to close. Marking a row that then succeeds costs nothing: it
+        # leaves 'pending' only if it failed, and success makes it terminal anyway.
+        with engine.db.transaction() as conn:
+            conn.executemany(
+                "UPDATE confirmed_use_claims SET last_attempt_at = datetime('now') "
+                "WHERE whisper_log_id = ? AND node_id = ?",
+                [(r["whisper_log_id"], r["node_id"]) for r in rows],
+            )
+
+        repaired = 0
+        for row in rows:
+            # Isolated per row: one unreadable node must not abandon the rest of the
+            # batch, exactly as the call sites isolate their own reinforcement.
+            try:
+                engine._record_confirmed_use(
+                    row["node_id"], whisper_log_id=row["whisper_log_id"]
+                )
+                repaired += 1
+            except Exception:
+                logger.exception(
+                    "reinforcement retry failed for node %s (whisper_log %s)",
+                    row["node_id"],
+                    row["whisper_log_id"],
+                )
+
+        logger.info(
+            "Reinforcement retry: %d/%d claims repaired", repaired, len(rows)
+        )
+    except Exception:
+        logger.exception("Reinforcement retry job failed")

--- a/src/ormah/background/scheduler.py
+++ b/src/ormah/background/scheduler.py
@@ -157,6 +157,17 @@ def start_scheduler(engine: MemoryEngine) -> tuple[BackgroundScheduler, JobTrack
         misfire_grace_time=_MISFIRE_GRACE,
     )
 
+    from ormah.background.reinforcement_retry import run_reinforcement_retry
+
+    scheduler.add_job(
+        tracked(tracker, "reinforcement_retry", run_reinforcement_retry, engine),
+        "interval",
+        minutes=s.reinforcement_retry_interval_minutes,
+        id="reinforcement_retry",
+        name="Reinforcement retry",
+        misfire_grace_time=_MISFIRE_GRACE,
+    )
+
     scheduler.start()
     logger.info("Background scheduler started with %d jobs", len(scheduler.get_jobs()))
     return scheduler, tracker

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -606,6 +606,7 @@ def _record_whisper_usage_signals(
                 row["node_id"],
                 signal=record["polarity"],
                 source=_LLM_JUDGE_AFFINITY_SOURCE,
+                strength=record["strength"],
             ):
                 confirmed_node_ids.append(row["node_id"])
 

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -17,7 +17,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from ormah import signal_strength
-from ormah.engine.memory_engine import MemoryEngine
+from ormah.engine.memory_engine import HEURISTIC_CONFIRM_FLOOR, MemoryEngine
 from ormah.text.tokens import distinctive_tokens
 from ormah.transcript.parser import (
     TranscriptResult,
@@ -449,7 +449,12 @@ def _record_whisper_usage_signals(
                 SELECT 1 FROM signals s
                 WHERE s.whisper_log_id = wl.id
                   AND s.source = ?
-            ) AS has_llm_judge
+            ) AS has_llm_judge,
+            EXISTS (
+                SELECT 1 FROM confirmed_use_claims c
+                WHERE c.whisper_log_id = wl.id
+                  AND c.node_id = wl.node_id
+            ) AS already_confirmed
         FROM whisper_log wl
         LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id
         JOIN nodes n ON n.id = wl.node_id
@@ -483,11 +488,15 @@ def _record_whisper_usage_signals(
         has_heuristic = heuristic_polarity is not None
         has_llm_judge = bool(row["has_llm_judge"])
 
-        referenced = False
+        confirms = False
         if not has_heuristic:
             referenced, strength, evidence = _node_usage_evidence(row, response)
             signal_type = "whisper_referenced" if referenced else "whisper_unreferenced"
             polarity = 1 if referenced else 0
+            # Issue #272: whether THIS hit will take the claim in the transaction below.
+            # Not the same question as `referenced`: a token_overlap hit is referenced
+            # but sits under the floor, so it confirms nothing.
+            confirms = referenced and strength >= HEURISTIC_CONFIRM_FLOOR
             heuristic_records.append({
                 "row": row,
                 "signal_type": signal_type,
@@ -499,10 +508,17 @@ def _record_whisper_usage_signals(
                     "response_chars": len(response),
                 },
             })
-        else:
-            referenced = int(heuristic_polarity) == 1
 
-        if llm_judge_enabled and not has_llm_judge and not referenced:
+        # Issue #272: suppress the judge only for an event that is already settled —
+        # not for any heuristic sighting. A below-floor hit keeps the judge, which is
+        # the only route left that can still confirm it.
+        #
+        # already_confirmed covers the two cases `confirms` cannot: a re-ingest, where
+        # the strength is not in scope at all, and a positive submit_feedback through
+        # MCP, which has_llm_judge is structurally blind to because it only sees this
+        # watcher's own signal source (#220 contract 13a).
+        settled = confirms or bool(row["already_confirmed"])
+        if llm_judge_enabled and not has_llm_judge and not settled:
             llm_groups.setdefault((prompt_text, response), []).append(row)
 
     heuristic_confirmed_ids: list[str] = []
@@ -627,6 +643,35 @@ def _record_whisper_usage_signals(
                     signal=record["polarity"],
                     source=_LLM_JUDGE_AFFINITY_SOURCE,
                     confirmed_at=now_iso,
+                )
+                # Issue #272: affinity is keyed unique on (node_id, whisper_log_id) and
+                # _insert_affinity is ON CONFLICT DO NOTHING, so for an event the
+                # heuristic block already wrote a +1 for, the INSERT above is a no-op.
+                # Before this task that could not happen — a positive hit never reached
+                # the judge — but Step 4 is what sends weak hits here, so without this
+                # UPDATE an `irrelevant` verdict would be recorded in signals and
+                # silently ignored by retrieval, which would keep consuming the +1.
+                #
+                # Same shape _submit_feedback_locked uses for explicit feedback
+                # (memory_engine.py:2869-2877): INSERT ... DO NOTHING, then an UPDATE
+                # scoped by source. Scoped to auto_heuristic ONLY — the judge outranks
+                # the heuristic, and explicit feedback outranks the judge.
+                conn.execute(
+                    """
+                    UPDATE affinity
+                    SET signal = ?, source = ?, confirmed_at = ?
+                    WHERE node_id = ?
+                      AND whisper_log_id = ?
+                      AND source = ?
+                    """,
+                    (
+                        record["polarity"],
+                        _LLM_JUDGE_AFFINITY_SOURCE,
+                        now_iso,
+                        row["node_id"],
+                        row["id"],
+                        _HEURISTIC_AFFINITY_SOURCE,
+                    ),
                 )
             # Issue #220: the same at-most-once claim submit_feedback takes, not a
             # parallel polarity check. has_llm_judge only sees this watcher's own

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -550,7 +550,9 @@ def _record_whisper_usage_signals(
                 "row": row,
                 "signal_type": signal_type,
                 "polarity": polarity,
-                "strength": confidence,
+                "strength": signal_strength.judge_strength(
+                    confidence, min_confidence, polarity
+                ),
                 "evidence": {
                     "detector": _LLM_JUDGE_SOURCE,
                     "verdict": verdict,

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -148,10 +148,16 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
     denominator = min(len(candidate_tokens), 12)
     overlap_ratio = (len(overlap) / denominator) if denominator else 0.0
     if len(overlap) >= 4 and overlap_ratio >= signal_strength.OVERLAP_GATE:
-        return True, signal_strength.token_overlap_strength(overlap_ratio), {
+        # Round ONCE, then use that same value for both the strength and the evidence.
+        # The #218 backfill recomputes strength from evidence, so a strength derived
+        # from a more precise ratio than the one recorded makes the recompute perturb
+        # a correct row instead of confirming it. The gate above still reads the raw
+        # ratio, so which responses count as referenced is unchanged.
+        recorded_ratio = round(overlap_ratio, 3)
+        return True, signal_strength.token_overlap_strength(recorded_ratio), {
             "match": "token_overlap",
             "overlap": overlap[:12],
-            "overlap_ratio": round(overlap_ratio, 3),
+            "overlap_ratio": recorded_ratio,
         }
 
     return False, 0.0, {

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -16,6 +16,7 @@ from threading import Event, Lock, Thread, Timer
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
+from ormah import signal_strength
 from ormah.engine.memory_engine import MemoryEngine
 from ormah.text.tokens import distinctive_tokens
 from ormah.transcript.parser import (
@@ -37,8 +38,8 @@ class IngestResult(Enum):
 
 _STATE_FILENAME = ".session_watcher_state"
 MAX_RECONCILE_RETRIES = 3
-_HEURISTIC_SOURCE = "transcript_watcher_heuristic"
-_LLM_JUDGE_SOURCE = "transcript_watcher_llm_judge"
+_HEURISTIC_SOURCE = signal_strength.HEURISTIC_SOURCE
+_LLM_JUDGE_SOURCE = signal_strength.LLM_JUDGE_SOURCE
 _HEURISTIC_AFFINITY_SOURCE = "auto_heuristic"
 _LLM_JUDGE_AFFINITY_SOURCE = "auto_llm_judge"
 _FENCE_RE = re.compile(r"```(?:json)?\s*\n(.*?)```", re.DOTALL)
@@ -116,13 +117,13 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
     node_id = row["node_id"]
     short_id = node_id[:8] if node_id else ""
     if short_id and short_id.lower() in response_text.lower():
-        return True, 1.0, {"match": "node_id", "short_id": short_id}
+        return True, signal_strength.VERBATIM_NODE_ID, {"match": "node_id", "short_id": short_id}
 
     title = row["title"] or ""
     title_tokens = distinctive_tokens(title, extra_stop_words={"memory", "ormah"})
     title_norm = _normalise_text(title)
     if len(title_tokens) >= 2 and len(title_norm) >= 12 and title_norm in response_norm:
-        return True, 0.95, {"match": "title", "title": title}
+        return True, signal_strength.VERBATIM_TITLE, {"match": "title", "title": title}
 
     content = row["content"] or ""
     for sentence in re.split(r"[\n.!?]+", content):
@@ -132,7 +133,10 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
         sentence_tokens = distinctive_tokens(sentence, extra_stop_words={"memory", "ormah"})
         sentence_norm = _normalise_text(sentence)
         if len(sentence_tokens) >= 4 and sentence_norm in response_norm:
-            return True, 0.9, {"match": "sentence", "text": sentence[:160]}
+            return True, signal_strength.VERBATIM_SENTENCE, {
+                "match": "sentence",
+                "text": sentence[:160],
+            }
 
     node_tokens = distinctive_tokens(
         f"{title} {content}",
@@ -143,8 +147,8 @@ def _node_usage_evidence(row, response_text: str) -> tuple[bool, float, dict]:
     overlap = sorted(candidate_tokens & response_tokens)
     denominator = min(len(candidate_tokens), 12)
     overlap_ratio = (len(overlap) / denominator) if denominator else 0.0
-    if len(overlap) >= 4 and overlap_ratio >= 0.5:
-        return True, min(0.85, 0.45 + overlap_ratio), {
+    if len(overlap) >= 4 and overlap_ratio >= signal_strength.OVERLAP_GATE:
+        return True, signal_strength.token_overlap_strength(overlap_ratio), {
             "match": "token_overlap",
             "overlap": overlap[:12],
             "overlap_ratio": round(overlap_ratio, 3),

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -505,6 +505,7 @@ def _record_whisper_usage_signals(
         if llm_judge_enabled and not has_llm_judge and not referenced:
             llm_groups.setdefault((prompt_text, response), []).append(row)
 
+    heuristic_confirmed_ids: list[str] = []
     with engine.db.transaction() as conn:
         for record in heuristic_records:
             row = record["row"]
@@ -527,6 +528,40 @@ def _record_whisper_usage_signals(
                     source=_HEURISTIC_AFFINITY_SOURCE,
                     confirmed_at=now_iso,
                 )
+                # Issue #272: the same at-most-once claim the judge block takes. The
+                # engine gates it on HEURISTIC_CONFIRM_FLOOR, so a token_overlap hit
+                # records its evidence here and confirms nothing.
+                #
+                # _insert_affinity MUST stay above this call: the claim helper reads
+                # changes(), so nothing may sit between its INSERT and that read.
+                if engine._claim_confirmed_use(
+                    conn,
+                    row["id"],
+                    row["node_id"],
+                    signal=1,
+                    source=_HEURISTIC_AFFINITY_SOURCE,
+                    strength=record["strength"],
+                ):
+                    heuristic_confirmed_ids.append(row["node_id"])
+
+    # Issue #272: reinforcement runs after the transaction commits — _record_confirmed_use
+    # does file I/O, and calling it inside would hold the process-wide write lock across
+    # N markdown saves and take db_lock before memory_lock, inverting the order every
+    # serialized writer uses.
+    #
+    # This is deliberately NOT the judge's loop below: the `if not llm_groups: return`
+    # that follows means the judge's loop never runs when there is nothing to judge —
+    # which, since a confirming heuristic hit now suppresses the judge, is exactly the
+    # case this loop exists for.
+    #
+    # Isolated per node: the signals and claims are already committed, so letting one
+    # failure escape would abandon every later node with its claim taken and nothing to
+    # retry it. At-most-once means a miss is logged, never raised.
+    for node_id in heuristic_confirmed_ids:
+        try:
+            engine._record_confirmed_use(node_id)
+        except Exception:
+            logger.exception("confirmed-use reinforcement failed for node %s", node_id)
 
     if not llm_groups:
         return recorded

--- a/src/ormah/background/session_watcher.py
+++ b/src/ormah/background/session_watcher.py
@@ -521,7 +521,7 @@ def _record_whisper_usage_signals(
         if llm_judge_enabled and not has_llm_judge and not settled:
             llm_groups.setdefault((prompt_text, response), []).append(row)
 
-    heuristic_confirmed_ids: list[str] = []
+    heuristic_confirmed_ids: list[tuple[int, str]] = []
     with engine.db.transaction() as conn:
         for record in heuristic_records:
             row = record["row"]
@@ -558,7 +558,7 @@ def _record_whisper_usage_signals(
                     source=_HEURISTIC_AFFINITY_SOURCE,
                     strength=record["strength"],
                 ):
-                    heuristic_confirmed_ids.append(row["node_id"])
+                    heuristic_confirmed_ids.append((row["id"], row["node_id"]))
 
     # Issue #272: reinforcement runs after the transaction commits — _record_confirmed_use
     # does file I/O, and calling it inside would hold the process-wide write lock across
@@ -573,9 +573,9 @@ def _record_whisper_usage_signals(
     # Isolated per node: the signals and claims are already committed, so letting one
     # failure escape would abandon every later node with its claim taken and nothing to
     # retry it. At-most-once means a miss is logged, never raised.
-    for node_id in heuristic_confirmed_ids:
+    for whisper_log_id, node_id in heuristic_confirmed_ids:
         try:
-            engine._record_confirmed_use(node_id)
+            engine._record_confirmed_use(node_id, whisper_log_id=whisper_log_id)
         except Exception:
             logger.exception("confirmed-use reinforcement failed for node %s", node_id)
 
@@ -621,7 +621,7 @@ def _record_whisper_usage_signals(
                 },
             })
 
-    confirmed_node_ids: list[str] = []
+    confirmed_node_ids: list[tuple[int, str]] = []
     with engine.db.transaction() as conn:
         for record in judge_records:
             row = record["row"]
@@ -688,7 +688,7 @@ def _record_whisper_usage_signals(
                 source=_LLM_JUDGE_AFFINITY_SOURCE,
                 strength=record["strength"],
             ):
-                confirmed_node_ids.append(row["node_id"])
+                confirmed_node_ids.append((row["id"], row["node_id"]))
 
     # Issue #220: reinforcement runs after the transaction commits. db.transaction()
     # holds a process-level lock for its whole body and _record_confirmed_use writes
@@ -701,9 +701,9 @@ def _record_whisper_usage_signals(
     # node, and leave both has_llm_judge set and the claims taken — nothing would ever
     # retry them. Failures here are logged, never raised. This is the at-most-once
     # contract.
-    for node_id in confirmed_node_ids:
+    for whisper_log_id, node_id in confirmed_node_ids:
         try:
-            engine._record_confirmed_use(node_id)
+            engine._record_confirmed_use(node_id, whisper_log_id=whisper_log_id)
         except Exception:
             logger.exception("confirmed-use reinforcement failed for node %s", node_id)
 

--- a/src/ormah/config.py
+++ b/src/ormah/config.py
@@ -65,6 +65,7 @@ class Settings(BaseSettings):
     conflict_check_all_spaces: bool = False
     duplicate_check_interval_minutes: int = 1440
     auto_cluster_interval_minutes: int = 60
+    reinforcement_retry_interval_minutes: int = 60
 
     # Hippocampus (file watching & auto-ingestion)
     hippocampus_watch_dirs: list[Path] = []
@@ -378,6 +379,7 @@ class Settings(BaseSettings):
         "conflict_check_interval_minutes",
         "duplicate_check_interval_minutes",
         "auto_cluster_interval_minutes",
+        "reinforcement_retry_interval_minutes",
     )
     @classmethod
     def _interval_minutes_positive(cls, v: int) -> int:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from ormah import lifecycle
+from ormah import signal_strength
 from ormah.config import Settings
 from ormah.embeddings.text import embedding_text as _embedding_text
 from ormah.engine.context_builder import ContextBuilder
@@ -2800,7 +2801,7 @@ class MemoryEngine:
                     resolved_node_id,
                     "feedback_submitted",
                     signal,
-                    1.0,
+                    signal_strength.feedback_strength(source, signal),
                     source,
                     session_id,
                     "submit_feedback",

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2273,8 +2273,8 @@ class MemoryEngine:
         exists in _seed_stability_from_access_count, _migrate_identity_tiers,
         and _ensure_self_node, but all three run only from startup() before the
         server serves, so the two orders never interleave today. Invariant this
-        depends on: never call file_store inside db.transaction() outside
-        startup().
+        depends on: never call file_store inside db.transaction() unless the
+        memory lock is already held.
 
         Issue #272: the claim's outcome commits with this write, so a reinforcement
         that never landed stays visible as state = 'pending' and
@@ -2390,12 +2390,19 @@ class MemoryEngine:
 
             access_count = row["access_count"] + 1
 
+            # Final review I1: an out-of-order sweep (an older claim applied after a
+            # newer one already moved last_accessed forward) must not walk the decay
+            # anchor backwards. now stays claimed_at everywhere above — the FSRS clock
+            # is untouched — but the value actually WRITTEN as last_accessed is clamped
+            # to never go earlier than what the row already holds.
+            new_last_accessed = max(now, last_accessed) if last_accessed is not None else now
+
             conn.execute(
                 "UPDATE nodes SET access_count = ?, last_accessed = ?, stability = ?, "
                 "last_review = ? WHERE id = ?",
                 (
                     access_count,
-                    now.isoformat(),
+                    new_last_accessed.isoformat(),
                     stability,
                     last_review.isoformat() if last_review else None,
                     node_id,
@@ -2405,7 +2412,7 @@ class MemoryEngine:
             # The markdown is the projection: it is set to the computed values, never
             # incremented from whatever it happened to hold.
             node.access_count = access_count
-            node.last_accessed = now
+            node.last_accessed = new_last_accessed
             node.stability = stability
             node.last_review = last_review
             self.file_store.save(node)

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -72,6 +72,10 @@ LIFECYCLE_MODEL_VERSION = 2
 # values or mappings change, so a stamped store recomputes from its evidence.
 SIGNAL_STRENGTH_LADDER_VERSION = 1
 
+# Backfill version for the #272 heuristic confirmed-use repair. Bump to force a full
+# re-scan when the floor or the selection changes.
+HEURISTIC_CONFIRMED_USE_VERSION = 1
+
 
 def _generate_title(content: str, max_chars: int = 60) -> str:
     """Generate a short title from the first line/sentence of content."""
@@ -172,6 +176,11 @@ class MemoryEngine:
         # One-time FSRS data migration: seed stability from access patterns
         self._migrate_fsrs()
         self._migrate_signal_strength()
+        # Defence in depth, NOT the safety mechanism: eligibility is recomputed from each
+        # row's own evidence, so a stale DEFAULT-1.0 strength cannot claim whatever the
+        # order. The two migrations commit separately, so ordering never closed that
+        # window on its own anyway (#272).
+        self._migrate_heuristic_confirmed_use()
 
         self._ensure_self_node()
         self._migrate_identity_tiers()
@@ -263,6 +272,127 @@ class MemoryEngine:
                 len(rows),
                 lower_bound,
                 SIGNAL_STRENGTH_LADDER_VERSION,
+            )
+
+    def _migrate_heuristic_confirmed_use(self) -> None:
+        """Claim and reinforce heuristic rows the pre-#272 code left unclaimed.
+
+        The heuristic detector recorded positive signals for years without ever taking
+        a confirmed-use claim, because only the judge block called the helper. Those
+        rows are evidence of real use that never reached the lifecycle. This repairs
+        the ones whose evidence clears HEURISTIC_CONFIRM_FLOOR.
+
+        Eligibility is recomputed from each row's own evidence with
+        strength_from_evidence, and never read from signals.strength. That column
+        defaults to 1.0 -- above the floor -- and _migrate_signal_strength commits in a
+        SEPARATE transaction, so an old binary (#238) can write a stale 1.0 row in the
+        window between the two; ordering alone would not stop this from claiming it. The
+        recompute is a pure function of stored evidence and fail-closed (an unknown or
+        malformed match returns UNKNOWN, 0.40), so the stored column cannot mislead it.
+        Running after _migrate_signal_strength stays correct, as defence in depth.
+
+        Rescans on every boot rather than stamping once, for the reason
+        _migrate_signal_strength documents: an old binary -- a rollback, or the second
+        unmanaged process of #238 -- can write pre-fix rows AFTER a one-time stamp, and
+        they would stay unclaimed forever on a table the stamp calls migrated.
+
+        The claims are taken inside one transaction and the reinforcement runs after it
+        commits: _record_confirmed_use does file I/O, so calling it inside would hold
+        the process-wide write lock across N markdown saves and take db_lock before
+        memory_lock, inverting the order every serialized writer uses (#220 4.3).
+        """
+        version = self._meta_int("heuristic_confirmed_use_version")
+        lower_bound = (
+            self._meta_int("heuristic_confirmed_use_cutoff")
+            if version >= HEURISTIC_CONFIRMED_USE_VERSION
+            else 0
+        )
+
+        confirmed_node_ids: list[str] = []
+        with self.db.transaction() as conn:
+            # EVERY eligibility test is applied in Python, and the SELECT filters only on
+            # source and the cutoff. Council round 1 (Codex, MEDIUM) caught the earlier
+            # shape: any predicate in the WHERE hides those rows' ids from the loop, so
+            # processed_max stalls behind them and every boot rescans a growing tail —
+            # and on a store whose newest heuristic rows are all polarity 0, non-injected,
+            # or below the floor, the cutoff never advances at all.
+            # LEFT JOIN, not INNER. Council round 3 (Codex, MEDIUM): signals.whisper_log_id
+            # is nullable and declared ON DELETE SET NULL, so whisper_log_cleanup orphans
+            # rows routinely. An INNER JOIN drops those ids before the loop sees them —
+            # the same cutoff stall in a third disguise. Missing provenance is ineligible,
+            # but it is ineligible IN PYTHON, after its id has advanced the high-water mark.
+            rows = conn.execute(
+                """
+                SELECT s.id, s.whisper_log_id, s.node_id, s.polarity, s.evidence,
+                       wl.was_injected, wl.node_id AS event_node_id
+                FROM signals s
+                LEFT JOIN whisper_log wl ON wl.id = s.whisper_log_id
+                WHERE s.id > ?
+                  AND s.source = ?
+                ORDER BY s.id ASC
+                """,
+                (lower_bound, signal_strength.HEURISTIC_SOURCE),
+            ).fetchall()
+            processed_max = lower_bound
+            for row in rows:
+                # Council round 1 (Codex, HIGH): the claim helper inserts the node id it is
+                # GIVEN, checking only that the event was injected — it never asserts the
+                # node belongs to the event. The live path is safe because its query reads
+                # both ids from the same whisper_log row, but here they come from different
+                # tables, so a legacy or hand-repaired signal could reinforce a node the
+                # agent never saw for this event. Checked explicitly.
+                # Recomputed, never read from signals.strength. That column defaults to
+                # 1.0 -- above the floor -- and the ladder migration commits in a separate
+                # transaction, so a stale row written in the window between the two would
+                # otherwise take an irreversible claim. Pure function of stored evidence,
+                # fail-closed: an unknown or malformed match returns UNKNOWN (0.40).
+                strength = signal_strength.strength_from_evidence(
+                    signal_strength.HEURISTIC_SOURCE,
+                    row["polarity"],
+                    row["evidence"],
+                )
+                eligible = (
+                    row["whisper_log_id"] is not None
+                    and row["event_node_id"] is not None  # LEFT JOIN found no parent row
+                    and row["polarity"] == 1
+                    and row["was_injected"] == 1
+                    and row["node_id"] == row["event_node_id"]
+                    and strength >= HEURISTIC_CONFIRM_FLOOR
+                )
+                if eligible and self._claim_confirmed_use(
+                    conn,
+                    row["whisper_log_id"],
+                    row["node_id"],
+                    signal=1,
+                    source="auto_heuristic",
+                    strength=strength,
+                ):
+                    confirmed_node_ids.append(row["node_id"])
+                processed_max = max(processed_max, row["id"])
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                "('heuristic_confirmed_use_version', ?)",
+                (str(HEURISTIC_CONFIRMED_USE_VERSION),),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                "('heuristic_confirmed_use_cutoff', ?)",
+                (str(processed_max),),
+            )
+
+        # Isolated per node: the claims are committed, so letting one failure escape
+        # would abandon every later node with its claim taken and nothing to retry it.
+        for node_id in confirmed_node_ids:
+            try:
+                self._record_confirmed_use(node_id)
+            except Exception:
+                logger.exception("confirmed-use backfill failed for node %s", node_id)
+
+        if confirmed_node_ids:
+            logger.info(
+                "Backfilled confirmed use on %d heuristic events above id %d (#272)",
+                len(confirmed_node_ids),
+                lower_bound,
             )
 
     def _migrate_fsrs(self) -> None:

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -366,6 +366,7 @@ class MemoryEngine:
                     signal=1,
                     source="auto_heuristic",
                     strength=strength,
+                    historical=True,
                 ):
                     confirmed_node_ids.append((row["whisper_log_id"], row["node_id"]))
                 processed_max = max(processed_max, row["id"])
@@ -2962,6 +2963,7 @@ class MemoryEngine:
         signal: int,
         source: str,
         strength: float,
+        historical: bool = False,
     ) -> bool:
         """Take the at-most-once confirmed-use claim for one (event, node) pair.
 
@@ -3012,15 +3014,31 @@ class MemoryEngine:
         # the CALLER is wrong, and dropping the claim would hide that instead of failing.
         if source == "auto_heuristic" and strength < HEURISTIC_CONFIRM_FLOOR:
             return False
+        # Issue #272 (council finding 1): a backfilled claim carries the EVENT's
+        # clock, not the boot's — claimed_at drives last_accessed, last_review and
+        # FSRS in _record_confirmed_use, so stamping datetime('now') would credit
+        # 2-13 day old uses with recency they never earned. The truthful timestamp
+        # comes from the very whisper_log row this INSERT already reads, and SQLite's
+        # datetime() normalizes its Python-isoformat shape ('...T...+00:00') to the
+        # same space-format UTC datetime('now') writes — the sweeper compares
+        # claimed_at lexicographically (reinforcement_retry.py), so mixed shapes
+        # would misorder. COALESCE: a malformed logged_at (datetime() -> NULL) falls
+        # back to the boot clock rather than aborting the whole backfill transaction
+        # (claimed_at is NOT NULL) or orphaning the signal forever (the cutoff
+        # advances regardless). Live claims keep datetime('now'): their skew is
+        # minutes, and their sources' semantics are not this fix's scope.
         conn.execute(
             """
             INSERT INTO confirmed_use_claims (whisper_log_id, node_id, claimed_at, state)
-            SELECT wl.id, ?, datetime('now'), 'pending'
+            SELECT wl.id, ?,
+                   CASE WHEN ? THEN COALESCE(datetime(wl.logged_at), datetime('now'))
+                        ELSE datetime('now') END,
+                   'pending'
             FROM whisper_log wl
             WHERE wl.id = ? AND wl.was_injected = 1
             ON CONFLICT DO NOTHING
             """,
-            (node_id, whisper_log_id),
+            (node_id, 1 if historical else 0, whisper_log_id),
         )
         return conn.execute("SELECT changes()").fetchone()[0] == 1
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -172,32 +172,60 @@ class MemoryEngine:
         self._warmup_embedder()
         self._warmup_reranker()
 
-    def _migrate_signal_strength(self) -> None:
-        """Recompute signals.strength onto the #218 ordinal evidence ladder.
-
-        Exact rather than estimated: every row carries the evidence its own channel
-        needs, and the judge stamps the min_confidence in force when the row was
-        written -- so a row recomputes to what it would have stored had the ladder
-        existed then, not to what today's settings would produce.
-
-        Re-runnable by construction: evidence is never written, so a later revision
-        of the ladder recomputes from the same untouched source. Only strength moves.
-
-        No file_store call, so this does not take db-lock before memory-lock and
-        stays outside the ordering hazard documented on _record_confirmed_use.
-        """
-        stamp = self.db.conn.execute(
-            "SELECT value FROM meta WHERE key = 'signal_strength_ladder_version'"
-        ).fetchone()
+    def _meta_int(self, key: str) -> int:
+        """Read an integer meta value, treating absent or unparseable as 0."""
+        row = self.db.conn.execute("SELECT value FROM meta WHERE key = ?", (key,)).fetchone()
         try:
-            version = int(stamp["value"]) if stamp else 0
+            return int(row["value"]) if row else 0
         except (TypeError, ValueError):
-            version = 0
-        if version >= SIGNAL_STRENGTH_LADDER_VERSION:
-            return
+            return 0
+
+    def _migrate_signal_strength(self) -> None:
+        """Normalise signals.strength onto the #218 ordinal evidence ladder.
+
+        Runs on every startup, not once. The first pass covers the whole table; every
+        later pass covers only rows that appeared since the previous one, tracked by a
+        cutoff on signals.id (AUTOINCREMENT, so ids are monotonic and never reused).
+
+        The rescan exists because a one-time stamp cannot repair what an OLD binary
+        writes AFTER the stamp is set -- a rollback then re-upgrade, or the second
+        unmanaged server process this project already knows about (#238). Those rows
+        would carry pre-ladder values forever on a table the stamp calls migrated, and
+        the column would silently mix incomparable scales.
+
+        Rescanning already-correct rows is safe because strength_from_evidence is a
+        pure function of (source, polarity, evidence) and every write site stores
+        exactly what it returns for what it recorded, so a row written by the current
+        code recomputes to itself. That property is what makes this a repair instead
+        of a drift, and it did not hold until evidence became a lossless record of the
+        overlap ratio.
+
+        The cutoff advances only to the highest id actually processed, never to
+        MAX(id): a row inserted between the SELECT and the stamp keeps an id above the
+        cutoff and is picked up on the next start rather than skipped.
+
+        Recompute is exact, not estimated: the judge stamps the min_confidence in
+        force when its row was written, so a row normalises to what it would have
+        stored had the ladder existed then, not to what today's settings would give.
+
+        No file_store call, so this does not take db-lock before memory-lock and stays
+        outside the ordering hazard documented on _record_confirmed_use.
+        """
+        version = self._meta_int("signal_strength_ladder_version")
+        # An unstamped store, or one stamped by a build that predates the cutoff, gets
+        # a full pass: 0 is the only lower bound that cannot skip a row.
+        lower_bound = (
+            self._meta_int("signal_strength_ladder_cutoff")
+            if version >= SIGNAL_STRENGTH_LADDER_VERSION
+            else 0
+        )
 
         with self.db.transaction() as conn:
-            rows = conn.execute("SELECT id, source, polarity, evidence FROM signals").fetchall()
+            rows = conn.execute(
+                "SELECT id, source, polarity, evidence FROM signals WHERE id > ?",
+                (lower_bound,),
+            ).fetchall()
+            processed_max = lower_bound
             for row in rows:
                 conn.execute(
                     "UPDATE signals SET strength = ? WHERE id = ?",
@@ -208,16 +236,24 @@ class MemoryEngine:
                         row["id"],
                     ),
                 )
+                processed_max = max(processed_max, row["id"])
             conn.execute(
                 "INSERT OR REPLACE INTO meta (key, value) VALUES "
                 "('signal_strength_ladder_version', ?)",
                 (str(SIGNAL_STRENGTH_LADDER_VERSION),),
             )
-        logger.info(
-            "Recomputed strength on %d signal rows (#218 ladder v%d)",
-            len(rows),
-            SIGNAL_STRENGTH_LADDER_VERSION,
-        )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                "('signal_strength_ladder_cutoff', ?)",
+                (str(processed_max),),
+            )
+        if rows:
+            logger.info(
+                "Normalised strength on %d signal rows above id %d (#218 ladder v%d)",
+                len(rows),
+                lower_bound,
+                SIGNAL_STRENGTH_LADDER_VERSION,
+            )
 
     def _migrate_fsrs(self) -> None:
         """Seed FSRS stability once, and record the store's lifecycle-model version."""

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2293,8 +2293,6 @@ class MemoryEngine:
         memory with recency it never earned. reinforced_at, not these fields,
         records when the write itself landed.
         """
-        node = self.file_store.load(node_id)
-
         # Issue #272: one transaction covers the claim's outcome, the nodes row and the
         # markdown write. Calling file_store inside db.transaction() is safe HERE and
         # nowhere else: @_serialized_memory_operation already holds
@@ -2307,6 +2305,12 @@ class MemoryEngine:
         # the counters come FROM the nodes row and the clock comes FROM claimed_at, so
         # a retry recomputes the SAME values and overwrites the phantom instead of
         # compounding it — one event, one increment, one stability step.
+        #
+        # The load also lives inside (council #272 finding 2): BEGIN IMMEDIATE can
+        # block up to busy_timeout between statements, and loading before the
+        # transaction reopened the load->save window this method had closed. A
+        # failed latch now returns before any file I/O. Cross-process, load and
+        # save remain non-atomic — that race predates this branch.
         with self.db.transaction() as conn:
             conn.execute(
                 "UPDATE confirmed_use_claims SET state = 'applied', "
@@ -2319,6 +2323,8 @@ class MemoryEngine:
                 # the same shape _claim_confirmed_use uses. Nothing may sit between the
                 # UPDATE and this read.
                 return
+
+            node = self.file_store.load(node_id)
 
             # reinforced_at records when the write ran; claimed_at is when the memory
             # was actually used, and that is the clock the lifecycle values use.

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -308,7 +308,7 @@ class MemoryEngine:
             else 0
         )
 
-        confirmed_node_ids: list[str] = []
+        confirmed_node_ids: list[tuple[int, str]] = []
         with self.db.transaction() as conn:
             # EVERY eligibility test is applied in Python, and the SELECT filters only on
             # source and the cutoff. Council round 1 (Codex, MEDIUM) caught the earlier
@@ -367,7 +367,7 @@ class MemoryEngine:
                     source="auto_heuristic",
                     strength=strength,
                 ):
-                    confirmed_node_ids.append(row["node_id"])
+                    confirmed_node_ids.append((row["whisper_log_id"], row["node_id"]))
                 processed_max = max(processed_max, row["id"])
             conn.execute(
                 "INSERT OR REPLACE INTO meta (key, value) VALUES "
@@ -382,9 +382,9 @@ class MemoryEngine:
 
         # Isolated per node: the claims are committed, so letting one failure escape
         # would abandon every later node with its claim taken and nothing to retry it.
-        for node_id in confirmed_node_ids:
+        for whisper_log_id, node_id in confirmed_node_ids:
             try:
-                self._record_confirmed_use(node_id)
+                self._record_confirmed_use(node_id, whisper_log_id=whisper_log_id)
             except Exception:
                 logger.exception("confirmed-use backfill failed for node %s", node_id)
 
@@ -990,7 +990,9 @@ class MemoryEngine:
             # lifecycle write. At-most-once means the claim stays taken and this
             # reinforcement is simply a logged miss; a retry would only log a second event.
             try:
-                self._record_confirmed_use(resolved_node_id)
+                self._record_confirmed_use(
+                    resolved_node_id, whisper_log_id=target_log_id
+                )
             except Exception:
                 logger.exception(
                     "confirmed-use reinforcement failed for node %s", resolved_node_id
@@ -2256,7 +2258,7 @@ class MemoryEngine:
             self.file_store.save(self_node)
 
     @_serialized_memory_operation
-    def _record_confirmed_use(self, node_id: str) -> None:
+    def _record_confirmed_use(self, node_id: str, *, whisper_log_id: int) -> None:
         """Record confirmed use, updating stability only when it is off cooldown.
 
         Serialized because the cooldown is a check-then-write pair (#221,
@@ -2273,53 +2275,140 @@ class MemoryEngine:
         server serves, so the two orders never interleave today. Invariant this
         depends on: never call file_store inside db.transaction() outside
         startup().
+
+        Issue #272: the claim's outcome commits with this write, so a reinforcement
+        that never landed stays visible as state = 'pending' and
+        run_reinforcement_retry repairs it. The retry is idempotent because the
+        target is a pure function of the claim: the counters come from the nodes
+        row rather than from the loaded markdown, and the clock comes from
+        claimed_at rather than from datetime.now(). os.replace cannot be rolled
+        back and COMMIT runs after this body, so a failed COMMIT can leave the file
+        one step ahead — recomputing the same values overwrites that phantom
+        instead of compounding it. The markdown is a projection of the lifecycle
+        state, not a second source of it.
+
+        claimed_at is also the truthful clock. last_accessed is the decay anchor,
+        and a sweep hours after the fact stamping datetime.now() would credit the
+        memory with recency it never earned. reinforced_at, not these fields,
+        records when the write itself landed.
         """
         node = self.file_store.load(node_id)
-        if node is None:
-            return
-        now = datetime.now(timezone.utc)
 
-        # One numeric stability update per node per cooldown window (#221): the
-        # old formula let ten same-session touches compound to ~57x. last_accessed
-        # below still advances on every call, and Task 4 repoints decay and
-        # importance at it, so a node in active use never reads as stale even
-        # though last_review now lags by up to one cooldown window.
-        if lifecycle.reinforcement_due(
-            node.last_review, now, self.settings.fsrs_reinforcement_cooldown_days
-        ):
-            # reinforcement cooldown can leave last_review a full window behind
-            # a use that already landed inside it (PR #239 review comment):
-            # last_accessed is the actual spacing signal, last_review only gates.
-            anchor = node.last_accessed or node.last_review
-            days_since = max((now - anchor).total_seconds() / 86400, 0.0)
-            node.stability = lifecycle.reinforced_stability(
-                node.stability,
-                days_since,
-                growth_factor=self.settings.fsrs_growth_factor,
-                growth_exponent=self.settings.fsrs_growth_exponent,
-                spacing_cap=self.settings.fsrs_spacing_cap,
-                max_stability=self.settings.fsrs_max_stability,
-                initial_stability=self.settings.fsrs_initial_stability,
-            )
-            node.last_review = now
-
-        # Standard access tracking
-        node.last_accessed = now
-        node.access_count += 1
-
-        self.file_store.save(node)
+        # Issue #272: one transaction covers the claim's outcome, the nodes row and the
+        # markdown write. Calling file_store inside db.transaction() is safe HERE and
+        # nowhere else: @_serialized_memory_operation already holds
+        # _memory_operation_lock and FileStore shares that RLock (:109), so this
+        # re-enters rather than taking db_lock before memory_lock.
+        #
+        # NOT atomic across the two stores: os.replace is irreversible and COMMIT runs
+        # after this body, so a failed COMMIT can leave the markdown one step ahead.
+        # What makes that safe is that the target is a pure function of the claim:
+        # the counters come FROM the nodes row and the clock comes FROM claimed_at, so
+        # a retry recomputes the SAME values and overwrites the phantom instead of
+        # compounding it — one event, one increment, one stability step.
         with self.db.transaction() as conn:
+            conn.execute(
+                "UPDATE confirmed_use_claims SET state = 'applied', "
+                "reinforced_at = datetime('now') "
+                "WHERE whisper_log_id = ? AND node_id = ? AND state = 'pending'",
+                (whisper_log_id, node_id),
+            )
+            if conn.execute("SELECT changes()").fetchone()[0] != 1:
+                # Already applied, terminal, or claimed by another runner. At-most-once,
+                # the same shape _claim_confirmed_use uses. Nothing may sit between the
+                # UPDATE and this read.
+                return
+
+            # reinforced_at records when the write ran; claimed_at is when the memory
+            # was actually used, and that is the clock the lifecycle values use.
+            claim = conn.execute(
+                "SELECT claimed_at FROM confirmed_use_claims "
+                "WHERE whisper_log_id = ? AND node_id = ?",
+                (whisper_log_id, node_id),
+            ).fetchone()
+
+            row = conn.execute(
+                "SELECT access_count, last_accessed, stability, last_review "
+                "FROM nodes WHERE id = ?",
+                (node_id,),
+            ).fetchone()
+            if node is None or row is None:
+                # Terminal, and honest about which terminal. Marking it 'applied' would
+                # record a reinforcement that never happened — the same falsehood the
+                # legacy migration above refuses to write.
+                conn.execute(
+                    "UPDATE confirmed_use_claims SET state = 'orphaned', "
+                    "reinforced_at = NULL "
+                    "WHERE whisper_log_id = ? AND node_id = ?",
+                    (whisper_log_id, node_id),
+                )
+                return
+
+            # Issue #272 (council round 1, Cursor): the clock is the claim's, not the
+            # wall clock. reinforced_stability is a function of days_since, so a sweep
+            # six hours after a failed attempt would compute a DIFFERENT target and the
+            # convergence promise above would hold for access_count only. Sourcing it
+            # from claimed_at makes the whole target a pure function of the claim.
+            #
+            # It is also the honest value: last_accessed is the decay anchor, and a late
+            # retry stamping the wall clock would credit the memory with recency it
+            # never earned. datetime('now') writes UTC with no offset, so the tzinfo is
+            # attached explicitly — astimezone would read the naive value as local time.
+            now = datetime.fromisoformat(claim["claimed_at"]).replace(
+                tzinfo=timezone.utc
+            )
+            stability = row["stability"]
+            last_review = (
+                datetime.fromisoformat(row["last_review"]) if row["last_review"] else None
+            )
+            last_accessed = (
+                datetime.fromisoformat(row["last_accessed"])
+                if row["last_accessed"]
+                else None
+            )
+
+            # One numeric stability update per node per cooldown window (#221): the
+            # old formula let ten same-session touches compound to ~57x.
+            if lifecycle.reinforcement_due(
+                last_review, now, self.settings.fsrs_reinforcement_cooldown_days
+            ):
+                # reinforcement cooldown can leave last_review a full window behind a
+                # use that already landed inside it (PR #239 review comment):
+                # last_accessed is the actual spacing signal, last_review only gates.
+                anchor = last_accessed or last_review
+                days_since = max((now - anchor).total_seconds() / 86400, 0.0)
+                stability = lifecycle.reinforced_stability(
+                    stability,
+                    days_since,
+                    growth_factor=self.settings.fsrs_growth_factor,
+                    growth_exponent=self.settings.fsrs_growth_exponent,
+                    spacing_cap=self.settings.fsrs_spacing_cap,
+                    max_stability=self.settings.fsrs_max_stability,
+                    initial_stability=self.settings.fsrs_initial_stability,
+                )
+                last_review = now
+
+            access_count = row["access_count"] + 1
+
             conn.execute(
                 "UPDATE nodes SET access_count = ?, last_accessed = ?, stability = ?, "
                 "last_review = ? WHERE id = ?",
                 (
-                    node.access_count,
-                    node.last_accessed.isoformat(),
-                    node.stability,
-                    node.last_review.isoformat() if node.last_review else None,
+                    access_count,
+                    now.isoformat(),
+                    stability,
+                    last_review.isoformat() if last_review else None,
                     node_id,
                 ),
             )
+
+            # The markdown is the projection: it is set to the computed values, never
+            # incremented from whatever it happened to hold.
+            node.access_count = access_count
+            node.last_accessed = now
+            node.stability = stability
+            node.last_review = last_review
+            self.file_store.save(node)
 
     # --- Private helpers ---
 
@@ -2918,8 +3007,8 @@ class MemoryEngine:
             return False
         conn.execute(
             """
-            INSERT INTO confirmed_use_claims (whisper_log_id, node_id, claimed_at)
-            SELECT wl.id, ?, datetime('now')
+            INSERT INTO confirmed_use_claims (whisper_log_id, node_id, claimed_at, state)
+            SELECT wl.id, ?, datetime('now'), 'pending'
             FROM whisper_log wl
             WHERE wl.id = ? AND wl.was_injected = 1
             ON CONFLICT DO NOTHING
@@ -2937,11 +3026,13 @@ class MemoryEngine:
     ) -> str:
         """Record feedback while preventing retention from deleting its event."""
         with self.db.transaction():
-            resolved_node_id, became_confirmed, message = self._submit_feedback_locked(
-                node_id=node_id,
-                signal=signal,
-                source=source,
-                whisper_log_id=whisper_log_id,
+            resolved_node_id, became_confirmed, claimed_log_id, message = (
+                self._submit_feedback_locked(
+                    node_id=node_id,
+                    signal=signal,
+                    source=source,
+                    whisper_log_id=whisper_log_id,
+                )
             )
         # Reinforcement runs after the transaction commits: db.transaction() holds a
         # process-level lock for its whole body, and _record_confirmed_use does file
@@ -2953,9 +3044,17 @@ class MemoryEngine:
         # so raising here would report a failure for evidence that was recorded. The
         # contract is at-most-once: the claim stays taken and
         # this reinforcement is simply lost, as a logged miss.
+        #
+        # claimed_log_id, not the whisper_log_id parameter (which may be None on the
+        # legacy fallback path): the claim was taken on the id _submit_feedback_locked
+        # resolved internally, and re-resolving here could pick a DIFFERENT event.
+        # It cannot be None when became_confirmed is True — _claim_confirmed_use
+        # returns False for a None id.
         if became_confirmed:
             try:
-                self._record_confirmed_use(resolved_node_id)
+                self._record_confirmed_use(
+                    resolved_node_id, whisper_log_id=claimed_log_id
+                )
             except Exception:
                 logger.exception(
                     "confirmed-use reinforcement failed for node %s", resolved_node_id
@@ -2968,7 +3067,7 @@ class MemoryEngine:
         signal: int,
         source: str = "explicit",
         whisper_log_id: int | None = None,
-    ) -> tuple[str | None, bool, str]:
+    ) -> tuple[str | None, bool, int | None, str]:
         """Record explicit or implicit feedback signal for a whisper candidate.
 
         When *whisper_log_id* is supplied, feedback attaches to that exact
@@ -2981,7 +3080,7 @@ class MemoryEngine:
             node_id, whisper_log_id,
         )
         if error is not None:
-            return None, False, error
+            return None, False, None, error
         assert resolved_node_id is not None
         assert row is not None
 
@@ -3074,6 +3173,7 @@ class MemoryEngine:
         return (
             resolved_node_id,
             became_confirmed,
+            whisper_log_id,
             f"Feedback recorded for node {resolved_node_id[:8]}...",
         )
 

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -201,8 +201,11 @@ class MemoryEngine:
         overlap ratio.
 
         The cutoff advances only to the highest id actually processed, never to
-        MAX(id): a row inserted between the SELECT and the stamp keeps an id above the
-        cutoff and is picked up on the next start rather than skipped.
+        MAX(id). db.transaction() opens BEGIN IMMEDIATE, so no writer -- in this
+        process or any other -- can commit between the SELECT and the stamp, which
+        means that interleaving cannot occur as the code stands. Advancing by
+        processed id is therefore defence in depth against a future change to that
+        isolation, not a fix for a reachable race.
 
         Recompute is exact, not estimated: the judge stamps the min_confidence in
         force when its row was written, so a row normalises to what it would have

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -53,8 +53,15 @@ _EMBEDDING_SCHEMA_VERSION = 2
 
 # Issue #220: the only feedback sources that count as confirmed use. Fail-closed —
 # anything not listed here, and every negative signal, does not reinforce.
-# auto_heuristic is excluded pending #218 signal calibration.
-_CONFIRMED_USE_SOURCES = frozenset({"explicit", "implicit", "auto_llm_judge"})
+# auto_heuristic was excluded pending #218 signal calibration; #272 admits it above
+# HEURISTIC_CONFIRM_FLOOR, which the ladder now makes meaningful.
+_CONFIRMED_USE_SOURCES = frozenset({"explicit", "implicit", "auto_llm_judge", "auto_heuristic"})
+
+# Issue #272: the evidence rung a heuristic hit must reach to confirm use. Defined by
+# reference to the ladder, not as a literal, so the two cannot drift apart in silence.
+# At IMPLICIT (0.80) this admits the three verbatim match kinds and excludes
+# token_overlap by construction — that band's supremum is 0.78.
+HEURISTIC_CONFIRM_FLOOR = signal_strength.IMPLICIT
 
 # Lifecycle-model version. 1 = the legacy FSRS seed (previously recorded as the
 # boolean meta key 'fsrs_migrated'); 2 = bounded reinforcement (#221). An integer
@@ -844,6 +851,7 @@ class MemoryEngine:
                     resolved_node_id,
                     signal=1,
                     source="explicit",
+                    strength=signal_strength.EXPLICIT,
                 )
         if claimed:
             # Isolated, and never propagated — the same contract submit_feedback and the
@@ -2727,6 +2735,7 @@ class MemoryEngine:
         *,
         signal: int,
         source: str,
+        strength: float,
     ) -> bool:
         """Take the at-most-once confirmed-use claim for one (event, node) pair.
 
@@ -2760,8 +2769,22 @@ class MemoryEngine:
         mutator instead would let two concurrent confirmations both pass and
         both reinforce; @_serialized_memory_operation keeps the read-modify-write
         correct but cannot enforce once-per-event.
+
+        Issue #272 admits auto_heuristic, but only above HEURISTIC_CONFIRM_FLOOR.
+        submit_feedback needs no special case for it: feedback_strength maps that
+        source to UNKNOWN (0.40), below the floor by construction, because a
+        submit_feedback call carries no evidence of a verbatim match and so cannot
+        earn a verbatim rung.
         """
         if whisper_log_id is None or signal != 1 or source not in _CONFIRMED_USE_SOURCES:
+            return False
+        # Issue #272: auto_heuristic confirms only on verbatim evidence. Scoped to that
+        # one source deliberately: explicit (1.00) and implicit (0.80) clear the floor
+        # anyway, and the judge's band starts at 0.82 — applying it to them would add a
+        # second gate on paths that do not need one, and would couple the judge's band
+        # to a constant it does not own. A low strength arriving on those sources means
+        # the CALLER is wrong, and dropping the claim would hide that instead of failing.
+        if source == "auto_heuristic" and strength < HEURISTIC_CONFIRM_FLOOR:
             return False
         conn.execute(
             """
@@ -2838,6 +2861,9 @@ class MemoryEngine:
         session_id = row["session_id"]
         space = row["space"]
         whisper_log_id = row["id"]
+        # Computed once and used twice: the claim's floor and the signals row must
+        # agree by construction, not by two call sites happening to match.
+        strength = signal_strength.feedback_strength(source, signal)
 
         with self.db.transaction() as conn:
             became_confirmed = self._claim_confirmed_use(
@@ -2846,6 +2872,7 @@ class MemoryEngine:
                 resolved_node_id,
                 signal=signal,
                 source=source,
+                strength=strength,
             )
             conn.execute(
                 """
@@ -2892,7 +2919,7 @@ class MemoryEngine:
                     resolved_node_id,
                     "feedback_submitted",
                     signal,
-                    signal_strength.feedback_strength(source, signal),
+                    strength,
                     source,
                     session_id,
                     "submit_feedback",

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -61,6 +61,10 @@ _CONFIRMED_USE_SOURCES = frozenset({"explicit", "implicit", "auto_llm_judge"})
 # so a future curve migration can tell which model produced the stored values.
 LIFECYCLE_MODEL_VERSION = 2
 
+# Evidence-ladder version for signals.strength (#218). Bump when the ladder's
+# values or mappings change, so a stamped store recomputes from its evidence.
+SIGNAL_STRENGTH_LADDER_VERSION = 1
+
 
 def _generate_title(content: str, max_chars: int = 60) -> str:
     """Generate a short title from the first line/sentence of content."""
@@ -160,12 +164,60 @@ class MemoryEngine:
 
         # One-time FSRS data migration: seed stability from access patterns
         self._migrate_fsrs()
+        self._migrate_signal_strength()
 
         self._ensure_self_node()
         self._migrate_identity_tiers()
         self._seed_initial_maintenance_grace_period()
         self._warmup_embedder()
         self._warmup_reranker()
+
+    def _migrate_signal_strength(self) -> None:
+        """Recompute signals.strength onto the #218 ordinal evidence ladder.
+
+        Exact rather than estimated: every row carries the evidence its own channel
+        needs, and the judge stamps the min_confidence in force when the row was
+        written -- so a row recomputes to what it would have stored had the ladder
+        existed then, not to what today's settings would produce.
+
+        Re-runnable by construction: evidence is never written, so a later revision
+        of the ladder recomputes from the same untouched source. Only strength moves.
+
+        No file_store call, so this does not take db-lock before memory-lock and
+        stays outside the ordering hazard documented on _record_confirmed_use.
+        """
+        stamp = self.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'signal_strength_ladder_version'"
+        ).fetchone()
+        try:
+            version = int(stamp["value"]) if stamp else 0
+        except (TypeError, ValueError):
+            version = 0
+        if version >= SIGNAL_STRENGTH_LADDER_VERSION:
+            return
+
+        with self.db.transaction() as conn:
+            rows = conn.execute("SELECT id, source, polarity, evidence FROM signals").fetchall()
+            for row in rows:
+                conn.execute(
+                    "UPDATE signals SET strength = ? WHERE id = ?",
+                    (
+                        signal_strength.strength_from_evidence(
+                            row["source"], row["polarity"], row["evidence"]
+                        ),
+                        row["id"],
+                    ),
+                )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES "
+                "('signal_strength_ladder_version', ?)",
+                (str(SIGNAL_STRENGTH_LADDER_VERSION),),
+            )
+        logger.info(
+            "Recomputed strength on %d signal rows (#218 ladder v%d)",
+            len(rows),
+            SIGNAL_STRENGTH_LADDER_VERSION,
+        )
 
     def _migrate_fsrs(self) -> None:
         """Seed FSRS stability once, and record the store's lifecycle-model version."""

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -167,6 +167,66 @@ class Database:
             # (which skips the block above) still gets the index.
             conn.execute("CREATE INDEX IF NOT EXISTS idx_nodes_seq ON nodes(seq)")
 
+            # Issue #272: confirmed_use_claims gains an outcome. Rows written before
+            # this column existed become 'legacy_unknown', NOT 'applied'.
+            #
+            # Stamping them as successes was this plan's first draft, and the council
+            # (Codex, HIGH) refuted it: the premise of this task is that some claims
+            # committed and then lost their reinforcement, those rows are exactly the
+            # ones the defect produced, and the old schema cannot tell them apart from
+            # the successes. Calling them applied would hide the data loss forever.
+            # Calling them pending is no better — the overwhelming majority DID apply,
+            # and re-running them would be mass over-reinforcement of an at-most-once
+            # latch. 'legacy_unknown' is terminal for the sweeper and honest about why.
+            claim_cols = [
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(confirmed_use_claims)"
+                ).fetchall()
+            ]
+            if claim_cols and "reinforced_at" not in claim_cols:
+                conn.execute(
+                    "ALTER TABLE confirmed_use_claims ADD COLUMN reinforced_at TEXT"
+                )
+            if claim_cols and "last_attempt_at" not in claim_cols:
+                conn.execute(
+                    "ALTER TABLE confirmed_use_claims ADD COLUMN last_attempt_at TEXT"
+                )
+            if claim_cols and "state" not in claim_cols:
+                # Counted BEFORE the ALTER, because after it every row already reads
+                # legacy_unknown and there is nothing left to distinguish.
+                legacy = conn.execute(
+                    "SELECT COUNT(*) FROM confirmed_use_claims"
+                ).fetchone()[0]
+                # The column lands plain: ADD COLUMN cannot carry the CHECK. Fresh
+                # databases get the constraint from schema.sql; migrated ones rely on
+                # the writers, which only ever set the four listed values.
+                #
+                # The DEFAULT does double duty. It backfills every existing row to
+                # legacy_unknown in one statement — no UPDATE needed — and it is the
+                # same terminal default schema.sql carries, so an old binary writing
+                # into this migrated database lands terminal too.
+                conn.execute(
+                    "ALTER TABLE confirmed_use_claims "
+                    "ADD COLUMN state TEXT NOT NULL DEFAULT 'legacy_unknown'"
+                )
+                # Measured, not guessed: the size of the historical gap is logged so it
+                # can be reasoned about instead of assumed away.
+                logger.info(
+                    "confirmed_use_claims: %d pre-#272 claim(s) marked legacy_unknown "
+                    "(outcome not recoverable from the old schema)",
+                    legacy,
+                )
+
+            # Partial index: the sweeper only ever selects the pending rows, which are a
+            # vanishing fraction of the table. Keyed on the same expression the sweeper
+            # orders by, so the batch scan stays index-only.
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_claims_pending "
+                "ON confirmed_use_claims(COALESCE(last_attempt_at, claimed_at)) "
+                "WHERE state = 'pending'"
+            )
+
             # Create new feedback/logging tables if missing
             existing_tables = {
                 row[0]

--- a/src/ormah/index/schema.sql
+++ b/src/ormah/index/schema.sql
@@ -244,6 +244,26 @@ CREATE TABLE IF NOT EXISTS confirmed_use_claims (
     whisper_log_id INTEGER NOT NULL REFERENCES whisper_log(id) ON DELETE CASCADE,
     node_id        TEXT NOT NULL,
     claimed_at     TEXT NOT NULL,
+    -- Issue #272: the claim's outcome, which the latch alone could not express.
+    --   pending        the reinforcement has not landed yet — the sweeper retries these
+    --   applied        it landed; reinforced_at carries when
+    --   legacy_unknown written before this column existed; outcome unknowable
+    --   orphaned       the node is gone, so there is nothing left to reinforce
+    --
+    -- The DEFAULT is TERMINAL, and deliberately so. A pre-#272 binary running against
+    -- this database inserts (whisper_log_id, node_id, claimed_at) without naming this
+    -- column, and its mutator never marks anything applied. A 'pending' default would
+    -- leave that row eligible forever and the sweeper would re-reinforce it every
+    -- hour, compounding the reinforcement the old binary already performed. Two
+    -- binaries on one store is not hypothetical here — see issue #238 in CLAUDE.md.
+    -- Only the new _claim_confirmed_use writes 'pending', and it names the column.
+    state          TEXT NOT NULL DEFAULT 'legacy_unknown'
+                   CHECK (state IN ('pending', 'applied', 'legacy_unknown', 'orphaned')),
+    reinforced_at  TEXT,
+    -- When the sweeper last tried this claim. Without it, ORDER BY claimed_at ASC
+    -- LIMIT N lets N permanently-failing claims fill every batch forever and no new
+    -- claim is ever attempted.
+    last_attempt_at TEXT,
     PRIMARY KEY (whisper_log_id, node_id)
 );
 

--- a/src/ormah/signal_strength.py
+++ b/src/ormah/signal_strength.py
@@ -1,0 +1,159 @@
+"""The ordinal evidence-strength ladder behind ``signals.strength`` (issue #218).
+
+``strength`` is the strength of the evidence backing a signal row's polarity, on a
+single ordinal scale, comparable in RANK across channels. It is NOT a calibrated
+probability: 0.86 from the LLM judge and 0.86 from anywhere else mean "the same
+rung", not "the same likelihood".
+
+The load-bearing assertion is that the CHANNEL DOMINATES within-channel confidence.
+A verbatim match outranks any LLM judgment however confident; an LLM judgment
+outranks any agent self-report. Bands are therefore disjoint per channel, and native
+confidence modulates only WITHIN a band.
+
+    1.00         explicit ......... the user was actually asked
+    0.98         node_id .......... the short id was printed verbatim
+    0.94         title ............ the title was printed verbatim
+    0.92         sentence ......... a content sentence was printed verbatim
+    0.82 - 0.90  auto_llm_judge ... affine over [min_confidence, 1.0]
+    0.80         implicit ......... the agent's own self-assessment
+    0.40 - 0.78  token_overlap .... asymptotic in overlap_ratio
+    0.00         polarity == 0 .... a row that asserts nothing has no evidence
+
+A polarity-zero row asserts nothing, so it carries no evidence strength. Its native
+confidence still survives in ``signals.evidence``; nothing is lost.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+# Detector source labels. Owned here because this module maps them onto the ladder;
+# session_watcher imports them rather than repeating the literals.
+HEURISTIC_SOURCE = "transcript_watcher_heuristic"
+LLM_JUDGE_SOURCE = "transcript_watcher_llm_judge"
+
+EXPLICIT = 1.00
+VERBATIM_NODE_ID = 0.98
+VERBATIM_TITLE = 0.94
+VERBATIM_SENTENCE = 0.92
+JUDGE_LO = 0.82
+JUDGE_HI = 0.90
+IMPLICIT = 0.80
+
+# token_overlap: floored at the detector's own entry gate, asymptotic to FLOOR + SPAN.
+OVERLAP_GATE = 0.5
+OVERLAP_FLOOR = 0.40
+OVERLAP_SPAN = 0.38
+OVERLAP_K = 1.0
+
+# Bottom of the ladder. Unknown provenance is the weakest evidence there is.
+UNKNOWN = OVERLAP_FLOOR
+
+# (channel, band_low, band_high). Disjointness is the executable form of the
+# "channel dominates confidence" assertion; test_signal_strength.py pins it.
+BANDS = (
+    ("explicit", EXPLICIT, EXPLICIT),
+    ("node_id", VERBATIM_NODE_ID, VERBATIM_NODE_ID),
+    ("title", VERBATIM_TITLE, VERBATIM_TITLE),
+    ("sentence", VERBATIM_SENTENCE, VERBATIM_SENTENCE),
+    ("auto_llm_judge", JUDGE_LO, JUDGE_HI),
+    ("implicit", IMPLICIT, IMPLICIT),
+    ("token_overlap", OVERLAP_FLOOR, OVERLAP_FLOOR + OVERLAP_SPAN),
+)
+
+_FEEDBACK_LADDER = {
+    "explicit": EXPLICIT,
+    "implicit": IMPLICIT,
+    # submit_feedback carries no confidence, so a judge-sourced row arriving through
+    # it lands on the floor of the judge band rather than anywhere inside it.
+    "auto_llm_judge": JUDGE_LO,
+    "auto_heuristic": UNKNOWN,
+}
+
+
+def _as_float(value: object, default: float = 0.0) -> float:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def token_overlap_strength(ratio: float) -> float:
+    """Map ``overlap_ratio`` onto the token_overlap band.
+
+    Asymptotic rather than clamped, because ``overlap_ratio`` is unbounded above --
+    its denominator is ``min(len(candidate_tokens), 12)`` while its numerator is not
+    capped. Any clamp ties every row above it, recreating the exact saturation defect
+    #218 reports; a clamp at 1.50 would tie 38% of the rows observed on a live store.
+
+    The supremum FLOOR + SPAN = 0.78 is strict in exact arithmetic but not in float64,
+    which reaches it around ratio 37 -- five times the 7.583 maximum observed.
+    """
+    return OVERLAP_FLOOR + OVERLAP_SPAN * (
+        1.0 - math.exp(-OVERLAP_K * max(ratio - OVERLAP_GATE, 0.0))
+    )
+
+
+def judge_strength(confidence: float, min_confidence: float, polarity: int) -> float:
+    """Map the judge's confidence onto its band, affine over [min_confidence, 1.0].
+
+    The domain is anchored on the caller's ``min_confidence`` rather than the literal
+    0.75, so the band re-anchors if the setting moves. That domain is sound because
+    the judge assigns a non-zero polarity only when ``confidence >= min_confidence``,
+    so no scoring row can sit below the band floor.
+    """
+    if polarity == 0:
+        return 0.0
+    if min_confidence >= 1.0:
+        return JUDGE_HI
+    span = (confidence - min_confidence) / (1.0 - min_confidence)
+    return JUDGE_LO + (JUDGE_HI - JUDGE_LO) * max(0.0, min(1.0, span))
+
+
+def feedback_strength(source: str, signal: int) -> float:
+    """Map a ``submit_feedback`` row onto the ladder.
+
+    Fail-closed: a source the ladder does not know lands on ``UNKNOWN``, the bottom
+    rung. ``submit_feedback`` validates ``signal`` only at its HTTP boundary
+    (``FeedbackRequest``), so a direct Python caller can still arrive here with 0.
+    """
+    if signal == 0:
+        return 0.0
+    return _FEEDBACK_LADDER.get(source, UNKNOWN)
+
+
+def strength_from_evidence(source: str, polarity: int, evidence_json: str | None) -> float:
+    """Recompute a stored row's strength from the ``evidence`` it already carries.
+
+    Used by the #218 backfill, and exact rather than estimated: each channel records
+    what its own mapping needs, and the judge stamps the ``min_confidence`` in force
+    when the row was written -- so the recompute uses that value, not today's.
+    """
+    if polarity == 0:
+        return 0.0
+    try:
+        evidence = json.loads(evidence_json) if evidence_json else {}
+    except (TypeError, ValueError):
+        evidence = {}
+    if not isinstance(evidence, dict):
+        evidence = {}
+
+    if source == HEURISTIC_SOURCE:
+        match = evidence.get("match")
+        if match == "node_id":
+            return VERBATIM_NODE_ID
+        if match == "title":
+            return VERBATIM_TITLE
+        if match == "sentence":
+            return VERBATIM_SENTENCE
+        if match == "token_overlap":
+            return token_overlap_strength(_as_float(evidence.get("overlap_ratio")))
+        return UNKNOWN
+    if source == LLM_JUDGE_SOURCE:
+        return judge_strength(
+            _as_float(evidence.get("confidence")),
+            _as_float(evidence.get("min_confidence"), default=0.75),
+            polarity,
+        )
+    return feedback_strength(source, polarity)

--- a/src/ormah/signal_strength.py
+++ b/src/ormah/signal_strength.py
@@ -73,10 +73,38 @@ _FEEDBACK_LADDER = {
 
 
 def _as_float(value: object, default: float = 0.0) -> float:
+    """Coerce a stored evidence value to a FINITE float, else *default*.
+
+    Both guards exist because the #218 migration runs on every startup and writes
+    into ``signals.strength``, which is ``REAL NOT NULL``:
+
+    - ``OverflowError`` is in the except tuple because ``json.loads`` returns an
+      unbounded Python ``int`` for a large integer literal, and ``float()`` of one
+      beyond the double range raises it -- not ``ValueError``.
+    - Non-finite results are rejected because ``json.loads`` accepts bare ``NaN``
+      and ``Infinity``, and SQLite stores a NaN REAL as NULL. Binding one would
+      raise ``IntegrityError`` inside the migration, and since the migration runs
+      at every boot, a single poisoned historical row would stop the server from
+      ever starting again.
+
+    Reported by the Codex peer, /council-pr of 2026-08-26.
+    """
     try:
-        return float(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError):
         return default
+    return result if math.isfinite(result) else default
+
+
+def _finite(value: float) -> float:
+    """Last guard before a strength reaches the NOT NULL column.
+
+    ``_as_float`` already keeps non-finite values out of the inputs, so this cannot
+    fire today. It guards the OUTPUT side instead: a future change to one of the
+    band formulas could produce a non-finite result from finite inputs, and the
+    cost of that reaching the every-boot migration is a server that never starts.
+    """
+    return value if math.isfinite(value) else UNKNOWN
 
 
 def token_overlap_strength(ratio: float) -> float:
@@ -148,12 +176,14 @@ def strength_from_evidence(source: str, polarity: int, evidence_json: str | None
         if match == "sentence":
             return VERBATIM_SENTENCE
         if match == "token_overlap":
-            return token_overlap_strength(_as_float(evidence.get("overlap_ratio")))
+            return _finite(token_overlap_strength(_as_float(evidence.get("overlap_ratio"))))
         return UNKNOWN
     if source == LLM_JUDGE_SOURCE:
-        return judge_strength(
-            _as_float(evidence.get("confidence")),
-            _as_float(evidence.get("min_confidence"), default=0.75),
-            polarity,
+        return _finite(
+            judge_strength(
+                _as_float(evidence.get("confidence")),
+                _as_float(evidence.get("min_confidence"), default=0.75),
+                polarity,
+            )
         )
     return feedback_strength(source, polarity)

--- a/tests/test_background/test_reinforcement_retry.py
+++ b/tests/test_background/test_reinforcement_retry.py
@@ -1,0 +1,167 @@
+"""#272 D5: the sleep-cycle sweeper that makes the confirmed-use claim durable."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from ormah.background.reinforcement_retry import _BATCH_SIZE, run_reinforcement_retry
+from tests.test_engine.test_confirmed_use_contract import (  # noqa: E402
+    _claim_row,
+    _make_nodes,
+    _seed_whisper_log,
+    _snapshot,
+)
+
+
+@pytest.fixture
+def seeded_claim(engine):
+    """A node and a whisper_log row, with the node's pre-reinforcement snapshot."""
+    node_id = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, node_id)
+    return log_id, node_id, _snapshot(engine, node_id)
+
+
+def _stale_claim(engine, log_id, node_id, minutes_ago=30):
+    """Insert a claim that was taken but never applied, old enough to be swept.
+
+    `state` is named explicitly. The column DEFAULT is the terminal 'legacy_unknown'
+    (Step 3), so an INSERT that omits it produces a row the sweeper correctly ignores
+    — which would make every test in this file pass vacuously.
+    """
+    claimed_at = (datetime.now(timezone.utc) - timedelta(minutes=minutes_ago)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "INSERT INTO confirmed_use_claims "
+            "(whisper_log_id, node_id, claimed_at, state) VALUES (?, ?, ?, 'pending')",
+            (log_id, node_id, claimed_at),
+        )
+
+
+def test_sweeper_reinforces_a_pending_claim(engine, seeded_claim):
+    """#272 D5-3: a claim the mutator never applied is repaired."""
+    log_id, node_id, before = seeded_claim
+    _stale_claim(engine, log_id, node_id)
+
+    run_reinforcement_retry(engine)
+
+    row = engine.db.conn.execute(
+        "SELECT state, reinforced_at FROM confirmed_use_claims WHERE whisper_log_id = ?",
+        (log_id,),
+    ).fetchone()
+    assert row["state"] == "applied", "the sweeper did not apply the claim"
+    assert row["reinforced_at"] is not None
+    assert _snapshot(engine, node_id) != before, "the sweeper marked but did not reinforce"
+
+
+def test_sweeper_never_touches_terminal_claims(engine, seeded_claim):
+    """#272 D5-8a: legacy_unknown and orphaned are terminal, not work items."""
+    log_id, node_id, before = seeded_claim
+    _stale_claim(engine, log_id, node_id)
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "UPDATE confirmed_use_claims SET state = 'legacy_unknown' "
+            "WHERE whisper_log_id = ? AND node_id = ?",
+            (log_id, node_id),
+        )
+
+    run_reinforcement_retry(engine)
+
+    assert _snapshot(engine, node_id) == before, "the sweeper re-reinforced a legacy claim"
+    assert _claim_row(engine, log_id, node_id)["state"] == "legacy_unknown"
+
+
+def test_sweeper_is_at_most_once_across_runs(engine, seeded_claim):
+    """#272 D5-4: running the sweeper twice reinforces once."""
+    log_id, node_id, _ = seeded_claim
+    _stale_claim(engine, log_id, node_id)
+
+    run_reinforcement_retry(engine)
+    after_first = _snapshot(engine, node_id)
+    run_reinforcement_retry(engine)
+
+    assert _snapshot(engine, node_id) == after_first, "the second sweep reinforced again"
+
+
+def test_sweeper_skips_claims_inside_the_grace_margin(engine, seeded_claim):
+    """#272 D5-5: a claim taken seconds ago may still be in flight — do not race it."""
+    log_id, node_id, before = seeded_claim
+    _stale_claim(engine, log_id, node_id, minutes_ago=0)
+
+    run_reinforcement_retry(engine)
+
+    assert _snapshot(engine, node_id) == before, "the sweeper raced an in-flight claim"
+
+
+def test_sweeper_isolates_one_bad_node_from_the_batch(engine, seeded_claim, monkeypatch):
+    """#272 D5-6: one RAISING node must not abandon the rest of the batch.
+
+    The failure has to be injected. A claim for a node that merely does not exist
+    returns cleanly through the terminal-claim path and would prove nothing about
+    isolation. Both claims hang off the same whisper_log row: the primary key is
+    (whisper_log_id, node_id) and only whisper_log_id carries a foreign key, so
+    this is a legal pair. The bad one is older so ORDER BY claimed_at runs it first.
+    """
+    log_id, node_id, before = seeded_claim
+    _stale_claim(engine, log_id, "ghost-node", minutes_ago=60)
+    _stale_claim(engine, log_id, node_id, minutes_ago=30)
+
+    real = engine._record_confirmed_use
+
+    def flaky(target, *, whisper_log_id):
+        if target == "ghost-node":
+            raise OSError("disk full")
+        return real(target, whisper_log_id=whisper_log_id)
+
+    monkeypatch.setattr(engine, "_record_confirmed_use", flaky)
+
+    run_reinforcement_retry(engine)
+
+    assert _snapshot(engine, node_id) != before, "a sibling failure abandoned the batch"
+
+
+def test_a_wall_of_failing_claims_does_not_starve_the_newest(
+    engine, seeded_claim, monkeypatch
+):
+    """#272 D5-11: permanently-failing claims must not monopolise every run.
+
+    Council round 1 (Codex, MEDIUM, 0.96) found this. Per-row isolation only saves the
+    rest of THIS batch; it does nothing about the next run picking the same rows. With
+    `ORDER BY claimed_at ASC LIMIT _BATCH_SIZE` and no record of attempts, _BATCH_SIZE
+    permanently-broken claims fill every batch forever and a claim taken today is never
+    tried at all — the sweeper reports itself healthy while the feature it exists to
+    deliver is dead for every new claim.
+
+    last_attempt_at plus the retry backoff is what breaks the tie: an attempted row
+    steps out of the eligible set until the backoff expires, so the next run reaches
+    past the wall. The wall here is deliberately larger than _BATCH_SIZE and OLDER than
+    the victim, so claimed_at ordering alone would never get to it.
+    """
+    log_id, node_id, before = seeded_claim
+
+    wall = _BATCH_SIZE + 5
+    for i in range(wall):
+        _stale_claim(engine, log_id, f"broken-{i}", minutes_ago=600 + i)
+    _stale_claim(engine, log_id, node_id, minutes_ago=30)
+
+    real = engine._record_confirmed_use
+
+    def flaky(target, *, whisper_log_id):
+        if target.startswith("broken-"):
+            raise OSError("disk full")
+        return real(target, whisper_log_id=whisper_log_id)
+
+    monkeypatch.setattr(engine, "_record_confirmed_use", flaky)
+
+    run_reinforcement_retry(engine)
+    assert _snapshot(engine, node_id) == before, (
+        "the wall is not large enough — the victim was reached on run 1, so run 2 "
+        "proves nothing"
+    )
+
+    run_reinforcement_retry(engine)
+
+    assert _snapshot(engine, node_id) != before, (
+        "the failing wall starved the newer claim across every run"
+    )

--- a/tests/test_background/test_reinforcement_retry.py
+++ b/tests/test_background/test_reinforcement_retry.py
@@ -1,10 +1,12 @@
 """#272 D5: the sleep-cycle sweeper that makes the confirmed-use claim durable."""
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
 
 from ormah.background.reinforcement_retry import _BATCH_SIZE, run_reinforcement_retry
+from ormah.config import Settings
 from tests.test_engine.test_confirmed_use_contract import (  # noqa: E402
     _claim_row,
     _make_nodes,
@@ -165,3 +167,45 @@ def test_a_wall_of_failing_claims_does_not_starve_the_newest(
     assert _snapshot(engine, node_id) != before, (
         "the failing wall starved the newer claim across every run"
     )
+
+
+def test_scheduler_registers_reinforcement_retry(tmp_path, monkeypatch):
+    """Final review I2: pin the sweeper's scheduler registration.
+
+    Every other test in this file calls run_reinforcement_retry(engine) directly.
+    Deleting the add_job block in start_scheduler would leave every one of them
+    green while the durability this branch exists to add is silently off in
+    production. Same shape as test_scheduler_registers_whisper_log_cleanup
+    (tests/test_background/test_whisper_log_cleanup.py) and its siblings in
+    tests/test_backup.py and tests/test_cloud_jobs.py.
+    """
+    from ormah.background import scheduler as scheduler_module
+
+    class FakeScheduler:
+        def __init__(self):
+            self.jobs = []
+
+        def add_job(self, func, trigger, **kwargs):
+            self.jobs.append({"func": func, "trigger": trigger, **kwargs})
+
+        def start(self):
+            pass
+
+        def get_jobs(self):
+            return self.jobs
+
+    monkeypatch.setattr(scheduler_module, "BackgroundScheduler", FakeScheduler)
+    settings = Settings(
+        memory_dir=tmp_path / "memory",
+        reinforcement_retry_interval_minutes=45,
+    )
+    engine = SimpleNamespace(
+        settings=settings,
+        builder=SimpleNamespace(incremental_update=lambda: (0, 0)),
+    )
+
+    fake_scheduler, _tracker = scheduler_module.start_scheduler(engine)
+
+    job = next(job for job in fake_scheduler.jobs if job["id"] == "reinforcement_retry")
+    assert job["trigger"] == "interval"
+    assert job["minutes"] == 45

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ormah import signal_strength
 from ormah.background.session_watcher import (
     IngestResult,
     SessionHandler,
@@ -424,7 +425,10 @@ def test_llm_judge_promotes_used_verdict(engine, tmp_path):
     assert judge_signal is not None
     assert judge_signal["signal_type"] == "whisper_judged_used"
     assert judge_signal["polarity"] == 1
-    assert judge_signal["strength"] == 0.88
+    # #218: strength is the judge's band position now, not its raw confidence.
+    assert judge_signal["strength"] == pytest.approx(
+        signal_strength.judge_strength(0.88, engine.settings.feedback_llm_judge_min_confidence, 1)
+    )
 
     affinity = engine.db.conn.execute(
         "SELECT * FROM affinity WHERE whisper_log_id = ?", (whisper_log_id,)

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -2770,3 +2770,331 @@ def test_one_failing_node_does_not_skip_the_rest_of_the_batch(engine, tmp_path):
     assert _lifecycle(engine, second_id) != before_second, (
         "the first node's failure skipped the second node's reinforcement"
     )
+
+
+def test_a_weak_heuristic_hit_still_reaches_the_judge(engine, tmp_path):
+    """#272 D3: below the floor, the judge is the only route left — do not suppress it.
+
+    Before #272 any heuristic hit suppressed the judge, so a token_overlap match
+    could neither claim nor be judged. That is 1,587 of the 1,629 measured rows.
+    """
+    prompt = "What about the retention policy?"
+    # MEASURED by executing _node_usage_evidence, not reasoned about: this text gives
+    # match="token_overlap", overlap_ratio 0.6, strength 0.436 — a REAL weak hit, below
+    # the 0.80 floor. The previous text ("Retention uses decay, stability and archival
+    # thresholds together.") gave overlap_ratio 0.4, under OVERLAP_GATE 0.5, so the
+    # match was "none": no hit, polarity 0, and NO affinity row written at all.
+    response = (
+        "The decay process lowers stability, and archival thresholds eventually "
+        "move things along."
+    )
+    transcript_path = tmp_path / "weak-to-judge-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Decay lowers stability until archival thresholds move a node out of working.",
+        type="fact",
+        title="Decay stability archival thresholds",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="weak-to-judge-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({"verdicts": [{
+        "whisper_log_id": whisper_log_id,
+        "verdict": "used",
+        "confidence": 0.95,
+        "reason": "The answer applies the retention guidance.",
+    }]})
+    before = _lifecycle(engine, node_id)
+    with patch(_LLM_PATCH, return_value=llm_response) as mock_llm:
+        _record_whisper_usage_signals(engine, transcript)
+
+    assert mock_llm.called, "a weak heuristic hit suppressed the judge"
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert claim is not None, "the judge confirmed nothing for a weak heuristic hit"
+    assert _lifecycle(engine, node_id) != before
+
+
+def test_an_irrelevant_verdict_overrides_the_weak_heuristic_affinity(engine, tmp_path):
+    """#272, council (Codex HIGH): the judge outranks the heuristic for the same event.
+
+    This task is what makes the conflict reachable: a token_overlap hit now gets both
+    an affinity +1 from the heuristic block AND a trip to the judge. affinity has a
+    unique (node_id, whisper_log_id) index and _insert_affinity is ON CONFLICT DO
+    NOTHING, so without Step 5 the judge's -1 is silently dropped and retrieval keeps
+    consuming a +1 the judge just rejected.
+
+    Red before Step 5 on the final row's polarity, not on the signal: the signals table
+    records the negative verdict either way. The affinity row is the falsifier.
+    """
+    prompt = "What about the retention policy?"
+    # MEASURED by executing _node_usage_evidence, not reasoned about: this text gives
+    # match="token_overlap", overlap_ratio 0.6, strength 0.436 — a REAL weak hit, below
+    # the 0.80 floor. The previous text ("Retention uses decay, stability and archival
+    # thresholds together.") gave overlap_ratio 0.4, under OVERLAP_GATE 0.5, so the
+    # match was "none": no hit, polarity 0, and NO affinity row written at all.
+    response = (
+        "The decay process lowers stability, and archival thresholds eventually "
+        "move things along."
+    )
+    transcript_path = tmp_path / "irrelevant-override-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Decay lowers stability until archival thresholds move a node out of working.",
+        type="fact",
+        title="Decay stability archival thresholds",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="irrelevant-override-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({"verdicts": [{
+        "whisper_log_id": whisper_log_id,
+        "verdict": "irrelevant",
+        "confidence": 0.95,
+        "reason": "The answer never uses the injected memory.",
+    }]})
+    with patch(_LLM_PATCH, return_value=llm_response) as mock_llm:
+        _record_whisper_usage_signals(engine, transcript)
+
+    assert mock_llm.called, "the weak hit never reached the judge — check Step 4"
+
+    affinity = engine.db.conn.execute(
+        "SELECT signal, source FROM affinity WHERE node_id = ? AND whisper_log_id = ?",
+        (node_id, whisper_log_id),
+    ).fetchall()
+    assert len(affinity) == 1, "the unique index should keep exactly one row per event"
+    assert affinity[0]["signal"] == -1, (
+        "the heuristic's +1 survived an irrelevant verdict — retrieval will keep boosting "
+        "a memory the judge rejected"
+    )
+    assert affinity[0]["source"] == "auto_llm_judge"
+
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert claim is None, "a negative verdict took a confirmed-use claim"
+
+
+def test_explicit_feedback_outranks_a_later_judge_verdict(engine, tmp_path):
+    """#272: precedence is explicit > auto_llm_judge > auto_heuristic, not last-write-wins.
+
+    Step 5's UPDATE is scoped to source = 'auto_heuristic' precisely so a human's
+    explicit feedback is never overwritten by an automated verdict. Drop that WHERE
+    clause and this goes red.
+
+    The feedback is NEGATIVE, and that is load-bearing — not a stylistic choice.
+    An earlier draft used signal=1 and could not fail: a positive explicit feedback
+    takes the _claim_confirmed_use latch synchronously inside _submit_feedback_locked
+    (memory_engine.py:2842-2849), so Step 3's already_confirmed reads True, Step 4's
+    `settled` is True, the judge is never queued, the patched LLM is never called and
+    Step 5's UPDATE never runs at all. The assertion then passed on Task 2's
+    ON CONFLICT DO NOTHING alone, with the scoping clause deleted or intact.
+
+    signal=-1 is the path that reaches Step 5: _claim_confirmed_use returns False for
+    any signal != 1, so the affinity row is written as 'explicit' while NO claim is
+    taken. already_confirmed is False, `confirms` is False (the response only
+    token-overlaps, whose band supremum 0.78 sits under the 0.80 floor), so the event
+    is unsettled, the judge runs, and its UPDATE fires against a row whose source is
+    'explicit'. Only the `AND source = 'auto_heuristic'` clause leaves it standing.
+
+    It is also the real scenario: a human marked a memory as NOT useful, which does
+    not settle the event, and the judge's later verdict must not overwrite the
+    attribution back to itself.
+    """
+    prompt = "What about the retention policy?"
+    # MEASURED by executing _node_usage_evidence, not reasoned about: this text gives
+    # match="token_overlap", overlap_ratio 0.6, strength 0.436 — a REAL weak hit, below
+    # the 0.80 floor. The previous text ("Retention uses decay, stability and archival
+    # thresholds together.") gave overlap_ratio 0.4, under OVERLAP_GATE 0.5, so the
+    # match was "none": no hit, polarity 0, and NO affinity row written at all.
+    response = (
+        "The decay process lowers stability, and archival thresholds eventually "
+        "move things along."
+    )
+    transcript_path = tmp_path / "explicit-outranks-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Decay lowers stability until archival thresholds move a node out of working.",
+        type="fact",
+        title="Decay stability archival thresholds",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="explicit-outranks-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    # A human says this memory was NOT useful, through MCP. This writes the affinity
+    # row as 'explicit' WITHOUT taking the claim (signal != 1), which is what leaves
+    # the event unsettled so the judge below actually runs. See the docstring.
+    engine.submit_feedback(node_id, signal=-1, source="explicit", whisper_log_id=whisper_log_id)
+
+    llm_response = json.dumps({"verdicts": [{
+        "whisper_log_id": whisper_log_id,
+        "verdict": "irrelevant",
+        "confidence": 0.95,
+        "reason": "The answer never uses the injected memory.",
+    }]})
+    with patch(_LLM_PATCH, return_value=llm_response) as mock_judge:
+        _record_whisper_usage_signals(engine, transcript)
+
+    affinity = engine.db.conn.execute(
+        "SELECT signal, source FROM affinity WHERE node_id = ? AND whisper_log_id = ?",
+        (node_id, whisper_log_id),
+    ).fetchone()
+    assert affinity["source"] == "explicit", "an automated verdict overwrote explicit feedback"
+    assert affinity["signal"] == -1, "the human's negative signal was replaced"
+
+    # The guard on the guard: if the judge never ran, the two assertions above hold
+    # trivially and prove nothing about the scoping clause. This is what the earlier
+    # signal=1 draft failed silently.
+    assert mock_judge.called, (
+        "the judge never ran, so Step 5's UPDATE never executed and this test cannot "
+        "distinguish a scoped UPDATE from an unscoped one"
+    )
+
+
+def test_a_confirming_heuristic_hit_does_not_reach_the_judge(engine, tmp_path):
+    """#272 D3: judging an event that already confirmed is wasted spend.
+
+    Council (Cursor, MEDIUM) on the final plan: asserting only `not mock_llm.called`
+    is not enough. The plan itself notes this already passes on the old `referenced`
+    rule, so on its own it pins nothing about #272. Worse, an implementation that
+    calls _claim_confirmed_use only when `not llm_judge_enabled` would keep every
+    Task 2 test green (the judge is off by default there) AND this one green — while
+    in production, with the judge armed, a verbatim hit would be neither claimed nor
+    judged. The claim and lifecycle assertions below are what falsify that.
+    """
+    prompt = "How should we solve feedback collection?"
+    response = "The right fix is the transcript watcher mines feedback usage approach."
+    transcript_path = tmp_path / "strong-skips-judge-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="The transcript watcher mines feedback usage from completed transcripts.",
+        type="fact",
+        title="Transcript watcher mines feedback usage",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="strong-skips-judge-session", prompt=prompt,
+    )
+    # The judge is ENABLED here on purpose: with it off, "not called" would be
+    # vacuously true and the test would pass against any suppression rule at all.
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    before = _lifecycle(engine, node_id)
+    with patch(_LLM_PATCH) as mock_llm:
+        _record_whisper_usage_signals(engine, transcript)
+
+    assert not mock_llm.called, "a confirming heuristic hit was judged anyway"
+
+    # The judge is ARMED here. These two are what stop a claim-only-when-judge-disabled
+    # implementation from shipping green.
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ? AND node_id = ?",
+        (whisper_log_id, node_id),
+    ).fetchone()
+    assert claim is not None, (
+        "a verbatim hit took no claim while the judge was enabled — it is now neither "
+        "confirmed nor judged"
+    )
+    assert _lifecycle(engine, node_id) != before, "the claim was taken but nothing reinforced"
+
+
+def test_an_already_confirmed_event_is_not_rejudged_on_reingest(engine, tmp_path):
+    """#272 D3: on RE-INGEST the claim table is the only authority left.
+
+    Council R3 (Cursor, MEDIUM) rejected the first version of this test: it used a
+    verbatim response, so the base's old rule suppressed the judge on BOTH passes
+    (`referenced` on the first, `heuristic_polarity == 1` on the second) and the test
+    passed unchanged. It proved nothing about `already_confirmed`.
+
+    The response is unreferenced instead, and the claim comes from MCP feedback. On
+    the second pass `has_heuristic` is true with polarity 0, so the base computes
+    `referenced = False` and QUEUES the judge — red today. Only `already_confirmed`
+    can suppress it, which is exactly the predicate under test.
+    """
+    prompt = "How should we solve feedback collection?"
+    response = "I don't know."
+    transcript_path = tmp_path / "reingest-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="The transcript watcher mines feedback usage from completed transcripts.",
+        type="fact",
+        title="Transcript watcher mines feedback usage",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="reingest-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    # The claim arrives through MCP, the one caller has_llm_judge cannot see.
+    engine.submit_feedback(node_id, signal=1, source="implicit", whisper_log_id=whisper_log_id)
+
+    # First pass writes the polarity-0 heuristic row that makes the next pass a re-ingest.
+    with patch(_LLM_PATCH) as first_llm:
+        _record_whisper_usage_signals(engine, transcript)
+    assert not first_llm.called, "the judge ran on an event MCP had already confirmed"
+
+    after_first = _lifecycle(engine, node_id)
+
+    # Second pass: has_heuristic is now true, polarity 0. Only the claim can settle it.
+    with patch(_LLM_PATCH) as second_llm:
+        _record_whisper_usage_signals(engine, transcript)
+
+    assert not second_llm.called, "a settled event was sent to the judge on re-ingest"
+    assert _lifecycle(engine, node_id) == after_first, "the event reinforced twice"
+
+
+def test_mcp_feedback_suppresses_the_judge_for_that_event(engine, tmp_path):
+    """#272 D3: closes the cross-caller blindness has_llm_judge cannot see (#220 13a).
+
+    The response is deliberately UNREFERENCED. Council R2 (Cursor, MEDIUM) caught the
+    earlier fixture: it overlapped the node, so `referenced` was already true and the
+    base's `not referenced` suppressed the judge on its own — the test passed before
+    and after, proving nothing. With no textual reference, the base queues the judge
+    (red today) and only `already_confirmed` can suppress it (green after).
+    """
+    prompt = "What about the retention policy?"
+    response = "I don't know."
+    transcript_path = tmp_path / "mcp-first-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Decay lowers stability until archival thresholds move a node out of working.",
+        type="fact",
+        title="Decay stability archival thresholds",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="mcp-first-session", prompt=prompt,
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    engine.submit_feedback(node_id, signal=1, source="implicit", whisper_log_id=whisper_log_id)
+    after_feedback = _lifecycle(engine, node_id)
+
+    with patch(_LLM_PATCH) as mock_llm:
+        _record_whisper_usage_signals(engine, transcript)
+
+    assert not mock_llm.called, "an event already confirmed through MCP was judged again"
+    assert _lifecycle(engine, node_id) == after_feedback, "the event reinforced twice"

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -2563,10 +2563,10 @@ def test_one_nodes_reinforcement_failure_does_not_stop_the_batch(engine, tmp_pat
     before_second = _lifecycle(engine, second)
     real = engine._record_confirmed_use
 
-    def flaky(node_id):
+    def flaky(node_id, *, whisper_log_id):
         if node_id == first:
             raise ZeroDivisionError("simulated mutator failure")
-        return real(node_id)
+        return real(node_id, whisper_log_id=whisper_log_id)
 
     with patch.object(engine, "_record_confirmed_use", side_effect=flaky):
         recorded = _record_whisper_usage_signals(engine, transcript)
@@ -2747,10 +2747,10 @@ def test_one_failing_node_does_not_skip_the_rest_of_the_batch(engine, tmp_path):
 
     real_mutator = engine._record_confirmed_use
 
-    def failing_for_first(node_id):
+    def failing_for_first(node_id, *, whisper_log_id):
         if node_id == first_id:
             raise ZeroDivisionError("float division by zero")
-        return real_mutator(node_id)
+        return real_mutator(node_id, whisper_log_id=whisper_log_id)
 
     llm_response = json.dumps({
         "verdicts": [

--- a/tests/test_background/test_session_watcher.py
+++ b/tests/test_background/test_session_watcher.py
@@ -2401,45 +2401,221 @@ def test_llm_judge_unused_verdict_does_not_record_confirmed_use(engine, tmp_path
     assert _lifecycle(engine, node_id) == before, "an unused verdict changed lifecycle fields"
 
 
-def test_heuristic_positive_does_not_record_confirmed_use(engine, tmp_path):
-    """Issue #220: auto_heuristic yields polarity 1 but never confirms use.
+@pytest.mark.parametrize("title,content,response,should_confirm", [
+    # title match (0.94) — the title appears verbatim in the response
+    (
+        "Transcript watcher mines feedback usage",
+        "The transcript watcher mines feedback usage from completed transcripts.",
+        "The right fix is the transcript watcher mines feedback usage approach.",
+        True,
+    ),
+    # sentence match (0.92) — a content sentence appears verbatim
+    (
+        "Vector search notes",
+        "Sqlite vec stores embeddings inside the same database file as the nodes.",
+        "As noted: sqlite vec stores embeddings inside the same database file as the nodes.",
+        True,
+    ),
+])
+def test_verbatim_heuristic_match_confirms_use(
+    engine, tmp_path, title, content, response, should_confirm,
+):
+    """#272: a verbatim heuristic hit reinforces the memory. Contract 12, inverted.
 
-    The heuristic path is excluded pending #218 signal calibration. This is the
-    case that matters: it is positive, so only the source keeps it out.
+    This is the issue's acceptance criterion: 0 of 1,629 positive heuristic pairs
+    took a claim, because only the judge block ever called _claim_confirmed_use.
     """
     prompt = "How should we solve feedback collection?"
-    response = "The right fix is the transcript watcher mines feedback usage approach."
-    transcript_path = tmp_path / "heuristic-no-confirm-session.jsonl"
+    transcript_path = tmp_path / "verbatim-confirm-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(content=content, type="fact", title=title))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="verbatim-confirm-session", prompt=prompt,
+    )
+
+    before = _lifecycle(engine, node_id)
+    recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 1
+    signal = engine.db.conn.execute(
+        "SELECT polarity, strength FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert signal["polarity"] == 1
+    assert signal["strength"] >= 0.80, "fixture did not produce a verbatim match — check the text"
+
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ? AND node_id = ?",
+        (whisper_log_id, node_id),
+    ).fetchone()
+    assert claim is not None, "the heuristic path took no confirmed-use claim"
+    assert _lifecycle(engine, node_id) != before, "the claim was taken but nothing reinforced"
+
+
+def test_node_id_heuristic_match_confirms_use(engine, tmp_path):
+    """#272 spec case 1: the strongest match kind (0.98).
+
+    Separate from the parametrized test above because the response must quote the
+    node's short id, which only exists after the node is created.
+    """
+    prompt = "Which memory covers the retention policy?"
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Retention is governed by decay and archival thresholds.",
+        type="fact",
+        title="Retention policy overview",
+    ))
+    response = f"That is memory {node_id[:8]}, which covers it."
+
+    transcript_path = tmp_path / "nodeid-confirm-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="nodeid-confirm-session", prompt=prompt,
+    )
+
+    before = _lifecycle(engine, node_id)
+    _record_whisper_usage_signals(engine, transcript)
+
+    signal = engine.db.conn.execute(
+        "SELECT strength, evidence FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert json.loads(signal["evidence"])["match"] == "node_id"
+    assert signal["strength"] == signal_strength.VERBATIM_NODE_ID
+
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ? AND node_id = ?",
+        (whisper_log_id, node_id),
+    ).fetchone()
+    assert claim is not None, "a node_id match — the strongest evidence there is — did not claim"
+    assert _lifecycle(engine, node_id) != before
+
+
+def test_token_overlap_heuristic_match_does_not_confirm(engine, tmp_path):
+    """#272 D1: the weak channel records evidence but never reinforces.
+
+    97.4% of heuristic hits are token_overlap; admitting them would give the least
+    precise kind the same lifecycle power as a verbatim node_id match.
+    """
+    prompt = "What about the retention policy?"
+    # Overlapping vocabulary, but no verbatim title or sentence.
+    response = (
+        "The decay process lowers stability, and archival thresholds eventually "
+        "move things along."
+    )
+    transcript_path = tmp_path / "overlap-no-confirm-session.jsonl"
     _write_turn_jsonl(transcript_path, prompt, response)
     transcript = parse_transcript(transcript_path)
 
     node_id, _ = engine.remember(CreateNodeRequest(
-        content="The transcript watcher mines feedback usage from completed transcripts.",
+        content="Decay lowers stability until archival thresholds move a node out of working.",
         type="fact",
-        title="Transcript watcher mines feedback usage",
+        title="Decay stability archival thresholds",
     ))
     whisper_log_id = _insert_injected_whisper_log(
-        engine, node_id=node_id, session_id="heuristic-no-confirm-session", prompt=prompt,
+        engine, node_id=node_id, session_id="overlap-no-confirm-session", prompt=prompt,
     )
 
     before = _lifecycle(engine, node_id)
+    with patch(_LLM_PATCH, return_value=None):  # judge unavailable — isolate the heuristic
+        _record_whisper_usage_signals(engine, transcript)
 
-    recorded = _record_whisper_usage_signals(engine, transcript)
-
-    # The heuristic signal is still recorded — this is about lifecycle, not observability.
-    assert recorded == 1
     signal = engine.db.conn.execute(
-        "SELECT * FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+        "SELECT polarity, strength, evidence FROM signals WHERE whisper_log_id = ?",
+        (whisper_log_id,),
     ).fetchone()
-    assert signal["polarity"] == 1
+    assert signal["polarity"] == 1, "fixture did not match at all — check the vocabulary overlap"
+    assert json.loads(signal["evidence"])["match"] == "token_overlap"
+    assert signal["strength"] < 0.80
 
-    assert _lifecycle(engine, node_id) == before, "auto_heuristic confirmed use — it must not"
-
-    # And it claimed nothing, so a later qualified positive can still confirm.
     claim = engine.db.conn.execute(
         "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (whisper_log_id,)
     ).fetchone()
-    assert claim is None, "the heuristic path took a confirmed-use claim"
+    assert claim is None, "token_overlap took a claim — it is below the evidence floor"
+    assert _lifecycle(engine, node_id) == before
+
+
+def test_one_nodes_reinforcement_failure_does_not_stop_the_batch(engine, tmp_path):
+    """#272: the batch is isolated per node, matching the judge path's contract."""
+    prompt = "How should we solve feedback collection?"
+    response = (
+        "Two things: the transcript watcher mines feedback usage approach, "
+        "and sqlite vec stores embeddings inside the same database file as the nodes."
+    )
+    transcript_path = tmp_path / "batch-failure-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    first, _ = engine.remember(CreateNodeRequest(
+        content="The transcript watcher mines feedback usage from completed transcripts.",
+        type="fact", title="Transcript watcher mines feedback usage",
+    ))
+    second, _ = engine.remember(CreateNodeRequest(
+        content="Sqlite vec stores embeddings inside the same database file as the nodes.",
+        type="fact", title="Vector search notes",
+    ))
+    for node_id in (first, second):
+        _insert_injected_whisper_log(
+            engine, node_id=node_id, session_id="batch-failure-session", prompt=prompt,
+        )
+
+    before_second = _lifecycle(engine, second)
+    real = engine._record_confirmed_use
+
+    def flaky(node_id):
+        if node_id == first:
+            raise ZeroDivisionError("simulated mutator failure")
+        return real(node_id)
+
+    with patch.object(engine, "_record_confirmed_use", side_effect=flaky):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 2, "a mutator failure changed the recorded count"
+    assert _lifecycle(engine, second) != before_second, "node 2 lost its reinforcement"
+
+
+def test_heuristic_below_the_floor_does_not_record_confirmed_use(engine, tmp_path):
+    """Contract 12, as amended by #272: the floor, not the source, is the gate.
+
+    Before #272 no heuristic hit could confirm. Now a verbatim one does, and only
+    evidence below HEURISTIC_CONFIRM_FLOOR is kept out. The verbatim half of this
+    contract lives in test_verbatim_heuristic_match_confirms_use.
+    """
+    prompt = "What about the retention policy?"
+    response = (
+        "The decay process lowers stability, and archival thresholds eventually "
+        "move things along."
+    )
+    transcript_path = tmp_path / "contract12-session.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Decay lowers stability until archival thresholds move a node out of working.",
+        type="fact",
+        title="Decay stability archival thresholds",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id="contract12-session", prompt=prompt,
+    )
+
+    before = _lifecycle(engine, node_id)
+    with patch(_LLM_PATCH, return_value=None):
+        recorded = _record_whisper_usage_signals(engine, transcript)
+
+    assert recorded == 1
+    signal = engine.db.conn.execute(
+        "SELECT polarity, strength FROM signals WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert signal["polarity"] == 1, "the signal is still recorded — this is lifecycle, not observability"
+    assert signal["strength"] < 0.80
+
+    assert _lifecycle(engine, node_id) == before, "a below-floor hit confirmed use — it must not"
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (whisper_log_id,)
+    ).fetchone()
+    assert claim is None, "a below-floor hit took a confirmed-use claim"
 
 
 def test_replaying_the_judge_does_not_reconfirm(engine, tmp_path):

--- a/tests/test_background/test_usage_signal_strength.py
+++ b/tests/test_background/test_usage_signal_strength.py
@@ -70,3 +70,75 @@ def test_every_heuristic_rung_sits_inside_its_band():
     """The verbatim rungs must stay above the judge band, the overlap rung below implicit."""
     assert ss.VERBATIM_SENTENCE > ss.JUDGE_HI
     assert ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN < ss.IMPLICIT
+
+
+import json  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
+from ormah.background.session_watcher import _record_whisper_usage_signals  # noqa: E402
+from ormah.models.node import CreateNodeRequest  # noqa: E402
+from ormah.transcript.parser import parse_transcript  # noqa: E402
+from tests.test_background.test_session_watcher import (  # noqa: E402
+    _LLM_PATCH,
+    _insert_injected_whisper_log,
+    _write_turn_jsonl,
+)
+
+
+def _judged(engine, tmp_path, *, verdict, confidence, slug):
+    """Drive one whisper through the judge and return its stored signal row."""
+    prompt = "How should we handle the blue deployment rollback?"
+    response = "Nothing in particular comes to mind about that."
+    transcript_path = tmp_path / f"{slug}.jsonl"
+    _write_turn_jsonl(transcript_path, prompt, response)
+    transcript = parse_transcript(transcript_path)
+
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="Roll back a blue deployment by repointing the load balancer first.",
+        type="fact",
+        title="Blue deployment rollback marker",
+    ))
+    whisper_log_id = _insert_injected_whisper_log(
+        engine, node_id=node_id, session_id=slug, prompt=prompt
+    )
+    engine.settings.llm_provider = "ollama"
+    engine.settings.feedback_llm_judge_enabled = True
+
+    llm_response = json.dumps({"verdicts": [{
+        "whisper_log_id": whisper_log_id,
+        "verdict": verdict,
+        "confidence": confidence,
+        "reason": "fixture",
+    }]})
+    with patch(_LLM_PATCH, return_value=llm_response):
+        _record_whisper_usage_signals(engine, transcript)
+
+    return engine.db.conn.execute(
+        "SELECT * FROM signals WHERE whisper_log_id = ? "
+        "AND source = 'transcript_watcher_llm_judge'",
+        (whisper_log_id,),
+    ).fetchone()
+
+
+def test_a_used_verdict_lands_inside_the_judge_band(engine, tmp_path):
+    """It used to store the raw confidence, which collides with other channels."""
+    signal = _judged(engine, tmp_path, verdict="used", confidence=0.88, slug="judge-band-used")
+    assert signal["polarity"] == 1
+    assert signal["strength"] != 0.88
+    assert ss.JUDGE_LO <= signal["strength"] <= ss.JUDGE_HI
+    assert signal["strength"] == pytest.approx(
+        ss.judge_strength(0.88, engine.settings.feedback_llm_judge_min_confidence, 1)
+    )
+
+
+def test_an_uncertain_verdict_carries_no_strength(engine, tmp_path):
+    """Below min_confidence the polarity is 0, so the row asserts nothing.
+
+    Its confidence is not lost: it stays in signals.evidence.
+    """
+    signal = _judged(
+        engine, tmp_path, verdict="used", confidence=0.35, slug="judge-band-uncertain"
+    )
+    assert signal["polarity"] == 0
+    assert signal["strength"] == 0.0
+    assert json.loads(signal["evidence"])["confidence"] == 0.35

--- a/tests/test_background/test_usage_signal_strength.py
+++ b/tests/test_background/test_usage_signal_strength.py
@@ -142,3 +142,24 @@ def test_an_uncertain_verdict_carries_no_strength(engine, tmp_path):
     assert signal["polarity"] == 0
     assert signal["strength"] == 0.0
     assert json.loads(signal["evidence"])["confidence"] == 0.35
+
+
+def test_recorded_evidence_reproduces_the_stored_strength():
+    """evidence must be a lossless record of what determined strength.
+
+    The #218 backfill recomputes strength from evidence. Deriving the stored strength
+    from a more precise ratio than the one recorded makes that recompute perturb a
+    correct row instead of confirming it — and makes any future rescan of new rows a
+    drift rather than a no-op.
+
+    4 overlaps over 6 candidates is 0.6666..., recorded as 0.667. That gap used to be
+    ~1e-04 of strength.
+    """
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="Q", content="quantum entanglement decoherence topology manifold curvature"),
+        "Consider decoherence, topology, the manifold and curvature when planning.",
+    )
+    assert referenced
+    assert evidence["match"] == "token_overlap"
+    assert evidence["overlap_ratio"] == pytest.approx(0.667)
+    assert strength == ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, json.dumps(evidence))

--- a/tests/test_background/test_usage_signal_strength.py
+++ b/tests/test_background/test_usage_signal_strength.py
@@ -1,0 +1,72 @@
+"""The heuristic detector places matches on the #218 ordinal ladder."""
+
+import pytest
+
+from ormah import signal_strength as ss
+from ormah.background.session_watcher import _node_usage_evidence
+
+
+def _row(node_id="a1b2c3d4-dead-beef-0000-000000000000", title="", content="", prompt_text=""):
+    """_node_usage_evidence reads its row purely by key, so a dict is a valid row."""
+    return {"node_id": node_id, "title": title, "content": content, "prompt_text": prompt_text}
+
+
+def test_node_id_match_takes_the_top_heuristic_rung():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(content="anything"), "As memory a1b2c3d4 records, we chose X."
+    )
+    assert referenced
+    assert evidence["match"] == "node_id"
+    assert strength == ss.VERBATIM_NODE_ID
+
+
+def test_title_match_takes_the_title_rung():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(
+            title="Transcript watcher mines feedback usage",
+            content="Some unrelated body text goes here.",
+        ),
+        "The transcript watcher mines feedback usage, as noted.",
+    )
+    assert referenced
+    assert evidence["match"] == "title"
+    assert strength == ss.VERBATIM_TITLE
+
+
+def test_sentence_match_takes_the_sentence_rung():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="T", content="The consolidator summarizes from full source content."),
+        "Recall that the consolidator summarizes from full source content today.",
+    )
+    assert referenced
+    assert evidence["match"] == "sentence"
+    assert strength == ss.VERBATIM_SENTENCE
+
+
+def test_token_overlap_varies_with_its_ratio():
+    """The defect #218 names: every token_overlap match used to report exactly 0.85."""
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="Q", content="quantum entanglement decoherence topology manifold"),
+        "We should consider decoherence, then topology, then the manifold, "
+        "and finally quantum entanglement in that order.",
+    )
+    assert referenced
+    assert evidence["match"] == "token_overlap"
+    assert evidence["overlap_ratio"] == pytest.approx(1.0)
+    assert strength == pytest.approx(ss.token_overlap_strength(1.0))
+    assert strength != 0.85
+
+
+def test_no_match_carries_no_strength():
+    referenced, strength, evidence = _node_usage_evidence(
+        _row(title="Z", content="alpha beta gamma delta"), "Completely unrelated prose here."
+    )
+    assert not referenced
+    assert evidence["match"] == "none"
+    assert strength == 0.0
+
+
+def test_every_heuristic_rung_sits_inside_its_band():
+    """The verbatim rungs must stay above the judge band, the overlap rung below implicit."""
+    assert ss.VERBATIM_SENTENCE > ss.JUDGE_HI
+    assert ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN < ss.IMPLICIT

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -7,6 +7,7 @@ rotted, and vice versa.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
@@ -751,3 +752,340 @@ def test_recall_search_structured_rejects_positional_tuning_args(engine):
     assert isinstance(engine.recall_search_structured(
         "caching architecture", limit=4, min_relevance=0.0, spread_activation=False,
     ), list)
+
+
+# --- Task 4: backfill the rows the defect already wrote (#272) -------------
+
+def _seed_heuristic_signal(engine, node_id, whisper_log_id, strength, match="node_id"):
+    """Write a positive heuristic signal row as the pre-#272 code would have."""
+    engine.db.conn.execute(
+        """
+        INSERT INTO signals
+            (whisper_log_id, node_id, signal_type, polarity, strength, source,
+             session_id, surface, space, prompt_hash, evidence, created)
+        VALUES (?, ?, 'whisper_referenced', 1, ?, 'transcript_watcher_heuristic',
+                's1', 'transcript', 'myproject', 'h', ?, datetime('now'))
+        """,
+        (whisper_log_id, node_id, strength, json.dumps({"match": match})),
+    )
+    engine.db.conn.commit()
+
+
+def test_backfill_claims_and_reinforces_historical_verbatim_rows(engine):
+    """#272 D4: the rows the defect already wrote are repaired at boot."""
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+    _seed_heuristic_signal(engine, target, log_id, strength=0.98)
+
+    before = _snapshot(engine, target)
+    engine._migrate_heuristic_confirmed_use()
+
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ? AND node_id = ?",
+        (log_id, target),
+    ).fetchone()
+    assert claim is not None, "the backfill claimed nothing"
+    assert _snapshot(engine, target) != before, "the backfill claimed but did not reinforce"
+
+
+def test_backfill_is_idempotent(engine):
+    """#272 D4: a second boot must not reinforce the same event again."""
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+    _seed_heuristic_signal(engine, target, log_id, strength=0.98)
+
+    engine._migrate_heuristic_confirmed_use()
+    after_first = _snapshot(engine, target)
+
+    engine._migrate_heuristic_confirmed_use()
+
+    assert _snapshot(engine, target) == after_first, "the backfill reinforced twice"
+
+
+@pytest.mark.parametrize("strength,match", [(0.40, "token_overlap"), (0.7799, "token_overlap")])
+def test_backfill_skips_rows_below_the_floor(engine, strength, match):
+    """#272 D4: the backfill uses the same floor as the live path."""
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+    _seed_heuristic_signal(engine, target, log_id, strength=strength, match=match)
+
+    before = _snapshot(engine, target)
+    engine._migrate_heuristic_confirmed_use()
+
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (log_id,)
+    ).fetchone()
+    assert claim is None, "a below-floor row was backfilled"
+    assert _snapshot(engine, target) == before
+
+
+def test_backfill_skips_a_never_injected_event(engine):
+    """#272 D4: was_injected = 1 is the provenance test the claim helper enforces.
+
+    A memory the agent never saw cannot have been used, however the signal reads.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+    engine.db.conn.execute("UPDATE whisper_log SET was_injected = 0 WHERE id = ?", (log_id,))
+    engine.db.conn.commit()
+    _seed_heuristic_signal(engine, target, log_id, strength=0.98)
+
+    before = _snapshot(engine, target)
+    engine._migrate_heuristic_confirmed_use()
+
+    assert _snapshot(engine, target) == before, "a non-injected event was backfilled"
+
+
+def test_backfill_skips_an_already_claimed_event(engine):
+    """#272 D4: an event confirmed through another caller must not reinforce twice."""
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+    engine.submit_feedback(target, signal=1, source="explicit", whisper_log_id=log_id)
+    _seed_heuristic_signal(engine, target, log_id, strength=0.98)
+
+    after_feedback = _snapshot(engine, target)
+    engine._migrate_heuristic_confirmed_use()
+
+    assert _snapshot(engine, target) == after_feedback, "an already-claimed event reinforced again"
+
+
+def test_backfill_cutoff_advances_to_the_highest_processed_id(engine):
+    """#272 D4: the cutoff advances by processed id, never to MAX(id).
+
+    Same defence-in-depth _migrate_signal_strength documents: a row committed by
+    another writer between the SELECT and the stamp must not be skipped forever.
+    A below-floor row is still 'processed' — it was examined and rejected.
+    """
+    strong, weak = _make_nodes(engine, count=2)
+    strong_log = _seed_whisper_log(engine, strong, prompt="caching strong")
+    _seed_heuristic_signal(engine, strong, strong_log, strength=0.98)
+    # Seeded LAST and below the floor: the cutoff must still clear it, or the scan
+    # window would grow forever on a store whose newest rows are all token_overlap.
+    weak_log = _seed_whisper_log(engine, weak, prompt="caching weak")
+    _seed_heuristic_signal(engine, weak, weak_log, strength=0.40, match="token_overlap")
+
+    highest = engine.db.conn.execute(
+        "SELECT MAX(id) AS m FROM signals WHERE source = 'transcript_watcher_heuristic'"
+    ).fetchone()["m"]
+
+    engine._migrate_heuristic_confirmed_use()
+
+    cutoff = engine._meta_int("heuristic_confirmed_use_cutoff")
+    assert cutoff == highest, (
+        f"cutoff {cutoff} stopped short of the last processed id {highest} — "
+        "a below-floor row was examined but not counted as processed"
+    )
+    assert engine._meta_int("heuristic_confirmed_use_version") == 1
+
+
+def test_backfill_skips_a_signal_whose_node_is_not_the_events_node(engine):
+    """#272, council R1 (Codex HIGH): the claim helper does not check event/node ownership.
+
+    It inserts the node id it is handed after testing only was_injected. The live
+    path reads both ids off one whisper_log row so they always agree; the backfill
+    reads them from different tables, so a legacy or hand-repaired signal could
+    reinforce a node the agent never saw for that event.
+    """
+    victim, other = _make_nodes(engine, count=2)
+    log_id = _seed_whisper_log(engine, victim)
+    # The event belongs to `victim`, but the signal names `other`.
+    _seed_heuristic_signal(engine, other, log_id, strength=0.98)
+
+    before_other = _snapshot(engine, other)
+    engine._migrate_heuristic_confirmed_use()
+
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ? AND node_id = ?",
+        (log_id, other),
+    ).fetchone()
+    assert claim is None, "a signal claimed an event that belonged to a different node"
+    assert _snapshot(engine, other) == before_other
+
+
+def test_backfill_cutoff_clears_every_kind_of_ineligible_tail(engine):
+    """#272, council R1+R3 (Codex): no eligibility predicate may live in the WHERE.
+
+    Three shapes, because the defect reappeared in three disguises across the review:
+      - polarity 0            -> excluded by a WHERE predicate (round 1)
+      - was_injected = 0      -> excluded by a WHERE predicate (round 1)
+      - whisper_log_id NULL   -> excluded by an INNER JOIN (round 3). The column is
+                                 nullable and ON DELETE SET NULL, so whisper_log_cleanup
+                                 orphans rows routinely — this is the common case, not
+                                 an exotic one.
+    Any of them at the high-id tail must still advance the cutoff, or every boot
+    rescans a growing tail forever.
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    not_injected_log = _seed_whisper_log(engine, target, prompt="caching not injected")
+    engine.db.conn.execute(
+        "UPDATE whisper_log SET was_injected = 0 WHERE id = ?", (not_injected_log,)
+    )
+
+    def _tail(whisper_log_id, polarity):
+        engine.db.conn.execute(
+            """
+            INSERT INTO signals
+                (whisper_log_id, node_id, signal_type, polarity, strength, source,
+                 session_id, surface, space, prompt_hash, evidence, created)
+            VALUES (?, ?, 'whisper_referenced', ?, 0.98, 'transcript_watcher_heuristic',
+                    's1', 'transcript', 'myproject', 'h', ?, datetime('now'))
+            """,
+            (whisper_log_id, target, polarity, json.dumps({"match": "node_id"})),
+        )
+
+    _tail(log_id, 0)                # polarity 0
+    _tail(not_injected_log, 1)      # was_injected = 0
+    _tail(None, 1)                  # orphaned: no whisper_log parent at all
+    engine.db.conn.commit()
+
+    highest = engine.db.conn.execute(
+        "SELECT MAX(id) AS m FROM signals WHERE source = 'transcript_watcher_heuristic'"
+    ).fetchone()["m"]
+
+    engine._migrate_heuristic_confirmed_use()
+
+    assert engine._meta_int("heuristic_confirmed_use_cutoff") == highest, (
+        "an ineligible trailing row pinned the cutoff — the scan window will grow forever"
+    )
+    assert engine.db.conn.execute(
+        "SELECT COUNT(*) AS n FROM confirmed_use_claims"
+    ).fetchone()["n"] == 0, "an ineligible row was claimed"
+
+
+def test_backfill_runs_from_startup_and_ignores_stale_stored_strength(engine):
+    """#272, council R1+R2 (Cursor) + the final-plan run: call site AND recompute.
+
+    This test USED to pin the migration order, back when eligibility read
+    `signals.strength`. It no longer can: eligibility is recomputed from `evidence`,
+    so both assertions hold whichever order the two migrations run in. That is the
+    point — the order stopped being load-bearing, and a test claiming to prove an
+    order it can no longer falsify would be worse than no test.
+
+    What it pins now, both of which are real:
+      - `startup()` actually calls the backfill (swap the call out and the verbatim
+        assertion goes red);
+      - the stored column does not decide anything. Both seeds carry a strength that
+        contradicts their evidence, and the outcome follows the evidence:
+          * token_overlap stored at a stale 1.0 (above the floor) -> recomputes to
+            ~0.55 -> must NOT claim;
+          * node_id stored at a stale 0.50 (below the floor) -> recomputes to 0.98
+            -> must claim.
+        An implementation that reads `row["strength"]` turns BOTH red.
+
+    The inter-transaction window itself is covered by
+    test_backfill_ignores_a_stale_row_written_after_the_ladder_committed, which a
+    sequential startup() test cannot express.
+    """
+    overlap_node, verbatim_node = _make_nodes(engine, count=2)
+    overlap_log = _seed_whisper_log(engine, overlap_node, prompt="caching overlap")
+    verbatim_log = _seed_whisper_log(engine, verbatim_node, prompt="caching verbatim")
+
+    _seed_heuristic_signal(
+        engine, overlap_node, overlap_log, strength=1.0, match="token_overlap",
+    )
+    engine.db.conn.execute(
+        "UPDATE signals SET evidence = ? WHERE whisper_log_id = ?",
+        (json.dumps({"match": "token_overlap", "overlap_ratio": 1.0}), overlap_log),
+    )
+    _seed_heuristic_signal(engine, verbatim_node, verbatim_log, strength=0.50)
+
+    # Force both migrations to re-run on the next startup.
+    engine.db.conn.execute(
+        "DELETE FROM meta WHERE key IN "
+        "('heuristic_confirmed_use_version', 'heuristic_confirmed_use_cutoff', "
+        "'signal_strength_ladder_version', 'signal_strength_ladder_cutoff')"
+    )
+    engine.db.conn.commit()
+
+    engine.startup()
+
+    verbatim_claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (verbatim_log,)
+    ).fetchone()
+    assert verbatim_claim is not None, (
+        "startup() never ran the backfill, or eligibility read the stale stored 0.50 "
+        "instead of recomputing 0.98 from evidence.match = node_id"
+    )
+
+    overlap_claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (overlap_log,)
+    ).fetchone()
+    assert overlap_claim is None, (
+        "a stale DEFAULT-1.0 token_overlap row confirmed — eligibility trusted the stored "
+        "column instead of recomputing from evidence"
+    )
+
+
+def test_backfill_ignores_a_stale_row_written_after_the_ladder_committed(engine):
+    """#272, final-plan council (Codex HIGH + Cursor MEDIUM, converging independently).
+
+    The falsifier for the inter-transaction window. `_migrate_signal_strength` and this
+    backfill commit SEPARATELY, so an old binary — the second unmanaged process of #238
+    — can write a pre-ladder row carrying the schema default of 1.0 *after* the ladder
+    has committed and *before* this SELECT begins. Ordering the two calls cannot close
+    that window, and a sequential startup() test cannot expose it.
+
+    Simulated exactly: run the ladder to completion, THEN insert the stale row, THEN run
+    only the backfill. An implementation that reads `signals.strength` claims it, and the
+    claim is a monotonic latch with a markdown write already on disk — no undo.
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target, prompt="caching stale window")
+
+    # The ladder runs first and commits — exactly as startup() orders it.
+    engine._migrate_signal_strength()
+
+    # The window: an old binary commits a token_overlap row at the schema default of
+    # 1.0, which the ladder has already finished and will not revisit this boot.
+    _seed_heuristic_signal(
+        engine, target, log_id, strength=1.0, match="token_overlap",
+    )
+    engine.db.conn.execute(
+        "UPDATE signals SET evidence = ? WHERE whisper_log_id = ?",
+        (json.dumps({"match": "token_overlap", "overlap_ratio": 1.0}), log_id),
+    )
+    engine.db.conn.commit()
+
+    before = _snapshot(engine, target)
+    engine._migrate_heuristic_confirmed_use()
+
+    claim = engine.db.conn.execute(
+        "SELECT 1 FROM confirmed_use_claims WHERE whisper_log_id = ?", (log_id,)
+    ).fetchone()
+    assert claim is None, (
+        "a stale DEFAULT-1.0 row written in the window between the two migrations took "
+        "an irreversible claim — eligibility must recompute from evidence, not read the column"
+    )
+    assert _snapshot(engine, target) == before
+
+    # The cutoff still advanced past it: ineligible is not unprocessed.
+    assert engine._meta_int("heuristic_confirmed_use_cutoff") == engine.db.conn.execute(
+        "SELECT MAX(id) AS m FROM signals WHERE source = 'transcript_watcher_heuristic'"
+    ).fetchone()["m"]
+
+
+def test_backfill_isolates_one_nodes_failure(engine):
+    """#272 D4: one unreadable node must not cost every later node its repair."""
+    first, second = _make_nodes(engine, count=2)
+    for node_id in (first, second):
+        log_id = _seed_whisper_log(engine, node_id, prompt=f"caching {node_id}")
+        _seed_heuristic_signal(engine, node_id, log_id, strength=0.98)
+
+    before_second = _snapshot(engine, second)
+    real = engine._record_confirmed_use
+
+    def flaky(node_id):
+        if node_id == first:
+            raise ZeroDivisionError("simulated mutator failure")
+        return real(node_id)
+
+    with patch.object(engine, "_record_confirmed_use", side_effect=flaky):
+        engine._migrate_heuristic_confirmed_use()
+
+    assert _snapshot(engine, second) != before_second, "node 2 lost its backfill"

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -245,7 +245,12 @@ def test_qualified_positive_feedback_confirms_use(engine, source):
 
 
 def test_auto_heuristic_positive_does_not_confirm(engine):
-    """Contract 9: auto_heuristic is excluded pending #218 — fail-closed."""
+    """Contract 9: submit_feedback(auto_heuristic) is below the #272 evidence floor.
+
+    Not an exclusion by source any more — auto_heuristic IS in the allowlist since
+    #272. feedback_strength maps it to UNKNOWN (0.40), under HEURISTIC_CONFIRM_FLOOR,
+    because a submit_feedback call carries no evidence of a verbatim match.
+    """
     ids = _make_nodes(engine, count=1)
     target = ids[0]
     log_id = _seed_whisper_log(engine, target)
@@ -254,6 +259,46 @@ def test_auto_heuristic_positive_does_not_confirm(engine):
     engine.submit_feedback(target, signal=1, source="auto_heuristic", whisper_log_id=log_id)
 
     assert _snapshot(engine, target) == before, "auto_heuristic must not confirm use"
+
+
+@pytest.mark.parametrize("strength,should_confirm", [
+    (0.80, True),    # exactly the floor — inclusive
+    (0.7999, False), # just below
+    (0.98, True),    # node_id
+    (0.40, False),   # token_overlap floor
+])
+def test_heuristic_claim_respects_the_evidence_floor(engine, strength, should_confirm):
+    """#272 D1/D2: the floor lives in the claim helper, not in its callers."""
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    with engine.db.transaction() as conn:
+        claimed = engine._claim_confirmed_use(
+            conn, log_id, target,
+            signal=1, source="auto_heuristic", strength=strength,
+        )
+
+    assert claimed is should_confirm
+
+
+def test_the_floor_does_not_gate_the_other_sources(engine):
+    """#272 D2: the floor is scoped to auto_heuristic only.
+
+    explicit is 1.00 on the ladder, so a low strength reaching this helper would
+    mean the caller computed it wrong — but gating it here would silently drop a
+    real confirmation instead of surfacing that bug.
+    """
+    ids = _make_nodes(engine, count=1)
+    target = ids[0]
+    log_id = _seed_whisper_log(engine, target)
+
+    with engine.db.transaction() as conn:
+        claimed = engine._claim_confirmed_use(
+            conn, log_id, target, signal=1, source="explicit", strength=0.0,
+        )
+
+    assert claimed is True, "the floor must not apply to non-heuristic sources"
 
 
 @pytest.mark.parametrize("source", ["explicit", "implicit", "auto_llm_judge", "auto_heuristic"])

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -8,12 +8,17 @@ rotted, and vice versa.
 from __future__ import annotations
 
 import json
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from ormah import lifecycle
 from ormah.api.routes_ui import router as ui_router
 from ormah.config import Settings
 from ormah.engine.memory_engine import MemoryEngine
@@ -33,6 +38,29 @@ def _snapshot(engine, node_id):
         "file": tuple(getattr(node, f) for f in LIFECYCLE_FIELDS),
         "db": tuple(row[f] for f in LIFECYCLE_FIELDS),
     }
+
+
+def _snapshot_stores_agree(snapshot):
+    """True if a _snapshot's `file` and `db` halves carry the same VALUES.
+
+    `_snapshot`'s `file` tuple carries parsed datetime objects (MemoryNode's
+    last_accessed/last_review are typed datetime); its `db` tuple carries the
+    raw TEXT sqlite3 returns for the same columns. A plain `file == db` tuple
+    comparison therefore never matches, even when the two stores fully agree —
+    proven by executing it: both sides print the identical instant, one as a
+    datetime, one as its isoformat string. Only used where the two are compared
+    directly against each other; every other _snapshot comparison in this file
+    is same-shape-vs-same-shape and is unaffected.
+    """
+    file_vals, db_vals = snapshot["file"], snapshot["db"]
+
+    def _dt(value):
+        return datetime.fromisoformat(value) if isinstance(value, str) else value
+
+    return all(
+        _dt(f) == _dt(d)
+        for f, d in zip(file_vals, db_vals, strict=True)
+    )
 
 
 def _make_nodes(engine, count=2):
@@ -165,8 +193,18 @@ def test_concurrent_confirmed_use_does_not_lose_increments(engine):
     target = ids[0]
     before = engine.file_store.load(target).access_count
 
-    threads = [threading.Thread(target=engine._record_confirmed_use, args=(target,))
-               for _ in range(8)]
+    # Issue #272: each thread needs its OWN claimed event — the mutator is now
+    # at-most-once per (whisper_log_id, node_id), so 8 threads sharing one claim
+    # would only reinforce once. Claimed up front, sequentially, since claiming
+    # must happen inside its own transaction before the mutator runs.
+    log_ids = [_claim_fresh_event(engine, target) for _ in range(8)]
+    threads = [
+        threading.Thread(
+            target=engine._record_confirmed_use,
+            kwargs={"node_id": target, "whisper_log_id": log_id},
+        )
+        for log_id in log_ids
+    ]
     for t in threads:
         t.start()
     for t in threads:
@@ -197,6 +235,55 @@ def _seed_whisper_log(engine, node_id, prompt="what about caching?"):
     ).fetchone()
     assert row is not None, "no whisper_log row was created — check the surface used"
     return row["id"]
+
+
+def _claim_fresh_event(engine, node_id):
+    """Insert a whisper_log row for node_id and take its confirmed-use claim.
+
+    Issue #272 made whisper_log_id a required keyword on _record_confirmed_use:
+    every real caller reaches it only after _claim_confirmed_use has taken a claim
+    inside its own transaction, so a direct call needs the same shape. Bypasses
+    recall_search (unlike _seed_whisper_log above) so cooldown/stamping tests that
+    call the mutator many times on one node get one fresh, independently-claimable
+    event per call rather than depending on search surfacing the same node again.
+    """
+    with engine.db.transaction() as conn:
+        cursor = conn.execute(
+            "INSERT INTO whisper_log "
+            "(session_id, prompt_hash, prompt_vec, node_id, score, was_injected, logged_at) "
+            "VALUES ('test-direct-claim', ?, X'00', ?, 1.0, 1, datetime('now'))",
+            (uuid.uuid4().hex, node_id),
+        )
+        whisper_log_id = cursor.lastrowid
+        engine._claim_confirmed_use(
+            conn, whisper_log_id, node_id, signal=1, source="explicit", strength=1.0,
+        )
+        # _claim_confirmed_use's INSERT stamps claimed_at with SQL datetime('now'),
+        # which truncates to whole seconds. The mutator's clock is claimed_at, so a
+        # test that calls _reinforce several times faster than 1 second apart (the
+        # cooldown tests do) would see identical or barely-advancing timestamps —
+        # and near an exact cooldown-day boundary, that truncation alone can flip
+        # `reinforcement_due`. Overwritten here with a microsecond-precision Python
+        # timestamp, the same precision _age_for_fsrs already relies on for the
+        # same reason.
+        conn.execute(
+            "UPDATE confirmed_use_claims SET claimed_at = ? "
+            "WHERE whisper_log_id = ? AND node_id = ?",
+            (datetime.now(timezone.utc).isoformat(), whisper_log_id, node_id),
+        )
+    return whisper_log_id
+
+
+def _reinforce(engine, node_id):
+    """Claim a fresh event for node_id and reinforce it in one step.
+
+    The direct replacement for the pre-#272 `engine._record_confirmed_use(node_id)`
+    call shape, used by tests that exercise the mutator's lifecycle arithmetic
+    (cooldown, stamping) rather than the claiming path itself.
+    """
+    engine._record_confirmed_use(
+        node_id, whisper_log_id=_claim_fresh_event(engine, node_id)
+    )
 
 
 def test_recall_node_confirms_only_the_requested_node(engine):
@@ -1106,12 +1193,411 @@ def test_backfill_isolates_one_nodes_failure(engine):
     before_second = _snapshot(engine, second)
     real = engine._record_confirmed_use
 
-    def flaky(node_id):
+    def flaky(node_id, *, whisper_log_id):
         if node_id == first:
             raise ZeroDivisionError("simulated mutator failure")
-        return real(node_id)
+        return real(node_id, whisper_log_id=whisper_log_id)
 
     with patch.object(engine, "_record_confirmed_use", side_effect=flaky):
         engine._migrate_heuristic_confirmed_use()
 
     assert _snapshot(engine, second) != before_second, "node 2 lost its backfill"
+
+
+# --- Task 5: durable reinforcement (#220 debt) ------------------------------
+
+
+def _claim_row(engine, log_id, node_id):
+    return engine.db.conn.execute(
+        "SELECT claimed_at, state, reinforced_at FROM confirmed_use_claims "
+        "WHERE whisper_log_id = ? AND node_id = ?",
+        (log_id, node_id),
+    ).fetchone()
+
+
+def _take_claim(engine, log_id, node_id):
+    with engine.db.transaction() as conn:
+        engine._claim_confirmed_use(
+            conn, log_id, node_id, signal=1, source="explicit", strength=1.0,
+        )
+
+
+def _age_for_fsrs(engine, log_id, node_id, node_days=3, claim_days=1):
+    """Push the node's last_accessed and the claim's claimed_at into the past.
+
+    Without this the FSRS assertions are vacuous. _make_nodes seeds last_accessed
+    from datetime.now(), and a claim taken milliseconds later gives days_since ~= 0
+    — so `now = claimed_at` and `now = datetime.now()` produce the SAME stability to
+    any tolerance, and the test would pass with the bug fully present.
+
+    Two different ages are required, not one. days_since is `now - last_accessed`
+    clamped at 0, so ageing only the claim would leave both variants clamped to 0
+    and still indistinguishable. With last_accessed 3 days back and claimed_at 1 day
+    back, the claimed_at clock yields days_since = 1 and the wall clock yields
+    days_since = 3 — a gap the assertions can see.
+
+    Both ages are kept UNDER the spacing-factor's saturation point, not just apart
+    from each other. spacing_factor caps at fsrs_spacing_cap (2.0) once
+    0.2 * days_since / stability reaches log(2) ~= 3.47 days at the default
+    stability = 1.0 seeded by _make_nodes — verified by executing
+    reinforced_stability(1.0, days, ...): 10 and 20 days both round to the SAME
+    2.0, indistinguishable regardless of which clock produced them, while 1 and 3
+    days round to 1.61 and 1.91. Widening the gap without checking the cap would
+    silently recreate the same vacuous test this helper exists to prevent.
+
+    The nodes row is the source the mutator reads, so ageing the row is enough; the
+    markdown is overwritten from it on the next write.
+    """
+    node_at = datetime.now(timezone.utc) - timedelta(days=node_days)
+    claim_at = datetime.now(timezone.utc) - timedelta(days=claim_days)
+    with engine.db.transaction() as conn:
+        conn.execute(
+            "UPDATE nodes SET last_accessed = ? WHERE id = ?",
+            (node_at.isoformat(), node_id),
+        )
+        conn.execute(
+            "UPDATE confirmed_use_claims SET claimed_at = ? "
+            "WHERE whisper_log_id = ? AND node_id = ?",
+            (claim_at.strftime("%Y-%m-%d %H:%M:%S"), log_id, node_id),
+        )
+
+
+def _as_utc(claimed_at):
+    """The mutator's clock: claimed_at, as SQLite wrote it, made tz-aware.
+
+    datetime('now') emits 'YYYY-MM-DD HH:MM:SS' in UTC with no offset, so the
+    conversion is a fromisoformat plus an explicit tzinfo — never an astimezone,
+    which would treat the naive value as local time and shift it.
+    """
+    return datetime.fromisoformat(claimed_at).replace(tzinfo=timezone.utc)
+
+
+def _expected_reinforced_stability(engine, base_row, claimed_at):
+    """ONE application of the growth formula, mirroring the mutator step for step.
+
+    Recomputed rather than hardcoded: a literal would still pass if the mutator
+    stopped calling reinforced_stability at all. It mirrors the mutator exactly —
+    same gate, same anchor expression, same clock — so if the two ever diverge the
+    test fails instead of quietly asserting a different formula.
+    """
+    now = _as_utc(claimed_at)
+    last_review = (
+        datetime.fromisoformat(base_row["last_review"])
+        if base_row["last_review"]
+        else None
+    )
+    last_accessed = (
+        datetime.fromisoformat(base_row["last_accessed"])
+        if base_row["last_accessed"]
+        else None
+    )
+    if not lifecycle.reinforcement_due(
+        last_review, now, engine.settings.fsrs_reinforcement_cooldown_days
+    ):
+        return base_row["stability"]
+
+    anchor = last_accessed or last_review
+    days_since = max((now - anchor).total_seconds() / 86400, 0.0)
+    return lifecycle.reinforced_stability(
+        base_row["stability"],
+        days_since,
+        growth_factor=engine.settings.fsrs_growth_factor,
+        growth_exponent=engine.settings.fsrs_growth_exponent,
+        spacing_cap=engine.settings.fsrs_spacing_cap,
+        max_stability=engine.settings.fsrs_max_stability,
+        initial_stability=engine.settings.fsrs_initial_stability,
+    )
+
+
+def test_mutator_failure_leaves_no_residue(engine, monkeypatch):
+    """#272 D5-1: a failed save rolls back the claim state AND the nodes row."""
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _take_claim(engine, log_id, target)
+
+    before = _snapshot(engine, target)
+
+    def boom(node):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(engine.file_store, "save", boom)
+    with pytest.raises(OSError):
+        engine._record_confirmed_use(target, whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) == before, "the failed mutator left a partial write"
+    assert _claim_row(engine, log_id, target)["state"] == "pending", (
+        "the claim left 'pending' even though nothing was applied"
+    )
+
+
+def test_failed_commit_does_not_inflate_the_counter(engine, monkeypatch):
+    """#272 D5-2: the convergence claim, tested at the one place it can break.
+
+    os.replace cannot be rolled back and COMMIT runs after the transaction body, so a
+    failing COMMIT leaves the markdown one step ahead of the nodes row. Because the new
+    values are computed FROM the nodes row and the clock comes FROM claimed_at, the
+    retry recomputes the same target and overwrites the phantom — it must not add a
+    second increment, nor a second stability step, on top of it.
+
+    The failure is injected through Database.transaction, NOT through conn.execute.
+    Council round 1 (Codex, MEDIUM, 1.0) proved by execution that patching the
+    connection raises AttributeError: 'sqlite3.Connection' object attribute 'execute'
+    is read-only, so the earlier draft of this test could never have run. Raising after
+    the with-body returns is behaviourally identical to a failing COMMIT: file_store.save
+    has already run and os.replace is irreversible, and the real transaction's
+    except-clause issues the ROLLBACK that discards the row and the claim.
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _take_claim(engine, log_id, target)
+    # Required, not decorative: without it claimed_at and the wall clock are
+    # milliseconds apart and every FSRS assertion below passes with the bug present.
+    _age_for_fsrs(engine, log_id, target)
+
+    base_row = engine.db.conn.execute(
+        "SELECT access_count, stability, last_accessed, last_review FROM nodes "
+        "WHERE id = ?",
+        (target,),
+    ).fetchone()
+    baseline, baseline_stability = base_row["access_count"], base_row["stability"]
+    # The whole row is kept, not just two fields: _expected_reinforced_stability
+    # mirrors the mutator, which reads last_accessed and last_review from it too.
+    # Asserting against a value derived from what _make_nodes actually seeded, rather
+    # than from an assumption about it, is what keeps this from passing for the wrong
+    # reason if the fixture changes.
+
+    real_transaction = type(engine.db).transaction
+
+    @contextmanager
+    def commit_fails(self):
+        with real_transaction(self) as conn:
+            yield conn
+            raise sqlite3.OperationalError("disk I/O error")
+
+    monkeypatch.setattr(type(engine.db), "transaction", commit_fails)
+    with pytest.raises(sqlite3.OperationalError):
+        engine._record_confirmed_use(target, whisper_log_id=log_id)
+    monkeypatch.undo()
+
+    # The markdown ran ahead; the row and the claim did not.
+    phantom = engine.file_store.load(target)
+    assert phantom.access_count == baseline + 1
+    assert engine.db.conn.execute(
+        "SELECT access_count FROM nodes WHERE id = ?", (target,)
+    ).fetchone()["access_count"] == baseline
+    assert _claim_row(engine, log_id, target)["state"] == "pending"
+
+    engine._record_confirmed_use(target, whisper_log_id=log_id)
+
+    after = _snapshot(engine, target)
+    assert _snapshot_stores_agree(after), "the stores did not converge"
+    final = engine.db.conn.execute(
+        "SELECT access_count, stability, last_accessed FROM nodes WHERE id = ?",
+        (target,),
+    ).fetchone()
+    assert final["access_count"] == baseline + 1, (
+        "one event produced more than one increment"
+    )
+
+    # The FSRS half of convergence: the retry must land on the SAME stability the
+    # phantom did, which is only true because the clock came from claimed_at. With
+    # datetime.now() the two attempts feed different days_since to
+    # reinforced_stability and this equality fails — that is the bug this pins.
+    assert final["stability"] == pytest.approx(phantom.stability), (
+        "the retry recomputed a different FSRS target than the failed attempt"
+    )
+    assert final["stability"] != pytest.approx(baseline_stability), (
+        "stability never moved, so the equality above proves nothing"
+    )
+
+    # And it is ONE application of the growth formula, not two compounded.
+    claimed_at = _claim_row(engine, log_id, target)["claimed_at"]
+    expected = _expected_reinforced_stability(engine, base_row, claimed_at)
+    assert final["stability"] == pytest.approx(expected), (
+        "stability compounded across the failed attempt and the retry"
+    )
+
+    # The assertion that actually kills the bug. With the wall clock the mutator would
+    # feed days_since = (now - last_accessed) = 3 days instead of the claim's 1, so
+    # this value must NOT be reachable. Computed, not hardcoded, so it tracks whatever
+    # the settings say.
+    wall_clock_target = lifecycle.reinforced_stability(
+        baseline_stability,
+        max(
+            (
+                datetime.now(timezone.utc)
+                - datetime.fromisoformat(base_row["last_accessed"])
+            ).total_seconds()
+            / 86400,
+            0.0,
+        ),
+        growth_factor=engine.settings.fsrs_growth_factor,
+        growth_exponent=engine.settings.fsrs_growth_exponent,
+        spacing_cap=engine.settings.fsrs_spacing_cap,
+        max_stability=engine.settings.fsrs_max_stability,
+        initial_stability=engine.settings.fsrs_initial_stability,
+    )
+    assert wall_clock_target != pytest.approx(expected), (
+        "the two clocks agree, so this test cannot tell them apart — widen the ages "
+        "in _age_for_fsrs"
+    )
+    assert final["stability"] != pytest.approx(wall_clock_target), (
+        "the mutator used datetime.now() instead of the claim's claimed_at"
+    )
+
+    assert final["last_accessed"] == _as_utc(claimed_at).isoformat(), (
+        "last_accessed records the retry's clock instead of when the memory was used"
+    )
+
+
+def test_happy_path_agrees_across_claim_row_and_markdown(engine):
+    """#272 D5-9: on success all three carry the same values."""
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _take_claim(engine, log_id, target)
+
+    before = _snapshot(engine, target)
+    engine._record_confirmed_use(target, whisper_log_id=log_id)
+    after = _snapshot(engine, target)
+
+    assert after != before, "nothing was reinforced"
+    assert _snapshot_stores_agree(after), "markdown and database disagree"
+    row = _claim_row(engine, log_id, target)
+    assert row["state"] == "applied"
+    assert row["reinforced_at"] is not None
+
+
+def test_mutator_is_at_most_once_on_an_applied_claim(engine):
+    """#272 D5-4: a second call on an applied claim is a no-op."""
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _take_claim(engine, log_id, target)
+    engine._record_confirmed_use(target, whisper_log_id=log_id)
+
+    after_first = _snapshot(engine, target)
+    engine._record_confirmed_use(target, whisper_log_id=log_id)
+
+    assert _snapshot(engine, target) == after_first, "the second call reinforced again"
+
+
+def test_missing_node_ends_orphaned_not_applied(engine):
+    """#272 D5-7: a deleted node is terminal, and is not recorded as a success.
+
+    The claim is inserted directly for a node_id that has no markdown file. Only
+    whisper_log_id carries a foreign key (PRAGMA foreign_keys=ON), so a claim can
+    legitimately outlive its node — which is exactly the state being tested.
+
+    'applied' would be a lie of the same kind the legacy migration refuses to write,
+    so the assertion pins the distinction, not merely "it stopped being pending".
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    with engine.db.transaction() as conn:
+        # `state` named explicitly: the DEFAULT is terminal (Step 3), and a claim that
+        # starts terminal would reach 'orphaned' by never being touched at all.
+        conn.execute(
+            "INSERT INTO confirmed_use_claims "
+            "(whisper_log_id, node_id, claimed_at, state) "
+            "VALUES (?, 'ghost-node', datetime('now'), 'pending')",
+            (log_id,),
+        )
+
+    engine._record_confirmed_use("ghost-node", whisper_log_id=log_id)
+
+    row = _claim_row(engine, log_id, "ghost-node")
+    assert row["state"] == "orphaned", (
+        "a claim for a deleted node must be orphaned, never pending (retried forever) "
+        "nor applied (a reinforcement that never happened)"
+    )
+    assert row["reinforced_at"] is None
+
+
+def test_a_claim_written_without_state_is_not_swept(engine):
+    """#272 D5-10: an old binary's INSERT must land terminal, not pending.
+
+    Council round 1 (Codex, HIGH, 0.99) found this. The pre-#272 _claim_confirmed_use
+    inserts (whisper_log_id, node_id, claimed_at) without naming `state`, so it takes
+    whatever the column DEFAULT gives. That binary's _record_confirmed_use has no idea
+    the column exists and never marks the row applied — so if the DEFAULT were
+    'pending', the row would sit there forever and the new sweeper would reinforce it
+    again every hour, on top of the reinforcement the old binary already did.
+
+    This is not hypothetical: CLAUDE.md documents issue #238, where `make server`
+    starts a second, launchd-unmanaged process against the same store. Two binaries on
+    one database is a state this project has already been in.
+
+    The DEFAULT is therefore terminal ('legacy_unknown') and only the new code inserts
+    'pending' explicitly. This test writes the OLD statement verbatim.
+    """
+    node_id = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, node_id)
+
+    with engine.db.transaction() as conn:
+        # Verbatim the pre-#272 statement: the column list omits `state`.
+        conn.execute(
+            "INSERT INTO confirmed_use_claims (whisper_log_id, node_id, claimed_at) "
+            "VALUES (?, ?, datetime('now'))",
+            (log_id, node_id),
+        )
+
+    row = _claim_row(engine, log_id, node_id)
+    assert row["state"] == "legacy_unknown", (
+        "an old binary's claim landed in a state the sweeper will retry forever"
+    )
+
+
+def test_the_new_claim_path_writes_pending(engine):
+    """#272 D5-10b: the guard above must not disable the feature it protects.
+
+    If _claim_confirmed_use stopped naming `state`, every new claim would inherit the
+    terminal DEFAULT and nothing would ever be swept — the durability this whole task
+    adds would be silently off, and every other test here would still pass because
+    they exercise the mutator directly. This is the test that fails in that case.
+    """
+    node_id = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, node_id)
+    _take_claim(engine, log_id, node_id)
+
+    assert _claim_row(engine, log_id, node_id)["state"] == "pending", (
+        "a fresh claim is not pending, so the sweeper can never pick it up"
+    )
+
+
+def test_migration_marks_preexisting_claims_legacy_unknown(tmp_path):
+    """#272 D5-8b: pre-#272 claims are neither swept nor recorded as successes.
+
+    Council round 1 (Codex, HIGH) killed the first draft, which stamped them
+    reinforced. The premise of this task is that SOME of those claims lost their
+    reinforcement; the old schema cannot tell which, so calling them applied would
+    hide exactly the data loss the task exists to repair. 'pending' is equally wrong
+    — the majority did apply, and re-running them is mass over-reinforcement of an
+    at-most-once latch. The assertion pins the third state, not "not pending".
+    """
+    from ormah.index.db import Database
+
+    db = Database(tmp_path / "m.db")
+    db.init_schema()
+    db.conn.executescript(
+        """
+        DROP TABLE confirmed_use_claims;
+        CREATE TABLE confirmed_use_claims (
+            whisper_log_id INTEGER NOT NULL,
+            node_id        TEXT NOT NULL,
+            claimed_at     TEXT NOT NULL,
+            PRIMARY KEY (whisper_log_id, node_id)
+        );
+        INSERT INTO confirmed_use_claims VALUES (1, 'n1', '2026-01-01 00:00:00');
+        """
+    )
+
+    db._migrate()
+
+    row = db.conn.execute(
+        "SELECT state, reinforced_at FROM confirmed_use_claims"
+    ).fetchone()
+    assert row["state"] == "legacy_unknown", (
+        "a pre-existing claim was classified, but its outcome is not knowable"
+    )
+    assert row["reinforced_at"] is None, (
+        "reinforced_at asserts a reinforcement happened — it did not, or is unknown"
+    )

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -1590,6 +1590,32 @@ def test_mutator_is_at_most_once_on_an_applied_claim(engine):
     assert _snapshot(engine, target) == after_first, "the second call reinforced again"
 
 
+def test_a_failed_latch_never_loads_the_file(engine, monkeypatch):
+    """Council #272 finding 2: the load belongs inside the transaction, after
+    the latch. Observable consequence — and this test's RED: when the claim is
+    already applied, the mutator must return before any file I/O. Today the
+    load runs unconditionally before the transaction even opens.
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _take_claim(engine, log_id, target)
+    engine._record_confirmed_use(target, whisper_log_id=log_id)  # applies the claim
+
+    calls = []
+    real_load = engine.file_store.load
+    monkeypatch.setattr(
+        engine.file_store, "load",
+        lambda node_id: calls.append(node_id) or real_load(node_id),
+    )
+
+    engine._record_confirmed_use(target, whisper_log_id=log_id)  # latch fails
+
+    assert calls == [], (
+        "the mutator loaded the markdown for a claim it then refused to apply — "
+        "the load must sit inside the transaction, after the at-most-once latch"
+    )
+
+
 def test_missing_node_ends_orphaned_not_applied(engine):
     """#272 D5-7: a deleted node is terminal, and is not recorded as a success.
 

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -1204,6 +1204,116 @@ def test_backfill_isolates_one_nodes_failure(engine):
     assert _snapshot(engine, second) != before_second, "node 2 lost its backfill"
 
 
+def test_backfill_does_not_advance_last_accessed_to_boot_time(engine):
+    """Council #272 finding 1: a historical use must not be recorded as use now.
+
+    last_accessed sits BETWEEN the signal's logged_at and boot time, so with the
+    truthful clock max(claimed_at, last_accessed) keeps it; with the buggy boot
+    clock the claim wins and drags it to now — which is exactly the RED.
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _seed_heuristic_signal(engine, target, log_id, strength=0.98)
+    event_time = datetime.now(timezone.utc) - timedelta(days=10)
+    anchor_time = datetime.now(timezone.utc) - timedelta(days=2)
+    engine.db.conn.execute(
+        "UPDATE whisper_log SET logged_at = ? WHERE id = ?",
+        (event_time.isoformat(), log_id),
+    )
+    engine.db.conn.execute(
+        "UPDATE nodes SET last_accessed = ? WHERE id = ?",
+        (anchor_time.isoformat(), target),
+    )
+    engine.db.conn.commit()
+
+    engine._migrate_heuristic_confirmed_use()
+
+    row = engine.db.conn.execute(
+        "SELECT last_accessed FROM nodes WHERE id = ?", (target,)
+    ).fetchone()
+    assert datetime.fromisoformat(row["last_accessed"]) == anchor_time, (
+        "backfilling a 10-day-old signal moved last_accessed to boot time — "
+        "the claim must carry the event's clock, not the wall clock"
+    )
+
+
+def test_backfill_claim_carries_the_events_time_normalized(engine):
+    """Council #272 finding 1: claimed_at = logged_at, in datetime('now') shape.
+
+    The space-format assertion is the sweeper's contract: reinforcement_retry
+    compares claimed_at lexicographically against datetime('now', ...), where
+    'T' (0x54) sorts above ' ' (0x20).
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _seed_heuristic_signal(engine, target, log_id, strength=0.98)
+    engine.db.conn.execute(
+        "UPDATE whisper_log SET logged_at = '2026-08-15T12:00:00.123456+00:00' "
+        "WHERE id = ?",
+        (log_id,),
+    )
+    engine.db.conn.commit()
+
+    engine._migrate_heuristic_confirmed_use()
+
+    row = _claim_row(engine, log_id, target)
+    assert row is not None, "the backfill claimed nothing"
+    assert row["claimed_at"] == "2026-08-15 12:00:00", (
+        f"claimed_at is {row['claimed_at']!r}: the backfill must stamp the "
+        "event's logged_at, normalized to SQLite's space-format UTC"
+    )
+
+
+def test_backfill_survives_a_malformed_logged_at(engine):
+    """Guard, not RED: a malformed logged_at falls back to the boot clock.
+
+    datetime('not-a-timestamp') is NULL and claimed_at is NOT NULL — without the
+    COALESCE the INSERT raises IntegrityError and the whole backfill transaction
+    dies at boot. Falling back keeps today's behavior for that one row instead of
+    losing the signal forever (the cutoff advances regardless).
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    _seed_heuristic_signal(engine, target, log_id, strength=0.98)
+    engine.db.conn.execute(
+        "UPDATE whisper_log SET logged_at = 'not-a-timestamp' WHERE id = ?",
+        (log_id,),
+    )
+    engine.db.conn.commit()
+
+    engine._migrate_heuristic_confirmed_use()
+
+    row = _claim_row(engine, log_id, target)
+    assert row is not None, "a malformed logged_at must not cost the claim"
+    assert "T" not in row["claimed_at"]
+    stamped = datetime.fromisoformat(row["claimed_at"]).replace(tzinfo=timezone.utc)
+    assert abs((datetime.now(timezone.utc) - stamped).total_seconds()) < 60
+
+
+def test_live_claim_still_stamps_now(engine):
+    """Guard, not RED: the historical clock is backfill-only (decision 2026-08-28).
+
+    A live claim's skew from its event is minutes; its sources' semantics
+    (explicit/implicit/judge) are out of this fix's scope.
+    """
+    target = _make_nodes(engine, count=1)[0]
+    log_id = _seed_whisper_log(engine, target)
+    engine.db.conn.execute(
+        "UPDATE whisper_log SET logged_at = ? WHERE id = ?",
+        ((datetime.now(timezone.utc) - timedelta(days=10)).isoformat(), log_id),
+    )
+    engine.db.conn.commit()
+
+    _take_claim(engine, log_id, target)
+
+    row = _claim_row(engine, log_id, target)
+    assert "T" not in row["claimed_at"]
+    stamped = datetime.fromisoformat(row["claimed_at"]).replace(tzinfo=timezone.utc)
+    assert abs((datetime.now(timezone.utc) - stamped).total_seconds()) < 60, (
+        "a live claim must keep the wall clock even when its event is old"
+    )
+
+
 # --- Task 5: durable reinforcement (#220 debt) ------------------------------
 
 

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -756,8 +756,21 @@ def test_recall_search_structured_rejects_positional_tuning_args(engine):
 
 # --- Task 4: backfill the rows the defect already wrote (#272) -------------
 
-def _seed_heuristic_signal(engine, node_id, whisper_log_id, strength, match="node_id"):
-    """Write a positive heuristic signal row as the pre-#272 code would have."""
+def _seed_heuristic_signal(
+    engine, node_id, whisper_log_id, strength, match="node_id", overlap_ratio=None
+):
+    """Write a positive heuristic signal row as the pre-#272 code would have.
+
+    ``strength`` only fills the cosmetic ``signals.strength`` column, which the
+    backfill deliberately ignores — it recomputes from ``evidence`` instead
+    (issue #272). ``overlap_ratio``, when given, is written into ``evidence``
+    and is what actually drives that recompute for a token_overlap row via
+    ``strength_from_evidence``. Defaults to omitted so existing callers keep
+    their current evidence shape unchanged.
+    """
+    evidence = {"match": match}
+    if overlap_ratio is not None:
+        evidence["overlap_ratio"] = overlap_ratio
     engine.db.conn.execute(
         """
         INSERT INTO signals
@@ -766,7 +779,7 @@ def _seed_heuristic_signal(engine, node_id, whisper_log_id, strength, match="nod
         VALUES (?, ?, 'whisper_referenced', 1, ?, 'transcript_watcher_heuristic',
                 's1', 'transcript', 'myproject', 'h', ?, datetime('now'))
         """,
-        (whisper_log_id, node_id, strength, json.dumps({"match": match})),
+        (whisper_log_id, node_id, strength, json.dumps(evidence)),
     )
     engine.db.conn.commit()
 
@@ -804,13 +817,26 @@ def test_backfill_is_idempotent(engine):
     assert _snapshot(engine, target) == after_first, "the backfill reinforced twice"
 
 
-@pytest.mark.parametrize("strength,match", [(0.40, "token_overlap"), (0.7799, "token_overlap")])
-def test_backfill_skips_rows_below_the_floor(engine, strength, match):
-    """#272 D4: the backfill uses the same floor as the live path."""
+@pytest.mark.parametrize("strength,match,overlap_ratio", [
+    (0.40, "token_overlap", 0.5),      # ratio <= OVERLAP_GATE recomputes to the floor itself
+    (0.7799, "token_overlap", 8.7428), # asymptotic near-supremum, still strictly under 0.80
+])
+def test_backfill_skips_rows_below_the_floor(engine, strength, match, overlap_ratio):
+    """#272 D4: the backfill uses the same floor as the live path.
+
+    The seeded ``strength`` only fills the cosmetic ``signals.strength`` column,
+    which the backfill ignores by design — it recomputes from ``evidence`` via
+    ``strength_from_evidence``. ``overlap_ratio`` is what actually drives that
+    recompute, so the two cases genuinely land at different points on the
+    token_overlap band (0.40 and ~0.7799) instead of both silently falling
+    back to the same OVERLAP_FLOOR default.
+    """
     ids = _make_nodes(engine, count=1)
     target = ids[0]
     log_id = _seed_whisper_log(engine, target)
-    _seed_heuristic_signal(engine, target, log_id, strength=strength, match=match)
+    _seed_heuristic_signal(
+        engine, target, log_id, strength=strength, match=match, overlap_ratio=overlap_ratio
+    )
 
     before = _snapshot(engine, target)
     engine._migrate_heuristic_confirmed_use()

--- a/tests/test_engine/test_feedback_signal_strength.py
+++ b/tests/test_engine/test_feedback_signal_strength.py
@@ -1,0 +1,61 @@
+"""submit_feedback records a real strength, not a hardcoded 1.0 (#218)."""
+
+import pytest
+
+from ormah import signal_strength as ss
+from ormah.models.node import CreateNodeRequest
+
+
+def _node_with_whisper(engine, title):
+    """Create a node and a whisper_log row submit_feedback can resolve."""
+    node_id, _ = engine.remember(CreateNodeRequest(
+        content="caching architecture note for the strength ladder",
+        title=title,
+        type="fact",
+        tier="working",
+    ))
+    engine.recall_search("caching architecture", limit=10)
+    row = engine.db.conn.execute(
+        "SELECT id FROM whisper_log WHERE node_id = ? ORDER BY id DESC LIMIT 1",
+        (node_id,),
+    ).fetchone()
+    assert row is not None, "no whisper_log row was created — check the surface used"
+    return node_id, row["id"]
+
+
+def _stored_strength(engine, whisper_log_id):
+    return engine.db.conn.execute(
+        "SELECT strength FROM signals WHERE whisper_log_id = ? "
+        "AND signal_type = 'feedback_submitted'",
+        (whisper_log_id,),
+    ).fetchone()["strength"]
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        ("explicit", ss.EXPLICIT),
+        ("implicit", ss.IMPLICIT),
+        ("auto_heuristic", ss.UNKNOWN),
+    ],
+)
+def test_each_feedback_source_records_its_own_rung(engine, source, expected):
+    node_id, log_id = _node_with_whisper(engine, f"Caching {source}")
+    engine.submit_feedback(node_id, signal=1, source=source, whisper_log_id=log_id)
+    assert _stored_strength(engine, log_id) == expected
+
+
+def test_explicit_and_implicit_no_longer_collide(engine):
+    """Both used to store exactly 1.0, leaving source as the only discriminator."""
+    explicit_id, explicit_log = _node_with_whisper(engine, "Caching E")
+    implicit_id, implicit_log = _node_with_whisper(engine, "Caching I")
+    engine.submit_feedback(explicit_id, signal=1, source="explicit", whisper_log_id=explicit_log)
+    engine.submit_feedback(implicit_id, signal=1, source="implicit", whisper_log_id=implicit_log)
+    assert _stored_strength(engine, explicit_log) != _stored_strength(engine, implicit_log)
+
+
+def test_negative_feedback_keeps_its_channel_rung(engine):
+    """strength is the evidence for THIS row's polarity, so -1 is not weaker."""
+    node_id, log_id = _node_with_whisper(engine, "Caching N")
+    engine.submit_feedback(node_id, signal=-1, source="explicit", whisper_log_id=log_id)
+    assert _stored_strength(engine, log_id) == ss.EXPLICIT

--- a/tests/test_engine/test_mutation_stamping.py
+++ b/tests/test_engine/test_mutation_stamping.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 from ormah.models.node import ConnectRequest, CreateNodeRequest, EdgeType, NodeType
 from ormah.store.markdown import parse_node
+from tests.test_engine.test_confirmed_use_contract import _reinforce
 
 PAST = datetime(2020, 1, 1, tzinfo=timezone.utc)
 
@@ -143,7 +144,7 @@ def test_engine_access_tracking_does_not_advance_updated(engine):
     node_id = _create(engine, "Read often", "Frequently accessed fact.")
     _backdate(engine.file_store, node_id)
 
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
 
     node = engine.file_store.load(node_id)
     assert node.updated == PAST

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from ormah.models.node import CreateNodeRequest, NodeType, Tier
+from tests.test_engine.test_confirmed_use_contract import _claim_fresh_event, _reinforce
 
 
 def _row(engine, node_id: str):
@@ -43,11 +44,11 @@ def _backdate_review(engine, node_id: str, days: float) -> None:
 def test_ten_touches_in_one_day_produce_one_stability_update(engine):
     """AC4: ten uses, one numeric update, and the latest use time is recorded."""
     node_id = _make_node(engine)
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
 
     after_first = _row(engine, node_id)
     for _ in range(9):
-        engine._record_confirmed_use(node_id)
+        _reinforce(engine, node_id)
     after_ten = _row(engine, node_id)
 
     assert after_ten["stability"] == after_first["stability"]
@@ -58,11 +59,11 @@ def test_ten_touches_in_one_day_produce_one_stability_update(engine):
 
 def test_a_touch_after_the_cooldown_moves_stability_again(engine):
     node_id = _make_node(engine)
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
     before = _row(engine, node_id)
 
     _backdate_review(engine, node_id, days=1.0)
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
     after = _row(engine, node_id)
 
     assert after["stability"] > before["stability"]
@@ -90,7 +91,7 @@ def test_reinforcement_anchors_on_last_accessed_not_a_lagging_last_review(engine
     )
     engine.db.conn.commit()
 
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
 
     assert _row(engine, node_id)["stability"] == pytest.approx(1.50, abs=0.01)
 
@@ -107,7 +108,7 @@ def test_a_thirty_day_old_node_is_bounded_to_double(engine):
     engine.db.conn.commit()
     _backdate_review(engine, node_id, days=30.0)
 
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
 
     assert _row(engine, node_id)["stability"] == 2.0
 
@@ -115,10 +116,10 @@ def test_a_thirty_day_old_node_is_bounded_to_double(engine):
 def test_the_cooldown_does_not_freeze_the_decay_anchor(engine):
     """last_accessed must keep moving so decay never sees an active node as stale."""
     node_id = _make_node(engine)
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
     first = _row(engine, node_id)
 
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
     second = _row(engine, node_id)
 
     assert second["last_accessed"] >= first["last_accessed"]
@@ -134,7 +135,7 @@ def test_reinforcement_survives_a_zero_stability_node(engine):
     engine.db.conn.execute("UPDATE nodes SET stability = 0.0 WHERE id = ?", (node_id,))
     engine.db.conn.commit()
 
-    engine._record_confirmed_use(node_id)
+    _reinforce(engine, node_id)
 
     assert _row(engine, node_id)["stability"] > 0.0
 
@@ -201,13 +202,18 @@ def test_concurrent_touches_run_reinforcement_once(engine, monkeypatch):
 
     errors: list[BaseException] = []
 
-    def _touch() -> None:
+    # Issue #272: each thread needs its own claimed event up front — claiming
+    # must complete (its own transaction) before the mutator race below runs,
+    # and the mutator is now at-most-once per (whisper_log_id, node_id).
+    log_ids = [_claim_fresh_event(engine, node_id) for _ in range(4)]
+
+    def _touch(whisper_log_id: int) -> None:
         try:
-            engine._record_confirmed_use(node_id)
+            engine._record_confirmed_use(node_id, whisper_log_id=whisper_log_id)
         except BaseException as exc:  # noqa: BLE001 - surfaced via `errors` below
             errors.append(exc)
 
-    threads = [threading.Thread(target=_touch) for _ in range(4)]
+    threads = [threading.Thread(target=_touch, args=(log_id,)) for log_id in log_ids]
     for t in threads:
         t.start()
     for t in threads:

--- a/tests/test_engine/test_reinforcement_cooldown.py
+++ b/tests/test_engine/test_reinforcement_cooldown.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -124,6 +125,67 @@ def test_the_cooldown_does_not_freeze_the_decay_anchor(engine):
 
     assert second["last_accessed"] >= first["last_accessed"]
     assert second["last_review"] == first["last_review"]
+
+
+def _seed_pending_claim(engine, node_id: str, claimed_at: datetime) -> int:
+    """Insert a whisper_log row and a 'pending' claim stamped with claimed_at.
+
+    Mirrors _claim_fresh_event's insert shape but takes claimed_at explicitly
+    (rather than SQL datetime('now')) so an out-of-order pair of claims can be
+    built: an older one applied AFTER a newer one already moved last_accessed
+    forward. strftime truncates to whole seconds, matching what
+    _claim_confirmed_use's own datetime('now') produces, so the round trip
+    through the DB does not introduce a spurious sub-second mismatch.
+    """
+    with engine.db.transaction() as conn:
+        cursor = conn.execute(
+            "INSERT INTO whisper_log "
+            "(session_id, prompt_hash, prompt_vec, node_id, score, was_injected, logged_at) "
+            "VALUES ('test-out-of-order', ?, X'00', ?, 1.0, 1, datetime('now'))",
+            (uuid.uuid4().hex, node_id),
+        )
+        whisper_log_id = cursor.lastrowid
+        conn.execute(
+            "INSERT INTO confirmed_use_claims "
+            "(whisper_log_id, node_id, claimed_at, state) VALUES (?, ?, ?, 'pending')",
+            (whisper_log_id, node_id, claimed_at.strftime("%Y-%m-%d %H:%M:%S")),
+        )
+    return whisper_log_id
+
+
+def test_out_of_order_reinforcement_does_not_regress_last_accessed(engine):
+    """Final review I1: a sweep applied out of claimed_at order must not walk
+    last_accessed backwards.
+
+    C1 is claimed at T0, on event E1. C2 is claimed at T1 > T0, on event E2
+    for the SAME node. C2 is applied first (e.g. C1 failed and stayed
+    'pending' while a later use went through cleanly), moving last_accessed
+    to T1. A retry sweep later applies C1 with its own clock, T0. T0 < T1,
+    so the write must not move last_accessed back to T0.
+    """
+    node_id = _make_node(engine)
+    now = datetime.now(timezone.utc)
+    t0 = now - timedelta(hours=2)
+    t1 = now - timedelta(hours=1)
+    assert t0 < t1, "the two claim clocks must be distinguishable and ordered"
+
+    log_c1 = _seed_pending_claim(engine, node_id, t0)
+    log_c2 = _seed_pending_claim(engine, node_id, t1)
+
+    # C2 (the newer claim) lands first.
+    engine._record_confirmed_use(node_id, whisper_log_id=log_c2)
+    after_c2 = _row(engine, node_id)
+    assert after_c2["access_count"] == 1
+
+    # C1 (the older claim) is applied afterwards, as a retry sweep would.
+    engine._record_confirmed_use(node_id, whisper_log_id=log_c1)
+    after_c1 = _row(engine, node_id)
+
+    assert after_c1["access_count"] == 2, "the older claim's use was not counted"
+    assert after_c1["last_accessed"] == after_c2["last_accessed"], (
+        "an out-of-order claim regressed last_accessed: "
+        f"{after_c2['last_accessed']!r} -> {after_c1['last_accessed']!r}"
+    )
 
 
 def test_reinforcement_survives_a_zero_stability_node(engine):

--- a/tests/test_engine/test_signal_strength.py
+++ b/tests/test_engine/test_signal_strength.py
@@ -5,6 +5,7 @@ import math
 
 import pytest
 
+from ormah import signal_strength
 from ormah import signal_strength as ss
 
 
@@ -166,3 +167,24 @@ def test_recompute_stays_finite_and_in_band_for_poisoned_confidence(confidence):
     result = ss.strength_from_evidence(ss.LLM_JUDGE_SOURCE, 1, evidence)
     assert math.isfinite(result)
     assert ss.JUDGE_LO <= result <= ss.JUDGE_HI
+
+
+def test_token_overlap_never_reaches_the_confirm_floor():
+    """#272 D1: token_overlap is excluded from confirmed use BY CONSTRUCTION.
+
+    The band's supremum is OVERLAP_FLOOR + OVERLAP_SPAN == 0.78, so no reachable
+    overlap_ratio can clear a 0.80 floor. Measured max on a live store: 7.583.
+    """
+    from ormah.engine.memory_engine import HEURISTIC_CONFIRM_FLOOR
+
+    for ratio in (0.5, 1.0, 1.167, 1.5, 3.0, 7.583, 37.0, 1e6):
+        assert signal_strength.token_overlap_strength(ratio) < HEURISTIC_CONFIRM_FLOOR
+
+
+def test_verbatim_match_kinds_clear_the_confirm_floor():
+    """#272 D1: the three verbatim kinds are exactly the ones admitted."""
+    from ormah.engine.memory_engine import HEURISTIC_CONFIRM_FLOOR
+
+    assert signal_strength.VERBATIM_NODE_ID >= HEURISTIC_CONFIRM_FLOOR
+    assert signal_strength.VERBATIM_TITLE >= HEURISTIC_CONFIRM_FLOOR
+    assert signal_strength.VERBATIM_SENTENCE >= HEURISTIC_CONFIRM_FLOOR

--- a/tests/test_engine/test_signal_strength.py
+++ b/tests/test_engine/test_signal_strength.py
@@ -1,6 +1,7 @@
 """Unit tests for the #218 ordinal evidence ladder."""
 
 import json
+import math
 
 import pytest
 
@@ -127,3 +128,41 @@ def test_recompute_survives_malformed_evidence():
     assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, "not json") == ss.UNKNOWN
     assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, None) == ss.UNKNOWN
     assert ss.strength_from_evidence("implicit", 0, None) == 0.0
+
+
+# --- Non-finite and out-of-range evidence (#218, Codex peer 2026-08-26) ---------
+#
+# The migration runs on every startup. json.loads accepts NaN and Infinity by
+# default and returns an unbounded int for a large integer literal; SQLite stores a
+# NaN REAL as NULL and signals.strength is NOT NULL. So one poisoned historical row
+# would raise IntegrityError inside the migration and the server would never boot
+# again. These pin the coercion that prevents it.
+
+def test_as_float_survives_an_integer_beyond_the_double_range():
+    """float() of a huge int raises OverflowError, which is not a ValueError."""
+    assert ss._as_float(int("9" * 400)) == 0.0
+    assert ss._as_float(int("9" * 400), default=0.75) == 0.75
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_as_float_rejects_non_finite_values(value):
+    assert ss._as_float(value) == 0.0
+    assert ss._as_float(value, default=0.75) == 0.75
+
+
+@pytest.mark.parametrize(
+    "ratio", [float("nan"), float("inf"), float("-inf"), int("9" * 400)]
+)
+def test_recompute_stays_finite_and_in_band_for_poisoned_overlap_ratio(ratio):
+    evidence = json.dumps({"match": "token_overlap", "overlap_ratio": ratio})
+    result = ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, evidence)
+    assert math.isfinite(result)
+    assert ss.OVERLAP_FLOOR <= result <= ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN
+
+
+@pytest.mark.parametrize("confidence", [float("nan"), float("inf"), int("9" * 400)])
+def test_recompute_stays_finite_and_in_band_for_poisoned_confidence(confidence):
+    evidence = json.dumps({"confidence": confidence, "min_confidence": 0.75})
+    result = ss.strength_from_evidence(ss.LLM_JUDGE_SOURCE, 1, evidence)
+    assert math.isfinite(result)
+    assert ss.JUDGE_LO <= result <= ss.JUDGE_HI

--- a/tests/test_engine/test_signal_strength.py
+++ b/tests/test_engine/test_signal_strength.py
@@ -1,0 +1,129 @@
+"""Unit tests for the #218 ordinal evidence ladder."""
+
+import json
+
+import pytest
+
+from ormah import signal_strength as ss
+
+
+def test_bands_are_disjoint_and_ordered():
+    """The ladder's central assertion: channel dominates within-channel confidence."""
+    ordered = sorted(ss.BANDS, key=lambda band: -band[1])
+    assert [band[0] for band in ordered] == [
+        "explicit",
+        "node_id",
+        "title",
+        "sentence",
+        "auto_llm_judge",
+        "implicit",
+        "token_overlap",
+    ]
+    for (upper, upper_lo, _), (lower, _, lower_hi) in zip(ordered, ordered[1:]):
+        assert lower_hi < upper_lo, f"{lower} band overlaps {upper}"
+
+
+def test_token_overlap_starts_at_the_band_floor():
+    assert ss.token_overlap_strength(ss.OVERLAP_GATE) == pytest.approx(ss.OVERLAP_FLOOR)
+
+
+def test_token_overlap_separates_the_observed_domain():
+    """0.5..7.583 is the range measured on a live store; no two ratios may tie."""
+    values = [ss.token_overlap_strength(r) for r in (0.5, 0.55, 1.167, 1.5, 3.0, 7.583)]
+    assert values == sorted(values)
+    assert len(set(values)) == len(values)
+    assert values[-1] < ss.IMPLICIT
+
+
+def test_token_overlap_fixes_the_defect_218_names():
+    """Today min(0.85, 0.45 + ratio) returns exactly 0.85 for both of these."""
+    assert ss.token_overlap_strength(0.5) != ss.token_overlap_strength(1.8)
+
+
+def test_token_overlap_never_exceeds_its_band():
+    """The supremum is strict in exact arithmetic, not in float64.
+
+    float64 reaches it around ratio 37 — five times above the 7.583 maximum observed
+    on a live store. That crossover is libm-dependent, so it is documented here and
+    not asserted; what is asserted is that the band is never exceeded.
+    """
+    supremum = ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN
+    assert all(ss.token_overlap_strength(n / 10) <= supremum for n in range(5, 1000))
+    assert supremum < ss.IMPLICIT
+
+
+@pytest.mark.parametrize("min_confidence", [0.75, 0.80])
+def test_judge_band_is_affine_over_the_callers_min_confidence(min_confidence):
+    assert ss.judge_strength(min_confidence, min_confidence, 1) == pytest.approx(ss.JUDGE_LO)
+    assert ss.judge_strength(1.0, min_confidence, 1) == pytest.approx(ss.JUDGE_HI)
+    midpoint = (min_confidence + 1.0) / 2
+    assert ss.judge_strength(midpoint, min_confidence, 1) == pytest.approx(
+        (ss.JUDGE_LO + ss.JUDGE_HI) / 2
+    )
+
+
+def test_judge_zero_polarity_carries_no_strength():
+    """An uncertain verdict asserts nothing. Its confidence survives in evidence."""
+    assert ss.judge_strength(0.35, 0.75, 0) == 0.0
+    assert ss.judge_strength(0.99, 0.75, 0) == 0.0
+
+
+def test_judge_negative_polarity_uses_the_same_band():
+    """A confident 'irrelevant' is strong evidence for its own polarity."""
+    assert ss.judge_strength(1.0, 0.75, -1) == pytest.approx(ss.JUDGE_HI)
+
+
+def test_judge_degenerate_min_confidence_does_not_divide_by_zero():
+    assert ss.judge_strength(1.0, 1.0, 1) == ss.JUDGE_HI
+
+
+def test_explicit_and_implicit_no_longer_share_a_strength():
+    """Today submit_feedback hardcodes 1.0 for both."""
+    assert ss.feedback_strength("explicit", 1) == ss.EXPLICIT
+    assert ss.feedback_strength("implicit", 1) == ss.IMPLICIT
+    assert ss.feedback_strength("explicit", 1) != ss.feedback_strength("implicit", 1)
+
+
+def test_feedback_zero_signal_carries_no_strength():
+    """Unreachable through the HTTP surface; reachable from a direct Python caller."""
+    assert ss.feedback_strength("explicit", 0) == 0.0
+
+
+def test_unknown_source_fails_closed_to_the_bottom_rung():
+    assert ss.feedback_strength("something_new", 1) == ss.UNKNOWN
+    assert ss.feedback_strength("auto_heuristic", -1) == ss.UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "match,expected",
+    [
+        ("node_id", ss.VERBATIM_NODE_ID),
+        ("title", ss.VERBATIM_TITLE),
+        ("sentence", ss.VERBATIM_SENTENCE),
+    ],
+)
+def test_recompute_reads_the_heuristic_match_kind(match, expected):
+    evidence = json.dumps({"match": match})
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, evidence) == expected
+
+
+def test_recompute_reads_the_overlap_ratio():
+    evidence = json.dumps({"match": "token_overlap", "overlap_ratio": 1.167})
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, evidence) == pytest.approx(
+        ss.token_overlap_strength(1.167)
+    )
+
+
+def test_recompute_uses_the_rows_own_min_confidence():
+    """Not today's setting: the judge stamps min_confidence on every row it writes."""
+    lenient = json.dumps({"confidence": 0.80, "min_confidence": 0.75})
+    strict = json.dumps({"confidence": 0.80, "min_confidence": 0.80})
+    assert ss.strength_from_evidence(
+        ss.LLM_JUDGE_SOURCE, 1, lenient
+    ) > ss.strength_from_evidence(ss.LLM_JUDGE_SOURCE, 1, strict)
+
+
+def test_recompute_survives_malformed_evidence():
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, "not json") == ss.UNKNOWN
+    assert ss.strength_from_evidence(ss.HEURISTIC_SOURCE, 1, None) == ss.UNKNOWN
+    assert ss.strength_from_evidence("implicit", 0, None) == 0.0

--- a/tests/test_engine/test_signal_strength_backfill.py
+++ b/tests/test_engine/test_signal_strength_backfill.py
@@ -202,3 +202,36 @@ def test_the_cutoff_advances_after_a_repair(engine):
     engine._migrate_signal_strength()
 
     assert _row(engine, legacy)["strength"] == 0.123, "the cutoff did not advance"
+
+
+def test_a_poisoned_evidence_row_cannot_block_startup(engine):
+    """One malformed historical value must not stop the server from ever booting.
+
+    The migration runs at every startup and writes into signals.strength, which is
+    REAL NOT NULL. SQLite stores a NaN REAL as NULL, so binding one raises
+    IntegrityError — and with an every-boot migration that failure is permanent,
+    not a one-time hiccup. Codex peer finding, /council-pr of 2026-08-26.
+    """
+    poisoned = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": float("nan")},
+    )
+    huge = _seed(
+        engine,
+        source=ss.LLM_JUDGE_SOURCE,
+        polarity=1,
+        evidence={"confidence": int("9" * 400), "min_confidence": 0.75},
+    )
+
+    _rerun(engine)          # must not raise
+    engine._migrate_signal_strength()   # and the next boot must not raise either
+
+    for signal_id, lo, hi in (
+        (poisoned, ss.OVERLAP_FLOOR, ss.OVERLAP_FLOOR + ss.OVERLAP_SPAN),
+        (huge, ss.JUDGE_LO, ss.JUDGE_HI),
+    ):
+        strength = _row(engine, signal_id)["strength"]
+        assert strength is not None
+        assert lo <= strength <= hi

--- a/tests/test_engine/test_signal_strength_backfill.py
+++ b/tests/test_engine/test_signal_strength_backfill.py
@@ -25,9 +25,10 @@ def _seed(engine, *, source, polarity, evidence, strength=0.85):
 
 
 def _rerun(engine):
-    """Clear the version stamp so the guarded migration runs again."""
+    """Clear both markers so the migration makes a full pass over the table."""
     engine.db.conn.execute(
-        "DELETE FROM meta WHERE key = 'signal_strength_ladder_version'"
+        "DELETE FROM meta WHERE key IN "
+        "('signal_strength_ladder_version', 'signal_strength_ladder_cutoff')"
     )
     engine.db.conn.commit()
     engine._migrate_signal_strength()
@@ -130,8 +131,8 @@ def test_backfill_is_idempotent(engine):
     assert once == twice
 
 
-def test_backfill_does_not_rerun_once_stamped(engine):
-    """The version guard, not the recompute, is what makes the second boot free."""
+def test_rows_at_or_below_the_cutoff_are_not_rescanned(engine):
+    """The cutoff, not the recompute, is what keeps a later start cheap."""
     signal_id = _seed(
         engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence={"match": "node_id"}
     )
@@ -142,3 +143,62 @@ def test_backfill_does_not_rerun_once_stamped(engine):
     engine._migrate_signal_strength()
 
     assert _row(engine, signal_id)["strength"] == 0.123
+
+
+def test_rescan_repairs_a_legacy_row_written_after_the_stamp(engine):
+    """A one-time stamp cannot repair what an old binary writes after it.
+
+    A rollback then re-upgrade, or the second unmanaged server process this project
+    already knows about (#238), inserts pre-ladder values into a table the stamp
+    declares migrated. Council peer finding, /council-pr of 2026-08-26.
+    """
+    _rerun(engine)
+
+    legacy = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "node_id"},
+        strength=1.0,
+    )
+    engine._migrate_signal_strength()
+
+    assert _row(engine, legacy)["strength"] == ss.VERBATIM_NODE_ID
+
+
+def test_rescan_leaves_an_already_correct_row_untouched(engine):
+    """The repair is a repair only because a current-code row recomputes to itself.
+
+    strength_from_evidence is a pure function of (source, polarity, evidence), and
+    every write site stores exactly what it returns for what it recorded. Without
+    that, rescanning would drift correct rows instead of confirming them.
+    """
+    _rerun(engine)
+
+    correct = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": 0.667},
+        strength=ss.token_overlap_strength(0.667),
+    )
+    before = _row(engine, correct)["strength"]
+    engine._migrate_signal_strength()
+
+    assert _row(engine, correct)["strength"] == before
+
+
+def test_the_cutoff_advances_after_a_repair(engine):
+    """Each start covers only what arrived since the last one."""
+    _rerun(engine)
+    legacy = _seed(
+        engine, source="implicit", polarity=1, evidence={"source": "implicit"}, strength=1.0
+    )
+    engine._migrate_signal_strength()
+    assert _row(engine, legacy)["strength"] == ss.IMPLICIT
+
+    engine.db.conn.execute("UPDATE signals SET strength = 0.123 WHERE id = ?", (legacy,))
+    engine.db.conn.commit()
+    engine._migrate_signal_strength()
+
+    assert _row(engine, legacy)["strength"] == 0.123, "the cutoff did not advance"

--- a/tests/test_engine/test_signal_strength_backfill.py
+++ b/tests/test_engine/test_signal_strength_backfill.py
@@ -1,0 +1,144 @@
+"""The #218 backfill recomputes historical strength exactly, and only once."""
+
+import json
+
+import pytest
+
+from ormah import signal_strength as ss
+
+
+def _seed(engine, *, source, polarity, evidence, strength=0.85):
+    """Insert a signals row with a stale strength.
+
+    whisper_log_id stays NULL: the unique index on
+    (whisper_log_id, signal_type, source) is partial on whisper_log_id IS NOT NULL,
+    so NULL rows never collide however many are seeded.
+    """
+    cursor = engine.db.conn.execute(
+        "INSERT INTO signals "
+        "(whisper_log_id, node_id, signal_type, polarity, strength, source, evidence, created) "
+        "VALUES (NULL, 'seed-node', 'seeded', ?, ?, ?, ?, datetime('now'))",
+        (polarity, strength, source, json.dumps(evidence) if evidence is not None else None),
+    )
+    engine.db.conn.commit()
+    return cursor.lastrowid
+
+
+def _rerun(engine):
+    """Clear the version stamp so the guarded migration runs again."""
+    engine.db.conn.execute(
+        "DELETE FROM meta WHERE key = 'signal_strength_ladder_version'"
+    )
+    engine.db.conn.commit()
+    engine._migrate_signal_strength()
+
+
+def _row(engine, signal_id):
+    return engine.db.conn.execute(
+        "SELECT strength, polarity, evidence FROM signals WHERE id = ?", (signal_id,)
+    ).fetchone()
+
+
+def test_backfill_recomputes_each_channel_exactly(engine):
+    verbatim = _seed(
+        engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence={"match": "node_id"}
+    )
+    overlap = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": 1.167},
+    )
+    judged = _seed(
+        engine,
+        source=ss.LLM_JUDGE_SOURCE,
+        polarity=1,
+        evidence={"confidence": 0.88, "min_confidence": 0.75},
+    )
+    implicit = _seed(engine, source="implicit", polarity=1, evidence={"source": "implicit"},
+                     strength=1.0)
+
+    _rerun(engine)
+
+    assert _row(engine, verbatim)["strength"] == ss.VERBATIM_NODE_ID
+    assert _row(engine, overlap)["strength"] == pytest.approx(ss.token_overlap_strength(1.167))
+    assert _row(engine, judged)["strength"] == pytest.approx(ss.judge_strength(0.88, 0.75, 1))
+    assert _row(engine, implicit)["strength"] == ss.IMPLICIT
+
+
+def test_backfill_uses_the_rows_own_min_confidence(engine):
+    """Not today's setting — the judge stamped it on the row when it wrote it."""
+    lenient = _seed(
+        engine, source=ss.LLM_JUDGE_SOURCE, polarity=1,
+        evidence={"confidence": 0.80, "min_confidence": 0.75},
+    )
+    strict = _seed(
+        engine, source=ss.LLM_JUDGE_SOURCE, polarity=1,
+        evidence={"confidence": 0.80, "min_confidence": 0.80},
+    )
+
+    _rerun(engine)
+
+    assert _row(engine, lenient)["strength"] > _row(engine, strict)["strength"]
+
+
+def test_backfill_zeroes_rows_that_assert_nothing(engine):
+    uncertain = _seed(
+        engine, source=ss.LLM_JUDGE_SOURCE, polarity=0,
+        evidence={"confidence": 0.35, "min_confidence": 0.75},
+    )
+
+    _rerun(engine)
+
+    assert _row(engine, uncertain)["strength"] == 0.0
+
+
+def test_backfill_survives_missing_evidence(engine):
+    orphan = _seed(engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence=None)
+
+    _rerun(engine)
+
+    assert _row(engine, orphan)["strength"] == ss.UNKNOWN
+
+
+def test_backfill_leaves_evidence_and_polarity_untouched(engine):
+    evidence = {"match": "token_overlap", "overlap_ratio": 1.167}
+    signal_id = _seed(engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence=evidence)
+    before = _row(engine, signal_id)
+
+    _rerun(engine)
+
+    after = _row(engine, signal_id)
+    assert after["evidence"] == before["evidence"]
+    assert after["polarity"] == before["polarity"]
+    assert after["strength"] != before["strength"]
+
+
+def test_backfill_is_idempotent(engine):
+    signal_id = _seed(
+        engine,
+        source=ss.HEURISTIC_SOURCE,
+        polarity=1,
+        evidence={"match": "token_overlap", "overlap_ratio": 1.167},
+    )
+
+    _rerun(engine)
+    once = _row(engine, signal_id)["strength"]
+    _rerun(engine)
+    twice = _row(engine, signal_id)["strength"]
+
+    assert once == twice
+
+
+def test_backfill_does_not_rerun_once_stamped(engine):
+    """The version guard, not the recompute, is what makes the second boot free."""
+    signal_id = _seed(
+        engine, source=ss.HEURISTIC_SOURCE, polarity=1, evidence={"match": "node_id"}
+    )
+    _rerun(engine)
+
+    engine.db.conn.execute("UPDATE signals SET strength = 0.123 WHERE id = ?", (signal_id,))
+    engine.db.conn.commit()
+    engine._migrate_signal_strength()
+
+    assert _row(engine, signal_id)["strength"] == 0.123


### PR DESCRIPTION
Closes #272.

## Stacked on #273

**The first 8 commits of this branch belong to #273** (`fix/218-signal-strength-ladder`), which is
still open. This branch was cut from that PR's tip because #272's evidence floor reads the ordinal
strength ladder #218 introduces. Review or merge #273 first; the #272 work is the 9 commits from
`2867188` onward:

| Commit | What it delivers |
|---|---|
| `2867188` | `auto_heuristic` is admitted to confirmed use above an evidence floor |
| `5350c06` | the heuristic detector claims confirmed use |
| `f9f4161` | boot backfill claims the confirmed use the heuristic never claimed |
| `f41668c` | the 0.7799 backfill-floor fixture gets real `overlap_ratio` evidence |
| `52be2d5` | a weak heuristic hit no longer also loses the judge |
| `b841235` | the confirmed-use claim's promise becomes durable (#220 debt) |
| `e975a90` | final-review findings I1, I2, M1 closed |
| `dba2ba9` | the boot backfill stamps the event's time, not the boot's |
| `19ec283` | the node load moves inside the reinforcement transaction |

## What the last two commits fix

Both came out of an adversarial review of the branch and are worth calling out, because each
changes a durability property rather than adding a feature.

**`dba2ba9` — the backfill stamps the event's clock.** `_claim_confirmed_use` stamped
`claimed_at = datetime('now')` unconditionally, so the boot backfill recorded uses that happened
days earlier as happening at startup — and `_record_confirmed_use` pushes `claimed_at` into
`last_accessed` (the decay anchor), `last_review` and FSRS. A `historical` keyword now makes the
expression conditional: `CASE WHEN ? THEN COALESCE(datetime(wl.logged_at), datetime('now')) ELSE
datetime('now') END`. The truthful timestamp comes from the same `whisper_log` row the claim's FK
already references, and SQLite's `datetime()` normalizes Python isoformat to the space-format UTC
shape `datetime('now')` writes — which matters because the sweeper compares `claimed_at`
lexicographically (`reinforcement_retry.py`), where `'T'` (0x54) sorts above `' '` (0x20).
`COALESCE` keeps a malformed `logged_at` from aborting the whole backfill transaction
(`claimed_at` is `NOT NULL`). Live claims keep the wall clock.

**`19ec283` — the node load moves inside the write transaction.** `file_store.load()` ran before
`with self.db.transaction()`. `BEGIN IMMEDIATE` can block up to `busy_timeout=5000` ms between the
load and the save, and this branch's own diff had widened that window (load and save were
contiguous before it). The load now sits after the at-most-once latch, so a failed latch performs
no file I/O at all. **This does not fix the pre-existing cross-process dual-writer race**: load and
save remain non-atomic between binaries sharing the store.

## Known open findings — not fixed here

An adversarial review raised two `high` findings against the durable-retry protocol (`b841235`,
`e975a90`). Neither carries a reproduction command, so **neither has been reproduced nor refuted** —
they are recorded here as plausible and unmeasured, not as known-good:

1. **A failed COMMIT can still turn one claim into two increments**
   (`memory_engine.py`, the save/commit region). The markdown is saved before the enclosing
   transaction commits. If the save succeeds and the COMMIT fails, the file holds
   `access_count + 1` while the database rolls back; a subsequent `update_node` or reindex can
   promote that phantom counter into SQLite via `builder.index_single`, and the retry then writes
   `access_count + 2`. This contradicts the convergence argument the code's own comment makes —
   that argument holds only while no file-to-index operation runs between the failure and the retry.

2. **A missing markdown file permanently discards a still-existing node's reinforcement**
   (the orphan check). The claim is marked terminal `orphaned` when the file load fails **or** the
   node row is absent. A node can exist in SQLite while its markdown is temporarily absent during a
   sync or restore, and the sweeper then stops retrying forever. The existing test covers only
   absence from both stores.

Happy to fix either in this PR or a follow-up — say which you prefer.

## Testing

Full suite on the branch: **2055 passed**, 3 failed. The 3 failures are
`tests/test_setup.py::TestConfigureCodexMcp::*`, environmental and pre-existing (they fail on the
branch point too). `ruff check src/ tests/` clean.

Both new commits were written test-first; each new test was confirmed to fail against the pre-fix
code for its stated reason before the fix landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
