### PR TITLE
chore(release): prepare 0.15.0

### DIFF
--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.14.11",
+  "version": "0.15.0",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.14.11"
+version = "0.15.0"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Prepares the protected `v0.15.0` release.

This release contains the completed #191 lifecycle unit, including reversible archival promotion and the seven-day initial lease.

Changes:
- package version: `0.14.11 → 0.15.0`
- bundled Claude plugin manifest: `0.14.11 → 0.15.0`

Verification:
- release-version gate passed;
- wheel built successfully as `ormah-0.15.0-py3-none-any.whl`;
- PR #257 CI passed;
- fresh real-user installed-wheel acceptance passed;
- old-wheel → new-wheel upgrade acceptance passed.

After this PR merges, publish only through the protected GitHub Actions Release workflow.