### PR TITLE
fix(uninstall): disable desktop autostart truthfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ available. If complete recovery cannot be guaranteed, uninstall stops without
 removing data or integrations. Deleting the preserved files manually can make
 encrypted cloud backups permanently unreadable.
 
+When a positively identified Ormah Desktop install is present, interactive
+uninstall separately asks whether to remove its app bundle and local UI/WebKit
+data; it always disables the known desktop login item first. `ormah uninstall
+--yes` includes those known user-owned desktop artifacts. A macOS app bundle
+that cannot be removed and a Debian-owned desktop package are left in place and
+reported with the exact manual or package-manager action, so completion is not
+claimed prematurely.
+
 Restore on a new machine with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -191,13 +191,14 @@ available. If complete recovery cannot be guaranteed, uninstall stops without
 removing data or integrations. Deleting the preserved files manually can make
 encrypted cloud backups permanently unreadable.
 
-When a positively identified Ormah Desktop install is present, interactive
-uninstall separately asks whether to remove its app bundle and local UI/WebKit
-data; it always disables the known desktop login item first. `ormah uninstall
---yes` includes those known user-owned desktop artifacts. A macOS app bundle
-that cannot be removed and a Debian-owned desktop package are left in place and
-reported with the exact manual or package-manager action, so completion is not
-claimed prematurely.
+`ormah uninstall` also detects and disables the verified Ormah Desktop login
+item before removing the Python runtime, preventing the desktop from restoring
+that runtime at the next login. The CLI deliberately leaves the application
+bundle/package and its UI data to the operating system: on macOS, quit Ormah
+and move `Ormah.app` to Trash; for a Debian install, run the exact
+`sudo apt remove ...` command printed by uninstall; for AppImage, delete the
+AppImage after quitting it. Uninstall lists every detected desktop remainder
+and never claims full removal while one remains.
 
 Restore on a new machine with:
 

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -834,14 +834,9 @@ def main():
     # --- uninstall ---
     uninstall_p = sub.add_parser(
         "uninstall",
-        help="Remove backend and known desktop artifacts; preserve cloud recovery files",
+        help="Remove backend and integrations; disable desktop autostart",
     )
-    uninstall_p.add_argument(
-        "-y",
-        "--yes",
-        action="store_true",
-        help="Skip prompts and remove all known user-owned desktop artifacts",
-    )
+    uninstall_p.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts")
     uninstall_p.set_defaults(func=_cmd_uninstall)
 
     # --- claude-md ---

--- a/src/ormah/cli.py
+++ b/src/ormah/cli.py
@@ -834,9 +834,14 @@ def main():
     # --- uninstall ---
     uninstall_p = sub.add_parser(
         "uninstall",
-        help="Remove integrations and local data; preserve cloud recovery files",
+        help="Remove backend and known desktop artifacts; preserve cloud recovery files",
     )
-    uninstall_p.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompts")
+    uninstall_p.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Skip prompts and remove all known user-owned desktop artifacts",
+    )
     uninstall_p.set_defaults(func=_cmd_uninstall)
 
     # --- claude-md ---

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -69,10 +69,6 @@ def _find_binary(name: str) -> str | None:
 ENV_PATH = ENV_DIR / ".env"
 WRAPPER_PATH = ENV_DIR / "ormah-server"
 CLOUD_RECOVERY_FILENAMES = frozenset({"cloud.key", "ormah-recovery-kit.md"})
-
-# These values are part of the Tauri bundle configuration.  Keep desktop
-# removal deliberately narrow: all paths below are exact leaf targets, never
-# parents that might contain another application's data.
 DESKTOP_BUNDLE_IDENTIFIER = "dev.ormah.desktop"
 DESKTOP_PRODUCT_NAME = "Ormah"
 MACOS_SYSTEM_APPLICATIONS_DIR = Path("/Applications")
