### PR TITLE
fix: make fresh-install recovery reachable

### DIFF
--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -1062,7 +1062,8 @@ mod tests {
     fn protection_payload_rejects_secret_bearing_fields() {
         assert!(reject_forbidden_response_fields(&json!({
             "state": "protected",
-            "operation": { "id": "safe" }
+            "operation": { "id": "safe" },
+            "reason_code": "key_missing"
         }))
         .is_ok());
         for key in [

--- a/desktop/src-tauri/src/product_bridge.rs
+++ b/desktop/src-tauri/src/product_bridge.rs
@@ -1062,8 +1062,7 @@ mod tests {
     fn protection_payload_rejects_secret_bearing_fields() {
         assert!(reject_forbidden_response_fields(&json!({
             "state": "protected",
-            "operation": { "id": "safe" },
-            "reason_code": "key_missing"
+            "operation": { "id": "safe" }
         }))
         .is_ok());
         for key in [

--- a/src/ormah/api/routes_protection.py
+++ b/src/ormah/api/routes_protection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 import uuid
 
@@ -24,11 +25,25 @@ from ormah.cloud.state import (
 )
 from ormah.cloud.store_lock import StoreLockTimeout
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(
     prefix="/admin/cloud/protection",
     tags=["cloud-protection"],
     dependencies=[Depends(require_local_admin)],
 )
+
+_REMOTE_LISTING_MESSAGES = {
+    "key_missing": "This device is not connected to a cloud memory store.",
+    "sign_in_required": "Sign in again to check cloud backups.",
+}
+
+
+def _remote_listing_message(reason_code: str) -> str:
+    return _REMOTE_LISTING_MESSAGES.get(
+        reason_code,
+        "Cloud backups could not be checked.",
+    )
 
 
 class EmptyRequest(BaseModel):
@@ -195,21 +210,25 @@ def remote_snapshot(request: Request):
     try:
         newest = newest_cloud_snapshot(settings)
     except CloudRestoreError as exc:
+        if exc.reason_code != "key_missing":
+            logger.warning(
+                "Could not list cloud recovery points: %s",
+                safe_product_error_message(exc, getattr(settings, "account_token", None)),
+            )
         return {
             **unavailable,
             "reason_code": exc.reason_code,
-            "error": safe_product_error_message(
-                str(exc), getattr(settings, "account_token", None)
-            ),
+            "error": _remote_listing_message(exc.reason_code),
         }
     except Exception as exc:
+        logger.warning(
+            "Could not list cloud recovery points: %s",
+            safe_product_error_message(exc, getattr(settings, "account_token", None)),
+        )
         return {
             **unavailable,
             "reason_code": "remote_listing_failed",
-            "error": safe_product_error_message(
-                f"Could not read cloud backups: {exc}",
-                getattr(settings, "account_token", None),
-            ),
+            "error": _remote_listing_message("remote_listing_failed"),
         }
     if newest is None:
         return unavailable

--- a/src/ormah/api/routes_protection.py
+++ b/src/ormah/api/routes_protection.py
@@ -189,6 +189,7 @@ def remote_snapshot(request: Request):
         "size_bytes": None,
         "from_this_device": False,
         "restore_tested_here": False,
+        "reason_code": None,
         "error": None,
     }
     try:
@@ -196,6 +197,7 @@ def remote_snapshot(request: Request):
     except CloudRestoreError as exc:
         return {
             **unavailable,
+            "reason_code": exc.reason_code,
             "error": safe_product_error_message(
                 str(exc), getattr(settings, "account_token", None)
             ),
@@ -203,6 +205,7 @@ def remote_snapshot(request: Request):
     except Exception as exc:
         return {
             **unavailable,
+            "reason_code": "remote_listing_failed",
             "error": safe_product_error_message(
                 f"Could not read cloud backups: {exc}",
                 getattr(settings, "account_token", None),
@@ -218,6 +221,7 @@ def remote_snapshot(request: Request):
         "from_this_device": snapshot_id == state.get("last_successful_backup_snapshot_id"),
         # A device can only vouch for a check it ran itself.
         "restore_tested_here": snapshot_id == state.get("last_verified_snapshot_id"),
+        "reason_code": None,
         "error": None,
     }
 

--- a/tests/test_api/test_protection_routes.py
+++ b/tests/test_api/test_protection_routes.py
@@ -15,6 +15,7 @@ from ormah.api import routes_protection
 from ormah.api.local_auth import LOCAL_ADMIN_HEADER, require_loopback
 from ormah.cloud.operations import ProtectionOperationCoordinator
 from ormah.cloud.recovery import RecoveryKitError, RecoveryReadiness
+from ormah.cloud.restore import CloudRestoreError
 from ormah.cloud.state import (
     ProtectionOperation,
     ProtectionOperationKind,
@@ -627,6 +628,7 @@ def test_remote_reports_a_backup_made_by_another_device(protection_app, monkeypa
     assert payload["from_this_device"] is False
     # This device never checked that snapshot, so it cannot vouch for it.
     assert payload["restore_tested_here"] is False
+    assert payload["reason_code"] is None
     assert payload["error"] is None
 
 
@@ -654,6 +656,7 @@ def test_remote_recognises_this_devices_own_verified_upload(protection_app, monk
 
     assert payload["from_this_device"] is True
     assert payload["restore_tested_here"] is True
+    assert payload["reason_code"] is None
 
 
 def test_remote_degrades_without_taking_the_panel_down(protection_app, monkeypatch):
@@ -672,6 +675,7 @@ def test_remote_degrades_without_taking_the_panel_down(protection_app, monkeypat
     payload = response.json()
     assert payload["snapshot_id"] is None
     assert payload["from_this_device"] is False
+    assert payload["reason_code"] == "remote_listing_failed"
     assert payload["error"]
     assert "never-return-this-token" not in response.text
 
@@ -683,4 +687,26 @@ def test_remote_reports_an_empty_store_without_error(protection_app, monkeypatch
     payload = client.get("/admin/cloud/protection/remote", headers=HEADERS).json()
 
     assert payload["snapshot_id"] is None
+    assert payload["reason_code"] is None
     assert payload["error"] is None
+
+
+def test_remote_reports_missing_store_identity_with_a_typed_reason(protection_app, monkeypatch):
+    client, _, _, _ = protection_app
+
+    monkeypatch.setattr(
+        routes_protection,
+        "newest_cloud_snapshot",
+        lambda settings: (_ for _ in ()).throw(
+            CloudRestoreError(
+                "Cloud store id is missing; import a recovery kit first.",
+                "key_missing",
+            )
+        ),
+    )
+
+    payload = client.get("/admin/cloud/protection/remote", headers=HEADERS).json()
+
+    assert payload["snapshot_id"] is None
+    assert payload["reason_code"] == "key_missing"
+    assert payload["error"] == "Cloud store id is missing; import a recovery kit first."

--- a/tests/test_api/test_protection_routes.py
+++ b/tests/test_api/test_protection_routes.py
@@ -15,7 +15,6 @@ from ormah.api import routes_protection
 from ormah.api.local_auth import LOCAL_ADMIN_HEADER, require_loopback
 from ormah.cloud.operations import ProtectionOperationCoordinator
 from ormah.cloud.recovery import RecoveryKitError, RecoveryReadiness
-from ormah.cloud.restore import CloudRestoreError
 from ormah.cloud.state import (
     ProtectionOperation,
     ProtectionOperationKind,
@@ -676,7 +675,7 @@ def test_remote_degrades_without_taking_the_panel_down(protection_app, monkeypat
     assert payload["snapshot_id"] is None
     assert payload["from_this_device"] is False
     assert payload["reason_code"] == "remote_listing_failed"
-    assert payload["error"]
+    assert payload["error"] == "Cloud backups could not be checked."
     assert "never-return-this-token" not in response.text
 
 
@@ -691,22 +690,11 @@ def test_remote_reports_an_empty_store_without_error(protection_app, monkeypatch
     assert payload["error"] is None
 
 
-def test_remote_reports_missing_store_identity_with_a_typed_reason(protection_app, monkeypatch):
+def test_remote_reports_missing_store_identity_with_a_typed_reason(protection_app):
     client, _, _, _ = protection_app
-
-    monkeypatch.setattr(
-        routes_protection,
-        "newest_cloud_snapshot",
-        lambda settings: (_ for _ in ()).throw(
-            CloudRestoreError(
-                "Cloud store id is missing; import a recovery kit first.",
-                "key_missing",
-            )
-        ),
-    )
 
     payload = client.get("/admin/cloud/protection/remote", headers=HEADERS).json()
 
     assert payload["snapshot_id"] is None
     assert payload["reason_code"] == "key_missing"
-    assert payload["error"] == "Cloud store id is missing; import a recovery kit first."
+    assert payload["error"] == "This device is not connected to a cloud memory store."

--- a/ui/src/components/ProtectionPanel.test.tsx
+++ b/ui/src/components/ProtectionPanel.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { RemoteListingExplanation } from "./ProtectionPanel";
+
+describe("RemoteListingExplanation", () => {
+  it("shows the redacted missing-store explanation instead of treating cloud as empty", () => {
+    const markup = renderToStaticMarkup(
+      <RemoteListingExplanation
+        remote={{
+          snapshot_id: null,
+          created_at: null,
+          size_bytes: null,
+          from_this_device: false,
+          restore_tested_here: false,
+          reason_code: "key_missing",
+          error: "Cloud store id is missing; import a recovery kit first.",
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Cloud store id is missing; import a recovery kit first.");
+    expect(markup).not.toContain("no backup yet");
+  });
+});

--- a/ui/src/components/ProtectionPanel.test.tsx
+++ b/ui/src/components/ProtectionPanel.test.tsx
@@ -1,10 +1,33 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { RemoteListingExplanation } from "./ProtectionPanel";
+import { protectionActions, type ProtectionStatus } from "../productBridge";
+import {
+  ProtectionActionList,
+  RemoteListingExplanation,
+} from "./ProtectionPanel";
 
 describe("RemoteListingExplanation", () => {
-  it("shows the redacted missing-store explanation instead of treating cloud as empty", () => {
+  it("renders fixed product copy instead of a backend diagnostic", () => {
+    const markup = renderToStaticMarkup(
+      <RemoteListingExplanation
+        remote={{
+          snapshot_id: null,
+          created_at: null,
+          size_bytes: null,
+          from_this_device: false,
+          restore_tested_here: false,
+          reason_code: "remote_listing_failed",
+          error: "ConnectError(private-hostname:9443)",
+        }}
+      />,
+    );
+
+    expect(markup).toContain("Cloud backups could not be checked. Try again.");
+    expect(markup).not.toContain("private-hostname");
+  });
+
+  it("does not turn an uninitialized store into a warning", () => {
     const markup = renderToStaticMarkup(
       <RemoteListingExplanation
         remote={{
@@ -14,12 +37,49 @@ describe("RemoteListingExplanation", () => {
           from_this_device: false,
           restore_tested_here: false,
           reason_code: "key_missing",
-          error: "Cloud store id is missing; import a recovery kit first.",
+          error: "This device is not connected to a cloud memory store.",
         }}
       />,
     );
 
-    expect(markup).toContain("Cloud store id is missing; import a recovery kit first.");
-    expect(markup).not.toContain("no backup yet");
+    expect(markup).toBe("");
+  });
+});
+
+describe("ProtectionActionList", () => {
+  it("renders the two honest choices for a device without a store identity", () => {
+    const status: ProtectionStatus = {
+      enabled: false,
+      store_id: null,
+      entitlement: "none",
+      protection_state: "local_only",
+      protection_intent_id: null,
+      protection_intent_status: null,
+      protection_intent_expires_at: null,
+      last_operation_id: null,
+      last_operation_kind: null,
+      last_operation_phase: null,
+      last_successful_upload_at: null,
+      last_successful_backup_snapshot_id: null,
+      last_successful_verify_at: null,
+      last_verified_snapshot_id: null,
+      recovery_kit_verified_at: null,
+      device_loss_recovery_ready: false,
+      last_error_code: null,
+      last_error_message: null,
+      warnings: [],
+    };
+    const actions = protectionActions(true, "local_only", status, null);
+    const markup = renderToStaticMarkup(
+      <ProtectionActionList
+        actions={actions}
+        busy={false}
+        onAction={() => undefined}
+      />,
+    );
+
+    expect(markup).toContain("Protect this memory");
+    expect(markup).toContain("Recover existing memory");
+    expect(markup).toContain("Use the recovery kit saved from an existing protected memory.");
   });
 });

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -33,14 +33,17 @@ import {
   protectionPresentation,
   protectionReconnectDelay,
   protectionRepairAction,
+  remoteListingMessage,
   resolveCheckoutIntent,
   recoveryKitSectionVisible,
+  shouldLoadRemoteSnapshot,
   type AccountStatus,
   type CheckoutConfirmation,
   type ProtectionActionKind,
   type RemoteSnapshot,
   type BillingOffer,
   type OperationPhase,
+  type ProtectionAction,
   type ProtectionOperation,
   type ProtectionStatus,
 } from "../productBridge";
@@ -200,12 +203,40 @@ function errorMessage(value: unknown, fallback: string): string {
 }
 
 export function RemoteListingExplanation({ remote }: { remote: RemoteSnapshot | null }) {
-  if (!remote?.error) return null;
+  const message = remoteListingMessage(remote);
+  if (!message) return null;
   return (
     <div className="protection-remote-explanation" role="status">
       <AlertTriangle size={15} />
-      <span>{remote.error}</span>
+      <span>{message}</span>
     </div>
+  );
+}
+
+export function ProtectionActionList({
+  actions,
+  busy,
+  onAction,
+}: {
+  actions: ProtectionAction[];
+  busy: boolean;
+  onAction: (kind: ProtectionActionKind) => void;
+}) {
+  return (
+    <section className="protection-actions">
+      {actions.map((action) => (
+        <div className="protection-action" key={action.kind}>
+          <button
+            className={action.variant === "primary" ? "protection-primary" : "protection-secondary"}
+            disabled={busy || action.disabled}
+            onClick={() => onAction(action.kind)}
+          >
+            {ACTION_ICONS[action.kind]} {action.label}
+          </button>
+          {action.reason && <p className="protection-action-reason">{action.reason}</p>}
+        </div>
+      ))}
+    </section>
   );
 }
 
@@ -243,8 +274,8 @@ export default function ProtectionPanel({
   const reconnectAttempt = useRef(0);
   const desktop = isDesktopApp();
 
-  const refresh = useCallback(async () => {
-    if (!desktop) return;
+  const refresh = useCallback(async (): Promise<boolean> => {
+    if (!desktop) return false;
     setLoading(true);
     try {
       try {
@@ -264,11 +295,9 @@ export default function ProtectionPanel({
       setRefreshFailed(false);
       onStatusChange?.(nextStatus);
       setError(null);
-      // A signed-in fresh device has no store identity yet. Asking for the
-      // listing is still essential: its safe typed reason tells us whether to
-      // offer recovery-kit import rather than accidentally creating a store.
-      // A listing failure never takes the panel down.
-      if (nextAccount.signed_in) {
+      // A device without a store identity cannot list a store yet. The summary
+      // offers Start fresh and Recover existing memory as honest peer choices.
+      if (shouldLoadRemoteSnapshot(nextAccount.signed_in, nextStatus)) {
         try {
           setRemote(await productBridge.remoteSnapshot());
         } catch {
@@ -283,9 +312,11 @@ export default function ProtectionPanel({
           offerRequested.current = false;
         });
       }
+      return true;
     } catch (err) {
       setRefreshFailed(true);
       setError(errorMessage(err, "Protection status is unavailable."));
+      return false;
     } finally {
       setLoading(false);
     }
@@ -445,14 +476,18 @@ export default function ProtectionPanel({
     }
   }, [account?.signed_in, bindAndContinue]);
 
-  const startRestorePreparation = useCallback(async () => {
+  const startRestorePreparation = useCallback(async (
+    failureMessage = "Recovery could not start.",
+  ): Promise<boolean> => {
     setBusy(true);
     setError(null);
     try {
       setOperation(await productBridge.prepareRestore());
       setView("summary");
+      return true;
     } catch (err) {
-      setError(errorMessage(err, "Recovery could not start."));
+      setError(errorMessage(err, failureMessage));
+      return false;
     } finally {
       setBusy(false);
     }
@@ -537,14 +572,21 @@ export default function ProtectionPanel({
       const result = await completeRecoveryKitImport(
         productBridge.importRecoveryKit,
         refresh,
-        startRestorePreparation,
+        () => startRestorePreparation(
+          "The recovery kit was imported, but cloud recovery could not start.",
+        ),
       );
       if (result === "canceled") {
-        setOperation(null);
-        setView("summary");
         return;
       }
-      onToast("Recovery kit imported on this device.", "success");
+      if (result === "refresh_failed") {
+        setError(
+          "The recovery kit was imported, but Ormah could not refresh this device. Try again.",
+        );
+        return;
+      }
+      if (result === "restore_failed") return;
+      onToast("Recovery kit imported. Checking the newest cloud backup.", "success");
     } catch (err) {
       setError(errorMessage(err, "The recovery kit could not be imported."));
     } finally {
@@ -1151,12 +1193,12 @@ export default function ProtectionPanel({
                 {/* Not being able to read the listing is not the same as the
                     cloud being empty, and must never be shown as one. */}
                 <strong>{
-                  !remote
+                  !status.store_id
+                    ? "not connected on this device"
+                    : !remote
                     ? "backup listing unavailable"
                     : remote.error
-                      ? remote.reason_code === "key_missing"
-                        ? "recovery kit needed"
-                        : "backup listing unavailable"
+                      ? "backup listing unavailable"
                     : remote.created_at
                       ? `newest ${formatDate(remote.created_at)}`
                       : "no backup yet"
@@ -1170,20 +1212,11 @@ export default function ProtectionPanel({
           )}
 
           {view === "summary" && !activeLabel && (
-            <section className="protection-actions">
-              {actions.map((action) => (
-                <div className="protection-action" key={action.kind}>
-                  <button
-                    className={action.variant === "primary" ? "protection-primary" : "protection-secondary"}
-                    disabled={busy || action.disabled}
-                    onClick={() => void runProtectionAction(action.kind)}
-                  >
-                    {ACTION_ICONS[action.kind]} {action.label}
-                  </button>
-                  {action.reason && <p className="protection-action-reason">{action.reason}</p>}
-                </div>
-              ))}
-            </section>
+            <ProtectionActionList
+              actions={actions}
+              busy={busy}
+              onAction={(kind) => void runProtectionAction(kind)}
+            />
           )}
 
           {recoveryKitSectionVisible(status) && view === "summary" && (

--- a/ui/src/components/ProtectionPanel.tsx
+++ b/ui/src/components/ProtectionPanel.tsx
@@ -22,6 +22,7 @@ import {
   CHECKOUT_CONFIRMATION_INTERVAL_MS,
   checkoutConfirmationAfterCheck,
   checkoutConfirmationIsDelayed,
+  completeRecoveryKitImport,
   isDesktopApp,
   effectiveProtectionState,
   operationPhaseIsActive,
@@ -136,6 +137,7 @@ function operationLabel(
 const ACTION_ICONS: Record<ProtectionActionKind, JSX.Element> = {
   signin: <LogIn size={16} />,
   protect: <ShieldCheck size={16} />,
+  recover: <KeyRound size={16} />,
   backup: <RefreshCw size={15} />,
   restore: <CloudDownload size={15} />,
   verify: <ShieldCheck size={15} />,
@@ -197,6 +199,16 @@ function errorMessage(value: unknown, fallback: string): string {
   return fallback;
 }
 
+export function RemoteListingExplanation({ remote }: { remote: RemoteSnapshot | null }) {
+  if (!remote?.error) return null;
+  return (
+    <div className="protection-remote-explanation" role="status">
+      <AlertTriangle size={15} />
+      <span>{remote.error}</span>
+    </div>
+  );
+}
+
 export default function ProtectionPanel({
   open,
   nodeCount = null,
@@ -252,11 +264,18 @@ export default function ProtectionPanel({
       setRefreshFailed(false);
       onStatusChange?.(nextStatus);
       setError(null);
-      // One listing call, and only for a store that has something in the
-      // cloud. A failure here costs the device-versus-cloud comparison, never
-      // the panel itself, so it is deliberately not awaited into the catch.
-      if (nextStatus.enabled || nextStatus.store_id) {
-        productBridge.remoteSnapshot().then(setRemote).catch(() => setRemote(null));
+      // A signed-in fresh device has no store identity yet. Asking for the
+      // listing is still essential: its safe typed reason tells us whether to
+      // offer recovery-kit import rather than accidentally creating a store.
+      // A listing failure never takes the panel down.
+      if (nextAccount.signed_in) {
+        try {
+          setRemote(await productBridge.remoteSnapshot());
+        } catch {
+          setRemote(null);
+        }
+      } else {
+        setRemote(null);
       }
       if (nextAccount.signed_in && !offerRequested.current) {
         offerRequested.current = true;
@@ -515,16 +534,23 @@ export default function ProtectionPanel({
     setBusy(true);
     setError(null);
     try {
-      const result = await productBridge.importRecoveryKit();
-      if (result.status === "canceled") return;
+      const result = await completeRecoveryKitImport(
+        productBridge.importRecoveryKit,
+        refresh,
+        startRestorePreparation,
+      );
+      if (result === "canceled") {
+        setOperation(null);
+        setView("summary");
+        return;
+      }
       onToast("Recovery kit imported on this device.", "success");
-      await startRestorePreparation();
     } catch (err) {
       setError(errorMessage(err, "The recovery kit could not be imported."));
     } finally {
       setBusy(false);
     }
-  }, [onToast, startRestorePreparation]);
+  }, [onToast, refresh, startRestorePreparation]);
 
   const confirmRestore = useCallback(async () => {
     if (!operation?.operation_id || operation.phase !== "ready") return;
@@ -820,6 +846,11 @@ export default function ProtectionPanel({
       case "protect":
         await beginProtection();
         return;
+      case "recover":
+        setOperation(null);
+        setError(null);
+        setView("restore_key");
+        return;
       case "backup":
       case "verify":
         await runOperation(kind);
@@ -933,6 +964,8 @@ export default function ProtectionPanel({
               <span>{error}</span>
             </div>
           )}
+
+          {view === "summary" && <RemoteListingExplanation remote={remote} />}
 
           <div className="sr-status" aria-live="polite">{summaryTitle}</div>
 
@@ -1118,8 +1151,12 @@ export default function ProtectionPanel({
                 {/* Not being able to read the listing is not the same as the
                     cloud being empty, and must never be shown as one. */}
                 <strong>{
-                  !remote || remote.error
-                    ? "unavailable"
+                  !remote
+                    ? "backup listing unavailable"
+                    : remote.error
+                      ? remote.reason_code === "key_missing"
+                        ? "recovery kit needed"
+                        : "backup listing unavailable"
                     : remote.created_at
                       ? `newest ${formatDate(remote.created_at)}`
                       : "no backup yet"

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -14,8 +14,10 @@ import {
   protectionReconnectDelay,
   protectionRepairAction,
   protectionPresentation,
+  remoteListingMessage,
   recoveryKitSectionVisible,
   resolveCheckoutIntent,
+  shouldLoadRemoteSnapshot,
   verificationIsOverdue,
   type ProtectionAction,
   type ProtectionActionKind,
@@ -502,25 +504,32 @@ describe("protectionActions", () => {
       true,
       "local_only",
       status({ protection_state: "local_only", enabled: false, store_id: null }),
-      remote({
-        snapshot_id: null,
-        created_at: null,
-        size_bytes: null,
-        reason_code: "key_missing",
-        error: "Cloud store id is missing; import a recovery kit first.",
-      }),
+      null,
     );
 
     expect(actions.map((action) => action.kind)).toEqual(["protect", "recover"]);
-    expect(find(actions, "recover")?.label).toBe("Recover from a backup");
+    expect(find(actions, "recover")?.label).toBe("Recover existing memory");
   });
 
-  it("keeps Protect available for a genuinely new local-only account", () => {
+  it("gives a genuinely new account the same two neutral choices", () => {
     const actions = protectionActions(
       true,
       "local_only",
       status({ protection_state: "local_only", enabled: false, store_id: null }),
-      remote({ snapshot_id: null, created_at: null, size_bytes: null, reason_code: null }),
+      null,
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["protect", "recover"]);
+    expect(find(actions, "protect")?.variant).toBe("primary");
+    expect(find(actions, "recover")?.variant).toBe("secondary");
+  });
+
+  it("does not offer kit recovery after a store identity exists", () => {
+    const actions = protectionActions(
+      true,
+      "local_only",
+      status({ protection_state: "local_only", enabled: false }),
+      null,
     );
 
     expect(actions.map((action) => action.kind)).toEqual(["protect"]);
@@ -625,11 +634,11 @@ describe("completeRecoveryKitImport", () => {
         calls.push("import");
         return { status: "imported" };
       },
-      async () => { calls.push("refresh"); },
-      async () => { calls.push("prepare"); },
+      async () => { calls.push("refresh"); return true; },
+      async () => { calls.push("prepare"); return true; },
     );
 
-    expect(result).toBe("imported");
+    expect(result).toBe("restore_started");
     expect(calls).toEqual(["import", "refresh", "prepare"]);
   });
 
@@ -641,11 +650,56 @@ describe("completeRecoveryKitImport", () => {
         calls.push("import");
         return { status: "canceled" };
       },
-      async () => { calls.push("refresh"); },
-      async () => { calls.push("prepare"); },
+      async () => { calls.push("refresh"); return true; },
+      async () => { calls.push("prepare"); return true; },
     );
 
     expect(result).toBe("canceled");
     expect(calls).toEqual(["import"]);
+  });
+
+  it("does not prepare restore when the post-import refresh fails", async () => {
+    const calls: string[] = [];
+
+    const result = await completeRecoveryKitImport(
+      async () => { calls.push("import"); return { status: "imported" }; },
+      async () => { calls.push("refresh"); return false; },
+      async () => { calls.push("prepare"); return true; },
+    );
+
+    expect(result).toBe("refresh_failed");
+    expect(calls).toEqual(["import", "refresh"]);
+  });
+
+  it("reports restore preparation separately from successful import", async () => {
+    const calls: string[] = [];
+
+    const result = await completeRecoveryKitImport(
+      async () => { calls.push("import"); return { status: "imported" }; },
+      async () => { calls.push("refresh"); return true; },
+      async () => { calls.push("prepare"); return false; },
+    );
+
+    expect(result).toBe("restore_failed");
+    expect(calls).toEqual(["import", "refresh", "prepare"]);
+  });
+});
+
+describe("fresh-device remote discovery", () => {
+  it("waits for a store identity before asking the cloud", () => {
+    expect(shouldLoadRemoteSnapshot(false, status({}))).toBe(false);
+    expect(shouldLoadRemoteSnapshot(true, status({ store_id: null }))).toBe(false);
+    expect(shouldLoadRemoteSnapshot(true, status({}))).toBe(true);
+  });
+
+  it("maps reason codes to fixed product copy instead of backend text", () => {
+    expect(remoteListingMessage(remote({
+      reason_code: "remote_listing_failed",
+      error: "ConnectError(private-hostname:9443)",
+    }))).toBe("Cloud backups could not be checked. Try again.");
+    expect(remoteListingMessage(remote({
+      reason_code: "key_missing",
+      error: "Cloud store id is missing; import a recovery kit first.",
+    }))).toBeNull();
   });
 });

--- a/ui/src/productBridge.test.ts
+++ b/ui/src/productBridge.test.ts
@@ -5,6 +5,7 @@ import {
   CHECKOUT_CONFIRMATION_MAX_CHECKS,
   checkoutConfirmationAfterCheck,
   checkoutConfirmationIsDelayed,
+  completeRecoveryKitImport,
   effectiveProtectionState,
   operationPhaseIsActive,
   protectionCompletionSummary,
@@ -370,6 +371,7 @@ function remote(overrides: Partial<RemoteSnapshot> = {}): RemoteSnapshot {
     size_bytes: 1238414,
     from_this_device: true,
     restore_tested_here: true,
+    reason_code: null,
     error: null,
     ...overrides,
   };
@@ -495,6 +497,35 @@ describe("protectionActions", () => {
     expect(actions.map((action) => action.kind)).toEqual(["protect", "restore"]);
   });
 
+  it("offers kit recovery before a fresh device can list an existing store", () => {
+    const actions = protectionActions(
+      true,
+      "local_only",
+      status({ protection_state: "local_only", enabled: false, store_id: null }),
+      remote({
+        snapshot_id: null,
+        created_at: null,
+        size_bytes: null,
+        reason_code: "key_missing",
+        error: "Cloud store id is missing; import a recovery kit first.",
+      }),
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["protect", "recover"]);
+    expect(find(actions, "recover")?.label).toBe("Recover from a backup");
+  });
+
+  it("keeps Protect available for a genuinely new local-only account", () => {
+    const actions = protectionActions(
+      true,
+      "local_only",
+      status({ protection_state: "local_only", enabled: false, store_id: null }),
+      remote({ snapshot_id: null, created_at: null, size_bytes: null, reason_code: null }),
+    );
+
+    expect(actions.map((action) => action.kind)).toEqual(["protect"]);
+  });
+
   it("keeps backup visible and explained while cloud protection is offline", () => {
     const actions = protectionActions(
       true,
@@ -582,5 +613,39 @@ describe("recoveryKitSectionVisible", () => {
     }))).toBe(true);
     expect(recoveryKitSectionVisible(status({ enabled: false }))).toBe(false);
     expect(recoveryKitSectionVisible(null)).toBe(false);
+  });
+});
+
+describe("completeRecoveryKitImport", () => {
+  it("refreshes discovery before preparing restore after kit import", async () => {
+    const calls: string[] = [];
+
+    const result = await completeRecoveryKitImport(
+      async () => {
+        calls.push("import");
+        return { status: "imported" };
+      },
+      async () => { calls.push("refresh"); },
+      async () => { calls.push("prepare"); },
+    );
+
+    expect(result).toBe("imported");
+    expect(calls).toEqual(["import", "refresh", "prepare"]);
+  });
+
+  it("returns to the caller cleanly when choosing a kit is canceled", async () => {
+    const calls: string[] = [];
+
+    const result = await completeRecoveryKitImport(
+      async () => {
+        calls.push("import");
+        return { status: "canceled" };
+      },
+      async () => { calls.push("refresh"); },
+      async () => { calls.push("prepare"); },
+    );
+
+    expect(result).toBe("canceled");
+    expect(calls).toEqual(["import"]);
   });
 });

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -117,6 +117,11 @@ export type RecoveryKitActionResult =
   };
 
 export type RecoveryKitImportStatus = "imported" | "canceled";
+export type RecoveryKitImportCompletion =
+  | "canceled"
+  | "refresh_failed"
+  | "restore_failed"
+  | "restore_started";
 
 /**
  * Importing a kit gives this device a store identity. Refresh discovery before
@@ -125,14 +130,14 @@ export type RecoveryKitImportStatus = "imported" | "canceled";
  */
 export async function completeRecoveryKitImport(
   importKit: () => Promise<{ status: RecoveryKitImportStatus }>,
-  refresh: () => Promise<void>,
-  prepareRestore: () => Promise<void>,
-): Promise<RecoveryKitImportStatus> {
+  refresh: () => Promise<boolean>,
+  prepareRestore: () => Promise<boolean>,
+): Promise<RecoveryKitImportCompletion> {
   const result = await importKit();
   if (result.status === "canceled") return result.status;
-  await refresh();
-  await prepareRestore();
-  return result.status;
+  if (!await refresh()) return "refresh_failed";
+  if (!await prepareRestore()) return "restore_failed";
+  return "restore_started";
 }
 
 export function recoveryKitSectionVisible(
@@ -391,6 +396,21 @@ export interface RemoteSnapshot {
   error: string | null;
 }
 
+export function shouldLoadRemoteSnapshot(
+  signedIn: boolean,
+  status: ProtectionStatus | null | undefined,
+): boolean {
+  return signedIn && Boolean(status?.store_id);
+}
+
+export function remoteListingMessage(remote: RemoteSnapshot | null): string | null {
+  if (!remote?.reason_code || remote.reason_code === "key_missing") return null;
+  if (remote.reason_code === "sign_in_required") {
+    return "Sign in again to check cloud backups.";
+  }
+  return "Cloud backups could not be checked. Try again.";
+}
+
 // Two intervals of the weekly restore-verification job. Inside that window an
 // unchecked upload is the normal resting state, not a problem, so it must not
 // paint the panel with a warning.
@@ -427,7 +447,7 @@ export interface ProtectionAction {
 
 const BACKUP_LABEL = "Back up now";
 const RESTORE_LABEL = "Restore newest backup";
-const RECOVER_LABEL = "Recover from a backup";
+const RECOVER_LABEL = "Recover existing memory";
 
 const REPAIR_LABELS: Record<Exclude<ProtectionRepairAction, "none">, string> = {
   verify: "Retry recovery check",
@@ -529,16 +549,16 @@ export function protectionActions(
       reason: "Brings the newest cloud backup onto this device.",
     }]
     : [];
-  // A fresh device cannot list an existing store until its recovery kit has
-  // supplied the store identity. This is deliberately keyed only by the
-  // stable protocol reason, never the explanatory message.
-  const recoverMissingStore: ProtectionAction[] = remote?.reason_code === "key_missing"
+  // With no local store identity, Ormah cannot know whether this is a new user
+  // or a returning device. Offer both honest choices without attempting a
+  // cloud listing that cannot succeed before kit import.
+  const recoverUninitializedStore: ProtectionAction[] = status?.store_id === null
     ? [{
       kind: "recover",
       label: RECOVER_LABEL,
       variant: "secondary",
       disabled: false,
-      reason: "Import the recovery kit from an existing protected memory before choosing a new one.",
+      reason: "Use the recovery kit saved from an existing protected memory.",
     }]
     : [];
 
@@ -554,7 +574,7 @@ export function protectionActions(
           disabled: false,
           reason: null,
         },
-        ...recoverMissingStore,
+        ...recoverUninitializedStore,
         ...restoreOnly,
       ];
 

--- a/ui/src/productBridge.ts
+++ b/ui/src/productBridge.ts
@@ -116,6 +116,25 @@ export type RecoveryKitActionResult =
     recovery_kit_verified_at: null;
   };
 
+export type RecoveryKitImportStatus = "imported" | "canceled";
+
+/**
+ * Importing a kit gives this device a store identity. Refresh discovery before
+ * starting restore preparation, because preparation itself must not be the
+ * first attempt to list that newly reachable store.
+ */
+export async function completeRecoveryKitImport(
+  importKit: () => Promise<{ status: RecoveryKitImportStatus }>,
+  refresh: () => Promise<void>,
+  prepareRestore: () => Promise<void>,
+): Promise<RecoveryKitImportStatus> {
+  const result = await importKit();
+  if (result.status === "canceled") return result.status;
+  await refresh();
+  await prepareRestore();
+  return result.status;
+}
+
 export function recoveryKitSectionVisible(
   status: ProtectionStatus | null | undefined,
 ): boolean {
@@ -284,7 +303,7 @@ export const productBridge = {
   cancelRestore: (preparationOperationId: string) =>
     native<{ status: "discarded" }>("cancel_restore", { preparationOperationId }),
   importRecoveryKit: () =>
-    native<{ status: "imported" | "canceled" }>("import_recovery_kit"),
+    native<{ status: RecoveryKitImportStatus }>("import_recovery_kit"),
   openCheckout: (intentId: string) =>
     native<BillingHandoff>("open_checkout", { intentId }),
   openPortal: () => native<{ opened: boolean }>("open_billing_portal"),
@@ -367,6 +386,8 @@ export interface RemoteSnapshot {
   from_this_device: boolean;
   /** Only this device's own checks count; it cannot vouch for another's. */
   restore_tested_here: boolean;
+  /** Stable, product-safe reason why the remote listing is unavailable. */
+  reason_code: string | null;
   error: string | null;
 }
 
@@ -388,6 +409,7 @@ export function verificationIsOverdue(
 export type ProtectionActionKind =
   | "signin"
   | "protect"
+  | "recover"
   | "backup"
   | "restore"
   | "verify"
@@ -405,6 +427,7 @@ export interface ProtectionAction {
 
 const BACKUP_LABEL = "Back up now";
 const RESTORE_LABEL = "Restore newest backup";
+const RECOVER_LABEL = "Recover from a backup";
 
 const REPAIR_LABELS: Record<Exclude<ProtectionRepairAction, "none">, string> = {
   verify: "Retry recovery check",
@@ -506,6 +529,18 @@ export function protectionActions(
       reason: "Brings the newest cloud backup onto this device.",
     }]
     : [];
+  // A fresh device cannot list an existing store until its recovery kit has
+  // supplied the store identity. This is deliberately keyed only by the
+  // stable protocol reason, never the explanatory message.
+  const recoverMissingStore: ProtectionAction[] = remote?.reason_code === "key_missing"
+    ? [{
+      kind: "recover",
+      label: RECOVER_LABEL,
+      variant: "secondary",
+      disabled: false,
+      reason: "Import the recovery kit from an existing protected memory before choosing a new one.",
+    }]
+    : [];
 
   switch (state) {
     case "local_only":
@@ -519,6 +554,7 @@ export function protectionActions(
           disabled: false,
           reason: null,
         },
+        ...recoverMissingStore,
         ...restoreOnly,
       ];
 

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1067,6 +1067,17 @@ body.in-app .node-detail.tier-core {
   line-height: 1.45;
 }
 
+.protection-remote-explanation {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+  margin: 14px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 .protection-step,
 .protection-actions,
 .protection-account,


### PR DESCRIPTION
## Problem

A signed-in fresh device has no local store identity, so remote discovery returns `key_missing` with no snapshot. The panel previously skipped discovery in that state and only exposed recovery-kit import from an unreachable restore flow; choosing Protect could instead create a new store.

## Flow

- `/admin/cloud/protection/remote` now returns the stable, redacted `reason_code` alongside its human explanation.
- A signed-in `local_only` device with `reason_code: key_missing` shows **Recover from a backup** beside **Protect this memory**.
- Recovery opens the existing kit chooser directly, without prepare/list first.
- After import, the panel refreshes status and remote discovery before the existing restore preparation flow. Cancelling returns to summary.

## Screenshots

Not included: this is a desktop-native file chooser flow and the UI changes are covered by component/action tests.

## Tests

- `npm --prefix ui test -- --run`
- `npm --prefix ui run build`
- `ORMAH_LLM_PROVIDER=none uv run pytest tests/test_api/test_protection_routes.py -v`
- `uv run ruff check src/ormah/api/routes_protection.py src/ormah/cloud/restore.py tests/test_api/test_protection_routes.py`
- `git diff --check`

`cargo test --manifest-path desktop/src-tauri/Cargo.toml product_bridge::tests` is blocked in this checkout because the required `desktop/src-tauri/binaries/uv-x86_64-unknown-linux-gnu` sidecar resource is absent.

Closes #251