### PR TITLE
fix(cloud): make recovery imports idempotent

### DIFF
--- a/docs/15 - Cloud Backup, Verification, and Restore.md
+++ b/docs/15 - Cloud Backup, Verification, and Restore.md
@@ -487,6 +487,19 @@ ormah server stop
 ormah backup restore --cloud --yes
 ```
 
+Recovery-kit import is preflighted before either local resource changes. Ormah reads the kit once,
+validates its store ID and every identity, then compares them with any installed `.store_id` and
+`cloud.key`. The normal uninstall/reinstall state has a preserved matching key but no store ID; in
+that case Ormah installs only the missing store ID, leaves the key file byte-for-byte unchanged,
+regenerates the canonical recovery kit from the complete installed keyring, and exits successfully.
+Repeating an already-complete import is also a successful no-op. A different store ID or an identity
+that is not already present in an existing keyring fails before either resource is written.
+
+Human and JSON output report the store and key outcomes independently. JSON callers receive
+`store_id_status` and `key_status`; neither output includes private identity material. Existing
+keyrings with additional retained rotation identities are valid, and the refreshed recovery kit
+contains the full current-first keyring rather than preserving a stale or unrelated kit file.
+
 The restore command:
 
 1. reads the imported store ID instead of generating a new remote namespace;

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -515,7 +515,6 @@ def _cmd_cloud_init(args):
     from ormah.cloud.crypto import CloudCryptoError
     from ormah.cloud.keys import (
         KEY_PATH,
-        RECOVERY_KIT_PATH,
         MAX_RECOVERY_KIT_BYTES,
         CloudKeyError,
         apply_recovery_import,
@@ -523,6 +522,7 @@ def _cmd_cloud_init(args):
         init_key,
         load_identity_strings,
         plan_recovery_import,
+        validate_recovery_kit_destination,
         write_recovery_kit,
     )
     from ormah.config import settings
@@ -530,6 +530,7 @@ def _cmd_cloud_init(args):
 
     try:
         import_result = None
+        kit_path = None
         if args.import_key:
             import_source = args.import_key
             if import_source == "-":
@@ -545,6 +546,7 @@ def _cmd_cloud_init(args):
             # Preflight both resources before the first write. A preserved key
             # may contain extra pre-rotation identities, but it must contain
             # every identity carried by the recovery kit.
+            kit_path = validate_recovery_kit_destination()
             import_result = apply_recovery_import(
                 plan_recovery_import(import_source, settings.memory_dir)
             )
@@ -555,23 +557,25 @@ def _cmd_cloud_init(args):
 
     try:
         store_id = get_or_create_store_id(settings.memory_dir)
-        # A matching imported kit is already complete recovery material. Leave
-        # it untouched for a genuine idempotent recovery import; a fresh device
-        # still receives a local kit when one is not already present.
-        recovery_kit_preserved = args.import_key and RECOVERY_KIT_PATH.is_file()
-        if recovery_kit_preserved:
-            kit_path = RECOVERY_KIT_PATH
-        else:
-            kit_path = write_recovery_kit(
-                store_id,
-                account_email=getattr(settings, "account_email", None),
-            )
+        # The installed keyring is authoritative. Always regenerate the kit so
+        # an unrelated, stale, or damaged file is never affirmed as recovery.
+        kit_path = write_recovery_kit(
+            store_id,
+            kit_path=kit_path,
+            account_email=getattr(settings, "account_email", None),
+        )
         identity_count = len(load_identity_strings())
     except (CloudKeyError, CloudCryptoError, OSError) as exc:
-        _print_backup_error(
-            f"Encryption key was written to {KEY_PATH}, but finishing setup failed: {exc}\n"
-            "Complete it with: ormah cloud kit"
-        )
+        if import_result is not None:
+            _print_backup_error(
+                "Recovery identity was installed or verified, but the canonical recovery kit "
+                f"could not be refreshed: {exc}\nComplete it with: ormah cloud kit"
+            )
+        else:
+            _print_backup_error(
+                f"Encryption key was written to {KEY_PATH}, but finishing setup failed: {exc}\n"
+                "Complete it with: ormah cloud kit"
+            )
 
     if args.json:
         print(json.dumps({
@@ -599,16 +603,19 @@ def _cmd_cloud_init(args):
         else:
             ok(f"Store ID generated: {store_id}")
         if import_result.key_status == "installed":
-            ok(f"Recovery key installed: {KEY_PATH}")
+            ok(
+                f"Recovery key installed: {KEY_PATH} "
+                f"({identity_count} identit{'y' if identity_count == 1 else 'ies'})"
+            )
         else:
-            ok(f"Recovery key already matched and preserved: {KEY_PATH}")
+            ok(
+                f"Recovery key already matched and preserved: {KEY_PATH} "
+                f"({identity_count} identit{'y' if identity_count == 1 else 'ies'})"
+            )
     else:
         ok(f"Generated encryption key: {KEY_PATH}")
         info(f"Store id: {store_id}")
-    if recovery_kit_preserved:
-        info(f"Recovery kit already present: {kit_path}")
-    else:
-        ok(f"Recovery kit written: {kit_path}")
+    ok(f"Recovery kit written: {kit_path}")
     warn(
         "Store the recovery kit somewhere safe and OFFLINE. Anyone with it can "
         "read your backups; without it, nobody can — including us."

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -546,10 +546,9 @@ def _cmd_cloud_init(args):
             # Preflight both resources before the first write. A preserved key
             # may contain extra pre-rotation identities, but it must contain
             # every identity carried by the recovery kit.
-            kit_path = validate_recovery_kit_destination()
-            import_result = apply_recovery_import(
-                plan_recovery_import(import_source, settings.memory_dir)
-            )
+            import_plan = plan_recovery_import(import_source, settings.memory_dir)
+            kit_path = validate_recovery_kit_destination(import_plan)
+            import_result = apply_recovery_import(import_plan)
         else:
             init_key()
     except (CloudKeyError, CloudCryptoError, OSError) as exc:

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -515,20 +515,21 @@ def _cmd_cloud_init(args):
     from ormah.cloud.crypto import CloudCryptoError
     from ormah.cloud.keys import (
         KEY_PATH,
+        RECOVERY_KIT_PATH,
         MAX_RECOVERY_KIT_BYTES,
         CloudKeyError,
-        extract_store_id,
+        apply_recovery_import,
         get_or_create_store_id,
-        import_key,
         init_key,
-        install_store_id,
         load_identity_strings,
+        plan_recovery_import,
         write_recovery_kit,
     )
     from ormah.config import settings
     from ormah.console import info, ok, warn
 
     try:
+        import_result = None
         if args.import_key:
             import_source = args.import_key
             if import_source == "-":
@@ -541,14 +542,12 @@ def _cmd_cloud_init(args):
                     import_source = raw_bytes.decode("utf-8")
                 except UnicodeDecodeError as exc:
                     raise CloudKeyError("The recovery kit is not valid UTF-8 text.") from exc
-            # The kit's store id is the remote namespace — it must be
-            # installed too, or the restored machine would point at a brand
-            # new store and orphan every existing backup. Installed first so
-            # a store-id conflict aborts before any key material is written.
-            imported_store_id = extract_store_id(import_source)
-            if imported_store_id:
-                install_store_id(settings.memory_dir, imported_store_id)
-            import_key(import_source)
+            # Preflight both resources before the first write. A preserved key
+            # may contain extra pre-rotation identities, but it must contain
+            # every identity carried by the recovery kit.
+            import_result = apply_recovery_import(
+                plan_recovery_import(import_source, settings.memory_dir)
+            )
         else:
             init_key()
     except (CloudKeyError, CloudCryptoError, OSError) as exc:
@@ -556,10 +555,17 @@ def _cmd_cloud_init(args):
 
     try:
         store_id = get_or_create_store_id(settings.memory_dir)
-        kit_path = write_recovery_kit(
-            store_id,
-            account_email=getattr(settings, "account_email", None),
-        )
+        # A matching imported kit is already complete recovery material. Leave
+        # it untouched for a genuine idempotent recovery import; a fresh device
+        # still receives a local kit when one is not already present.
+        recovery_kit_preserved = args.import_key and RECOVERY_KIT_PATH.is_file()
+        if recovery_kit_preserved:
+            kit_path = RECOVERY_KIT_PATH
+        else:
+            kit_path = write_recovery_kit(
+                store_id,
+                account_email=getattr(settings, "account_email", None),
+            )
         identity_count = len(load_identity_strings())
     except (CloudKeyError, CloudCryptoError, OSError) as exc:
         _print_backup_error(
@@ -574,15 +580,35 @@ def _cmd_cloud_init(args):
             "imported": bool(args.import_key),
             "store_id": store_id,
             "recovery_kit": str(kit_path),
+            "store_id_status": (
+                import_result.store_id_status if import_result is not None else "generated"
+            ),
+            "key_status": (
+                import_result.key_status if import_result is not None else "generated"
+            ),
         }, indent=2, sort_keys=True))
         return
 
     if args.import_key:
-        ok(f"Imported {identity_count} encryption identit{'y' if identity_count == 1 else 'ies'} to {KEY_PATH}")
+        if import_result.store_id_status == "installed":
+            ok(f"Store ID installed: {store_id}")
+        elif import_result.store_id_status == "already_matched":
+            ok(f"Store ID already matched: {store_id}")
+        elif import_result.store_id_status == "already_present":
+            ok(f"Store ID already present: {store_id}")
+        else:
+            ok(f"Store ID generated: {store_id}")
+        if import_result.key_status == "installed":
+            ok(f"Recovery key installed: {KEY_PATH}")
+        else:
+            ok(f"Recovery key already matched and preserved: {KEY_PATH}")
     else:
         ok(f"Generated encryption key: {KEY_PATH}")
-    info(f"Store id: {store_id}")
-    ok(f"Recovery kit written: {kit_path}")
+        info(f"Store id: {store_id}")
+    if recovery_kit_preserved:
+        info(f"Recovery kit already present: {kit_path}")
+    else:
+        ok(f"Recovery kit written: {kit_path}")
     warn(
         "Store the recovery kit somewhere safe and OFFLINE. Anyone with it can "
         "read your backups; without it, nobody can — including us."

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -41,6 +41,7 @@ class RecoveryImportPlan:
     """A fully validated recovery import, ready to apply without conflicts."""
 
     identity_strings: tuple[str, ...]
+    installed_identity_strings: tuple[str, ...]
     store_id: str | None
     key_path: Path
     memory_dir: Path
@@ -404,8 +405,10 @@ def plan_recovery_import(
                 "then move it aside and retry."
             )
         key_status = "already_matched"
+        installed_identity_strings = tuple(existing_identities)
     else:
         key_status = "installed"
+        installed_identity_strings = identity_strings
 
     if store_id is None and existing_store_id is None:
         # Bare key material is still supported. Generate its namespace during
@@ -421,6 +424,7 @@ def plan_recovery_import(
 
     return RecoveryImportPlan(
         identity_strings=identity_strings,
+        installed_identity_strings=installed_identity_strings,
         store_id=store_id,
         key_path=key_path,
         memory_dir=memory_dir,
@@ -514,11 +518,48 @@ def _ensure_recovery_kit_can_be_rewritten(kit_path: Path) -> None:
         )
 
 
-def validate_recovery_kit_destination(kit_path: Path | None = None) -> Path:
-    """Validate the canonical kit destination before an import changes local state."""
+def validate_recovery_kit_destination(
+    plan: RecoveryImportPlan,
+    kit_path: Path | None = None,
+) -> Path:
+    """Ensure refreshing the canonical kit cannot discard unrelated recovery material."""
 
     kit_path = (RECOVERY_KIT_PATH if kit_path is None else kit_path).expanduser()
     _ensure_recovery_kit_can_be_rewritten(kit_path)
+    if not kit_path.exists():
+        return kit_path
+
+    text = kit_path.read_text(encoding="utf-8")
+    existing_store_id = extract_store_id_from_text(text)
+    if existing_store_id is not None and existing_store_id != plan.store_id:
+        raise CloudKeyError(
+            f"The existing recovery kit belongs to store {existing_store_id}, but this "
+            f"import targets {plan.store_id}. Refusing to overwrite unrelated recovery "
+            "material. No files were changed."
+        )
+
+    raw_identities = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip().startswith("AGE-SECRET-KEY-")
+    ]
+    if raw_identities:
+        try:
+            existing_identities = _identity_strings_from_text(text)
+        except CloudKeyError as exc:
+            raise CloudKeyError(
+                "The existing recovery kit contains invalid key material and was not "
+                "overwritten. No files were changed."
+            ) from exc
+        if any(
+            identity not in plan.installed_identity_strings
+            for identity in existing_identities
+        ):
+            raise CloudKeyError(
+                "The existing recovery kit contains an identity that is not present in the "
+                "planned cloud key. Refusing to overwrite unrelated recovery material. "
+                "No files were changed."
+            )
     return kit_path
 
 

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -30,6 +31,28 @@ MAX_RECOVERY_KIT_BYTES = 256 * 1024
 
 class CloudKeyError(RuntimeError):
     """Raised for key-file lifecycle failures."""
+
+
+@dataclass(frozen=True)
+class RecoveryImportPlan:
+    """A fully validated recovery import, ready to apply without conflicts."""
+
+    identity_strings: tuple[str, ...]
+    store_id: str | None
+    key_path: Path
+    memory_dir: Path
+    store_id_status: str
+    key_status: str
+
+
+@dataclass(frozen=True)
+class RecoveryImportResult:
+    """The independently observable outcomes of a recovery import."""
+
+    identity_strings: tuple[str, ...]
+    store_id: str | None
+    store_id_status: str
+    key_status: str
 
 
 def _atomic_write_0600(path: Path, text: str) -> None:
@@ -104,6 +127,31 @@ def init_key(key_path: Path | None = None) -> str:
     return identity_str
 
 
+def _read_import_source(source: str) -> str:
+    """Load a path-or-text import source exactly once."""
+    source_path = Path(source).expanduser()
+    try:
+        return source_path.read_text(encoding="utf-8") if source_path.is_file() else source
+    except OSError:
+        # Raw recovery-kit text can exceed the platform's maximum path length.
+        # `source` is documented to accept either form, so a failed path probe
+        # must fall back to parsing it as text.
+        return source
+
+
+def _identity_strings_from_text(text: str) -> list[str]:
+    strings = [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip().startswith("AGE-SECRET-KEY-")
+    ]
+    if not strings:
+        raise CloudKeyError("No age identities found in the provided key material.")
+    for string in strings:
+        identity_from_str(string)
+    return strings
+
+
 def import_key(source: str, key_path: Path | None = None) -> list[str]:
     """Install identities from a recovery kit or key file (fresh machine).
 
@@ -116,23 +164,7 @@ def import_key(source: str, key_path: Path | None = None) -> list[str]:
             f"A cloud key already exists at {key_path}; refusing to overwrite. "
             "Move it aside first if you really mean to replace it."
         )
-    source_path = Path(source).expanduser()
-    try:
-        text = source_path.read_text(encoding="utf-8") if source_path.is_file() else source
-    except OSError:
-        # Raw recovery-kit text can exceed the platform's maximum path length.
-        # `source` is documented to accept either form, so a failed path probe
-        # must fall back to parsing it as text.
-        text = source
-    strings = [
-        line.strip()
-        for line in text.splitlines()
-        if line.strip().startswith("AGE-SECRET-KEY-")
-    ]
-    if not strings:
-        raise CloudKeyError("No age identities found in the provided key material.")
-    for s in strings:  # validate before writing anything
-        identity_from_str(s)
+    strings = _identity_strings_from_text(_read_import_source(source))
     _atomic_write_0600(key_path, _serialize_key_file(strings, rotated=False))
     return strings
 
@@ -281,6 +313,122 @@ def install_store_id(memory_dir: Path, store_id: str) -> str:
     memory_dir.mkdir(parents=True, exist_ok=True)
     store_path.write_text(store_id + "\n", encoding="utf-8")
     return store_id
+
+
+def _existing_store_id(memory_dir: Path) -> str | None:
+    """Read and strictly validate the installed store id without changing it."""
+    store_path = memory_dir.expanduser() / STORE_ID_NAME
+    if not store_path.exists() and not store_path.is_symlink():
+        return None
+    if not store_path.is_file():
+        raise CloudKeyError(f"Cloud store id is not a readable file: {store_path}")
+    value = store_path.read_text(encoding="utf-8").strip()
+    try:
+        return _validate_store_id(value)
+    except CloudKeyError as exc:
+        raise CloudKeyError(f"Corrupt store id at {store_path}: {value!r}") from exc
+
+
+def plan_recovery_import(
+    source: str,
+    memory_dir: Path,
+    key_path: Path | None = None,
+) -> RecoveryImportPlan:
+    """Preflight a recovery-kit import before changing the key or store id.
+
+    The source is read and parsed once. Existing keyrings may retain identities
+    from rotation, but must already contain every identity carried by the kit.
+    """
+    key_path = (KEY_PATH if key_path is None else key_path).expanduser()
+    memory_dir = memory_dir.expanduser()
+    text = _read_import_source(source)
+    identity_strings = tuple(_identity_strings_from_text(text))
+    store_id = extract_store_id_from_text(text)
+
+    existing_store_id = _existing_store_id(memory_dir)
+    if store_id is not None and existing_store_id is not None and existing_store_id != store_id:
+        raise CloudKeyError(
+            f"This memory store already has store id {existing_store_id}, but the recovery "
+            f"kit carries {store_id}. Refusing to overwrite — restoring into a store that "
+            "belongs to a different remote namespace would orphan its backups. No files were "
+            "changed."
+        )
+
+    key_exists = key_path.exists() or key_path.is_symlink()
+    if key_exists and not key_path.is_file():
+        raise CloudKeyError(f"Cloud key is not a readable file: {key_path}. No files were changed.")
+    if key_exists:
+        existing_identities = load_identity_strings(key_path)
+        # Validate existing material as well; a malformed key must not be silently
+        # treated as a compatible keyring.
+        for identity in existing_identities:
+            identity_from_str(identity)
+        if any(identity not in existing_identities for identity in identity_strings):
+            raise CloudKeyError(
+                "The recovery kit contains an identity that is not present in the existing "
+                "cloud key. Refusing to merge or replace key material implicitly. No files "
+                "were changed."
+            )
+        key_status = "already_matched"
+    else:
+        key_status = "installed"
+
+    if store_id is None and existing_store_id is None:
+        # Bare key material is still supported. Generate its namespace during
+        # preflight so the subsequent store/key writes have the same conflict
+        # guarantees as a full recovery kit.
+        store_id = str(uuid.uuid4())
+        store_id_status = "generated"
+    elif store_id is None:
+        store_id = existing_store_id
+        store_id_status = "already_present"
+    else:
+        store_id_status = "already_matched" if existing_store_id is not None else "installed"
+
+    return RecoveryImportPlan(
+        identity_strings=identity_strings,
+        store_id=store_id,
+        key_path=key_path,
+        memory_dir=memory_dir,
+        store_id_status=store_id_status,
+        key_status=key_status,
+    )
+
+
+def apply_recovery_import(plan: RecoveryImportPlan) -> RecoveryImportResult:
+    """Apply a preflighted import and report each resource's actual outcome."""
+    if plan.store_id_status in {"installed", "generated"}:
+        try:
+            install_store_id(plan.memory_dir, plan.store_id or "")
+        except (CloudKeyError, OSError) as exc:
+            raise CloudKeyError(
+                "Recovery import failed before installing either resource. "
+                f"Store ID: not installed; recovery key: not installed. {exc}"
+            ) from exc
+
+    if plan.key_status == "installed":
+        try:
+            _atomic_write_0600(
+                plan.key_path,
+                _serialize_key_file(list(plan.identity_strings), rotated=False),
+            )
+        except OSError as exc:
+            store_outcome = {
+                "installed": "installed",
+                "generated": "generated",
+                "already_matched": "already matched",
+            }.get(plan.store_id_status, "not installed")
+            raise CloudKeyError(
+                "Recovery import partially completed. "
+                f"Store ID: {store_outcome}; recovery key: not installed. {exc}"
+            ) from exc
+
+    return RecoveryImportResult(
+        identity_strings=plan.identity_strings,
+        store_id=plan.store_id,
+        store_id_status=plan.store_id_status,
+        key_status=plan.key_status,
+    )
 
 
 # --- Recovery kit ---

--- a/src/ormah/cloud/keys.py
+++ b/src/ormah/cloud/keys.py
@@ -8,12 +8,15 @@ Nothing here is ever destructive; there is no ``--force``.
 from __future__ import annotations
 
 import logging
+import os
+import stat
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
 from ormah.cloud.crypto import (
+    CloudCryptoError,
     generate_identity,
     identity_from_str,
     identity_to_str,
@@ -147,19 +150,27 @@ def _identity_strings_from_text(text: str) -> list[str]:
     ]
     if not strings:
         raise CloudKeyError("No age identities found in the provided key material.")
+    if len(set(strings)) != len(strings):
+        raise CloudKeyError("The provided key material contains duplicate age identities.")
     for string in strings:
-        identity_from_str(string)
+        try:
+            identity_from_str(string)
+        except CloudCryptoError as exc:
+            raise CloudKeyError(
+                "The provided key material contains an invalid age identity."
+            ) from exc
     return strings
 
 
 def import_key(source: str, key_path: Path | None = None) -> list[str]:
-    """Install identities from a recovery kit or key file (fresh machine).
+    """Install identities into a missing key file.
 
-    Accepts a path or raw pasted text; extracts every AGE-SECRET-KEY line,
-    preserving order (current first). Refuses if a key file already exists.
+    This low-level helper preserves its original fresh-key-only contract. Full
+    recovery-kit imports must use ``plan_recovery_import`` followed by
+    ``apply_recovery_import`` so the store identity is preflighted too.
     """
     key_path = (KEY_PATH if key_path is None else key_path).expanduser()
-    if key_path.is_file():
+    if key_path.exists() or key_path.is_symlink():
         raise CloudKeyError(
             f"A cloud key already exists at {key_path}; refusing to overwrite. "
             "Move it aside first if you really mean to replace it."
@@ -281,13 +292,7 @@ def extract_store_id_from_text(text: str) -> str | None:
 
 def extract_store_id(source: str) -> str | None:
     """Pull the store id out of recovery-kit material (path or raw text)."""
-
-    source_path = Path(source).expanduser()
-    try:
-        text = source_path.read_text(encoding="utf-8") if source_path.is_file() else source
-    except OSError:
-        text = source
-    return extract_store_id_from_text(text)
+    return extract_store_id_from_text(_read_import_source(source))
 
 
 def install_store_id(memory_dir: Path, store_id: str) -> str:
@@ -300,6 +305,8 @@ def install_store_id(memory_dir: Path, store_id: str) -> str:
     store_id = _validate_store_id(store_id)
     memory_dir = memory_dir.expanduser()
     store_path = memory_dir / STORE_ID_NAME
+    if store_path.is_symlink():
+        raise CloudKeyError(f"Cloud store id must not be a symlink: {store_path}")
     if store_path.is_file():
         existing = store_path.read_text(encoding="utf-8").strip()
         if existing == store_id:
@@ -310,8 +317,7 @@ def install_store_id(memory_dir: Path, store_id: str) -> str:
             "store that belongs to a different remote namespace would orphan its "
             "backups. Use a fresh ORMAH_MEMORY_DIR or remove .store_id deliberately."
         )
-    memory_dir.mkdir(parents=True, exist_ok=True)
-    store_path.write_text(store_id + "\n", encoding="utf-8")
+    _atomic_write_0600(store_path, store_id + "\n")
     return store_id
 
 
@@ -320,13 +326,21 @@ def _existing_store_id(memory_dir: Path) -> str | None:
     store_path = memory_dir.expanduser() / STORE_ID_NAME
     if not store_path.exists() and not store_path.is_symlink():
         return None
+    if store_path.is_symlink():
+        raise CloudKeyError(
+            f"Cloud store id must not be a symlink: {store_path}. No files were changed."
+        )
     if not store_path.is_file():
-        raise CloudKeyError(f"Cloud store id is not a readable file: {store_path}")
+        raise CloudKeyError(
+            f"Cloud store id is not a readable file: {store_path}. No files were changed."
+        )
     value = store_path.read_text(encoding="utf-8").strip()
     try:
         return _validate_store_id(value)
     except CloudKeyError as exc:
-        raise CloudKeyError(f"Corrupt store id at {store_path}: {value!r}") from exc
+        raise CloudKeyError(
+            f"Corrupt store id at {store_path}: {value!r}. No files were changed."
+        ) from exc
 
 
 def plan_recovery_import(
@@ -355,19 +369,39 @@ def plan_recovery_import(
         )
 
     key_exists = key_path.exists() or key_path.is_symlink()
+    if key_path.is_symlink():
+        raise CloudKeyError(
+            f"Cloud key must not be a symlink: {key_path}. No files were changed."
+        )
     if key_exists and not key_path.is_file():
         raise CloudKeyError(f"Cloud key is not a readable file: {key_path}. No files were changed.")
     if key_exists:
         existing_identities = load_identity_strings(key_path)
         # Validate existing material as well; a malformed key must not be silently
         # treated as a compatible keyring.
-        for identity in existing_identities:
-            identity_from_str(identity)
+        if len(set(existing_identities)) != len(existing_identities):
+            raise CloudKeyError(
+                f"The existing cloud key contains duplicate identities: {key_path}. "
+                "No files were changed."
+            )
+        try:
+            for identity in existing_identities:
+                identity_from_str(identity)
+        except CloudCryptoError as exc:
+            raise CloudKeyError(
+                f"The existing cloud key is invalid: {key_path}. No files were changed."
+            ) from exc
+        if os.name != "nt" and stat.S_IMODE(key_path.stat().st_mode) & 0o077:
+            raise CloudKeyError(
+                f"Cloud key permissions are too broad at {key_path}; run `chmod 600 {key_path}` "
+                "and retry. No files were changed."
+            )
         if any(identity not in existing_identities for identity in identity_strings):
             raise CloudKeyError(
                 "The recovery kit contains an identity that is not present in the existing "
                 "cloud key. Refusing to merge or replace key material implicitly. No files "
-                "were changed."
+                "were changed. To replace it deliberately, preserve the existing key first, "
+                "then move it aside and retry."
             )
         key_status = "already_matched"
     else:
@@ -417,9 +451,16 @@ def apply_recovery_import(plan: RecoveryImportPlan) -> RecoveryImportResult:
                 "installed": "installed",
                 "generated": "generated",
                 "already_matched": "already matched",
-            }.get(plan.store_id_status, "not installed")
+                "already_present": "already present",
+            }.get(plan.store_id_status, "unchanged")
+            store_was_written = plan.store_id_status in {"installed", "generated"}
+            completion = (
+                "Recovery import partially completed."
+                if store_was_written
+                else "Recovery import failed without changing files."
+            )
             raise CloudKeyError(
-                "Recovery import partially completed. "
+                f"{completion} "
                 f"Store ID: {store_outcome}; recovery key: not installed. {exc}"
             ) from exc
 
@@ -471,6 +512,14 @@ def _ensure_recovery_kit_can_be_rewritten(kit_path: Path) -> None:
             "The recovery kit was created by a newer Ormah version; update Ormah before "
             "regenerating or rotating recovery material."
         )
+
+
+def validate_recovery_kit_destination(kit_path: Path | None = None) -> Path:
+    """Validate the canonical kit destination before an import changes local state."""
+
+    kit_path = (RECOVERY_KIT_PATH if kit_path is None else kit_path).expanduser()
+    _ensure_recovery_kit_can_be_rewritten(kit_path)
+    return kit_path
 
 
 def _serialize_recovery_kit(

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import io
 import json
+import stat
 from unittest.mock import patch
 
 import pytest
@@ -87,6 +88,183 @@ def test_cloud_init_import_key(cloud_paths, tmp_path, capsys):
     out = json.loads(capsys.readouterr().out)
     assert out["imported"] is True
     assert cloud_keys.load_identity_strings(key_path) == original
+
+
+def test_cloud_init_import_preserved_matching_key_installs_missing_store_id(
+    cloud_paths, capsys
+):
+    """Uninstall preserves recovery material but removes the memory directory."""
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    original_key_bytes = key_path.read_bytes()
+    original_store_id = (memory_dir / ".store_id").read_text(encoding="utf-8")
+    (memory_dir / ".store_id").unlink()
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", str(kit_path), "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["store_id"] == original_store_id.strip()
+    assert out["store_id_status"] == "installed"
+    assert out["key_status"] == "already_matched"
+    assert (memory_dir / ".store_id").read_text(encoding="utf-8") == original_store_id
+    assert key_path.read_bytes() == original_key_bytes
+
+
+def test_cloud_init_import_matching_material_is_a_noop(cloud_paths, capsys):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    key_before = key_path.read_bytes()
+    store_before = (memory_dir / ".store_id").read_bytes()
+    kit_before = kit_path.read_bytes()
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", str(kit_path), "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["store_id_status"] == "already_matched"
+    assert out["key_status"] == "already_matched"
+    assert key_path.read_bytes() == key_before
+    assert (memory_dir / ".store_id").read_bytes() == store_before
+    assert kit_path.read_bytes() == kit_before
+
+
+def test_cloud_init_import_accepts_existing_rotated_keyring(cloud_paths, tmp_path, capsys):
+    key_path, kit_path, _ = cloud_paths
+    _run(["cloud", "init", "--json"])
+    original_kit = tmp_path / "pre-rotation-kit.md"
+    original_kit.write_bytes(kit_path.read_bytes())
+    capsys.readouterr()
+    _run(["cloud", "rotate-key", "--yes", "--json"])
+    key_before = key_path.read_bytes()
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", str(original_kit), "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["key_status"] == "already_matched"
+    assert key_path.read_bytes() == key_before
+
+
+def test_cloud_init_import_store_conflict_changes_neither_resource(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    original_store_id = (memory_dir / ".store_id").read_text(encoding="utf-8").strip()
+    conflicting_kit = tmp_path / "conflicting-kit.md"
+    conflicting_kit.write_text(
+        kit_path.read_text(encoding="utf-8").replace(
+            f"store_id: {original_store_id}",
+            "store_id: 66666666-7777-4888-9999-aaaaaaaaaaaa",
+        ),
+        encoding="utf-8",
+    )
+    key_before = key_path.read_bytes()
+    store_before = (memory_dir / ".store_id").read_bytes()
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(conflicting_kit)])
+
+    assert "No files were changed" in capsys.readouterr().err
+    assert key_path.read_bytes() == key_before
+    assert (memory_dir / ".store_id").read_bytes() == store_before
+
+
+def test_cloud_init_import_unknown_key_identity_changes_neither_resource(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, _, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    store_id = (memory_dir / ".store_id").read_text(encoding="utf-8").strip()
+    unknown_identity = cloud_keys.init_key(tmp_path / "other" / "cloud.key")
+    conflicting_kit = tmp_path / "unknown-key-kit.md"
+    conflicting_kit.write_text(
+        f"{unknown_identity}\nstore_id: {store_id}\n", encoding="utf-8"
+    )
+    key_before = key_path.read_bytes()
+    store_before = (memory_dir / ".store_id").read_bytes()
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(conflicting_kit)])
+
+    assert "No files were changed" in capsys.readouterr().err
+    assert key_path.read_bytes() == key_before
+    assert (memory_dir / ".store_id").read_bytes() == store_before
+
+
+def test_cloud_init_import_raw_text_writes_new_key_with_0600(cloud_paths, capsys):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    recovery_text = kit_path.read_text(encoding="utf-8")
+    key_path.unlink()
+    (memory_dir / ".store_id").unlink()
+    kit_path.unlink()
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", recovery_text, "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["store_id_status"] == "installed"
+    assert out["key_status"] == "installed"
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+def test_cloud_init_import_bare_key_preflights_a_new_store_id(cloud_paths, capsys):
+    key_path, _, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    identity = cloud_keys.load_identity_strings(key_path)[0]
+    key_path.unlink()
+    (memory_dir / ".store_id").unlink()
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", identity, "--json"])
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["store_id_status"] == "generated"
+    assert out["key_status"] == "installed"
+    assert out["store_id"] == (memory_dir / ".store_id").read_text().strip()
+
+
+def test_cloud_init_import_human_output_has_separate_resource_outcomes(cloud_paths, capsys):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    identity = cloud_keys.load_identity_strings(key_path)[0]
+    (memory_dir / ".store_id").unlink()
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", str(kit_path)])
+
+    output = capsys.readouterr().out
+    assert "Store ID installed" in output
+    assert "Recovery key already matched and preserved" in output
+    assert identity not in output
+
+
+def test_cloud_init_import_reports_actual_partial_filesystem_failure(
+    cloud_paths, capsys, monkeypatch
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    recovery_text = kit_path.read_text(encoding="utf-8")
+    key_path.unlink()
+    (memory_dir / ".store_id").unlink()
+    capsys.readouterr()
+
+    def fail_key_write(path, text):
+        assert path == key_path
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cloud_keys, "_atomic_write_0600", fail_key_write)
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", recovery_text])
+
+    assert "Store ID: installed; recovery key: not installed" in capsys.readouterr().err
+    assert (memory_dir / ".store_id").is_file()
+    assert not key_path.exists()
 
 
 def test_cloud_init_imports_recovery_kit_from_stdin(cloud_paths, capsys, monkeypatch):
@@ -216,7 +394,7 @@ def test_import_key_refuses_store_id_conflict(cloud_paths, tmp_path, capsys):
     kit_copy.write_text(kit_path.read_text())
 
     key_path.rename(key_path.with_suffix(".bak"))
-    (memory_dir / ".store_id").write_text("99999999-8888-7777-6666-555555555555\n")
+    (memory_dir / ".store_id").write_text("99999999-8888-4777-8666-555555555555\n")
     capsys.readouterr()
 
     with pytest.raises(SystemExit):

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -196,6 +196,83 @@ def test_cloud_init_import_newer_canonical_kit_blocks_before_mutation(
     assert kit_path.read_bytes() == kit_before
 
 
+def test_cloud_init_import_does_not_overwrite_kit_for_another_store(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    import_source = tmp_path / "import.md"
+    import_source.write_bytes(kit_path.read_bytes())
+    current_store = (memory_dir / ".store_id").read_text(encoding="utf-8").strip()
+    kit_path.write_text(
+        kit_path.read_text(encoding="utf-8").replace(
+            f"store_id: {current_store}",
+            "store_id: 66666666-7777-4888-9999-aaaaaaaaaaaa",
+        ),
+        encoding="utf-8",
+    )
+    (memory_dir / ".store_id").unlink()
+    key_before = key_path.read_bytes()
+    kit_before = kit_path.read_bytes()
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(import_source)])
+
+    assert "unrelated recovery material" in capsys.readouterr().err
+    assert not (memory_dir / ".store_id").exists()
+    assert key_path.read_bytes() == key_before
+    assert kit_path.read_bytes() == kit_before
+
+
+def test_cloud_init_import_does_not_overwrite_kit_with_unknown_identity(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    import_source = tmp_path / "import.md"
+    import_source.write_bytes(kit_path.read_bytes())
+    other_key = tmp_path / "other" / "cloud.key"
+    other_identity = cloud_keys.init_key(other_key)
+    current_identity = cloud_keys.load_identity_strings(key_path)[0]
+    kit_path.write_text(
+        kit_path.read_text(encoding="utf-8").replace(
+            current_identity, other_identity
+        ),
+        encoding="utf-8",
+    )
+    key_before = key_path.read_bytes()
+    store_before = (memory_dir / ".store_id").read_bytes()
+    kit_before = kit_path.read_bytes()
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(import_source)])
+
+    assert "unrelated recovery material" in capsys.readouterr().err
+    assert key_path.read_bytes() == key_before
+    assert (memory_dir / ".store_id").read_bytes() == store_before
+    assert kit_path.read_bytes() == kit_before
+
+
+def test_cloud_init_import_repairs_empty_canonical_kit(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    import_source = tmp_path / "import.md"
+    import_source.write_bytes(kit_path.read_bytes())
+    kit_path.write_text("", encoding="utf-8")
+    (memory_dir / ".store_id").unlink()
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", str(import_source), "--json"])
+
+    repaired = kit_path.read_text(encoding="utf-8")
+    assert cloud_keys.load_identity_strings(key_path)[0] in repaired
+    assert cloud_keys.extract_store_id(repaired) is not None
+
+
 def test_cloud_init_import_store_conflict_changes_neither_resource(
     cloud_paths, tmp_path, capsys
 ):
@@ -292,11 +369,12 @@ def test_cloud_init_import_raw_text_writes_new_key_with_0600(cloud_paths, capsys
 
 
 def test_cloud_init_import_bare_key_preflights_a_new_store_id(cloud_paths, capsys):
-    key_path, _, memory_dir = cloud_paths
+    key_path, kit_path, memory_dir = cloud_paths
     _run(["cloud", "init", "--json"])
     identity = cloud_keys.load_identity_strings(key_path)[0]
     key_path.unlink()
     (memory_dir / ".store_id").unlink()
+    kit_path.unlink()
     capsys.readouterr()
 
     _run(["cloud", "init", "--import-key", identity, "--json"])

--- a/tests/test_cloud_cli.py
+++ b/tests/test_cloud_cli.py
@@ -116,7 +116,6 @@ def test_cloud_init_import_matching_material_is_a_noop(cloud_paths, capsys):
     _run(["cloud", "init", "--json"])
     key_before = key_path.read_bytes()
     store_before = (memory_dir / ".store_id").read_bytes()
-    kit_before = kit_path.read_bytes()
     capsys.readouterr()
 
     _run(["cloud", "init", "--import-key", str(kit_path), "--json"])
@@ -126,7 +125,9 @@ def test_cloud_init_import_matching_material_is_a_noop(cloud_paths, capsys):
     assert out["key_status"] == "already_matched"
     assert key_path.read_bytes() == key_before
     assert (memory_dir / ".store_id").read_bytes() == store_before
-    assert kit_path.read_bytes() == kit_before
+    assert cloud_keys.extract_store_id(str(kit_path)) == out["store_id"]
+    for identity in cloud_keys.load_identity_strings(key_path):
+        assert identity in kit_path.read_text(encoding="utf-8")
 
 
 def test_cloud_init_import_accepts_existing_rotated_keyring(cloud_paths, tmp_path, capsys):
@@ -144,6 +145,55 @@ def test_cloud_init_import_accepts_existing_rotated_keyring(cloud_paths, tmp_pat
     out = json.loads(capsys.readouterr().out)
     assert out["key_status"] == "already_matched"
     assert key_path.read_bytes() == key_before
+    for identity in cloud_keys.load_identity_strings(key_path):
+        assert identity in kit_path.read_text(encoding="utf-8")
+
+
+def test_cloud_init_import_repairs_stale_canonical_recovery_kit(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, kit_path, _ = cloud_paths
+    _run(["cloud", "init", "--json"])
+    old_kit = tmp_path / "old-kit.md"
+    old_kit.write_bytes(kit_path.read_bytes())
+    capsys.readouterr()
+    _run(["cloud", "rotate-key", "--yes", "--json"])
+    current_identities = cloud_keys.load_identity_strings(key_path)
+    kit_path.write_bytes(old_kit.read_bytes())
+    capsys.readouterr()
+
+    _run(["cloud", "init", "--import-key", str(old_kit), "--json"])
+
+    repaired = kit_path.read_text(encoding="utf-8")
+    assert all(identity in repaired for identity in current_identities)
+    assert cloud_keys.load_identity_strings(key_path) == current_identities
+
+
+def test_cloud_init_import_newer_canonical_kit_blocks_before_mutation(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    import_source = tmp_path / "import.md"
+    import_source.write_bytes(kit_path.read_bytes())
+    (memory_dir / ".store_id").unlink()
+    kit_path.write_text(
+        kit_path.read_text(encoding="utf-8").replace(
+            "format_version: 1", "format_version: 2\nfuture_field: preserve"
+        ),
+        encoding="utf-8",
+    )
+    key_before = key_path.read_bytes()
+    kit_before = kit_path.read_bytes()
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(import_source)])
+
+    assert "newer Ormah version" in capsys.readouterr().err
+    assert not (memory_dir / ".store_id").exists()
+    assert key_path.read_bytes() == key_before
+    assert kit_path.read_bytes() == kit_before
 
 
 def test_cloud_init_import_store_conflict_changes_neither_resource(
@@ -195,6 +245,31 @@ def test_cloud_init_import_unknown_key_identity_changes_neither_resource(
     assert (memory_dir / ".store_id").read_bytes() == store_before
 
 
+def test_cloud_init_import_unknown_key_with_missing_store_changes_neither_resource(
+    cloud_paths, tmp_path, capsys
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    store_id = (memory_dir / ".store_id").read_text(encoding="utf-8").strip()
+    unknown_identity = cloud_keys.init_key(tmp_path / "other" / "cloud.key")
+    conflicting_kit = tmp_path / "unknown-key-kit.md"
+    conflicting_kit.write_text(
+        f"{unknown_identity}\nstore_id: {store_id}\n", encoding="utf-8"
+    )
+    (memory_dir / ".store_id").unlink()
+    key_before = key_path.read_bytes()
+    kit_before = kit_path.read_bytes()
+    capsys.readouterr()
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", str(conflicting_kit)])
+
+    assert "No files were changed" in capsys.readouterr().err
+    assert not (memory_dir / ".store_id").exists()
+    assert key_path.read_bytes() == key_before
+    assert kit_path.read_bytes() == kit_before
+
+
 def test_cloud_init_import_raw_text_writes_new_key_with_0600(cloud_paths, capsys):
     key_path, kit_path, memory_dir = cloud_paths
     _run(["cloud", "init", "--json"])
@@ -210,6 +285,10 @@ def test_cloud_init_import_raw_text_writes_new_key_with_0600(cloud_paths, capsys
     assert out["store_id_status"] == "installed"
     assert out["key_status"] == "installed"
     assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert kit_path.is_file()
+    assert cloud_keys.load_identity_strings(key_path)[0] in kit_path.read_text(
+        encoding="utf-8"
+    )
 
 
 def test_cloud_init_import_bare_key_preflights_a_new_store_id(cloud_paths, capsys):
@@ -240,6 +319,7 @@ def test_cloud_init_import_human_output_has_separate_resource_outcomes(cloud_pat
     output = capsys.readouterr().out
     assert "Store ID installed" in output
     assert "Recovery key already matched and preserved" in output
+    assert "1 identity" in output
     assert identity not in output
 
 
@@ -253,9 +333,12 @@ def test_cloud_init_import_reports_actual_partial_filesystem_failure(
     (memory_dir / ".store_id").unlink()
     capsys.readouterr()
 
+    atomic_write = cloud_keys._atomic_write_0600
+
     def fail_key_write(path, text):
-        assert path == key_path
-        raise OSError("disk full")
+        if path == key_path:
+            raise OSError("disk full")
+        atomic_write(path, text)
 
     monkeypatch.setattr(cloud_keys, "_atomic_write_0600", fail_key_write)
 
@@ -265,6 +348,32 @@ def test_cloud_init_import_reports_actual_partial_filesystem_failure(
     assert "Store ID: installed; recovery key: not installed" in capsys.readouterr().err
     assert (memory_dir / ".store_id").is_file()
     assert not key_path.exists()
+
+
+def test_cloud_init_import_key_failure_reports_existing_store_truthfully(
+    cloud_paths, capsys, monkeypatch
+):
+    key_path, kit_path, memory_dir = cloud_paths
+    _run(["cloud", "init", "--json"])
+    identity = cloud_keys.load_identity_strings(key_path)[0]
+    key_path.unlink()
+    capsys.readouterr()
+
+    def fail_key_write(path, text):
+        assert path == key_path
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cloud_keys, "_atomic_write_0600", fail_key_write)
+
+    with pytest.raises(SystemExit):
+        _run(["cloud", "init", "--import-key", identity])
+
+    error = capsys.readouterr().err
+    assert "failed without changing files" in error
+    assert "Store ID: already present" in error
+    assert (memory_dir / ".store_id").is_file()
+    assert not key_path.exists()
+    assert kit_path.is_file()
 
 
 def test_cloud_init_imports_recovery_kit_from_stdin(cloud_paths, capsys, monkeypatch):

--- a/tests/test_cloud_keys.py
+++ b/tests/test_cloud_keys.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 import stat
 import uuid
 
@@ -13,6 +15,7 @@ from ormah.cloud.crypto import encrypt_bytes, decrypt_bytes
 from ormah.cloud.keys import (
     CloudKeyError,
     _rotate_key_without_recovery_kit,
+    apply_recovery_import,
     current_recipient,
     get_or_create_store_id,
     import_key,
@@ -20,6 +23,7 @@ from ormah.cloud.keys import (
     key_file_exists,
     load_identities,
     load_identity_strings,
+    plan_recovery_import,
     rotate_key_and_recovery_kit,
     write_recovery_kit,
 )
@@ -271,6 +275,170 @@ def test_import_validates_before_writing(tmp_path):
     assert not fresh.exists()
 
 
+def test_recovery_import_rejects_duplicate_kit_identities_before_writing(key_path):
+    identity = init_key(key_path)
+    fresh_key = key_path.parent / "fresh.key"
+    memory_dir = key_path.parent / "memory"
+
+    with pytest.raises(CloudKeyError, match="duplicate age identities"):
+        plan_recovery_import(
+            f"{identity}\n{identity}\nstore_id: 22222222-3333-4444-9555-666666666666\n",
+            memory_dir,
+            fresh_key,
+        )
+
+    assert not fresh_key.exists()
+    assert not (memory_dir / ".store_id").exists()
+
+
+def test_recovery_import_reads_source_file_once(tmp_path, key_path, monkeypatch):
+    init_key(key_path)
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-9555-666666666666",
+        key_path,
+        tmp_path / "kit.md",
+    )
+    original_read_text = Path.read_text
+    reads = 0
+
+    def count_source_reads(path, *args, **kwargs):
+        nonlocal reads
+        if path == kit_path:
+            reads += 1
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", count_source_reads)
+
+    plan_recovery_import(str(kit_path), tmp_path / "memory", key_path)
+
+    assert reads == 1
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink behavior")
+def test_recovery_import_rejects_symlinked_existing_key(tmp_path, key_path):
+    init_key(key_path)
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-9555-666666666666",
+        key_path,
+        tmp_path / "kit.md",
+    )
+    linked_key = tmp_path / "linked.key"
+    linked_key.symlink_to(key_path)
+
+    with pytest.raises(CloudKeyError, match="must not be a symlink"):
+        plan_recovery_import(str(kit_path), tmp_path / "memory", linked_key)
+
+    assert linked_key.is_symlink()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink behavior")
+def test_recovery_import_rejects_symlinked_existing_store(tmp_path, key_path):
+    init_key(key_path)
+    store_id = "22222222-3333-4444-9555-666666666666"
+    kit_path = write_recovery_kit(store_id, key_path, tmp_path / "kit.md")
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    target = tmp_path / "outside-store-id"
+    target.write_text(store_id + "\n", encoding="utf-8")
+    (memory_dir / ".store_id").symlink_to(target)
+
+    with pytest.raises(CloudKeyError, match="must not be a symlink"):
+        plan_recovery_import(str(kit_path), memory_dir, tmp_path / "fresh.key")
+
+    assert target.read_text(encoding="utf-8") == store_id + "\n"
+
+
+def test_recovery_import_rejects_malformed_existing_store(tmp_path, key_path):
+    init_key(key_path)
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-9555-666666666666",
+        key_path,
+        tmp_path / "kit.md",
+    )
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    store_path = memory_dir / ".store_id"
+    store_path.write_text("not-a-uuid\n", encoding="utf-8")
+    key_before = key_path.read_bytes()
+
+    with pytest.raises(CloudKeyError, match="Corrupt store id"):
+        plan_recovery_import(str(kit_path), memory_dir, key_path)
+
+    assert store_path.read_text(encoding="utf-8") == "not-a-uuid\n"
+    assert key_path.read_bytes() == key_before
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission behavior")
+def test_recovery_import_rejects_broad_existing_key_permissions(tmp_path, key_path):
+    init_key(key_path)
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-9555-666666666666",
+        key_path,
+        tmp_path / "kit.md",
+    )
+    key_path.chmod(0o644)
+
+    with pytest.raises(CloudKeyError, match="chmod 600"):
+        plan_recovery_import(str(kit_path), tmp_path / "memory", key_path)
+
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o644
+
+
+def test_recovery_import_wraps_malformed_existing_key(tmp_path, key_path):
+    source_key = tmp_path / "source.key"
+    init_key(source_key)
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-9555-666666666666",
+        source_key,
+        tmp_path / "kit.md",
+    )
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_text("AGE-SECRET-KEY-1NOTREAL\n", encoding="utf-8")
+    key_path.chmod(0o600)
+
+    with pytest.raises(CloudKeyError, match="existing cloud key is invalid"):
+        plan_recovery_import(str(kit_path), tmp_path / "memory", key_path)
+
+    assert key_path.read_text(encoding="utf-8") == "AGE-SECRET-KEY-1NOTREAL\n"
+
+
+def test_recovery_import_rejects_duplicate_existing_key(tmp_path, key_path):
+    source_key = tmp_path / "source.key"
+    identity = init_key(source_key)
+    kit_path = write_recovery_kit(
+        "22222222-3333-4444-9555-666666666666",
+        source_key,
+        tmp_path / "kit.md",
+    )
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_text(f"{identity}\n{identity}\n", encoding="utf-8")
+    key_path.chmod(0o600)
+
+    with pytest.raises(CloudKeyError, match="duplicate identities"):
+        plan_recovery_import(str(kit_path), tmp_path / "memory", key_path)
+
+    assert key_path.read_text(encoding="utf-8") == f"{identity}\n{identity}\n"
+
+
+def test_apply_recovery_import_installs_store_and_key(tmp_path, key_path):
+    source_key = tmp_path / "source.key"
+    identities = [init_key(source_key)]
+    store_id = "22222222-3333-4444-9555-666666666666"
+    kit_path = write_recovery_kit(store_id, source_key, tmp_path / "kit.md")
+    memory_dir = tmp_path / "memory"
+
+    result = apply_recovery_import(
+        plan_recovery_import(str(kit_path), memory_dir, key_path)
+    )
+
+    assert result.store_id_status == "installed"
+    assert result.key_status == "installed"
+    assert load_identity_strings(key_path) == identities
+    assert (memory_dir / ".store_id").read_text(encoding="utf-8").strip() == store_id
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE((memory_dir / ".store_id").stat().st_mode) == 0o600
+
+
 # --- store_id ---
 
 
@@ -370,6 +538,7 @@ def test_install_store_id_fresh_and_idempotent(tmp_path):
     sid = "55555555-6666-4777-8888-999999999999"
     assert install_store_id(memory_dir, sid) == sid
     assert (memory_dir / ".store_id").read_text().strip() == sid
+    assert stat.S_IMODE((memory_dir / ".store_id").stat().st_mode) == 0o600
     assert install_store_id(memory_dir, sid) == sid  # same id: no-op
 
 


### PR DESCRIPTION
## Problem

`ormah cloud init --import-key` installed a recovery kit store ID before refusing a preserved matching `cloud.key`, leaving a partial mutation after normal uninstall/reinstall.

## Invariants

- Preflight reads/parses the source once and validates kit identities, store ID, existing store ID, and existing keyring before writes.
- Matching preserved keyrings (including extra rotated identities) are retained byte-for-byte.
- Store/key conflicts abort with no resource changes; new key material is never merged implicitly.
- Fresh keys still use atomic 0600 writes; genuine post-write filesystem failures report separate resource outcomes.

## Tests

- Preserved key + missing store, full idempotent no-op, rotated keyring, store/key conflicts, file/raw/stdin inputs, permissions, output statuses, and partial-write reporting.
- `ORMAH_LLM_PROVIDER=none uv run pytest tests/test_cloud_keys.py tests/test_cloud_cli.py -v`
- `uv run ruff check src/ormah/cloud/keys.py src/ormah/cli.py tests/test_cloud_keys.py tests/test_cloud_cli.py`
- `git diff --check`

Closes #252