@@ -2140,137 +2136,96 @@ def _remove_config_preserving_cloud_recovery(config_dir: Path) -> tuple[Path, ..
 
 @dataclass
 class DesktopUninstallState:
-    """Known desktop artifacts and truthful cleanup outcomes for one uninstall."""
+    """Desktop presence and the one artifact the Python CLI may remove."""
 
-    app_bundles: list[Path] = field(default_factory=list)
-    data_dirs: list[Path] = field(default_factory=list)
-    launch_agent: Path | None = None
-    linux_appimage_files: list[Path] = field(default_factory=list)
+    system: str
+    autostart_path: Path | None = None
+    unrecognized_autostart: Path | None = None
+    artifacts: list[Path] = field(default_factory=list)
     package_removal_command: str | None = None
-    remaining: list[str] = field(default_factory=list)
-    autostart_removed: bool = True
-    process_stopped: bool = True
+    autostart_disabled: bool = False
 
     @property
     def detected(self) -> bool:
         return bool(
-            self.app_bundles
-            or self.data_dirs
-            or self.launch_agent
-            or self.linux_appimage_files
+            self.autostart_path
+            or self.unrecognized_autostart
+            or self.artifacts
             or self.package_removal_command
-            or self.remaining
         )
 
-    @property
-    def removable_artifacts(self) -> list[Path]:
-        return self.app_bundles + self.data_dirs + self.linux_appimage_files
+
+def _macos_autostart_path(home: Path) -> Path:
+    return home / "Library" / "LaunchAgents" / f"{DESKTOP_PRODUCT_NAME}.plist"
 
 
-def _is_safe_exact_directory(path: Path) -> bool:
-    """True only for a real directory at one already-known exact path."""
-    return path.is_dir() and not path.is_symlink()
+def _linux_autostart_path(home: Path) -> Path:
+    return home / ".config" / "autostart" / f"{DESKTOP_PRODUCT_NAME}.desktop"
 
 
-def _is_valid_ormah_app_bundle(path: Path) -> bool:
-    """Validate an exact macOS bundle before treating it as ours.
+def _macos_autostart_bundle(path: Path) -> Path | None:
+    """Return the app bundle named by a verified Tauri LaunchAgent."""
 
-    A directory named ``Ormah.app`` is not sufficient evidence.  In particular,
-    do not follow a bundle symlink or remove a hand-created directory that merely
-    has the same name.
-    """
-    if not _is_safe_exact_directory(path) or path.name != "Ormah.app":
-        return False
-    info_plist = path / "Contents" / "Info.plist"
-    if info_plist.is_symlink() or not info_plist.is_file():
-        return False
-    try:
-        info_data = plistlib.loads(info_plist.read_bytes())
-    except (OSError, plistlib.InvalidFileException):
-        return False
-    return (
-        isinstance(info_data, dict)
-        and info_data.get("CFBundleIdentifier") == DESKTOP_BUNDLE_IDENTIFIER
-        and info_data.get("CFBundleName", DESKTOP_PRODUCT_NAME) == DESKTOP_PRODUCT_NAME
-    )
-
-
-def _macos_desktop_paths(home: Path) -> tuple[list[Path], list[Path], Path]:
-    """Return exact Tauri-owned macOS locations, without probing parents."""
-    apps = [MACOS_SYSTEM_APPLICATIONS_DIR / "Ormah.app", home / "Applications" / "Ormah.app"]
-    data = [
-        home / "Library" / "Application Support" / DESKTOP_BUNDLE_IDENTIFIER,
-        home / "Library" / "WebKit" / DESKTOP_BUNDLE_IDENTIFIER,
-    ]
-    launch_agent = home / "Library" / "LaunchAgents" / f"{DESKTOP_BUNDLE_IDENTIFIER}.plist"
-    return apps, data, launch_agent
-
-
-def _is_valid_macos_desktop_data_dir(path: Path) -> bool:
-    """Validate an exact per-bundle Tauri data directory without following links."""
-    _, candidates, _ = _macos_desktop_paths(Path.home())
-    return path in candidates and _is_safe_exact_directory(path)
-
-
-def _is_valid_ormah_launch_agent(path: Path, app_bundles: list[Path]) -> bool:
-    """Validate the exact Tauri LaunchAgent rather than deleting by filename."""
-    if path.is_symlink() or not path.is_file() or path.name != f"{DESKTOP_BUNDLE_IDENTIFIER}.plist":
-        return False
+    if path.is_symlink() or not path.is_file() or path.name != "Ormah.plist":
+        return None
     try:
         data = plistlib.loads(path.read_bytes())
-    except (OSError, plistlib.InvalidFileException):
-        return False
-    if not isinstance(data, dict) or data.get("Label") != DESKTOP_BUNDLE_IDENTIFIER:
-        return False
+    except Exception:  # A damaged plist is not safe to remove automatically.
+        return None
+    if not isinstance(data, dict) or data.get("Label") != DESKTOP_PRODUCT_NAME:
+        return None
     arguments = data.get("ProgramArguments")
     if not isinstance(arguments, list) or not arguments or not isinstance(arguments[0], str):
-        return False
+        return None
     executable = Path(arguments[0])
-    # The entry remains safely recognizable even if the bundle was manually
-    # deleted first.  Do not resolve paths: resolving could follow a symlink.
-    expected_prefixes = [bundle / "Contents" / "MacOS" for bundle in app_bundles]
-    return any(
-        executable.parent == prefix and executable.name == "ormah-desktop"
-        for prefix in expected_prefixes
+    valid = (
+        executable.is_absolute()
+        and executable.name in {"ormah-desktop", DESKTOP_PRODUCT_NAME}
+        and executable.parent.name == "MacOS"
+        and executable.parent.parent.name == "Contents"
+        and executable.parent.parent.parent.name == "Ormah.app"
     )
+    return executable.parent.parent.parent if valid else None
 
 
-def _is_valid_appimage_desktop_entry(path: Path) -> bool:
-    """Recognize only the exact entry written by desktop/src-tauri/src/lib.rs."""
-    if path.is_symlink() or not path.is_file() or path.name != "ormah.desktop":
-        return False
+def _is_ormah_macos_autostart(path: Path) -> bool:
+    return _macos_autostart_bundle(path) is not None
+
+
+def _linux_autostart_executable(path: Path) -> Path | None:
+    """Return the executable named by a verified auto-launch desktop entry."""
+
+    if path.is_symlink() or not path.is_file() or path.name != "Ormah.desktop":
+        return None
     try:
         text = path.read_text(encoding="utf-8")
-    except OSError:
-        return False
-    return all(
-        marker in text
-        for marker in (
-            "[Desktop Entry]",
-            "Name=Ormah",
-            "Icon=ormah-desktop",
-            "StartupWMClass=ormah-desktop",
-        )
-    ) and any(line.startswith("Exec=") for line in text.splitlines())
-
-
-def _is_valid_appimage_icon(path: Path) -> bool:
-    """Validate one of the two exact icon paths written by AppImage integration."""
-    home = Path.home()
-    expected = {
-        home / ".local" / "share" / "icons" / "hicolor" / size / "apps" / "ormah-desktop.png"
-        for size in ("128x128", "256x256")
+    except (OSError, UnicodeDecodeError):
+        return None
+    required = {
+        "[Desktop Entry]",
+        "Type=Application",
+        "Name=Ormah",
+        "Terminal=false",
     }
-    return path in expected and path.is_file() and not path.is_symlink()
+    lines = {line.strip() for line in text.splitlines()}
+    executable = next(
+        (line.split("=", 1)[1].strip() for line in lines if line.startswith("Exec=")),
+        "",
+    )
+    if not required.issubset(lines):
+        return None
+    if executable.endswith("/ormah-desktop") or executable.endswith(".AppImage"):
+        return Path(executable)
+    return None
+
+
+def _is_ormah_linux_autostart(path: Path) -> bool:
+    return _linux_autostart_executable(path) is not None
 
 
 def _linux_debian_removal_command() -> str | None:
-    """Return a package-manager command only when dpkg proves ownership.
+    """Return the normal command only when dpkg proves package ownership."""
 
-    The .deb does not have a user-owned, stable install directory.  Asking dpkg
-    about its executable lets us report the actual package name instead of
-    guessing one or attempting an unsafe package removal ourselves.
-    """
     try:
         result = subprocess.run(
             ["dpkg-query", "-S", "/usr/bin/ormah-desktop"],
@@ -2278,201 +2233,160 @@ def _linux_debian_removal_command() -> str | None:
             text=True,
             timeout=5,
         )
-    except Exception:  # noqa: BLE001 - discovery must not block uninstall
+    except (OSError, subprocess.SubprocessError):
         return None
-    output = result.stdout if isinstance(result.stdout, str) else ""
-    if not isinstance(result.returncode, int) or result.returncode != 0 or ":" not in output:
+    if result.returncode != 0 or ":" not in result.stdout:
         return None
-    package = output.split(":", 1)[0].strip()
+    package = result.stdout.split(":", 1)[0].strip()
     if not re.fullmatch(r"[A-Za-z0-9.+-]+", package):
         return None
     return f"sudo apt remove {package}"
 
 
+def _appimage_executable(entry: Path) -> Path | None:
+    """Read an AppImage path for reporting only; never use it as a delete target."""
+
+    if entry.is_symlink() or not entry.is_file():
+        return None
+    try:
+        text = entry.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    for line in text.splitlines():
+        if not line.startswith("Exec="):
+            continue
+        try:
+            command = shlex.split(line.split("=", 1)[1])
+        except ValueError:
+            return None
+        if not command:
+            return None
+        executable = Path(command[0]).expanduser()
+        if executable.is_absolute() and executable.name.endswith(".AppImage"):
+            return executable
+    return None
+
+
 def _inspect_desktop_installation(system: str | None = None) -> DesktopUninstallState:
-    """Find only desktop artifacts with positive Ormah ownership evidence."""
+    """Find desktop autostart and report-only artifacts without deleting anything."""
+
     system = system or platform.system()
     home = Path.home()
-    state = DesktopUninstallState()
+    state = DesktopUninstallState(system=system)
     if system == "Darwin":
-        app_candidates, data_candidates, launch_agent = _macos_desktop_paths(home)
-        state.app_bundles = [path for path in app_candidates if _is_valid_ormah_app_bundle(path)]
-        state.remaining.extend(
-            str(path)
-            for path in app_candidates
-            if (path.exists() or path.is_symlink()) and path not in state.app_bundles
-        )
-        # Tauri namespaces these directories by its bundle identifier.  Exact
-        # paths plus no symlink is sufficient; unlike an app bundle, they do not
-        # carry an embedded identifier to inspect.
-        state.data_dirs = [path for path in data_candidates if _is_safe_exact_directory(path)]
-        state.remaining.extend(
-            str(path)
-            for path in data_candidates
-            if (path.exists() or path.is_symlink()) and path not in state.data_dirs
-        )
-        if _is_valid_ormah_launch_agent(launch_agent, app_candidates):
-            state.launch_agent = launch_agent
-        elif launch_agent.exists() or launch_agent.is_symlink():
-            state.remaining.append(str(launch_agent))
+        autostart = _macos_autostart_path(home)
+        autostart_bundle = _macos_autostart_bundle(autostart)
+        if autostart_bundle is not None:
+            state.autostart_path = autostart
+        elif autostart.exists() or autostart.is_symlink():
+            state.unrecognized_autostart = autostart
+        candidates = [
+            MACOS_SYSTEM_APPLICATIONS_DIR / "Ormah.app",
+            home / "Applications" / "Ormah.app",
+            home / "Library" / "Application Support" / DESKTOP_BUNDLE_IDENTIFIER,
+            home / "Library" / "WebKit" / DESKTOP_BUNDLE_IDENTIFIER,
+        ]
+        state.artifacts = [path for path in candidates if path.exists() or path.is_symlink()]
+        if (
+            autostart_bundle is not None
+            and (autostart_bundle.exists() or autostart_bundle.is_symlink())
+            and autostart_bundle not in state.artifacts
+        ):
+            state.artifacts.append(autostart_bundle)
     elif system == "Linux":
-        entry = home / ".local" / "share" / "applications" / "ormah.desktop"
-        if _is_valid_appimage_desktop_entry(entry):
-            state.linux_appimage_files.append(entry)
+        autostart = _linux_autostart_path(home)
+        autostart_executable = _linux_autostart_executable(autostart)
+        if autostart_executable is not None:
+            state.autostart_path = autostart
+        elif autostart.exists() or autostart.is_symlink():
+            state.unrecognized_autostart = autostart
+        menu_entry = home / ".local" / "share" / "applications" / "ormah.desktop"
+        if menu_entry.exists() or menu_entry.is_symlink():
+            state.artifacts.append(menu_entry)
+            appimage = _appimage_executable(menu_entry)
+            if appimage is not None:
+                state.artifacts.append(appimage)
             for size in ("128x128", "256x256"):
-                icon = home / ".local" / "share" / "icons" / "hicolor" / size / "apps" / "ormah-desktop.png"
-                if _is_valid_appimage_icon(icon):
-                    state.linux_appimage_files.append(icon)
-        elif entry.exists() or entry.is_symlink():
-            state.remaining.append(str(entry))
+                icon = (
+                    home
+                    / ".local"
+                    / "share"
+                    / "icons"
+                    / "hicolor"
+                    / size
+                    / "apps"
+                    / "ormah-desktop.png"
+                )
+                if icon.exists() or icon.is_symlink():
+                    state.artifacts.append(icon)
+        if (
+            autostart_executable is not None
+            and autostart_executable.name.endswith(".AppImage")
+            and (autostart_executable.exists() or autostart_executable.is_symlink())
+            and autostart_executable not in state.artifacts
+        ):
+            state.artifacts.append(autostart_executable)
         state.package_removal_command = _linux_debian_removal_command()
     return state
 
 
-def _remove_desktop_launch_agent(state: DesktopUninstallState) -> None:
-    """Unload and remove the validated desktop LaunchAgent before Python cleanup."""
-    if state.launch_agent is None:
+def _disable_desktop_autostart(state: DesktopUninstallState) -> None:
+    """Remove only the exact, revalidated Tauri autostart file."""
+
+    path = state.autostart_path
+    if path is None:
+        return
+    validator = (
+        _is_ormah_macos_autostart
+        if state.system == "Darwin"
+        else _is_ormah_linux_autostart
+    )
+    if not validator(path):
+        state.unrecognized_autostart = path
+        warn(f"Refusing to remove changed desktop autostart entry: {path}")
         return
     try:
-        result = subprocess.run(
-            ["launchctl", "bootout", f"gui/{os.getuid()}", str(state.launch_agent)],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        returncode = result.returncode
-        if isinstance(returncode, int) and returncode != 0:
-            detail = result.stderr.strip() if isinstance(result.stderr, str) else ""
-            warn(f"Could not unload desktop LaunchAgent {state.launch_agent}: {detail or f'exit {returncode}'}")
-        # Revalidate immediately before deleting: a replacement plist must not
-        # be removed merely because the earlier inspection found an Ormah one.
-        apps, _, _ = _macos_desktop_paths(Path.home())
-        if not _is_valid_ormah_launch_agent(state.launch_agent, apps):
-            warn(f"Refusing to remove changed desktop LaunchAgent: {state.launch_agent}")
-            state.autostart_removed = False
-            state.remaining.append(str(state.launch_agent))
-            return
-        state.launch_agent.unlink()
-        ok(f"Removed desktop LaunchAgent: {state.launch_agent}")
-    except (OSError, subprocess.SubprocessError) as exc:
-        warn(f"Could not remove desktop LaunchAgent {state.launch_agent}: {exc}")
-        state.autostart_removed = False
-        state.remaining.append(str(state.launch_agent))
-
-
-def _find_running_macos_desktop_processes(app_bundles: list[Path]) -> list[int]:
-    """Find the app only by an exact, validated bundle executable path."""
-    expected_prefixes = {str(bundle / "Contents" / "MacOS") + os.sep for bundle in app_bundles}
-    if not expected_prefixes:
-        return []
-    try:
-        result = subprocess.run(
-            ["ps", "-x", "-o", "pid=,command="], capture_output=True, text=True, timeout=5
-        )
-    except (OSError, subprocess.SubprocessError):
-        return []
-    output = result.stdout if isinstance(result.stdout, str) else ""
-    pids: list[int] = []
-    for line in output.splitlines():
-        pid_text, _, command = line.strip().partition(" ")
-        try:
-            pid = int(pid_text)
-        except ValueError:
-            continue
-        executable = command.strip().split(" ", 1)[0]
-        if any(executable.startswith(prefix) for prefix in expected_prefixes):
-            pids.append(pid)
-    return pids
-
-
-def _stop_running_macos_desktop(state: DesktopUninstallState) -> None:
-    """Ask the identified app to quit; never use broad process-name killing."""
-    pids = _find_running_macos_desktop_processes(state.app_bundles)
-    if not pids:
+        path.unlink()
+    except OSError as exc:
+        warn(f"Could not disable Ormah Desktop autostart at {path}: {exc}")
+        state.unrecognized_autostart = path
         return
-    try:
-        result = subprocess.run(
-            ["osascript", "-e", f'tell application id "{DESKTOP_BUNDLE_IDENTIFIER}" to quit'],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if isinstance(result.returncode, int) and result.returncode != 0:
-            detail = result.stderr.strip() if isinstance(result.stderr, str) else ""
-            warn(f"Could not ask Ormah Desktop to quit: {detail or f'exit {result.returncode}'}")
-    except (OSError, subprocess.SubprocessError) as exc:
-        warn(f"Could not ask Ormah Desktop to quit: {exc}")
-    if _find_running_macos_desktop_processes(state.app_bundles):
-        state.process_stopped = False
-        for bundle in state.app_bundles:
-            if str(bundle) not in state.remaining:
-                state.remaining.append(str(bundle))
-        warn("Ormah Desktop is still running; quit it, then remove the remaining desktop artifacts.")
+    state.autostart_disabled = True
+    ok(f"Disabled Ormah Desktop autostart: {path}")
 
 
-def _remove_selected_desktop_artifacts(state: DesktopUninstallState, system: str) -> None:
-    """Delete exact validated desktop targets after autostart/process handling."""
-    if system == "Darwin" and not state.process_stopped:
-        return
-    for path in state.removable_artifacts:
-        valid = (
-            _is_valid_ormah_app_bundle(path)
-            if path.suffix == ".app"
-            else _is_valid_macos_desktop_data_dir(path)
-            if system == "Darwin" and (path.is_dir() or path.is_symlink())
-            else _is_valid_appimage_desktop_entry(path)
-            if path.name == "ormah.desktop"
-            else _is_valid_appimage_icon(path)
-        )
-        if not valid:
-            warn(f"Refusing to delete unexpected desktop artifact: {path}")
-            state.remaining.append(str(path))
-            continue
-        try:
-            if path.is_dir():
-                shutil.rmtree(path)
-            else:
-                path.unlink()
-            ok(f"Deleted desktop artifact: {path}")
-        except OSError as exc:
-            warn(f"Could not delete desktop artifact {path}: {exc}")
-            state.remaining.append(str(path))
+def _print_desktop_uninstall_summary(state: DesktopUninstallState) -> bool:
+    """Report exactly what remains; the hybrid CLI never deletes the desktop app."""
 
+    complete = True
+    if state.unrecognized_autostart is not None:
+        warn("Desktop autostart could not be safely disabled; remove this entry manually:")
+        warn(f"  {state.unrecognized_autostart}")
+        complete = False
+    elif state.autostart_path is not None and not state.autostart_disabled:
+        warn(f"Desktop autostart remains enabled: {state.autostart_path}")
+        complete = False
 
-def _print_desktop_uninstall_summary(state: DesktopUninstallState, desktop_selected: bool) -> bool:
-    """Report desktop status and return whether a truthful full removal occurred."""
-    remaining = list(dict.fromkeys(state.remaining))
-    if state.package_removal_command:
-        warn(f"Debian-owned Ormah Desktop remains; remove it with: {state.package_removal_command}")
-        remaining.append(state.package_removal_command)
-    if state.detected and not desktop_selected:
-        for path in state.removable_artifacts:
-            remaining.append(str(path))
-        warn("Desktop app and local UI data were kept by request; its autostart was disabled.")
-    if remaining:
-        warn("Backend removal completed, but these desktop artifacts remain:")
-        for item in dict.fromkeys(remaining):
-            warn(f"  {item}")
-        return False
-    return True
+    if state.artifacts or state.package_removal_command:
+        complete = False
+        warn("Ormah Desktop remains installed; opening it can reinstall the backend:")
+        for path in dict.fromkeys(state.artifacts):
+            warn(f"  {path}")
+        if state.system == "Darwin":
+            info("Quit Ormah, then move Ormah.app to Trash.")
+        if state.package_removal_command:
+            info(f"Remove the desktop package with: {state.package_removal_command}")
+        elif state.system == "Linux":
+            info("Delete the Ormah AppImage after quitting the app.")
+    return complete
 
 
 def run_uninstall(yes: bool = False) -> None:
     """Remove Ormah while preserving zero-knowledge cloud recovery material."""
-    system = platform.system()
-    desktop = _inspect_desktop_installation(system)
     print(
         "This will remove Ormah integrations, local memory, caches, and account "
         "configuration. Cloud recovery files are preserved.\n"
     )
-
-    if desktop.detected:
-        info("Ormah Desktop artifacts were detected.")
-        if system == "Darwin":
-            info("Its login LaunchAgent will be disabled so it cannot reinstall the backend.")
-        elif desktop.package_removal_command:
-            info(f"The Debian package is package-managed and must be removed separately: {desktop.package_removal_command}")
-        print()
 
     config_dir = Path.home() / ".config" / "ormah"
     recovery_paths = _cloud_recovery_paths(config_dir)
@@ -2502,19 +2416,6 @@ def run_uninstall(yes: bool = False) -> None:
         if confirm != "yes":
             info("Uninstall cancelled")
             return
-
-    # --yes is deliberately a full uninstall request: remove every known,
-    # positively identified user-owned desktop artifact.  Interactive callers
-    # retain the existing top-level confirmation, then make this narrower choice.
-    desktop_selected = yes
-    if not yes and desktop.removable_artifacts:
-        try:
-            answer = input(
-                "Remove the Ormah Desktop app and its local UI/WebKit data? (Y/n) "
-            ).strip().lower()
-        except EOFError:
-            answer = ""
-        desktop_selected = answer not in ("n", "no")
 
     print()
 
@@ -2547,19 +2448,22 @@ def run_uninstall(yes: bool = False) -> None:
         else:
             ok("Cloud recovery material is complete and verified")
 
-    # a. Disable the desktop login item before uninstalling Python.  The desktop
-    # app installs its pinned runtime when launched, so this must happen first.
-    if system == "Darwin":
+    # a. Disable the desktop's own login item before removing its Python
+    # runtime. The hybrid CLI leaves the app/package for normal OS removal.
+    desktop = _inspect_desktop_installation()
+    if desktop.autostart_path is not None or desktop.unrecognized_autostart is not None:
         step("Disabling Ormah Desktop autostart")
-        _remove_desktop_launch_agent(desktop)
-        if desktop_selected:
-            step("Closing Ormah Desktop")
-            _stop_running_macos_desktop(desktop)
-            step("Removing Ormah Desktop artifacts")
-            _remove_selected_desktop_artifacts(desktop, system)
-    elif desktop_selected and desktop.removable_artifacts:
-        step("Removing Ormah Desktop integration")
-        _remove_selected_desktop_artifacts(desktop, system)
+        if desktop.unrecognized_autostart is not None:
+            warn(
+                "Uninstall cannot safely identify this desktop autostart entry: "
+                f"{desktop.unrecognized_autostart}"
+            )
+            warn("Uninstall cancelled before removing the backend or integrations.")
+            return
+        _disable_desktop_autostart(desktop)
+        if desktop.autostart_path is not None and not desktop.autostart_disabled:
+            warn("Uninstall cancelled before removing the backend or integrations.")
+            return
 
     # b. Stop daemon
     step("Stopping server")
@@ -2646,13 +2550,15 @@ def run_uninstall(yes: bool = False) -> None:
     if not uv_uninstalled and not removed_tool_files:
         warn("Could not remove package files — remove manually with: uv tool uninstall ormah")
 
-    desktop_complete = _print_desktop_uninstall_summary(desktop, desktop_selected)
+    desktop_complete = _print_desktop_uninstall_summary(desktop)
     package_complete = uv_uninstalled or removed_tool_files
     print()
     if desktop_complete and package_complete:
-        ok("Ormah has been completely uninstalled")
+        ok("Ormah has been uninstalled")
+    elif package_complete:
+        warn("Ormah backend cleanup completed, but Ormah Desktop remains installed.")
     else:
-        warn("Ormah backend cleanup completed, but Ormah has not been fully uninstalled.")
+        warn("Ormah cleanup is incomplete; follow the removal instructions above.")
 
 
 # ---------------------------------------------------------------------------

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -6,6 +6,8 @@ import contextlib
 import glob
 import json
 import os
+import platform
+import plistlib
 import re
 import shlex
 import shutil
@@ -67,6 +69,13 @@ def _find_binary(name: str) -> str | None:
 ENV_PATH = ENV_DIR / ".env"
 WRAPPER_PATH = ENV_DIR / "ormah-server"
 CLOUD_RECOVERY_FILENAMES = frozenset({"cloud.key", "ormah-recovery-kit.md"})
+
+# These values are part of the Tauri bundle configuration.  Keep desktop
+# removal deliberately narrow: all paths below are exact leaf targets, never
+# parents that might contain another application's data.
+DESKTOP_BUNDLE_IDENTIFIER = "dev.ormah.desktop"
+DESKTOP_PRODUCT_NAME = "Ormah"
+MACOS_SYSTEM_APPLICATIONS_DIR = Path("/Applications")
 
 CLAUDE_MD_SENTINEL_START = "<!-- ormah:start -->"
 CLAUDE_MD_SENTINEL_END = "<!-- ormah:end -->"
@@ -2129,12 +2138,341 @@ def _remove_config_preserving_cloud_recovery(config_dir: Path) -> tuple[Path, ..
     return preserved
 
 
+@dataclass
+class DesktopUninstallState:
+    """Known desktop artifacts and truthful cleanup outcomes for one uninstall."""
+
+    app_bundles: list[Path] = field(default_factory=list)
+    data_dirs: list[Path] = field(default_factory=list)
+    launch_agent: Path | None = None
+    linux_appimage_files: list[Path] = field(default_factory=list)
+    package_removal_command: str | None = None
+    remaining: list[str] = field(default_factory=list)
+    autostart_removed: bool = True
+    process_stopped: bool = True
+
+    @property
+    def detected(self) -> bool:
+        return bool(
+            self.app_bundles
+            or self.data_dirs
+            or self.launch_agent
+            or self.linux_appimage_files
+            or self.package_removal_command
+            or self.remaining
+        )
+
+    @property
+    def removable_artifacts(self) -> list[Path]:
+        return self.app_bundles + self.data_dirs + self.linux_appimage_files
+
+
+def _is_safe_exact_directory(path: Path) -> bool:
+    """True only for a real directory at one already-known exact path."""
+    return path.is_dir() and not path.is_symlink()
+
+
+def _is_valid_ormah_app_bundle(path: Path) -> bool:
+    """Validate an exact macOS bundle before treating it as ours.
+
+    A directory named ``Ormah.app`` is not sufficient evidence.  In particular,
+    do not follow a bundle symlink or remove a hand-created directory that merely
+    has the same name.
+    """
+    if not _is_safe_exact_directory(path) or path.name != "Ormah.app":
+        return False
+    info_plist = path / "Contents" / "Info.plist"
+    if info_plist.is_symlink() or not info_plist.is_file():
+        return False
+    try:
+        info_data = plistlib.loads(info_plist.read_bytes())
+    except (OSError, plistlib.InvalidFileException):
+        return False
+    return (
+        isinstance(info_data, dict)
+        and info_data.get("CFBundleIdentifier") == DESKTOP_BUNDLE_IDENTIFIER
+        and info_data.get("CFBundleName", DESKTOP_PRODUCT_NAME) == DESKTOP_PRODUCT_NAME
+    )
+
+
+def _macos_desktop_paths(home: Path) -> tuple[list[Path], list[Path], Path]:
+    """Return exact Tauri-owned macOS locations, without probing parents."""
+    apps = [MACOS_SYSTEM_APPLICATIONS_DIR / "Ormah.app", home / "Applications" / "Ormah.app"]
+    data = [
+        home / "Library" / "Application Support" / DESKTOP_BUNDLE_IDENTIFIER,
+        home / "Library" / "WebKit" / DESKTOP_BUNDLE_IDENTIFIER,
+    ]
+    launch_agent = home / "Library" / "LaunchAgents" / f"{DESKTOP_BUNDLE_IDENTIFIER}.plist"
+    return apps, data, launch_agent
+
+
+def _is_valid_macos_desktop_data_dir(path: Path) -> bool:
+    """Validate an exact per-bundle Tauri data directory without following links."""
+    _, candidates, _ = _macos_desktop_paths(Path.home())
+    return path in candidates and _is_safe_exact_directory(path)
+
+
+def _is_valid_ormah_launch_agent(path: Path, app_bundles: list[Path]) -> bool:
+    """Validate the exact Tauri LaunchAgent rather than deleting by filename."""
+    if path.is_symlink() or not path.is_file() or path.name != f"{DESKTOP_BUNDLE_IDENTIFIER}.plist":
+        return False
+    try:
+        data = plistlib.loads(path.read_bytes())
+    except (OSError, plistlib.InvalidFileException):
+        return False
+    if not isinstance(data, dict) or data.get("Label") != DESKTOP_BUNDLE_IDENTIFIER:
+        return False
+    arguments = data.get("ProgramArguments")
+    if not isinstance(arguments, list) or not arguments or not isinstance(arguments[0], str):
+        return False
+    executable = Path(arguments[0])
+    # The entry remains safely recognizable even if the bundle was manually
+    # deleted first.  Do not resolve paths: resolving could follow a symlink.
+    expected_prefixes = [bundle / "Contents" / "MacOS" for bundle in app_bundles]
+    return any(
+        executable.parent == prefix and executable.name == "ormah-desktop"
+        for prefix in expected_prefixes
+    )
+
+
+def _is_valid_appimage_desktop_entry(path: Path) -> bool:
+    """Recognize only the exact entry written by desktop/src-tauri/src/lib.rs."""
+    if path.is_symlink() or not path.is_file() or path.name != "ormah.desktop":
+        return False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return all(
+        marker in text
+        for marker in (
+            "[Desktop Entry]",
+            "Name=Ormah",
+            "Icon=ormah-desktop",
+            "StartupWMClass=ormah-desktop",
+        )
+    ) and any(line.startswith("Exec=") for line in text.splitlines())
+
+
+def _is_valid_appimage_icon(path: Path) -> bool:
+    """Validate one of the two exact icon paths written by AppImage integration."""
+    home = Path.home()
+    expected = {
+        home / ".local" / "share" / "icons" / "hicolor" / size / "apps" / "ormah-desktop.png"
+        for size in ("128x128", "256x256")
+    }
+    return path in expected and path.is_file() and not path.is_symlink()
+
+
+def _linux_debian_removal_command() -> str | None:
+    """Return a package-manager command only when dpkg proves ownership.
+
+    The .deb does not have a user-owned, stable install directory.  Asking dpkg
+    about its executable lets us report the actual package name instead of
+    guessing one or attempting an unsafe package removal ourselves.
+    """
+    try:
+        result = subprocess.run(
+            ["dpkg-query", "-S", "/usr/bin/ormah-desktop"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:  # noqa: BLE001 - discovery must not block uninstall
+        return None
+    output = result.stdout if isinstance(result.stdout, str) else ""
+    if not isinstance(result.returncode, int) or result.returncode != 0 or ":" not in output:
+        return None
+    package = output.split(":", 1)[0].strip()
+    if not re.fullmatch(r"[A-Za-z0-9.+-]+", package):
+        return None
+    return f"sudo apt remove {package}"
+
+
+def _inspect_desktop_installation(system: str | None = None) -> DesktopUninstallState:
+    """Find only desktop artifacts with positive Ormah ownership evidence."""
+    system = system or platform.system()
+    home = Path.home()
+    state = DesktopUninstallState()
+    if system == "Darwin":
+        app_candidates, data_candidates, launch_agent = _macos_desktop_paths(home)
+        state.app_bundles = [path for path in app_candidates if _is_valid_ormah_app_bundle(path)]
+        state.remaining.extend(
+            str(path)
+            for path in app_candidates
+            if (path.exists() or path.is_symlink()) and path not in state.app_bundles
+        )
+        # Tauri namespaces these directories by its bundle identifier.  Exact
+        # paths plus no symlink is sufficient; unlike an app bundle, they do not
+        # carry an embedded identifier to inspect.
+        state.data_dirs = [path for path in data_candidates if _is_safe_exact_directory(path)]
+        state.remaining.extend(
+            str(path)
+            for path in data_candidates
+            if (path.exists() or path.is_symlink()) and path not in state.data_dirs
+        )
+        if _is_valid_ormah_launch_agent(launch_agent, app_candidates):
+            state.launch_agent = launch_agent
+        elif launch_agent.exists() or launch_agent.is_symlink():
+            state.remaining.append(str(launch_agent))
+    elif system == "Linux":
+        entry = home / ".local" / "share" / "applications" / "ormah.desktop"
+        if _is_valid_appimage_desktop_entry(entry):
+            state.linux_appimage_files.append(entry)
+            for size in ("128x128", "256x256"):
+                icon = home / ".local" / "share" / "icons" / "hicolor" / size / "apps" / "ormah-desktop.png"
+                if _is_valid_appimage_icon(icon):
+                    state.linux_appimage_files.append(icon)
+        elif entry.exists() or entry.is_symlink():
+            state.remaining.append(str(entry))
+        state.package_removal_command = _linux_debian_removal_command()
+    return state
+
+
+def _remove_desktop_launch_agent(state: DesktopUninstallState) -> None:
+    """Unload and remove the validated desktop LaunchAgent before Python cleanup."""
+    if state.launch_agent is None:
+        return
+    try:
+        result = subprocess.run(
+            ["launchctl", "bootout", f"gui/{os.getuid()}", str(state.launch_agent)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        returncode = result.returncode
+        if isinstance(returncode, int) and returncode != 0:
+            detail = result.stderr.strip() if isinstance(result.stderr, str) else ""
+            warn(f"Could not unload desktop LaunchAgent {state.launch_agent}: {detail or f'exit {returncode}'}")
+        # Revalidate immediately before deleting: a replacement plist must not
+        # be removed merely because the earlier inspection found an Ormah one.
+        apps, _, _ = _macos_desktop_paths(Path.home())
+        if not _is_valid_ormah_launch_agent(state.launch_agent, apps):
+            warn(f"Refusing to remove changed desktop LaunchAgent: {state.launch_agent}")
+            state.autostart_removed = False
+            state.remaining.append(str(state.launch_agent))
+            return
+        state.launch_agent.unlink()
+        ok(f"Removed desktop LaunchAgent: {state.launch_agent}")
+    except (OSError, subprocess.SubprocessError) as exc:
+        warn(f"Could not remove desktop LaunchAgent {state.launch_agent}: {exc}")
+        state.autostart_removed = False
+        state.remaining.append(str(state.launch_agent))
+
+
+def _find_running_macos_desktop_processes(app_bundles: list[Path]) -> list[int]:
+    """Find the app only by an exact, validated bundle executable path."""
+    expected_prefixes = {str(bundle / "Contents" / "MacOS") + os.sep for bundle in app_bundles}
+    if not expected_prefixes:
+        return []
+    try:
+        result = subprocess.run(
+            ["ps", "-x", "-o", "pid=,command="], capture_output=True, text=True, timeout=5
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    output = result.stdout if isinstance(result.stdout, str) else ""
+    pids: list[int] = []
+    for line in output.splitlines():
+        pid_text, _, command = line.strip().partition(" ")
+        try:
+            pid = int(pid_text)
+        except ValueError:
+            continue
+        executable = command.strip().split(" ", 1)[0]
+        if any(executable.startswith(prefix) for prefix in expected_prefixes):
+            pids.append(pid)
+    return pids
+
+
+def _stop_running_macos_desktop(state: DesktopUninstallState) -> None:
+    """Ask the identified app to quit; never use broad process-name killing."""
+    pids = _find_running_macos_desktop_processes(state.app_bundles)
+    if not pids:
+        return
+    try:
+        result = subprocess.run(
+            ["osascript", "-e", f'tell application id "{DESKTOP_BUNDLE_IDENTIFIER}" to quit'],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if isinstance(result.returncode, int) and result.returncode != 0:
+            detail = result.stderr.strip() if isinstance(result.stderr, str) else ""
+            warn(f"Could not ask Ormah Desktop to quit: {detail or f'exit {result.returncode}'}")
+    except (OSError, subprocess.SubprocessError) as exc:
+        warn(f"Could not ask Ormah Desktop to quit: {exc}")
+    if _find_running_macos_desktop_processes(state.app_bundles):
+        state.process_stopped = False
+        for bundle in state.app_bundles:
+            if str(bundle) not in state.remaining:
+                state.remaining.append(str(bundle))
+        warn("Ormah Desktop is still running; quit it, then remove the remaining desktop artifacts.")
+
+
+def _remove_selected_desktop_artifacts(state: DesktopUninstallState, system: str) -> None:
+    """Delete exact validated desktop targets after autostart/process handling."""
+    if system == "Darwin" and not state.process_stopped:
+        return
+    for path in state.removable_artifacts:
+        valid = (
+            _is_valid_ormah_app_bundle(path)
+            if path.suffix == ".app"
+            else _is_valid_macos_desktop_data_dir(path)
+            if system == "Darwin" and (path.is_dir() or path.is_symlink())
+            else _is_valid_appimage_desktop_entry(path)
+            if path.name == "ormah.desktop"
+            else _is_valid_appimage_icon(path)
+        )
+        if not valid:
+            warn(f"Refusing to delete unexpected desktop artifact: {path}")
+            state.remaining.append(str(path))
+            continue
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+            ok(f"Deleted desktop artifact: {path}")
+        except OSError as exc:
+            warn(f"Could not delete desktop artifact {path}: {exc}")
+            state.remaining.append(str(path))
+
+
+def _print_desktop_uninstall_summary(state: DesktopUninstallState, desktop_selected: bool) -> bool:
+    """Report desktop status and return whether a truthful full removal occurred."""
+    remaining = list(dict.fromkeys(state.remaining))
+    if state.package_removal_command:
+        warn(f"Debian-owned Ormah Desktop remains; remove it with: {state.package_removal_command}")
+        remaining.append(state.package_removal_command)
+    if state.detected and not desktop_selected:
+        for path in state.removable_artifacts:
+            remaining.append(str(path))
+        warn("Desktop app and local UI data were kept by request; its autostart was disabled.")
+    if remaining:
+        warn("Backend removal completed, but these desktop artifacts remain:")
+        for item in dict.fromkeys(remaining):
+            warn(f"  {item}")
+        return False
+    return True
+
+
 def run_uninstall(yes: bool = False) -> None:
     """Remove Ormah while preserving zero-knowledge cloud recovery material."""
+    system = platform.system()
+    desktop = _inspect_desktop_installation(system)
     print(
         "This will remove Ormah integrations, local memory, caches, and account "
         "configuration. Cloud recovery files are preserved.\n"
     )
+
+    if desktop.detected:
+        info("Ormah Desktop artifacts were detected.")
+        if system == "Darwin":
+            info("Its login LaunchAgent will be disabled so it cannot reinstall the backend.")
+        elif desktop.package_removal_command:
+            info(f"The Debian package is package-managed and must be removed separately: {desktop.package_removal_command}")
+        print()
 
     config_dir = Path.home() / ".config" / "ormah"
     recovery_paths = _cloud_recovery_paths(config_dir)
@@ -2164,6 +2502,19 @@ def run_uninstall(yes: bool = False) -> None:
         if confirm != "yes":
             info("Uninstall cancelled")
             return
+
+    # --yes is deliberately a full uninstall request: remove every known,
+    # positively identified user-owned desktop artifact.  Interactive callers
+    # retain the existing top-level confirmation, then make this narrower choice.
+    desktop_selected = yes
+    if not yes and desktop.removable_artifacts:
+        try:
+            answer = input(
+                "Remove the Ormah Desktop app and its local UI/WebKit data? (Y/n) "
+            ).strip().lower()
+        except EOFError:
+            answer = ""
+        desktop_selected = answer not in ("n", "no")
 
     print()
 
@@ -2196,28 +2547,42 @@ def run_uninstall(yes: bool = False) -> None:
         else:
             ok("Cloud recovery material is complete and verified")
 
-    # a. Stop daemon
+    # a. Disable the desktop login item before uninstalling Python.  The desktop
+    # app installs its pinned runtime when launched, so this must happen first.
+    if system == "Darwin":
+        step("Disabling Ormah Desktop autostart")
+        _remove_desktop_launch_agent(desktop)
+        if desktop_selected:
+            step("Closing Ormah Desktop")
+            _stop_running_macos_desktop(desktop)
+            step("Removing Ormah Desktop artifacts")
+            _remove_selected_desktop_artifacts(desktop, system)
+    elif desktop_selected and desktop.removable_artifacts:
+        step("Removing Ormah Desktop integration")
+        _remove_selected_desktop_artifacts(desktop, system)
+
+    # b. Stop daemon
     step("Stopping server")
     from ormah.server_manager import uninstall_autostart
     uninstall_autostart()
 
-    # b. Remove Claude Code hooks
+    # c. Remove Claude Code hooks
     step("Removing Claude Code hooks")
     _remove_claude_hooks()
     _remove_codex_hooks()
 
-    # c. Remove MCP registration
+    # d. Remove MCP registration
     step("Removing MCP registration")
     _remove_mcp_registration()
 
-    # c.5 Remove the Pi package registration before deleting Ormah's own files.
+    # d.5 Remove the Pi package registration before deleting Ormah's own files.
     step("Removing Pi extension")
     try:
         _remove_pi_extension()
     except Exception as exc:  # noqa: BLE001
         warn(f"Could not remove ormah-pi automatically: {exc}")
 
-    # d. Remove CLAUDE.md block
+    # e. Remove CLAUDE.md block
     step("Removing CLAUDE.md instructions")
     _remove_claude_md_block()
     _remove_codex_md_block()
@@ -2227,7 +2592,7 @@ def run_uninstall(yes: bool = False) -> None:
     _remove_pi_md_block()
     _remove_pi_agents()
 
-    # e. Delete data directories
+    # f. Delete data directories
     step("Deleting data directories")
 
     xdg_dirs = [
@@ -2257,7 +2622,7 @@ def run_uninstall(yes: bool = False) -> None:
         else:
             info(f"{d} not found — skipping")
 
-    # f. Delete fastembed model cache
+    # g. Delete fastembed model cache
     step("Removing embedding model cache")
     _remove_fastembed_cache()
 
@@ -2281,8 +2646,13 @@ def run_uninstall(yes: bool = False) -> None:
     if not uv_uninstalled and not removed_tool_files:
         warn("Could not remove package files — remove manually with: uv tool uninstall ormah")
 
+    desktop_complete = _print_desktop_uninstall_summary(desktop, desktop_selected)
+    package_complete = uv_uninstalled or removed_tool_files
     print()
-    ok("Ormah has been uninstalled")
+    if desktop_complete and package_complete:
+        ok("Ormah has been completely uninstalled")
+    else:
+        warn("Ormah backend cleanup completed, but Ormah has not been fully uninstalled.")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import plistlib
 import stat
 import subprocess
 from contextlib import ExitStack
@@ -2900,6 +2901,68 @@ class TestRunUninstall:
     def _patch_all(self, mock_uninstall_autostart, mock_hooks, mock_mcp, mock_md, mock_rmtree, mock_run):
         """Shared patcher helper — not used directly, see individual tests."""
 
+    def _safe_uninstall_operations(self):
+        """Suppress unrelated integrations while exercising real temp-path cleanup."""
+        stack = ExitStack()
+        for target in (
+            "ormah.server_manager.uninstall_autostart",
+            "ormah.setup._remove_claude_hooks",
+            "ormah.setup._remove_codex_hooks",
+            "ormah.setup._remove_mcp_registration",
+            "ormah.setup._remove_pi_extension",
+            "ormah.setup._remove_claude_md_block",
+            "ormah.setup._remove_codex_md_block",
+            "ormah.setup._remove_codex_agents",
+            "ormah.setup._remove_claude_agents",
+            "ormah.setup._remove_claude_commands",
+            "ormah.setup._remove_pi_md_block",
+            "ormah.setup._remove_pi_agents",
+            "ormah.setup._remove_fastembed_cache",
+        ):
+            stack.enter_context(patch(target))
+        return stack
+
+    @staticmethod
+    def _make_macos_desktop(home: Path, applications: Path) -> tuple[Path, Path, Path, Path]:
+        app = applications / "Ormah.app"
+        info = app / "Contents" / "Info.plist"
+        info.parent.mkdir(parents=True)
+        info.write_bytes(
+            plistlib.dumps(
+                {
+                    "CFBundleIdentifier": "dev.ormah.desktop",
+                    "CFBundleName": "Ormah",
+                }
+            )
+        )
+        support = home / "Library" / "Application Support" / "dev.ormah.desktop"
+        webkit = home / "Library" / "WebKit" / "dev.ormah.desktop"
+        support.mkdir(parents=True)
+        webkit.mkdir(parents=True)
+        launch_agent = home / "Library" / "LaunchAgents" / "dev.ormah.desktop.plist"
+        launch_agent.parent.mkdir(parents=True)
+        launch_agent.write_bytes(
+            plistlib.dumps(
+                {
+                    "Label": "dev.ormah.desktop",
+                    "ProgramArguments": [str(app / "Contents" / "MacOS" / "ormah-desktop")],
+                }
+            )
+        )
+        return app, support, webkit, launch_agent
+
+    @staticmethod
+    def _desktop_run(calls: list[list[str]], *, launchctl_returncode: int = 0, ps_output: str = ""):
+        def fake_run(args, **_kwargs):
+            calls.append(args)
+            if args[0] == "launchctl":
+                return MagicMock(returncode=launchctl_returncode, stdout="", stderr="launch failed")
+            if args[0] == "ps":
+                return MagicMock(returncode=0, stdout=ps_output, stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        return fake_run
+
     def test_cancels_on_first_no(self, monkeypatch, capsys):
         monkeypatch.setattr("builtins.input", lambda _: "n")
 
@@ -2942,6 +3005,208 @@ class TestRunUninstall:
 
         captured = capsys.readouterr()
         assert "uninstalled" in captured.out.lower()
+
+    def test_full_yes_removes_only_validated_macos_desktop_artifacts_before_uv(
+        self, tmp_path, capsys
+    ):
+        applications = tmp_path / "system-applications"
+        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
+        unrelated = tmp_path / "Library" / "Application Support" / "not-ormah"
+        unrelated.mkdir(parents=True)
+        calls: list[list[str]] = []
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
+            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
+        ):
+            run_uninstall(yes=True)
+
+        assert not app.exists()
+        assert not support.exists()
+        assert not webkit.exists()
+        assert not launch_agent.exists()
+        assert unrelated.exists()
+        launch_index = next(i for i, command in enumerate(calls) if command[0] == "launchctl")
+        uv_index = next(i for i, command in enumerate(calls) if command[:3] == ["uv", "tool", "uninstall"])
+        assert launch_index < uv_index
+        assert "completely uninstalled" in capsys.readouterr().out.lower()
+
+    def test_desktop_launchagent_failure_never_claims_complete_uninstall(self, tmp_path, capsys):
+        applications = tmp_path / "system-applications"
+        _, _, _, launch_agent = self._make_macos_desktop(tmp_path, applications)
+        calls: list[list[str]] = []
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
+            patch(
+                "ormah.setup.subprocess.run",
+                side_effect=self._desktop_run(calls, launchctl_returncode=1),
+            ),
+            patch("ormah.setup.Path.unlink", side_effect=PermissionError("permission denied")),
+        ):
+            run_uninstall(yes=True)
+
+        assert launch_agent.exists()
+        output = capsys.readouterr().out
+        assert str(launch_agent) in output
+        assert "not been fully uninstalled" in output
+        assert any(command[:3] == ["uv", "tool", "uninstall"] for command in calls)
+
+    def test_desktop_symlink_and_unexpected_data_fail_closed(self, tmp_path, capsys):
+        applications = tmp_path / "system-applications"
+        target = tmp_path / "someone-elses-app"
+        target.mkdir()
+        app = applications / "Ormah.app"
+        app.parent.mkdir(parents=True)
+        app.symlink_to(target, target_is_directory=True)
+        unsafe_data = tmp_path / "Library" / "WebKit" / "dev.ormah.desktop"
+        unsafe_data.parent.mkdir(parents=True)
+        unsafe_data.write_text("not a Tauri data directory")
+        calls: list[list[str]] = []
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
+            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
+        ):
+            run_uninstall(yes=True)
+
+        assert app.is_symlink()
+        assert unsafe_data.is_file()
+        output = capsys.readouterr().out
+        assert str(app) in output
+        assert str(unsafe_data) in output
+        assert "not been fully uninstalled" in output
+
+    def test_interactive_desktop_decline_keeps_app_but_disables_autostart(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        applications = tmp_path / "system-applications"
+        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
+        calls: list[list[str]] = []
+        answers = iter(["y", "yes", "n"])
+        monkeypatch.setattr("builtins.input", lambda _: next(answers))
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
+            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
+        ):
+            run_uninstall()
+
+        assert app.exists()
+        assert support.exists()
+        assert webkit.exists()
+        assert not launch_agent.exists()
+        output = capsys.readouterr().out.lower()
+        assert "kept by request" in output
+        assert "not been fully uninstalled" in output
+
+    def test_yes_is_noninteractive_and_includes_known_desktop_artifacts(
+        self, tmp_path, monkeypatch
+    ):
+        applications = tmp_path / "system-applications"
+        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
+        calls: list[list[str]] = []
+        monkeypatch.setattr("builtins.input", lambda _: pytest.fail("--yes must not prompt"))
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
+            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
+        ):
+            run_uninstall(yes=True)
+
+        assert not any(path.exists() for path in (app, support, webkit, launch_agent))
+
+    def test_permission_failure_reports_exact_remaining_desktop_app(self, tmp_path, capsys):
+        applications = tmp_path / "system-applications"
+        app, _, _, _ = self._make_macos_desktop(tmp_path, applications)
+        calls: list[list[str]] = []
+        real_rmtree = __import__("shutil").rmtree
+
+        def deny_app(path, *args, **kwargs):
+            if Path(path) == app:
+                raise PermissionError("permission denied")
+            return real_rmtree(path, *args, **kwargs)
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
+            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
+            patch("ormah.setup.shutil.rmtree", side_effect=deny_app),
+        ):
+            run_uninstall(yes=True)
+
+        assert app.exists()
+        output = capsys.readouterr().out
+        assert str(app) in output
+        assert "not been fully uninstalled" in output
+
+    def test_running_desktop_that_will_not_quit_is_left_in_place(self, tmp_path, capsys):
+        applications = tmp_path / "system-applications"
+        app, support, webkit, _ = self._make_macos_desktop(tmp_path, applications)
+        executable = app / "Contents" / "MacOS" / "ormah-desktop"
+        calls: list[list[str]] = []
+        ps_output = f"123 {executable}\n"
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
+            patch(
+                "ormah.setup.subprocess.run",
+                side_effect=self._desktop_run(calls, ps_output=ps_output),
+            ),
+        ):
+            run_uninstall(yes=True)
+
+        assert app.exists()
+        assert support.exists()
+        assert webkit.exists()
+        assert any(command[0] == "osascript" for command in calls)
+        assert "still running" in capsys.readouterr().out.lower()
+
+    def test_linux_removes_only_the_appimage_integration_and_reports_dpkg_owner(
+        self, tmp_path, capsys
+    ):
+        entry = tmp_path / ".local" / "share" / "applications" / "ormah.desktop"
+        entry.parent.mkdir(parents=True)
+        entry.write_text(
+            "[Desktop Entry]\nName=Ormah\nExec=\"/tmp/Ormah.AppImage\"\n"
+            "Icon=ormah-desktop\nStartupWMClass=ormah-desktop\n"
+        )
+        icon = tmp_path / ".local" / "share" / "icons" / "hicolor" / "128x128" / "apps" / "ormah-desktop.png"
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"icon")
+        calls: list[list[str]] = []
+
+        def linux_run(args, **_kwargs):
+            calls.append(args)
+            if args[0] == "dpkg-query":
+                return MagicMock(returncode=0, stdout="ormah-desktop: /usr/bin/ormah-desktop\n")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Linux"),
+            patch("ormah.setup.subprocess.run", side_effect=linux_run),
+        ):
+            run_uninstall(yes=True)
+
+        assert not entry.exists()
+        assert not icon.exists()
+        output = capsys.readouterr().out
+        assert "sudo apt remove ormah-desktop" in output
+        assert "not been fully uninstalled" in output
 
     def test_deletes_data_directories(self, tmp_path, capsys):
         share_dir = tmp_path / ".local" / "share" / "ormah"
@@ -3016,9 +3281,13 @@ class TestRunUninstall:
         key_content = key_path.read_text()
         kit_content = kit_path.read_text()
         (config_dir / ".env").write_text("ORMAH_ACCOUNT_TOKEN=secret\n")
+        applications = tmp_path / "system-applications"
+        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
 
         with (
             patch("ormah.server_manager.uninstall_autostart"),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
             patch("ormah.setup._remove_claude_hooks"),
             patch("ormah.setup._remove_codex_hooks"),
             patch("ormah.setup._remove_mcp_registration"),
@@ -3045,6 +3314,7 @@ class TestRunUninstall:
             "cloud.key",
             "ormah-recovery-kit.md",
         }
+        assert not any(path.exists() for path in (app, support, webkit, launch_agent))
         output = capsys.readouterr().out.lower()
         assert "preserved cloud recovery material" in output
         assert "permanently unreadable" in output

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -29,12 +29,16 @@ from ormah.setup import (
     CLAUDE_MD_SENTINEL_START,
     PI_AGENTS_MD_SENTINEL_END,
     PI_AGENTS_MD_SENTINEL_START,
+    DESKTOP_BUNDLE_IDENTIFIER,
+    DESKTOP_PRODUCT_NAME,
     _atomic_write,
     _claude_code_is_wired,
     _claude_code_plugin_provides_hooks,
     _claude_code_wire,
     _discover_transcripts,
     _get_agent,
+    _disable_desktop_autostart,
+    _inspect_desktop_installation,
     _is_ormah_hook,
     _merge_hooks,
     _merge_json_file,
@@ -2895,14 +2899,16 @@ class TestRunUninstall:
             patch("ormah.setup.Path.home", return_value=tmp_path),
             patch("ormah.config.settings", fake_settings),
             patch("ormah.setup._get_running_server_data_dir", return_value=None),
+            patch("ormah.setup.platform.system", return_value="Other"),
+            patch(
+                "ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR",
+                tmp_path / "system-applications",
+            ),
         ):
             yield
 
-    def _patch_all(self, mock_uninstall_autostart, mock_hooks, mock_mcp, mock_md, mock_rmtree, mock_run):
-        """Shared patcher helper — not used directly, see individual tests."""
-
-    def _safe_uninstall_operations(self):
-        """Suppress unrelated integrations while exercising real temp-path cleanup."""
+    @staticmethod
+    def _safe_uninstall_operations():
         stack = ExitStack()
         for target in (
             "ormah.server_manager.uninstall_autostart",
@@ -2923,45 +2929,236 @@ class TestRunUninstall:
         return stack
 
     @staticmethod
-    def _make_macos_desktop(home: Path, applications: Path) -> tuple[Path, Path, Path, Path]:
+    def _make_macos_desktop(home: Path, applications: Path):
         app = applications / "Ormah.app"
-        info = app / "Contents" / "Info.plist"
-        info.parent.mkdir(parents=True)
-        info.write_bytes(
-            plistlib.dumps(
-                {
-                    "CFBundleIdentifier": "dev.ormah.desktop",
-                    "CFBundleName": "Ormah",
-                }
-            )
-        )
-        support = home / "Library" / "Application Support" / "dev.ormah.desktop"
-        webkit = home / "Library" / "WebKit" / "dev.ormah.desktop"
+        app.mkdir(parents=True)
+        support = home / "Library" / "Application Support" / DESKTOP_BUNDLE_IDENTIFIER
+        webkit = home / "Library" / "WebKit" / DESKTOP_BUNDLE_IDENTIFIER
         support.mkdir(parents=True)
         webkit.mkdir(parents=True)
-        launch_agent = home / "Library" / "LaunchAgents" / "dev.ormah.desktop.plist"
+        launch_agent = home / "Library" / "LaunchAgents" / "Ormah.plist"
         launch_agent.parent.mkdir(parents=True)
         launch_agent.write_bytes(
             plistlib.dumps(
                 {
-                    "Label": "dev.ormah.desktop",
-                    "ProgramArguments": [str(app / "Contents" / "MacOS" / "ormah-desktop")],
+                    "Label": DESKTOP_PRODUCT_NAME,
+                    "ProgramArguments": [
+                        str(app / "Contents" / "MacOS" / "ormah-desktop")
+                    ],
+                    "RunAtLoad": True,
                 }
             )
         )
         return app, support, webkit, launch_agent
 
-    @staticmethod
-    def _desktop_run(calls: list[list[str]], *, launchctl_returncode: int = 0, ps_output: str = ""):
-        def fake_run(args, **_kwargs):
-            calls.append(args)
-            if args[0] == "launchctl":
-                return MagicMock(returncode=launchctl_returncode, stdout="", stderr="launch failed")
-            if args[0] == "ps":
-                return MagicMock(returncode=0, stdout=ps_output, stderr="")
-            return MagicMock(returncode=0, stdout="", stderr="")
+    def test_macos_hybrid_disables_real_login_item_and_keeps_app_data(
+        self, tmp_path, capsys
+    ):
+        applications = tmp_path / "Jane Smith Applications"
+        app, support, webkit, launch_agent = self._make_macos_desktop(
+            tmp_path, applications
+        )
 
-        return fake_run
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+        ):
+            run_uninstall(yes=True)
+
+        assert not launch_agent.exists()
+        assert app.exists()
+        assert support.exists()
+        assert webkit.exists()
+        output = capsys.readouterr().out
+        assert "Disabled Ormah Desktop autostart" in output
+        assert "move Ormah.app to Trash" in output
+        assert "Ormah Desktop remains installed" in output
+        assert "Ormah has been uninstalled" not in output
+
+    def test_linux_hybrid_disables_autostart_and_reports_debian_package(
+        self, tmp_path, capsys
+    ):
+        autostart = tmp_path / ".config" / "autostart" / "Ormah.desktop"
+        autostart.parent.mkdir(parents=True)
+        autostart.write_text(
+            "[Desktop Entry]\nType=Application\nVersion=1.0\nName=Ormah\n"
+            "Comment=Ormahstartup script\nExec=/usr/bin/ormah-desktop \n"
+            "StartupNotify=false\nTerminal=false",
+            encoding="utf-8",
+        )
+
+        def run_command(args, **_kwargs):
+            if args[0] == "dpkg-query":
+                return subprocess.CompletedProcess(
+                    args, 0, stdout="ormah: /usr/bin/ormah-desktop\n", stderr=""
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Linux"),
+            patch("subprocess.run", side_effect=run_command),
+        ):
+            run_uninstall(yes=True)
+
+        assert not autostart.exists()
+        output = capsys.readouterr().out
+        assert "Disabled Ormah Desktop autostart" in output
+        assert "sudo apt remove ormah" in output
+        assert "Ormah Desktop remains installed" in output
+
+    def test_linux_hybrid_reports_appimage_and_user_integration(
+        self, tmp_path, capsys
+    ):
+        appimage = tmp_path / "Apps" / "Ormah.AppImage"
+        appimage.parent.mkdir()
+        appimage.write_bytes(b"appimage")
+        autostart = tmp_path / ".config" / "autostart" / "Ormah.desktop"
+        autostart.parent.mkdir(parents=True)
+        autostart.write_text(
+            "[Desktop Entry]\nType=Application\nVersion=1.0\nName=Ormah\n"
+            f"Comment=Ormahstartup script\nExec={appimage} \n"
+            "StartupNotify=false\nTerminal=false",
+            encoding="utf-8",
+        )
+        menu = tmp_path / ".local" / "share" / "applications" / "ormah.desktop"
+        menu.parent.mkdir(parents=True)
+        menu.write_text(
+            f'[Desktop Entry]\nName=Ormah\nExec="{appimage}"\n',
+            encoding="utf-8",
+        )
+        icon = (
+            tmp_path
+            / ".local"
+            / "share"
+            / "icons"
+            / "hicolor"
+            / "128x128"
+            / "apps"
+            / "ormah-desktop.png"
+        )
+        icon.parent.mkdir(parents=True)
+        icon.write_bytes(b"icon")
+
+        def run_command(args, **_kwargs):
+            return subprocess.CompletedProcess(args, 1, stdout="", stderr="")
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Linux"),
+            patch("subprocess.run", side_effect=run_command),
+        ):
+            run_uninstall(yes=True)
+
+        assert not autostart.exists()
+        assert appimage.exists()
+        assert menu.exists()
+        assert icon.exists()
+        output = capsys.readouterr().out
+        assert str(appimage) in output
+        assert str(menu) in output
+        assert str(icon) in output
+        assert "Delete the Ormah AppImage" in output
+
+    @pytest.mark.parametrize(
+        "contents",
+        [b"not a plist", b'<?xml version="1.0"?><plist><dict><key>broken</key>'],
+    )
+    def test_malformed_macos_login_item_is_reported_not_removed(
+        self, tmp_path, contents
+    ):
+        launch_agent = tmp_path / "Library" / "LaunchAgents" / "Ormah.plist"
+        launch_agent.parent.mkdir(parents=True)
+        launch_agent.write_bytes(contents)
+
+        state = _inspect_desktop_installation("Darwin")
+        _disable_desktop_autostart(state)
+
+        assert launch_agent.read_bytes() == contents
+        assert state.unrecognized_autostart == launch_agent
+
+    def test_symlinked_linux_autostart_is_never_removed(self, tmp_path):
+        target = tmp_path / "not-ormah.desktop"
+        target.write_text("important\n", encoding="utf-8")
+        autostart = tmp_path / ".config" / "autostart" / "Ormah.desktop"
+        autostart.parent.mkdir(parents=True)
+        autostart.symlink_to(target)
+
+        with patch("subprocess.run", return_value=subprocess.CompletedProcess([], 1, "", "")):
+            state = _inspect_desktop_installation("Linux")
+        _disable_desktop_autostart(state)
+
+        assert autostart.is_symlink()
+        assert target.read_text(encoding="utf-8") == "important\n"
+        assert state.unrecognized_autostart == autostart
+
+    def test_unrecognized_autostart_aborts_before_backend_cleanup(
+        self, tmp_path, capsys
+    ):
+        launch_agent = tmp_path / "Library" / "LaunchAgents" / "Ormah.plist"
+        launch_agent.parent.mkdir(parents=True)
+        launch_agent.write_text("not an Ormah plist\n", encoding="utf-8")
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch("subprocess.run") as run_command,
+        ):
+            run_uninstall(yes=True)
+
+        run_command.assert_not_called()
+        assert launch_agent.exists()
+        assert "cancelled before removing the backend" in capsys.readouterr().out
+
+    def test_autostart_permission_failure_aborts_before_backend_cleanup(
+        self, tmp_path, capsys
+    ):
+        applications = tmp_path / "system-applications"
+        _, _, _, launch_agent = self._make_macos_desktop(tmp_path, applications)
+        real_unlink = Path.unlink
+
+        def deny_autostart(path, *args, **kwargs):
+            if path == launch_agent:
+                raise PermissionError("permission denied")
+            return real_unlink(path, *args, **kwargs)
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+            patch.object(Path, "unlink", autospec=True, side_effect=deny_autostart),
+            patch("subprocess.run") as run_command,
+        ):
+            run_uninstall(yes=True)
+
+        run_command.assert_not_called()
+        assert launch_agent.exists()
+        assert "cancelled before removing the backend" in capsys.readouterr().out
+
+    def test_recovery_preflight_failure_leaves_desktop_autostart_enabled(
+        self, tmp_path, capsys
+    ):
+        from ormah.cloud.keys import init_key
+
+        applications = tmp_path / "system-applications"
+        _, _, _, launch_agent = self._make_macos_desktop(tmp_path, applications)
+        init_key(tmp_path / ".config" / "ormah" / "cloud.key")
+
+        with (
+            self._safe_uninstall_operations(),
+            patch("ormah.setup.platform.system", return_value="Darwin"),
+        ):
+            run_uninstall(yes=True)
+
+        assert launch_agent.exists()
+        assert "cancelled before removing" in capsys.readouterr().out
+
+    def test_desktop_constants_match_tauri_configuration(self):
+        config_path = Path(__file__).parents[1] / "desktop" / "src-tauri" / "tauri.conf.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+
+        assert config["productName"] == DESKTOP_PRODUCT_NAME
+        assert config["identifier"] == DESKTOP_BUNDLE_IDENTIFIER
 
     def test_cancels_on_first_no(self, monkeypatch, capsys):
         monkeypatch.setattr("builtins.input", lambda _: "n")
@@ -3005,208 +3202,6 @@ class TestRunUninstall:
 
         captured = capsys.readouterr()
         assert "uninstalled" in captured.out.lower()
-
-    def test_full_yes_removes_only_validated_macos_desktop_artifacts_before_uv(
-        self, tmp_path, capsys
-    ):
-        applications = tmp_path / "system-applications"
-        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
-        unrelated = tmp_path / "Library" / "Application Support" / "not-ormah"
-        unrelated.mkdir(parents=True)
-        calls: list[list[str]] = []
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
-            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
-        ):
-            run_uninstall(yes=True)
-
-        assert not app.exists()
-        assert not support.exists()
-        assert not webkit.exists()
-        assert not launch_agent.exists()
-        assert unrelated.exists()
-        launch_index = next(i for i, command in enumerate(calls) if command[0] == "launchctl")
-        uv_index = next(i for i, command in enumerate(calls) if command[:3] == ["uv", "tool", "uninstall"])
-        assert launch_index < uv_index
-        assert "completely uninstalled" in capsys.readouterr().out.lower()
-
-    def test_desktop_launchagent_failure_never_claims_complete_uninstall(self, tmp_path, capsys):
-        applications = tmp_path / "system-applications"
-        _, _, _, launch_agent = self._make_macos_desktop(tmp_path, applications)
-        calls: list[list[str]] = []
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
-            patch(
-                "ormah.setup.subprocess.run",
-                side_effect=self._desktop_run(calls, launchctl_returncode=1),
-            ),
-            patch("ormah.setup.Path.unlink", side_effect=PermissionError("permission denied")),
-        ):
-            run_uninstall(yes=True)
-
-        assert launch_agent.exists()
-        output = capsys.readouterr().out
-        assert str(launch_agent) in output
-        assert "not been fully uninstalled" in output
-        assert any(command[:3] == ["uv", "tool", "uninstall"] for command in calls)
-
-    def test_desktop_symlink_and_unexpected_data_fail_closed(self, tmp_path, capsys):
-        applications = tmp_path / "system-applications"
-        target = tmp_path / "someone-elses-app"
-        target.mkdir()
-        app = applications / "Ormah.app"
-        app.parent.mkdir(parents=True)
-        app.symlink_to(target, target_is_directory=True)
-        unsafe_data = tmp_path / "Library" / "WebKit" / "dev.ormah.desktop"
-        unsafe_data.parent.mkdir(parents=True)
-        unsafe_data.write_text("not a Tauri data directory")
-        calls: list[list[str]] = []
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
-            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
-        ):
-            run_uninstall(yes=True)
-
-        assert app.is_symlink()
-        assert unsafe_data.is_file()
-        output = capsys.readouterr().out
-        assert str(app) in output
-        assert str(unsafe_data) in output
-        assert "not been fully uninstalled" in output
-
-    def test_interactive_desktop_decline_keeps_app_but_disables_autostart(
-        self, tmp_path, monkeypatch, capsys
-    ):
-        applications = tmp_path / "system-applications"
-        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
-        calls: list[list[str]] = []
-        answers = iter(["y", "yes", "n"])
-        monkeypatch.setattr("builtins.input", lambda _: next(answers))
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
-            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
-        ):
-            run_uninstall()
-
-        assert app.exists()
-        assert support.exists()
-        assert webkit.exists()
-        assert not launch_agent.exists()
-        output = capsys.readouterr().out.lower()
-        assert "kept by request" in output
-        assert "not been fully uninstalled" in output
-
-    def test_yes_is_noninteractive_and_includes_known_desktop_artifacts(
-        self, tmp_path, monkeypatch
-    ):
-        applications = tmp_path / "system-applications"
-        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
-        calls: list[list[str]] = []
-        monkeypatch.setattr("builtins.input", lambda _: pytest.fail("--yes must not prompt"))
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
-            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
-        ):
-            run_uninstall(yes=True)
-
-        assert not any(path.exists() for path in (app, support, webkit, launch_agent))
-
-    def test_permission_failure_reports_exact_remaining_desktop_app(self, tmp_path, capsys):
-        applications = tmp_path / "system-applications"
-        app, _, _, _ = self._make_macos_desktop(tmp_path, applications)
-        calls: list[list[str]] = []
-        real_rmtree = __import__("shutil").rmtree
-
-        def deny_app(path, *args, **kwargs):
-            if Path(path) == app:
-                raise PermissionError("permission denied")
-            return real_rmtree(path, *args, **kwargs)
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
-            patch("ormah.setup.subprocess.run", side_effect=self._desktop_run(calls)),
-            patch("ormah.setup.shutil.rmtree", side_effect=deny_app),
-        ):
-            run_uninstall(yes=True)
-
-        assert app.exists()
-        output = capsys.readouterr().out
-        assert str(app) in output
-        assert "not been fully uninstalled" in output
-
-    def test_running_desktop_that_will_not_quit_is_left_in_place(self, tmp_path, capsys):
-        applications = tmp_path / "system-applications"
-        app, support, webkit, _ = self._make_macos_desktop(tmp_path, applications)
-        executable = app / "Contents" / "MacOS" / "ormah-desktop"
-        calls: list[list[str]] = []
-        ps_output = f"123 {executable}\n"
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
-            patch(
-                "ormah.setup.subprocess.run",
-                side_effect=self._desktop_run(calls, ps_output=ps_output),
-            ),
-        ):
-            run_uninstall(yes=True)
-
-        assert app.exists()
-        assert support.exists()
-        assert webkit.exists()
-        assert any(command[0] == "osascript" for command in calls)
-        assert "still running" in capsys.readouterr().out.lower()
-
-    def test_linux_removes_only_the_appimage_integration_and_reports_dpkg_owner(
-        self, tmp_path, capsys
-    ):
-        entry = tmp_path / ".local" / "share" / "applications" / "ormah.desktop"
-        entry.parent.mkdir(parents=True)
-        entry.write_text(
-            "[Desktop Entry]\nName=Ormah\nExec=\"/tmp/Ormah.AppImage\"\n"
-            "Icon=ormah-desktop\nStartupWMClass=ormah-desktop\n"
-        )
-        icon = tmp_path / ".local" / "share" / "icons" / "hicolor" / "128x128" / "apps" / "ormah-desktop.png"
-        icon.parent.mkdir(parents=True)
-        icon.write_bytes(b"icon")
-        calls: list[list[str]] = []
-
-        def linux_run(args, **_kwargs):
-            calls.append(args)
-            if args[0] == "dpkg-query":
-                return MagicMock(returncode=0, stdout="ormah-desktop: /usr/bin/ormah-desktop\n")
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with (
-            self._safe_uninstall_operations(),
-            patch("ormah.setup.platform.system", return_value="Linux"),
-            patch("ormah.setup.subprocess.run", side_effect=linux_run),
-        ):
-            run_uninstall(yes=True)
-
-        assert not entry.exists()
-        assert not icon.exists()
-        output = capsys.readouterr().out
-        assert "sudo apt remove ormah-desktop" in output
-        assert "not been fully uninstalled" in output
 
     def test_deletes_data_directories(self, tmp_path, capsys):
         share_dir = tmp_path / ".local" / "share" / "ormah"
