### PR TITLE
chore(release): prepare desktop 0.3.27

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "ormah-desktop"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "libc",
  "once_cell",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormah-desktop"
-version = "0.3.26"
+version = "0.3.27"
 description = "Ormah menubar app — ambient memory counter + one-click agent setup"
 authors = ["Ormah"]
 edition = "2021"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ormah",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "identifier": "dev.ormah.desktop",
   "build": {
     "frontendDist": "../ui/dist",


### PR DESCRIPTION
Desktop-only release for PR #291. Updates Cargo.toml, Cargo.lock, and tauri.conf.json from 0.3.26 to 0.3.27. Python remains pinned at the existing PyPI release, Ormah 0.15.1.

Verification: cargo test in desktop/src-tauri, 30 passed.