### PR TITLE
fix(db): retire per-thread SQLite connections on thread death (fd leak, #83)

### DIFF
--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+import weakref
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -48,6 +49,11 @@ class Database:
             pass  # sqlite-vec not installed — vector search disabled
         with self._conns_lock:
             self._all_conns.append(conn)
+        # Auto-close this connection when its OWNING thread is garbage-collected. Without this,
+        # an ephemeral thread (e.g. a maintenance phase thread) leaks its connection — and its
+        # ~3 WAL fds — for the whole process lifetime, until [Errno 24]. finalize fires at most
+        # once; close() (shutdown) also handles any still-live threads' connections.
+        weakref.finalize(threading.current_thread(), self._retire_connection, conn)
         return conn
 
     @property
@@ -542,6 +548,18 @@ class Database:
                 )
         except ImportError:
             pass  # sqlite-vec not available, vector search disabled
+
+    def _retire_connection(self, conn: sqlite3.Connection) -> None:
+        """Drop a dead thread's connection from the registry and close it."""
+        with self._conns_lock:
+            try:
+                self._all_conns.remove(conn)
+            except ValueError:
+                pass  # already retired by close()
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001
+            pass
 
     def close(self) -> None:
         with self._conns_lock:

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -22,6 +22,7 @@ class Database:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._local = threading.local()
         self._all_conns: list[sqlite3.Connection] = []
+        self._finalizers: list[weakref.finalize] = []
         self._conns_lock = threading.Lock()
         self._lock = threading.RLock()  # serializes write transactions across threads
 
@@ -47,13 +48,19 @@ class Database:
             conn.enable_load_extension(False)
         except ImportError:
             pass  # sqlite-vec not installed — vector search disabled
-        with self._conns_lock:
-            self._all_conns.append(conn)
         # Auto-close this connection when its OWNING thread is garbage-collected. Without this,
         # an ephemeral thread (e.g. a maintenance phase thread) leaks its connection — and its
         # ~3 WAL fds — for the whole process lifetime, until [Errno 24]. finalize fires at most
         # once; close() (shutdown) also handles any still-live threads' connections.
-        weakref.finalize(threading.current_thread(), self._retire_connection, conn)
+        finalizer = weakref.finalize(threading.current_thread(), self._retire_connection, conn)
+        with self._conns_lock:
+            self._all_conns.append(conn)
+            # A finalizer keeps its callback and args alive, so this bound `_retire_connection`
+            # pins the Database until the OWNING thread dies — never, on a long-lived one.
+            # close() detaches them; drop the ones that already fired so the list stays bounded
+            # by live threads instead of growing once per thread ever seen.
+            self._finalizers = [f for f in self._finalizers if f.alive]
+            self._finalizers.append(finalizer)
         return conn
 
     @property
@@ -563,10 +570,16 @@ class Database:
 
     def close(self) -> None:
         with self._conns_lock:
-            for conn in self._all_conns:
-                try:
-                    conn.close()
-                except Exception:  # noqa: BLE001
-                    pass
-            self._all_conns.clear()
+            conns, self._all_conns = self._all_conns, []
+            finalizers, self._finalizers = self._finalizers, []
+        # Detaching drops the finalizer's refs to `self` and to the connection: without it a
+        # closed Database stays resident for as long as the thread that opened a connection on
+        # it lives. Done outside the lock — nothing here needs it.
+        for finalizer in finalizers:
+            finalizer.detach()
+        for conn in conns:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
         self._local = threading.local()

--- a/src/ormah/index/db.py
+++ b/src/ormah/index/db.py
@@ -23,7 +23,9 @@ class Database:
         self._local = threading.local()
         self._all_conns: list[sqlite3.Connection] = []
         self._finalizers: list[weakref.finalize] = []
-        self._conns_lock = threading.Lock()
+        # Re-entrant: the GC can fire a connection finalizer while this very thread is
+        # inside a section that already holds it — see _retire_connection.
+        self._conns_lock = threading.RLock()
         self._lock = threading.RLock()  # serializes write transactions across threads
 
     def _new_connection(self) -> sqlite3.Connection:

