### PR TITLE
chore(desktop): prepare 0.3.25

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.24"
+version = "0.3.25"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",


### PR DESCRIPTION
Prepares Desktop 0.3.25 to ship the already-published Ormah 0.15.0 runtime.

The Desktop sidecar intentionally pins the Python package version compiled from `pyproject.toml`. Desktop 0.3.24 therefore remains pinned to Ormah 0.14.11; this refresh delivers the tested 0.15.0 lifecycle release as one compatible Desktop product.

Changes:
- `desktop/src-tauri/Cargo.toml`: 0.3.24 → 0.3.25
- `desktop/src-tauri/Cargo.lock`: root package record to 0.3.25
- `desktop/src-tauri/tauri.conf.json`: 0.3.24 → 0.3.25

Verification:
- Cargo metadata succeeds.
- Cargo, Tauri and lockfile versions agree at 0.3.25.
- Bundled runtime resolves to pyproject version 0.15.0.
- Ormah 0.15.0 is public on PyPI.

After merge, push tag `desktop-v0.3.25` to run the signed Desktop release workflow.