### PR TITLE
chore(release): prepare 0.15.1 and desktop 0.3.26

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.25"
+version = "0.3.26"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ormah",
   "description": "Local-first persistent memory system with automatic context injection and durable memory tools.",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": {
     "name": "r-spade"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ormah"
-version = "0.15.0"
+version = "0.15.1"
 description = "Local-first, portable, LLM-agnostic memory system for AI agents"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release

- publish Ormah Python package and Claude plugin as `0.15.1`
- publish Desktop as `0.3.26`
- deliver merged fixes #284, #285, and #286: fresh-device recovery, safe idempotent recovery-kit import, and truthful desktop autostart uninstall

## Validation

- merged current-main recovery/uninstall integration: 330 Python tests passed
- UI: 57 tests and production build passed
- merged full PR CI: Python test, lint, and desktop jobs passed for #284, #285, and #286
- real installed Linux autostart/package detection passed without mutation
- release version verifier passed
- Ruff passed
- local Rust test source build is blocked only because source worktrees omit the release-only bundled `uv` sidecar; desktop CI covers that build path

## Publish order after merge

1. Run the guarded Release workflow for `0.15.1` from `main`.
2. Wait for PyPI to report `0.15.1`.
3. Tag `desktop-v0.3.26` at the same merge commit.
4. Confirm release artifacts and updater feed, then run fresh Mac/Linux acceptance.