@@ -3281,13 +3276,9 @@ class TestRunUninstall:
         key_content = key_path.read_text()
         kit_content = kit_path.read_text()
         (config_dir / ".env").write_text("ORMAH_ACCOUNT_TOKEN=secret\n")
-        applications = tmp_path / "system-applications"
-        app, support, webkit, launch_agent = self._make_macos_desktop(tmp_path, applications)
 
         with (
             patch("ormah.server_manager.uninstall_autostart"),
-            patch("ormah.setup.platform.system", return_value="Darwin"),
-            patch("ormah.setup.MACOS_SYSTEM_APPLICATIONS_DIR", applications),
             patch("ormah.setup._remove_claude_hooks"),
             patch("ormah.setup._remove_codex_hooks"),
             patch("ormah.setup._remove_mcp_registration"),
@@ -3314,7 +3305,6 @@ class TestRunUninstall:
             "cloud.key",
             "ormah-recovery-kit.md",
         }
-        assert not any(path.exists() for path in (app, support, webkit, launch_agent))
         output = capsys.readouterr().out.lower()
         assert "preserved cloud recovery material" in output
         assert "permanently unreadable" in output


### PR DESCRIPTION
Closes #253

## Problem

`ormah uninstall` removed the Python backend but left the Tauri desktop login item. At the next login, the app could start and reinstall the pinned backend. The previous version of this PR attempted to delete apps and desktop data from Python, but relied on incorrect platform filenames and introduced unnecessary destructive-path risk.