--- a/tests/test_index/test_db_fd_lifecycle.py
+++ b/tests/test_index/test_db_fd_lifecycle.py
@@ -1,0 +1,29 @@
+"""Ephemeral threads must not leak their per-thread SQLite connection (FD-leak regression)."""
+from __future__ import annotations
+
+import gc
+import threading
+
+from ormah.index.db import Database
+
+
+def test_ephemeral_thread_connection_is_retired(tmp_path):
+    db = Database(tmp_path / "t.db")
+    db.init_schema()  # opens the main-thread connection
+    baseline = len(db._all_conns)
+
+    def worker():
+        db.conn.execute("SELECT 1").fetchone()  # forces a new per-thread connection
+
+    threads = [threading.Thread(target=worker) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # `t` still holds a strong ref to the last thread after the loop above (the loop
+    # variable outlives the loop) — drop it explicitly, or that one thread never dies.
+    del threads, t
+    gc.collect()  # run the weakref finalizers for the now-dead threads
+
+    assert len(db._all_conns) <= baseline

--- a/tests/test_index/test_db_fd_lifecycle.py
+++ b/tests/test_index/test_db_fd_lifecycle.py
@@ -10,24 +10,27 @@ from ormah.index.db import Database
 
 def test_ephemeral_thread_connection_is_retired(tmp_path):
     db = Database(tmp_path / "t.db")
-    db.init_schema()  # opens the main-thread connection
-    baseline = len(db._all_conns)
+    try:
+        db.init_schema()  # opens the main-thread connection
+        baseline = len(db._all_conns)
 
-    def worker():
-        db.conn.execute("SELECT 1").fetchone()  # forces a new per-thread connection
+        def worker():
+            db.conn.execute("SELECT 1").fetchone()  # forces a new per-thread connection
 
-    threads = [threading.Thread(target=worker) for _ in range(20)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+        threads = [threading.Thread(target=worker) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
 
-    # `t` still holds a strong ref to the last thread after the loop above (the loop
-    # variable outlives the loop) — drop it explicitly, or that one thread never dies.
-    del threads, t
-    gc.collect()  # run the weakref finalizers for the now-dead threads
+        # `t` still holds a strong ref to the last thread after the loop above (the loop
+        # variable outlives the loop) — drop it explicitly, or that one thread never dies.
+        del threads, t
+        gc.collect()  # run the weakref finalizers for the now-dead threads
 
-    assert len(db._all_conns) <= baseline
+        assert len(db._all_conns) <= baseline
+    finally:
+        db.close()
 
 
 def test_close_releases_the_database_for_gc(tmp_path):
@@ -63,12 +66,15 @@ def test_retire_connection_is_reentrant_under_the_conns_lock(tmp_path):
     deadlock here takes the whole test process down with it.
     """
     db = Database(tmp_path / "t.db")
-    conn = db.conn
+    try:
+        conn = db.conn
 
-    with db._conns_lock:
-        reentrant = db._conns_lock.acquire(blocking=False)
-        if reentrant:
-            db._conns_lock.release()
-            db._retire_connection(conn)  # the real callback path, now provably safe
+        with db._conns_lock:
+            reentrant = db._conns_lock.acquire(blocking=False)
+            if reentrant:
+                db._conns_lock.release()
+                db._retire_connection(conn)  # the real callback path, now provably safe
 
-    assert reentrant, "_retire_connection would deadlock: _conns_lock is not re-entrant"
+        assert reentrant, "_retire_connection would deadlock: _conns_lock is not re-entrant"
+    finally:
+        db.close()

--- a/tests/test_index/test_db_fd_lifecycle.py
+++ b/tests/test_index/test_db_fd_lifecycle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import gc
 import threading
+import weakref
 
 from ormah.index.db import Database
 
@@ -27,3 +28,22 @@ def test_ephemeral_thread_connection_is_retired(tmp_path):
     gc.collect()  # run the weakref finalizers for the now-dead threads
 
     assert len(db._all_conns) <= baseline
+
+
+def test_close_releases_the_database_for_gc(tmp_path):
+    """close() must detach the per-thread finalizers.
+
+    A finalizer holds strong refs to its callback and args, so a bound
+    `_retire_connection` pins the whole Database until the OWNING thread dies. On a
+    long-lived thread (the main thread, a pool worker) that is never — every closed
+    temporary Database would stay resident for the process lifetime.
+    """
+    db = Database(tmp_path / "t.db")
+    db.init_schema()  # opens a connection on this (long-lived) thread
+    db.close()
+
+    ref = weakref.ref(db)
+    del db
+    gc.collect()
+
+    assert ref() is None

--- a/tests/test_index/test_db_fd_lifecycle.py
+++ b/tests/test_index/test_db_fd_lifecycle.py
@@ -47,3 +47,28 @@ def test_close_releases_the_database_for_gc(tmp_path):
     gc.collect()
 
     assert ref() is None
+
+
+def test_retire_connection_is_reentrant_under_the_conns_lock(tmp_path):
+    """A finalizer can fire while the same thread already holds the registry lock.
+
+    CPython runs weakref callbacks from the generational GC, which triggers on
+    allocation — including an allocation inside `_new_connection`'s own critical
+    section. If a dead thread is collected right there, `_retire_connection` re-enters
+    the lock on the very thread that holds it. With a plain Lock that is a hard deadlock,
+    and it does not end with the test: the finalizers still registered run at interpreter
+    exit and hang there too.
+
+    Probed non-blockingly rather than by actually deadlocking, precisely because a real
+    deadlock here takes the whole test process down with it.
+    """
+    db = Database(tmp_path / "t.db")
+    conn = db.conn
+
+    with db._conns_lock:
+        reentrant = db._conns_lock.acquire(blocking=False)
+        if reentrant:
+            db._conns_lock.release()
+            db._retire_connection(conn)  # the real callback path, now provably safe
+
+    assert reentrant, "_retire_connection would deadlock: _conns_lock is not re-entrant"


### PR DESCRIPTION
Fixes #83.

## What

`Database._new_connection` registers every per-thread connection in `_all_conns` and never closes it when the owning thread dies — the only close path is `Database.close()` at shutdown. Ephemeral threads (the maintenance phases spawn a fresh daemon thread per cycle) each leak a connection and its ~3 WAL fds for the whole process lifetime, until `[Errno 24] Too many open files` wedges the server (2641 fds on `index.db` observed in a live incident — details in #83).

## Fix

Register a `weakref.finalize` on the owning thread object at connection creation, so the connection is closed and removed from `_all_conns` when the thread is garbage-collected:

```python
weakref.finalize(threading.current_thread(), self._retire_connection, conn)
```

Root-cause and driver-agnostic — no need to hunt every ephemeral-thread call site. `Database.close()` still handles any still-live threads' connections at shutdown, and `_retire_connection` is idempotent with it.

## Testing

- New `tests/test_index/test_db_fd_lifecycle.py`: spawns ephemeral threads that each touch `db.conn`, joins them, forces GC, and asserts the connections are retired (fails on `main` today, passes with the fix).
- Full suite on this branch: 1949 passed; the 4 failures (`test_space_detect`/`TestConfigureCodexMcp`) also fail on unmodified `upstream/main` in the same environment — pre-existing, unrelated.

This fix has also been running continuously in my downstream beta since 2026-07-05 with no recurrence of the fd growth.

cc @r-spade — flagging because the failure mode takes down a long-running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)