## Hybrid fix

- validates the real Tauri autostart entries: `~/Library/LaunchAgents/Ormah.plist` on macOS and `~/.config/autostart/Ormah.desktop` on Linux
- revalidates and removes only that exact owner-user autostart file
- aborts before backend/integration deletion if an existing autostart entry cannot be identified or removed safely
- performs the existing recovery-kit preflight before touching autostart
- leaves app bundles, Debian/AppImage packages, menu integration, icons, and UI/WebKit data untouched
- reports every detected desktop remainder and the normal removal action; never claims full uninstall while one remains
- recognizes custom macOS app paths, including spaces, from the verified plist and AppImage paths from verified desktop entries
- confirms real Linux packaging as `sudo apt remove ormah`

A native Settings uninstall journey is tracked separately in #289.

## Safety

- no process killing
- no app/data recursive deletion
- no privilege escalation or package removal
- symlinked, malformed, changed, or unknown autostart files fail closed
- cloud key and recovery kit preservation is unchanged
- all destructive tests use temporary homes and a temporary Applications directory

## Verification

- `tests/test_setup.py`: 257 passed
- uninstall-focused subset: 36 passed
- non-socket server-manager tests: 11 passed
- repository-wide Ruff: passed
- `git diff --check`: passed
- real installed Linux inspection recognized `/home/r2205/.config/autostart/Ormah.desktop` and `sudo apt remove ormah` without mutation
- three server-manager socket tests cannot run in the local sandbox because socket creation is denied; GitHub CI provides the clean runner