### PR TITLE
fix(whisper): retire automatic retrospective review notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ When an agent knows it needs something, it can explicitly search memory. But mem
 
 Whisper evaluates standing preferences through a separate applicability path. This lets a rule govern a task even when it does not read like a passage that directly answers the prompt, without allowing preference guesses to suppress ordinary factual retrieval.
 
+On a first turn, Whisper can append one held-back memory for review only when its final ordinary selection already admitted a memory. Review never turns an otherwise silent retrieval decision into unrelated context.
+
 Whisper feedback can learn from transcript files after they stop changing: a local heuristic records clear usage for free, and an optional LLM judge can classify ambiguous turns into positive, negative, or uncertain retrieval signals.
 
 Read more: [Whisper - Involuntary Recall](https://www.ormah.me/docs/how-ormah-works/whisper), [Search and Ranking](https://www.ormah.me/docs/how-ormah-works/search-and-ranking), [Affinity and Feedback](https://www.ormah.me/docs/operations/affinity-and-feedback)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ When an agent knows it needs something, it can explicitly search memory. But mem
 
 Whisper evaluates standing preferences through a separate applicability path. This lets a rule govern a task even when it does not read like a passage that directly answers the prompt, without allowing preference guesses to suppress ordinary factual retrieval.
 
-On a first turn, Whisper can append one held-back memory for review only when its final ordinary selection already admitted a memory. Review never turns an otherwise silent retrieval decision into unrelated context.
+Whisper contains context selected for the current task; it never appends historical memory-review assignments. Existing feedback records remain available to `submit_feedback` for exact historical attribution.
 
 Whisper feedback can learn from transcript files after they stop changing: a local heuristic records clear usage for free, and an optional LLM judge can classify ambiguous turns into positive, negative, or uncertain retrieval signals.
 

--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ When an agent knows it needs something, it can explicitly search memory. But mem
 
 Whisper evaluates standing preferences through a separate applicability path. This lets a rule govern a task even when it does not read like a passage that directly answers the prompt, without allowing preference guesses to suppress ordinary factual retrieval.
 
-Whisper contains context selected for the current task; it never appends historical memory-review assignments. Existing feedback records remain available to `submit_feedback` for exact historical attribution.
-
 Whisper feedback can learn from transcript files after they stop changing: a local heuristic records clear usage for free, and an optional LLM judge can classify ambiguous turns into positive, negative, or uncertain retrieval signals.
 
 Read more: [Whisper - Involuntary Recall](https://www.ormah.me/docs/how-ormah-works/whisper), [Search and Ranking](https://www.ormah.me/docs/how-ormah-works/search-and-ranking), [Affinity and Feedback](https://www.ormah.me/docs/operations/affinity-and-feedback)

--- a/docs/04 - Whisper - Involuntary Recall.md
+++ b/docs/04 - Whisper - Involuntary Recall.md
@@ -174,7 +174,7 @@ maintenance_due
 Two important notes:
 
 - `maintenance_due` is appended as a bare line when enabled and due
-- on the first message of a session, Ormah may also append a review block for an older gated-out candidate
+- on the first message of a session, Ormah may also append a review block for an older gated-out candidate, but only when the final main, preference, or exploration selection already contains an admitted memory; maintenance output never qualifies
 
 ## Session Hook Flow
 

--- a/docs/04 - Whisper - Involuntary Recall.md
+++ b/docs/04 - Whisper - Involuntary Recall.md
@@ -42,7 +42,7 @@ flowchart TB
     OVERLAP --> GATE[Injection gate]
     GATE --> EXPLORE[Optional exploration slot]
     EXPLORE --> FORMAT[Flat markdown formatter]
-    FORMAT --> EXTRA[Append maintenance_due and/or review block]
+    FORMAT --> EXTRA[Append maintenance_due when due]
     EXTRA --> RESULT[additionalContext]
 ```
 
@@ -174,7 +174,7 @@ maintenance_due
 Two important notes:
 
 - `maintenance_due` is appended as a bare line when enabled and due
-- on the first message of a session, Ormah may also append a review block for an older gated-out candidate, but only when the final main, preference, or exploration selection already contains an admitted memory; maintenance output never qualifies
+- ordinary whisper never appends retrospective review assignments; it contains only current-task context plus the maintenance signal when due
 
 ## Session Hook Flow
 

--- a/docs/04 - Whisper - Involuntary Recall.md
+++ b/docs/04 - Whisper - Involuntary Recall.md
@@ -171,10 +171,7 @@ full content and related memories.
 maintenance_due
 ```
 
-Two important notes:
-
-- `maintenance_due` is appended as a bare line when enabled and due
-- ordinary whisper never appends retrospective review assignments; it contains only current-task context plus the maintenance signal when due
+`maintenance_due` is appended as a bare line when maintenance is enabled and due.
 
 ## Session Hook Flow
 

--- a/docs/09 - Affinity and Feedback.md
+++ b/docs/09 - Affinity and Feedback.md
@@ -200,10 +200,6 @@ flowchart LR
 
 It can rescue a borderline candidate or slightly suppress a noisy one, but it is capped.
 
-## Historical Review Records
-
-Ordinary whisper does not scan historical held-back candidates or append retrospective review assignments. Existing `review_log` rows remain for compatibility: explicit feedback still marks matching rows as answered, and historical `whisper_log` IDs remain valid for exact feedback attribution. Any future dedicated review workflow must operate outside the ordinary whisper path.
-
 ## Walkthrough Example
 
 1. whisper surfaces a node during a prompt about database decisions

--- a/docs/09 - Affinity and Feedback.md
+++ b/docs/09 - Affinity and Feedback.md
@@ -200,20 +200,9 @@ flowchart LR
 
 It can rescue a borderline candidate or slightly suppress a noisy one, but it is capped.
 
-## Review Loop
+## Historical Review Records
 
-On the first message of a session, whisper may surface one held-back candidate as a review suggestion. That review block asks the client/agent to call `submit_feedback(...)` later if the relevance can be judged.
-
-This remains one bridge between whisper behavior and future affinity learning. The transcript
-watcher now provides a second bridge by mining completed transcripts for clear memory usage.
-
-The review candidate is selected from recent `whisper_log` rows where:
-
-- `was_injected = 0`
-- the node has not also been injected recently
-- there is no strong existing affinity signal for similar prompts
-- it has not been surfaced for review too recently
-- it is not already "exhausted" with too many unanswered review prompts
+Ordinary whisper does not scan historical held-back candidates or append retrospective review assignments. Existing `review_log` rows remain for compatibility: explicit feedback still marks matching rows as answered, and historical `whisper_log` IDs remain valid for exact feedback attribution. Any future dedicated review workflow must operate outside the ordinary whisper path.
 
 ## Walkthrough Example
 

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -1111,8 +1111,10 @@ class ContextBuilder:
                     logger.warning("Failed to compute maintenance_due: %s", e)
 
         # First-message review: surface a gated-out whisper candidate for feedback.
+        # Keep a normal silence decision silent: reviews only piggyback on a
+        # final ordinary selection, not on formatting or maintenance output.
         # recent_prompts is None only on the first message of a session (buffer just created).
-        if recent_prompts is None and self.engine is not None:
+        if recent_prompts is None and final_candidate_count > 0 and self.engine is not None:
             settings = getattr(self.engine, "settings", None)
             try:
                 threshold = getattr(settings, "affinity_similarity_threshold", 0.70) if settings else 0.70

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -23,18 +23,6 @@ _WHISPER_FRAMING = (
 )
 
 
-_REVIEW_FRAMING = (
-    "\n\n## Ormah: one thing to review when you get a chance\n"
-    "In a recent session, the user was working on:\n"
-    "\"{prompt_snippet}\"\n\n"
-    "Ormah held back this memory because it wasn't confident it was relevant:\n"
-    "\"{title}\" — {content}  (id: {node_id}, whisper_log_id: {whisper_log_id})\n\n"
-    "When you can judge it, call submit_feedback(node_id=\"{node_id}\", "
-    "whisper_log_id={whisper_log_id}, signal=1 for yes, "
-    "signal=-1 for no, source=\"implicit\"). Skip if it's not a good moment — "
-    "this won't be surfaced again for 14 days."
-)
-
 _PREFERENCE_APPLICABILITY_PREFIX = "Relevant user preference for this action: "
 
 def _truncate_at_word_boundary(text: str, max_len: int = 300) -> str:
@@ -66,108 +54,6 @@ def _has_topical_overlap(prompt_tokens: set[str], node: dict) -> bool:
         part for part in (node.get("title"), node.get("content")) if isinstance(part, str)
     )
     return bool(prompt_tokens & _topic_tokens(node_text))
-
-
-def _find_review_candidate(conn, threshold: float) -> dict | None:
-    """Find a gated-out whisper candidate eligible for session-start review.
-
-    Applies three Python-side filters after SQL eligibility query:
-    1. No strong affinity signal (cosine sim < threshold against existing affinity rows)
-    2. Not recently surfaced (no review_log row within 14 days)
-    3. Not exhausted (fewer than 3 unanswered review_log rows)
-    """
-    try:
-        rows = conn.execute(
-            """
-            WITH ranked AS (
-              SELECT
-                wl.node_id, wl.score, wl.session_id,
-                COALESCE(re.space, wl.space) AS space,
-                COALESCE(re.prompt_text, wl.prompt_text) AS prompt_text,
-                wl.id AS whisper_log_id,
-                COALESCE(re.prompt_vec, wl.prompt_vec) AS prompt_vec,
-                n.title, n.content,
-                ROW_NUMBER() OVER (PARTITION BY wl.node_id ORDER BY wl.score DESC) AS rn
-              FROM whisper_log wl
-              LEFT JOIN retrieval_events re ON re.id = wl.retrieval_event_id
-              JOIN nodes n ON n.id = wl.node_id
-              WHERE wl.was_injected = 0
-                AND wl.decision_stage IN ('injection_gate', 'candidate_cap', 'legacy')
-                AND wl.logged_at > datetime('now', '-7 days')
-                AND NOT EXISTS (
-                  SELECT 1 FROM whisper_log wl2
-                  WHERE wl2.node_id = wl.node_id
-                    AND wl2.was_injected = 1
-                    AND wl2.logged_at > datetime('now', '-7 days')
-                )
-            )
-            SELECT
-              node_id, score, session_id, space, prompt_text, whisper_log_id,
-              prompt_vec, title, content
-            FROM ranked
-            WHERE rn = 1
-            ORDER BY score DESC
-            LIMIT 20
-            """
-        ).fetchall()
-    except Exception as e:
-        logger.warning("_find_review_candidate SQL failed: %s", e)
-        return None
-
-    for row in rows:
-        node_id = row["node_id"]
-        candidate_prompt_vec_blob = row["prompt_vec"]
-
-        # Step 2a: No strong affinity signal
-        try:
-            affinity_rows = conn.execute(
-                "SELECT prompt_vec FROM affinity WHERE node_id = ?", (node_id,)
-            ).fetchall()
-            if affinity_rows and candidate_prompt_vec_blob:
-                candidate_vec = np.frombuffer(candidate_prompt_vec_blob, dtype=np.float32)
-                candidate_norm = float(np.linalg.norm(candidate_vec))
-                skip = False
-                if candidate_norm > 0:
-                    for arow in affinity_rows:
-                        aff_vec = np.frombuffer(arow["prompt_vec"], dtype=np.float32)
-                        aff_norm = float(np.linalg.norm(aff_vec))
-                        if aff_norm > 0:
-                            sim = float(np.dot(candidate_vec, aff_vec) / (candidate_norm * aff_norm))
-                            if sim >= threshold:
-                                skip = True
-                                break
-                if skip:
-                    continue
-        except Exception as e:
-            logger.warning("Affinity check failed for node %s: %s", node_id, e)
-
-        # Step 2b: Not recently surfaced
-        try:
-            recently = conn.execute(
-                "SELECT 1 FROM review_log WHERE node_id = ? AND surfaced_at > datetime('now', '-14 days') LIMIT 1",
-                (node_id,),
-            ).fetchone()
-            if recently:
-                continue
-        except Exception as e:
-            logger.warning("review_log recency check failed for node %s: %s", node_id, e)
-            continue
-
-        # Step 2c: Not exhausted
-        try:
-            unanswered_count = conn.execute(
-                "SELECT COUNT(*) FROM review_log WHERE node_id = ? AND answered = 0",
-                (node_id,),
-            ).fetchone()[0]
-            if unanswered_count >= 3:
-                continue
-        except Exception as e:
-            logger.warning("review_log exhaustion check failed for node %s: %s", node_id, e)
-            continue
-
-        return dict(row)
-
-    return None
 
 
 def _gate_score(r: dict) -> float:
@@ -1109,38 +995,6 @@ class ContextBuilder:
                         )
                 except Exception as e:
                     logger.warning("Failed to compute maintenance_due: %s", e)
-
-        # First-message review: surface a gated-out whisper candidate for feedback.
-        # Keep a normal silence decision silent: reviews only piggyback on a
-        # final ordinary selection, not on formatting or maintenance output.
-        # recent_prompts is None only on the first message of a session (buffer just created).
-        if recent_prompts is None and final_candidate_count > 0 and self.engine is not None:
-            settings = getattr(self.engine, "settings", None)
-            try:
-                threshold = getattr(settings, "affinity_similarity_threshold", 0.70) if settings else 0.70
-                candidate = _find_review_candidate(self.graph.conn, threshold)
-                if candidate:
-                    current_session_id = session_id or ""
-                    with self.engine.db.transaction() as conn:
-                        conn.execute(
-                            "INSERT INTO review_log (node_id, session_id, surfaced_at) VALUES (?, ?, datetime('now'))",
-                            (candidate["node_id"], current_session_id),
-                        )
-                    prompt_snippet = _truncate_at_word_boundary(
-                        candidate["prompt_text"] or "", max_len=300
-                    )
-                    space_label = candidate["space"] or "global"
-                    review_block = _REVIEW_FRAMING.format(
-                        space=space_label,
-                        prompt_snippet=prompt_snippet,
-                        title=candidate["title"],
-                        content=candidate["content"],
-                        node_id=candidate["node_id"],
-                        whisper_log_id=candidate["whisper_log_id"],
-                    )
-                    result = result + review_block
-            except Exception as e:
-                logger.warning("Review mechanism failed: %s", e)
 
         if _return_debug:
             return result, _injected_ids

--- a/src/ormah/engine/memory_engine.py
+++ b/src/ormah/engine/memory_engine.py
@@ -2821,12 +2821,11 @@ class MemoryEngine:
         Fail-closed: an unqualified signal, a source outside the allowlist, a
         missing whisper_log_id, or an event that was never injected claims
         nothing. was_injected = 1 is the provenance test: only a memory the
-        agent actually saw can have been used. The session-start review path
-        (_find_review_candidate, _REVIEW_FRAMING) deliberately hands the agent a
-        was_injected = 0 event and asks whether it *would* have been useful, and
-        that answer is relevance, not use. The other two callers already satisfy
-        this — _log_feedback_candidates hardcodes was_injected = 1 and the
-        session watcher filters on it — so the condition costs them nothing.
+        agent actually saw can have been used. Historical held-back events have
+        was_injected = 0, so feedback on them can be relevance evidence but is
+        never use. The other two callers already satisfy this —
+        _log_feedback_candidates hardcodes was_injected = 1 and the session
+        watcher filters on it — so the condition costs them nothing.
 
         Enforced in SQL rather than by the caller so a future fourth caller
         cannot reopen the hole. changes() returns 0 both for a non-injected

--- a/tests/test_api/test_review_silence.py
+++ b/tests/test_api/test_review_silence.py
@@ -1,0 +1,70 @@
+"""API regressions for the review mechanism's silent first-turn inputs."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ormah.api import routes_agent
+from ormah.config import settings as global_settings
+
+
+def test_whisper_route_marks_sessionless_first_and_gap_turns_as_first(monkeypatch):
+    """All first-turn shapes pass ``recent_prompts=None`` to the builder.
+
+    The review guard receives these exact route inputs.  Its context-builder
+    regressions cover the eligible same-space history and assert that silence
+    performs no review lookup or write.
+    """
+    routes_agent._session_buffers.clear()
+    engine = MagicMock()
+    engine.get_whisper_context.return_value = ""
+    app = FastAPI()
+    app.include_router(routes_agent.router)
+    app.state.engine = engine
+
+    monkeypatch.setattr(global_settings, "whisper_session_gap_minutes", 10)
+    clock = iter([1000.0, 1601.0])
+    monkeypatch.setattr(routes_agent, "time", SimpleNamespace(time=lambda: next(clock)))
+
+    try:
+        with TestClient(app) as client:
+            sessionless = client.post(
+                "/agent/whisper",
+                json={"prompt": "Thanks, that helps.", "space": "myspace"},
+            )
+            first_turn = client.post(
+                "/agent/whisper",
+                json={
+                    "prompt": "Thanks, that helps.",
+                    "space": "myspace",
+                    "session_id": "review-gap",
+                },
+            )
+            after_gap = client.post(
+                "/agent/whisper",
+                json={
+                    "prompt": "Thanks, that helps.",
+                    "space": "myspace",
+                    "session_id": "review-gap",
+                },
+            )
+
+        assert sessionless.json() == {"text": "", "node_id": None}
+        assert first_turn.json() == {"text": "", "node_id": None}
+        assert after_gap.json() == {"text": "", "node_id": None}
+        assert [call.kwargs["recent_prompts"] for call in engine.get_whisper_context.call_args_list] == [
+            None,
+            None,
+            None,
+        ]
+        assert [call.kwargs["session_id"] for call in engine.get_whisper_context.call_args_list] == [
+            "",
+            "review-gap",
+            "review-gap",
+        ]
+    finally:
+        routes_agent._session_buffers.clear()

--- a/tests/test_api/test_review_silence.py
+++ b/tests/test_api/test_review_silence.py
@@ -1,4 +1,4 @@
-"""API regressions for the review mechanism's silent first-turn inputs."""
+"""API regression coverage for retired retrospective review notes."""
 
 from __future__ import annotations
 
@@ -12,22 +12,23 @@ from ormah.api import routes_agent
 from ormah.config import settings as global_settings
 
 
-def test_whisper_route_marks_sessionless_first_and_gap_turns_as_first(monkeypatch):
-    """All first-turn shapes pass ``recent_prompts=None`` to the builder.
+def test_whisper_route_preserves_context_across_first_gap_and_ongoing_turns(monkeypatch):
+    """Every route shape leaves the builder free to return only current context.
 
-    The review guard receives these exact route inputs.  Its context-builder
-    regressions cover the eligible same-space history and assert that silence
-    performs no review lookup or write.
+    The builder regression seeds historical withheld/review rows and asserts
+    that none of these session shapes can append a retrospective assignment.
+    This route test pins the exact ``recent_prompts`` inputs for sessionless,
+    first, post-gap, and ongoing requests.
     """
     routes_agent._session_buffers.clear()
     engine = MagicMock()
-    engine.get_whisper_context.return_value = ""
+    engine.get_whisper_context.return_value = "# Ormah whispers\n\nCurrent task context"
     app = FastAPI()
     app.include_router(routes_agent.router)
     app.state.engine = engine
 
     monkeypatch.setattr(global_settings, "whisper_session_gap_minutes", 10)
-    clock = iter([1000.0, 1601.0])
+    clock = iter([1000.0, 1001.0, 1602.0])
     monkeypatch.setattr(routes_agent, "time", SimpleNamespace(time=lambda: next(clock)))
 
     try:
@@ -39,7 +40,15 @@ def test_whisper_route_marks_sessionless_first_and_gap_turns_as_first(monkeypatc
             first_turn = client.post(
                 "/agent/whisper",
                 json={
-                    "prompt": "Thanks, that helps.",
+                    "prompt": "First task request with enough words.",
+                    "space": "myspace",
+                    "session_id": "review-gap",
+                },
+            )
+            ongoing = client.post(
+                "/agent/whisper",
+                json={
+                    "prompt": "Ongoing task request with enough words.",
                     "space": "myspace",
                     "session_id": "review-gap",
                 },
@@ -47,22 +56,26 @@ def test_whisper_route_marks_sessionless_first_and_gap_turns_as_first(monkeypatc
             after_gap = client.post(
                 "/agent/whisper",
                 json={
-                    "prompt": "Thanks, that helps.",
+                    "prompt": "Post gap task request with enough words.",
                     "space": "myspace",
                     "session_id": "review-gap",
                 },
             )
 
-        assert sessionless.json() == {"text": "", "node_id": None}
-        assert first_turn.json() == {"text": "", "node_id": None}
-        assert after_gap.json() == {"text": "", "node_id": None}
+        expected = {"text": "# Ormah whispers\n\nCurrent task context", "node_id": None}
+        assert sessionless.json() == expected
+        assert first_turn.json() == expected
+        assert ongoing.json() == expected
+        assert after_gap.json() == expected
         assert [call.kwargs["recent_prompts"] for call in engine.get_whisper_context.call_args_list] == [
             None,
             None,
+            ["First task request with enough words."],
             None,
         ]
         assert [call.kwargs["session_id"] for call in engine.get_whisper_context.call_args_list] == [
             "",
+            "review-gap",
             "review-gap",
             "review-gap",
         ]

--- a/tests/test_engine/test_confirmed_use_contract.py
+++ b/tests/test_engine/test_confirmed_use_contract.py
@@ -552,15 +552,15 @@ def test_recall_node_does_not_reinforce_without_an_event_to_claim(engine):
     )
 
 
-# --- Review relevance is not confirmed use (2026-08-16 council round) -------
+# --- Held-back relevance is not confirmed use (2026-08-16 council round) ----
 
 def _seed_held_back_whisper_log(engine, node_id, prompt="what about caching?"):
-    """Insert the kind of event the session-start review hands to the agent.
+    """Insert a historical event for a memory whisper held back.
 
-    _find_review_candidate selects rows with was_injected = 0 — memories Ormah
-    held back and never surfaced — and _REVIEW_FRAMING hands that id to the
-    agent asking for source="implicit" feedback. _seed_whisper_log cannot be
-    used here: it goes through recall_search, which writes was_injected = 1.
+    The automatic retrospective review producer is retired, but existing
+    was_injected = 0 rows remain valid feedback provenance. _seed_whisper_log
+    cannot be used here: it goes through recall_search, which writes
+    was_injected = 1.
 
     logged_at is a Python ISO timestamp, not SQLite's datetime('now'), because
     _log_feedback_candidates writes ISO and the fallback orders by this column
@@ -582,15 +582,12 @@ def _seed_held_back_whisper_log(engine, node_id, prompt="what about caching?"):
     return cursor.lastrowid
 
 
-def test_review_relevance_feedback_does_not_confirm_use(engine):
+def test_held_back_relevance_feedback_does_not_confirm_use(engine):
     """Contract 11: judging a held-back memory relevant is not using it.
 
-    The review path deliberately surfaces an event with was_injected = 0 and
-    asks "would this have been useful?" — a relevance adjudication, not a use.
-    _claim_confirmed_use allowlists "implicit" and checks no provenance, so the
-    claim is taken and the lifecycle advances on a memory the agent never saw.
-    That is fabricated retention entering through the review door, which is what
-    issue #220 exists to close.
+    Historical feedback may still be attached to a was_injected = 0 event, but
+    the memory was never shown to the agent. Treating the judgment as use would
+    fabricate retention, which issue #220 forbids.
     """
     ids = _make_nodes(engine, count=1)
     target = ids[0]

--- a/tests/test_engine/test_review_mechanism.py
+++ b/tests/test_engine/test_review_mechanism.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
 from ormah.engine.context_builder import ContextBuilder, _find_review_candidate
+from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
 from ormah.index.db import Database
 from ormah.index.graph import GraphIndex
 
@@ -226,11 +227,11 @@ class TestReviewPythonFilter:
 class TestReviewBlockInBuildWhisperContext:
     """Integration tests for review mechanism inside build_whisper_context."""
 
-    def _make_mock_engine(self, conn=None, threshold=0.70):
+    def _make_mock_engine(self, conn=None, threshold=0.70, maintenance_enabled=False):
         engine = MagicMock()
         settings = MagicMock()
         settings.affinity_similarity_threshold = threshold
-        settings.claude_maintenance_enabled = False
+        settings.claude_maintenance_enabled = maintenance_enabled
         engine.settings = settings
         # Disable embedding/search paths so they don't interfere
         engine._get_hybrid_search.return_value = None
@@ -241,6 +242,17 @@ class TestReviewBlockInBuildWhisperContext:
                 yield conn
             engine.db.transaction = _fake_transaction
         return engine
+
+    @staticmethod
+    def _admitted_ordinary_result(node_id="node-selected"):
+        """A final ordinary selection that permits the optional review append."""
+        node = _make_node_dict(
+            node_id,
+            "Current authentication design",
+            space="myspace",
+            content="Authentication uses scoped tokens for the current application.",
+        )
+        return {"node": node, "score": 0.80, "source": "hybrid"}
 
     def _insert_whisper_row(self, conn, node_id, prompt_text="how does auth work", prompt_vec_bytes=b""):
         cursor = conn.execute(
@@ -259,12 +271,14 @@ class TestReviewBlockInBuildWhisperContext:
         conn.commit()
 
         engine = self._make_mock_engine(conn)
+        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
         builder = ContextBuilder(mock_graph, engine=engine)
         result = builder.build_whisper_context(
             prompt="how does auth work", recent_prompts=None, session_id="test-session-123"
         )
 
         assert "one thing to review when you get a chance" in result
+        assert "Current authentication design" in result
         assert "Auth token storage" in result
         assert f"whisper_log_id: {whisper_log_id}" in result
         assert f"whisper_log_id={whisper_log_id}" in result
@@ -278,6 +292,7 @@ class TestReviewBlockInBuildWhisperContext:
         conn.commit()
 
         engine = self._make_mock_engine(conn)
+        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
         builder = ContextBuilder(mock_graph, engine=engine)
         builder.build_whisper_context(
             prompt="how does auth work", recent_prompts=None, session_id="test-session-456"
@@ -318,6 +333,7 @@ class TestReviewBlockInBuildWhisperContext:
         conn.commit()
 
         engine = self._make_mock_engine(conn)
+        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
         builder = ContextBuilder(mock_graph, engine=engine)
         result = builder.build_whisper_context(
             prompt="how does auth work",
@@ -326,6 +342,7 @@ class TestReviewBlockInBuildWhisperContext:
         )
 
         assert "one thing to review when you get a chance" not in result
+        assert "Current authentication design" in result
 
     def test_prompt_text_truncated_to_300(self, mock_graph):
         """Long prompt_text is truncated at word boundary to ≤300 chars + ellipsis."""
@@ -341,6 +358,7 @@ class TestReviewBlockInBuildWhisperContext:
         conn.commit()
 
         engine = self._make_mock_engine(conn)
+        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
         builder = ContextBuilder(mock_graph, engine=engine)
         result = builder.build_whisper_context(
             prompt="how does auth work", recent_prompts=None, session_id="test-session-truncate"
@@ -356,3 +374,159 @@ class TestReviewBlockInBuildWhisperContext:
             snippet_end = review_portion.find('"', snippet_start)
             snippet = review_portion[snippet_start:snippet_end]
             assert len(snippet) <= 301  # 300 chars + "…"
+
+    def _seed_same_space_review_candidate(self, conn, node_id="node-review-history"):
+        node = _make_node_dict(
+            node_id,
+            "Held-back authentication history",
+            space="myspace",
+        )
+        _insert_node(conn, node)
+        whisper_log_id = self._insert_whisper_row(conn, node_id)
+        conn.commit()
+        # This verifies the fixture is actually eligible before the silent
+        # selection below proves it does not consult the review mechanism.
+        candidate = _find_review_candidate(conn, threshold=0.70)
+        assert candidate is not None
+        assert candidate["node_id"] == node_id
+        return whisper_log_id
+
+    @pytest.mark.parametrize(
+        ("prompt", "session_id", "recent_prompts"),
+        [
+            pytest.param("Thanks, that helps.", None, None, id="sessionless-acknowledgement"),
+            pytest.param("Thanks, that helps.", "first-session", None, id="first-session-turn"),
+            pytest.param("Thanks, that helps.", "after-gap", None, id="after-session-gap"),
+            pytest.param(
+                "What is the boiling point of ethanol at sea level?",
+                None,
+                None,
+                id="unrelated-question",
+            ),
+            pytest.param("Thanks, that helps.", "same-space", None, id="same-space-history"),
+        ],
+    )
+    def test_no_candidates_do_not_lookup_or_log_review(
+        self, mock_graph, prompt, session_id, recent_prompts
+    ):
+        """A silent final selection stays silent even with eligible history."""
+        conn = mock_graph.conn
+        self._seed_same_space_review_candidate(conn)
+        engine = self._make_mock_engine(conn)
+        builder = ContextBuilder(mock_graph, engine=engine)
+
+        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
+            result = builder.build_whisper_context(
+                prompt=prompt,
+                space="myspace",
+                recent_prompts=recent_prompts,
+                session_id=session_id,
+            )
+
+        assert result == ""
+        review_lookup.assert_not_called()
+        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
+        outcome = conn.execute(
+            "SELECT outcome, injected_count FROM whisper_decisions ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert tuple(outcome) == ("silent_no_candidates", 0)
+
+    def test_gate_rejected_candidates_do_not_lookup_or_log_review(self, mock_graph):
+        """A non-empty retrieval pool that fails the final gate is still silence."""
+        conn = mock_graph.conn
+        self._seed_same_space_review_candidate(conn)
+        engine = self._make_mock_engine(conn)
+        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
+        builder = ContextBuilder(mock_graph, engine=engine)
+
+        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
+            result = builder.build_whisper_context(
+                prompt="how does auth work",
+                space="myspace",
+                recent_prompts=None,
+                session_id="gate-rejected",
+                injection_gate=0.90,
+            )
+
+        assert result == ""
+        review_lookup.assert_not_called()
+        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
+        outcome = conn.execute(
+            "SELECT outcome, injected_count FROM whisper_decisions ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        assert tuple(outcome) == ("silent_gate", 0)
+
+    def test_maintenance_only_output_does_not_trigger_review(self, mock_graph):
+        """Rendered maintenance text must not stand in for an admitted memory."""
+        conn = mock_graph.conn
+        self._seed_same_space_review_candidate(conn)
+        engine = self._make_mock_engine(conn, maintenance_enabled=True)
+        builder = ContextBuilder(mock_graph, engine=engine)
+
+        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
+            result = builder.build_whisper_context(
+                prompt="Thanks, that helps.",
+                space="myspace",
+                recent_prompts=None,
+                session_id="maintenance-only",
+            )
+
+        assert result == MAINTENANCE_DUE_SIGNAL
+        review_lookup.assert_not_called()
+        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
+
+    def test_short_prompt_stays_silent_without_review(self, mock_graph):
+        """The existing short-prompt silence contract precedes review lookup."""
+        conn = mock_graph.conn
+        self._seed_same_space_review_candidate(conn)
+        engine = self._make_mock_engine(conn)
+        builder = ContextBuilder(mock_graph, engine=engine)
+
+        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
+            result = builder.build_whisper_context(
+                prompt="ok",
+                space="myspace",
+                recent_prompts=None,
+                session_id="short-prompt",
+            )
+
+        assert result == ""
+        review_lookup.assert_not_called()
+        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
+
+    def test_preference_only_selection_allows_review_with_exact_attribution(self, mock_graph):
+        """An admitted preference is a final candidate and can carry a review."""
+        conn = mock_graph.conn
+        whisper_log_id = self._seed_same_space_review_candidate(conn)
+        preference = _make_node_dict(
+            "node-preference",
+            "Prefer concise architecture",
+            space="myspace",
+            content="Keep architecture decisions concise and written down.",
+        )
+        preference["type"] = "preference"
+        engine = self._make_mock_engine(conn)
+        engine.has_searchable_preferences.return_value = True
+        engine.recall_search_structured.side_effect = [
+            [],
+            [{"node": preference, "score": 0.65, "source": "hybrid"}],
+        ]
+        builder = ContextBuilder(mock_graph, engine=engine)
+        mock_cross_encoder = MagicMock()
+        mock_cross_encoder.rerank.return_value = [3.0]
+
+        with patch("ormah.embeddings.reranker._get_model", return_value=mock_cross_encoder):
+            result = builder.build_whisper_context(
+                prompt="plan this architecture change",
+                space="myspace",
+                recent_prompts=None,
+                session_id="preference-only",
+                reranker_enabled=True,
+                preference_applicability_enabled=True,
+                preference_applicability_gate=0.40,
+            )
+
+        assert "Prefer concise architecture" in result
+        assert "one thing to review when you get a chance" in result
+        assert f"whisper_log_id: {whisper_log_id}" in result
+        assert f"whisper_log_id={whisper_log_id}" in result

--- a/tests/test_engine/test_review_mechanism.py
+++ b/tests/test_engine/test_review_mechanism.py
@@ -1,23 +1,26 @@
-"""Tests for the review mechanism in build_whisper_context."""
+"""Regression coverage for retired automatic retrospective review notes."""
 
 from __future__ import annotations
 
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import numpy as np
 import pytest
 
-from ormah.engine.context_builder import ContextBuilder, _find_review_candidate
+from ormah.engine.context_builder import ContextBuilder
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
 from ormah.index.db import Database
 from ormah.index.graph import GraphIndex
 
 
+_REVIEW_HEADING = "one thing to review when you get a chance"
+
+
 def _make_node_dict(node_id, title, tier="core", space=None, importance=0.5, **kwargs):
     return {
         "id": node_id,
-        "type": "fact",
+        "type": kwargs.get("type", "fact"),
         "tier": tier,
         "title": title,
         "content": kwargs.get("content", f"Content about {title}"),
@@ -39,11 +42,23 @@ def _insert_node(conn, node):
         "created, updated, last_accessed, access_count, confidence, importance, "
         "file_path, file_hash) "
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        (node["id"], node["type"], node["tier"], node["source"],
-         node["space"], node["title"], node["content"],
-         node["created"], node["updated"], node["last_accessed"],
-         node["access_count"], node["confidence"], node["importance"],
-         "/fake/path", "abc123"),
+        (
+            node["id"],
+            node["type"],
+            node["tier"],
+            node["source"],
+            node["space"],
+            node["title"],
+            node["content"],
+            node["created"],
+            node["updated"],
+            node["last_accessed"],
+            node["access_count"],
+            node["confidence"],
+            node["importance"],
+            "/fake/path",
+            "abc123",
+        ),
     )
 
 
@@ -51,482 +66,275 @@ def _insert_node(conn, node):
 def mock_graph(tmp_path):
     db = Database(tmp_path / "index.db")
     db.init_schema()
-    graph = GraphIndex(db.conn)
-    return graph
+    return GraphIndex(db.conn)
 
 
-# ---------------------------------------------------------------------------
-# TestReviewCandidateSQL
-# ---------------------------------------------------------------------------
-
-class TestReviewCandidateSQL:
-    """Tests for SQL-level eligibility in _find_review_candidate."""
-
-    def test_no_whisper_log_returns_none(self, mock_graph):
-        """Empty DB returns None."""
-        result = _find_review_candidate(mock_graph.conn, threshold=0.70)
-        assert result is None
-
-    def test_injected_candidate_excluded(self, mock_graph):
-        """was_injected=1 row is excluded."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-1", "Auth token storage")
-        _insert_node(conn, node)
-        conn.execute(
-            "INSERT INTO whisper_log (node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, was_injected, logged_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-1 day'))",
-            ("node-1", 0.60, "sess-abc", "myspace", "how does auth work", "hash1", b"", 1),
-        )
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is None
-
-    def test_old_candidate_excluded(self, mock_graph):
-        """Candidates older than 7 days are excluded."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-2", "Old memory")
-        _insert_node(conn, node)
-        conn.execute(
-            "INSERT INTO whisper_log (node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, was_injected, logged_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-8 days'))",
-            ("node-2", 0.48, "sess-abc", "myspace", "how does auth work", "hash2", b"", 0),
-        )
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is None
-
-    def test_gated_out_candidate_found(self, mock_graph):
-        """was_injected=0 row within 7 days returns a candidate dict."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-3", "Session management")
-        _insert_node(conn, node)
-        conn.execute(
-            "INSERT INTO whisper_log (node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, was_injected, logged_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-1 day'))",
-            ("node-3", 0.48, "sess-abc", "myspace", "how does auth work", "hash3", b"", 0),
-        )
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is not None
-        assert result["node_id"] == "node-3"
-        assert result["title"] == "Session management"
-        assert result["content"] == "Content about Session management"
-        assert result["prompt_text"] == "how does auth work"
-
-    def test_node_with_successful_injection_excluded(self, mock_graph):
-        """Node with both was_injected=0 and was_injected=1 within 7 days is excluded."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-4", "Mixed signal node")
-        _insert_node(conn, node)
-        # Gated-out row
-        conn.execute(
-            "INSERT INTO whisper_log (node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, was_injected, logged_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-2 days'))",
-            ("node-4", 0.48, "sess-aaa", "myspace", "some prompt", "hash4a", b"", 0),
-        )
-        # Successful injection row for the same node
-        conn.execute(
-            "INSERT INTO whisper_log (node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, was_injected, logged_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-1 day'))",
-            ("node-4", 0.70, "sess-bbb", "myspace", "another prompt", "hash4b", b"", 1),
-        )
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is None
-
-
-# ---------------------------------------------------------------------------
-# TestReviewPythonFilter
-# ---------------------------------------------------------------------------
-
-class TestReviewPythonFilter:
-    """Tests for the Python-side filtering in _find_review_candidate."""
-
-    def _insert_whisper_row(self, conn, node_id, prompt_vec_bytes=b""):
-        conn.execute(
-            "INSERT INTO whisper_log (node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, was_injected, logged_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-1 day'))",
-            (node_id, 0.48, "sess-abc", "myspace", "how does auth work", "hash-py", prompt_vec_bytes, 0),
-        )
-
-    def test_strong_affinity_signal_skips_candidate(self, mock_graph):
-        """Candidate with affinity row whose prompt_vec cosine-matches >= 0.70 is skipped."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-5", "Auth system")
-        _insert_node(conn, node)
-
-        vec = np.random.rand(768).astype(np.float32)
-        vec_bytes = vec.tobytes()
-
-        self._insert_whisper_row(conn, "node-5", vec_bytes)
-        # Insert an affinity row with the same vector (cosine sim = 1.0)
-        conn.execute(
-            "INSERT INTO affinity (node_id, prompt_vec, prompt_text, signal, confirmed_at, session_id) "
-            "VALUES (?, ?, ?, ?, datetime('now'), ?)",
-            ("node-5", vec_bytes, "how does auth work", 1, "sess-affinity"),
-        )
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is None
-
-    def test_recently_surfaced_skips_candidate(self, mock_graph):
-        """Node surfaced in review_log within 14 days is skipped."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-6", "Recent review node")
-        _insert_node(conn, node)
-        self._insert_whisper_row(conn, "node-6")
-        conn.execute(
-            "INSERT INTO review_log (node_id, session_id, surfaced_at) VALUES (?, ?, datetime('now', '-7 days'))",
-            ("node-6", "sess-prev"),
-        )
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is None
-
-    def test_exhausted_candidate_skipped(self, mock_graph):
-        """Node with 3+ unanswered review_log rows is skipped."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-7", "Exhausted candidate")
-        _insert_node(conn, node)
-        self._insert_whisper_row(conn, "node-7")
-        # Insert 3 unanswered review_log rows (all older than 14 days to avoid the recency filter)
-        for i in range(3):
-            conn.execute(
-                "INSERT INTO review_log (node_id, session_id, surfaced_at, answered) "
-                "VALUES (?, ?, datetime('now', '-20 days'), 0)",
-                ("node-7", f"sess-old-{i}"),
-            )
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is None
-
-    def test_eligible_candidate_passes_all_checks(self, mock_graph):
-        """Candidate with no affinity, no recent review_log, under 3 unanswered → returned."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-8", "Eligible candidate")
-        _insert_node(conn, node)
-        self._insert_whisper_row(conn, "node-8")
-        conn.commit()
-
-        result = _find_review_candidate(conn, threshold=0.70)
-        assert result is not None
-        assert result["node_id"] == "node-8"
-
-
-# ---------------------------------------------------------------------------
-# TestReviewBlockInBuildCoreContext
-# ---------------------------------------------------------------------------
-
-class TestReviewBlockInBuildWhisperContext:
-    """Integration tests for review mechanism inside build_whisper_context."""
-
-    def _make_mock_engine(self, conn=None, threshold=0.70, maintenance_enabled=False):
-        engine = MagicMock()
-        settings = MagicMock()
-        settings.affinity_similarity_threshold = threshold
-        settings.claude_maintenance_enabled = maintenance_enabled
-        engine.settings = settings
-        # Disable embedding/search paths so they don't interfere
-        engine._get_hybrid_search.return_value = None
-        engine.recall_search_structured.return_value = []
-        if conn is not None:
-            @contextmanager
-            def _fake_transaction():
-                yield conn
-            engine.db.transaction = _fake_transaction
-        return engine
-
-    @staticmethod
-    def _admitted_ordinary_result(node_id="node-selected"):
-        """A final ordinary selection that permits the optional review append."""
-        node = _make_node_dict(
-            node_id,
-            "Current authentication design",
-            space="myspace",
-            content="Authentication uses scoped tokens for the current application.",
-        )
-        return {"node": node, "score": 0.80, "source": "hybrid"}
-
-    def _insert_whisper_row(self, conn, node_id, prompt_text="how does auth work", prompt_vec_bytes=b""):
-        cursor = conn.execute(
-            "INSERT INTO whisper_log (node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, was_injected, logged_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now', '-1 day'))",
-            (node_id, 0.48, "sess-abc", "myspace", prompt_text, "hash-blk", prompt_vec_bytes, 0),
-        )
-        return cursor.lastrowid
-
-    def test_review_block_appended_when_eligible(self, mock_graph):
-        """Eligible candidate causes review block to appear in result on first message."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-r1", "Auth token storage", space="myspace")
-        _insert_node(conn, node)
-        whisper_log_id = self._insert_whisper_row(conn, "node-r1")
-        conn.commit()
-
-        engine = self._make_mock_engine(conn)
-        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
-        builder = ContextBuilder(mock_graph, engine=engine)
-        result = builder.build_whisper_context(
-            prompt="how does auth work", recent_prompts=None, session_id="test-session-123"
-        )
-
-        assert "one thing to review when you get a chance" in result
-        assert "Current authentication design" in result
-        assert "Auth token storage" in result
-        assert f"whisper_log_id: {whisper_log_id}" in result
-        assert f"whisper_log_id={whisper_log_id}" in result
-
-    def test_review_log_row_inserted(self, mock_graph):
-        """After build_whisper_context with eligible candidate, review_log has 1 row."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-r2", "DB schema design", space="myspace")
-        _insert_node(conn, node)
-        self._insert_whisper_row(conn, "node-r2")
-        conn.commit()
-
-        engine = self._make_mock_engine(conn)
-        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
-        builder = ContextBuilder(mock_graph, engine=engine)
-        builder.build_whisper_context(
-            prompt="how does auth work", recent_prompts=None, session_id="test-session-456"
-        )
-
-        row_count = conn.execute(
-            "SELECT COUNT(*) FROM review_log WHERE node_id = ?", ("node-r2",)
-        ).fetchone()[0]
-        assert row_count == 1
-
-        row = conn.execute(
-            "SELECT node_id, session_id FROM review_log WHERE node_id = ?", ("node-r2",)
-        ).fetchone()
-        assert row["node_id"] == "node-r2"
-        assert row["session_id"] == "test-session-456"
-
-    def test_review_block_not_appended_without_engine(self, mock_graph):
-        """ContextBuilder with engine=None produces no review block."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-r3", "No engine node", space="myspace")
-        _insert_node(conn, node)
-        self._insert_whisper_row(conn, "node-r3")
-        conn.commit()
-
-        builder = ContextBuilder(mock_graph, engine=None)
-        result = builder.build_whisper_context(
-            prompt="how does auth work", recent_prompts=None, session_id="test-session-789"
-        )
-
-        assert "one thing to review when you get a chance" not in result
-
-    def test_review_block_not_appended_on_subsequent_messages(self, mock_graph):
-        """Review block only fires on first message (recent_prompts=None)."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-r5", "Subsequent message node", space="myspace")
-        _insert_node(conn, node)
-        self._insert_whisper_row(conn, "node-r5")
-        conn.commit()
-
-        engine = self._make_mock_engine(conn)
-        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
-        builder = ContextBuilder(mock_graph, engine=engine)
-        result = builder.build_whisper_context(
-            prompt="how does auth work",
-            recent_prompts=["previous message"],  # not first message
-            session_id="test-session-subseq",
-        )
-
-        assert "one thing to review when you get a chance" not in result
-        assert "Current authentication design" in result
-
-    def test_prompt_text_truncated_to_300(self, mock_graph):
-        """Long prompt_text is truncated at word boundary to ≤300 chars + ellipsis."""
-        conn = mock_graph.conn
-        node = _make_node_dict("node-r4", "Long prompt node", space="myspace")
-        _insert_node(conn, node)
-
-        long_prompt = ("This is a very long prompt that goes on and on about authentication "
-                       "and authorization flows in the application. ") * 4
-        assert len(long_prompt) > 300
-
-        self._insert_whisper_row(conn, "node-r4", prompt_text=long_prompt)
-        conn.commit()
-
-        engine = self._make_mock_engine(conn)
-        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
-        builder = ContextBuilder(mock_graph, engine=engine)
-        result = builder.build_whisper_context(
-            prompt="how does auth work", recent_prompts=None, session_id="test-session-truncate"
-        )
-
-        assert "one thing to review when you get a chance" in result
-        assert "…" in result
-        review_start = result.find("one thing to review when you get a chance")
-        review_portion = result[review_start:]
-        working_on_idx = review_portion.find('working on:\n"')
-        if working_on_idx != -1:
-            snippet_start = working_on_idx + len('working on:\n"')
-            snippet_end = review_portion.find('"', snippet_start)
-            snippet = review_portion[snippet_start:snippet_end]
-            assert len(snippet) <= 301  # 300 chars + "…"
-
-    def _seed_same_space_review_candidate(self, conn, node_id="node-review-history"):
-        node = _make_node_dict(
-            node_id,
-            "Held-back authentication history",
-            space="myspace",
-        )
-        _insert_node(conn, node)
-        whisper_log_id = self._insert_whisper_row(conn, node_id)
-        conn.commit()
-        # This verifies the fixture is actually eligible before the silent
-        # selection below proves it does not consult the review mechanism.
-        candidate = _find_review_candidate(conn, threshold=0.70)
-        assert candidate is not None
-        assert candidate["node_id"] == node_id
-        return whisper_log_id
-
-    @pytest.mark.parametrize(
-        ("prompt", "session_id", "recent_prompts"),
-        [
-            pytest.param("Thanks, that helps.", None, None, id="sessionless-acknowledgement"),
-            pytest.param("Thanks, that helps.", "first-session", None, id="first-session-turn"),
-            pytest.param("Thanks, that helps.", "after-gap", None, id="after-session-gap"),
-            pytest.param(
-                "What is the boiling point of ethanol at sea level?",
-                None,
-                None,
-                id="unrelated-question",
-            ),
-            pytest.param("Thanks, that helps.", "same-space", None, id="same-space-history"),
-        ],
+def _make_mock_engine(conn, *, maintenance_enabled=False):
+    engine = MagicMock()
+    engine.settings = SimpleNamespace(
+        claude_maintenance_enabled=maintenance_enabled,
+        claude_maintenance_interval_hours=24,
     )
-    def test_no_candidates_do_not_lookup_or_log_review(
-        self, mock_graph, prompt, session_id, recent_prompts
-    ):
-        """A silent final selection stays silent even with eligible history."""
-        conn = mock_graph.conn
-        self._seed_same_space_review_candidate(conn)
-        engine = self._make_mock_engine(conn)
-        builder = ContextBuilder(mock_graph, engine=engine)
+    engine._get_hybrid_search.return_value = None
+    engine.recall_search_structured.return_value = []
+    engine.has_searchable_preferences.return_value = False
 
-        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
-            result = builder.build_whisper_context(
-                prompt=prompt,
-                space="myspace",
-                recent_prompts=recent_prompts,
-                session_id=session_id,
-            )
+    @contextmanager
+    def transaction():
+        yield conn
 
-        assert result == ""
-        review_lookup.assert_not_called()
-        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
-        outcome = conn.execute(
-            "SELECT outcome, injected_count FROM whisper_decisions ORDER BY id DESC LIMIT 1"
-        ).fetchone()
-        assert tuple(outcome) == ("silent_no_candidates", 0)
+    engine.db.transaction = transaction
+    return engine
 
-    def test_gate_rejected_candidates_do_not_lookup_or_log_review(self, mock_graph):
-        """A non-empty retrieval pool that fails the final gate is still silence."""
-        conn = mock_graph.conn
-        self._seed_same_space_review_candidate(conn)
-        engine = self._make_mock_engine(conn)
-        engine.recall_search_structured.return_value = [self._admitted_ordinary_result()]
-        builder = ContextBuilder(mock_graph, engine=engine)
 
-        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
-            result = builder.build_whisper_context(
-                prompt="how does auth work",
-                space="myspace",
-                recent_prompts=None,
-                session_id="gate-rejected",
-                injection_gate=0.90,
-            )
+def _admitted_ordinary_result(node_id="node-selected"):
+    node = _make_node_dict(
+        node_id,
+        "Current authentication design",
+        space="myspace",
+        content="Authentication uses scoped tokens for the current application.",
+    )
+    return {"node": node, "score": 0.80, "source": "hybrid"}
 
-        assert result == ""
-        review_lookup.assert_not_called()
-        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
-        outcome = conn.execute(
-            "SELECT outcome, injected_count FROM whisper_decisions ORDER BY id DESC LIMIT 1"
-        ).fetchone()
-        assert tuple(outcome) == ("silent_gate", 0)
 
-    def test_maintenance_only_output_does_not_trigger_review(self, mock_graph):
-        """Rendered maintenance text must not stand in for an admitted memory."""
-        conn = mock_graph.conn
-        self._seed_same_space_review_candidate(conn)
-        engine = self._make_mock_engine(conn, maintenance_enabled=True)
-        builder = ContextBuilder(mock_graph, engine=engine)
+def _seed_historical_review_data(conn, node_id="node-held-back"):
+    """Seed prior withheld events and review history without producing a review."""
+    held_back = _make_node_dict(
+        node_id,
+        "Historical held-back memory",
+        space="myspace",
+        content="This historical content must never be appended to a new whisper.",
+    )
+    _insert_node(conn, held_back)
+    conn.execute(
+        "INSERT INTO whisper_log "
+        "(node_id, score, session_id, space, prompt_text, prompt_hash, prompt_vec, "
+        "decision_stage, was_injected, logged_at) "
+        "VALUES (?, 0.48, 'old-session', 'myspace', 'old task prompt', 'old-hash', X'', "
+        "'injection_gate', 0, datetime('now', '-1 day'))",
+        (node_id,),
+    )
+    conn.execute(
+        "INSERT INTO review_log (node_id, session_id, surfaced_at, answered) "
+        "VALUES (?, 'historic-review', datetime('now', '-20 days'), 0)",
+        (node_id,),
+    )
+    conn.execute(
+        "INSERT INTO review_log (node_id, session_id, surfaced_at, answered) "
+        "VALUES (?, 'answered-review', datetime('now', '-30 days'), 1)",
+        (node_id,),
+    )
+    conn.commit()
+    return held_back
 
-        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
-            result = builder.build_whisper_context(
-                prompt="Thanks, that helps.",
-                space="myspace",
-                recent_prompts=None,
-                session_id="maintenance-only",
-            )
 
-        assert result == MAINTENANCE_DUE_SIGNAL
-        review_lookup.assert_not_called()
-        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
+def _review_rows(conn):
+    return [
+        tuple(row)
+        for row in conn.execute(
+            "SELECT node_id, session_id, surfaced_at, answered FROM review_log ORDER BY id"
+        ).fetchall()
+    ]
 
-    def test_short_prompt_stays_silent_without_review(self, mock_graph):
-        """The existing short-prompt silence contract precedes review lookup."""
-        conn = mock_graph.conn
-        self._seed_same_space_review_candidate(conn)
-        engine = self._make_mock_engine(conn)
-        builder = ContextBuilder(mock_graph, engine=engine)
 
-        with patch("ormah.engine.context_builder._find_review_candidate") as review_lookup:
-            result = builder.build_whisper_context(
-                prompt="ok",
-                space="myspace",
-                recent_prompts=None,
-                session_id="short-prompt",
-            )
+@pytest.mark.parametrize(
+    ("session_id", "recent_prompts"),
+    [
+        pytest.param(None, None, id="sessionless"),
+        pytest.param("first-session", None, id="first-session-turn"),
+        pytest.param("after-gap", None, id="post-gap-turn"),
+        pytest.param("ongoing-session", ["earlier task"], id="ongoing-session"),
+    ],
+)
+def test_selected_context_never_appends_historical_review_or_writes_review_log(
+    mock_graph, session_id, recent_prompts
+):
+    """Current-task context remains useful without a retrospective assignment.
 
-        assert result == ""
-        review_lookup.assert_not_called()
-        assert conn.execute("SELECT COUNT(*) FROM review_log").fetchone()[0] == 0
+    This is the removal regression: at PR head 98ee602, first/sessionless/
+    post-gap shapes append the held-back title and add a review_log row even
+    though the normal selected memory is already present.
+    """
+    conn = mock_graph.conn
+    held_back = _seed_historical_review_data(conn)
+    before = _review_rows(conn)
+    engine = _make_mock_engine(conn)
+    engine.recall_search_structured.return_value = [_admitted_ordinary_result()]
 
-    def test_preference_only_selection_allows_review_with_exact_attribution(self, mock_graph):
-        """An admitted preference is a final candidate and can carry a review."""
-        conn = mock_graph.conn
-        whisper_log_id = self._seed_same_space_review_candidate(conn)
-        preference = _make_node_dict(
-            "node-preference",
-            "Prefer concise architecture",
+    result = ContextBuilder(mock_graph, engine=engine).build_whisper_context(
+        prompt="how does the current authentication design work",
+        space="myspace",
+        recent_prompts=recent_prompts,
+        session_id=session_id,
+    )
+
+    assert "Current authentication design" in result
+    assert _REVIEW_HEADING not in result
+    assert held_back["title"] not in result
+    assert held_back["content"] not in result
+    assert _review_rows(conn) == before
+
+
+def test_preference_only_context_never_appends_historical_review_or_writes_review_log(mock_graph):
+    """Applicable preferences remain injectable without bringing back reviews."""
+    conn = mock_graph.conn
+    held_back = _seed_historical_review_data(conn)
+    before = _review_rows(conn)
+    preference = _make_node_dict(
+        "node-preference",
+        "Prefer concise architecture",
+        space="myspace",
+        type="preference",
+        content="Keep architecture decisions concise and written down.",
+    )
+    engine = _make_mock_engine(conn)
+    engine.has_searchable_preferences.return_value = True
+    engine.recall_search_structured.side_effect = [
+        [],
+        [{"node": preference, "score": 0.65, "source": "hybrid"}],
+    ]
+    cross_encoder = MagicMock()
+    cross_encoder.rerank.return_value = [3.0]
+
+    with patch("ormah.embeddings.reranker._get_model", return_value=cross_encoder):
+        result = ContextBuilder(mock_graph, engine=engine).build_whisper_context(
+            prompt="plan this architecture change",
             space="myspace",
-            content="Keep architecture decisions concise and written down.",
+            recent_prompts=None,
+            session_id="preference-only",
+            reranker_enabled=True,
+            preference_applicability_enabled=True,
+            preference_applicability_gate=0.40,
         )
-        preference["type"] = "preference"
-        engine = self._make_mock_engine(conn)
-        engine.has_searchable_preferences.return_value = True
-        engine.recall_search_structured.side_effect = [
-            [],
-            [{"node": preference, "score": 0.65, "source": "hybrid"}],
-        ]
-        builder = ContextBuilder(mock_graph, engine=engine)
-        mock_cross_encoder = MagicMock()
-        mock_cross_encoder.rerank.return_value = [3.0]
 
-        with patch("ormah.embeddings.reranker._get_model", return_value=mock_cross_encoder):
-            result = builder.build_whisper_context(
-                prompt="plan this architecture change",
-                space="myspace",
-                recent_prompts=None,
-                session_id="preference-only",
-                reranker_enabled=True,
-                preference_applicability_enabled=True,
-                preference_applicability_gate=0.40,
-            )
+    assert "Prefer concise architecture" in result
+    assert _REVIEW_HEADING not in result
+    assert held_back["title"] not in result
+    assert _review_rows(conn) == before
 
-        assert "Prefer concise architecture" in result
-        assert "one thing to review when you get a chance" in result
-        assert f"whisper_log_id: {whisper_log_id}" in result
-        assert f"whisper_log_id={whisper_log_id}" in result
+
+@pytest.mark.parametrize(
+    ("prompt", "session_id", "recent_prompts", "kwargs", "expected"),
+    [
+        pytest.param(
+            "an unrelated question with enough words",
+            None,
+            None,
+            {},
+            "",
+            id="sessionless-no-candidates",
+        ),
+        pytest.param(
+            "an unrelated question with enough words",
+            "first-session",
+            None,
+            {},
+            "",
+            id="first-session-no-candidates",
+        ),
+        pytest.param(
+            "an unrelated question with enough words",
+            "after-gap",
+            None,
+            {},
+            "",
+            id="post-gap-no-candidates",
+        ),
+        pytest.param(
+            "an unrelated question with enough words",
+            "ongoing-session",
+            ["earlier task"],
+            {},
+            "",
+            id="ongoing-no-candidates",
+        ),
+        pytest.param(
+            "ok",
+            "short-prompt",
+            None,
+            {},
+            "",
+            id="short-prompt",
+        ),
+    ],
+)
+def test_silent_paths_preserve_historical_review_records(
+    mock_graph, prompt, session_id, recent_prompts, kwargs, expected
+):
+    """No candidate path can convert old review history into current context."""
+    conn = mock_graph.conn
+    _seed_historical_review_data(conn)
+    before = _review_rows(conn)
+    engine = _make_mock_engine(conn)
+
+    result = ContextBuilder(mock_graph, engine=engine).build_whisper_context(
+        prompt=prompt,
+        space="myspace",
+        recent_prompts=recent_prompts,
+        session_id=session_id,
+        **kwargs,
+    )
+
+    assert result == expected
+    assert _review_rows(conn) == before
+
+
+def test_gate_rejection_stays_silent_and_preserves_historical_review_records(mock_graph):
+    conn = mock_graph.conn
+    _seed_historical_review_data(conn)
+    before = _review_rows(conn)
+    engine = _make_mock_engine(conn)
+    engine.recall_search_structured.return_value = [_admitted_ordinary_result()]
+
+    result = ContextBuilder(mock_graph, engine=engine).build_whisper_context(
+        prompt="how does the current authentication design work",
+        space="myspace",
+        recent_prompts=None,
+        session_id="gate-rejected",
+        injection_gate=0.90,
+    )
+
+    assert result == ""
+    assert _review_rows(conn) == before
+    outcome = conn.execute(
+        "SELECT outcome, injected_count FROM whisper_decisions ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert tuple(outcome) == ("silent_gate", 0)
+
+
+def test_maintenance_signal_remains_bare_when_no_context_is_selected(mock_graph):
+    conn = mock_graph.conn
+    _seed_historical_review_data(conn)
+    before = _review_rows(conn)
+    engine = _make_mock_engine(conn, maintenance_enabled=True)
+
+    result = ContextBuilder(mock_graph, engine=engine).build_whisper_context(
+        prompt="an unrelated question with enough words",
+        space="myspace",
+        recent_prompts=None,
+        session_id="maintenance-only",
+    )
+
+    assert result == MAINTENANCE_DUE_SIGNAL
+    assert _review_rows(conn) == before
+
+
+def test_selected_context_and_maintenance_signal_remain_intact_without_review(mock_graph):
+    conn = mock_graph.conn
+    held_back = _seed_historical_review_data(conn)
+    before = _review_rows(conn)
+    engine = _make_mock_engine(conn, maintenance_enabled=True)
+    engine.recall_search_structured.return_value = [_admitted_ordinary_result()]
+
+    result = ContextBuilder(mock_graph, engine=engine).build_whisper_context(
+        prompt="how does the current authentication design work",
+        space="myspace",
+        recent_prompts=None,
+        session_id="selected-maintenance",
+    )
+
+    assert "Current authentication design" in result
+    assert result.endswith(MAINTENANCE_DUE_SIGNAL)
+    assert _REVIEW_HEADING not in result
+    assert held_back["title"] not in result
+    assert _review_rows(conn) == before

--- a/tests/test_engine/test_submit_feedback.py
+++ b/tests/test_engine/test_submit_feedback.py
@@ -160,7 +160,7 @@ class TestSubmitFeedbackBasic:
         assert engine.db.conn.execute("SELECT COUNT(*) FROM affinity").fetchone()[0] == 0
         assert engine.db.conn.execute("SELECT COUNT(*) FROM signals").fetchone()[0] == 0
 
-    def test_exact_feedback_accepts_active_review_held_back_event(self, engine):
+    def test_exact_feedback_accepts_historical_held_back_event(self, engine):
         node_id = "node-active-review-001"
         whisper_log_id = _insert_whisper_log(
             engine.db.conn,


### PR DESCRIPTION
## What users experience

Whispers now contain context selected for the current task, not historical relevance-review assignments. The historical “one thing to review” note is never appended on silent, selected, sessionless, first, post-gap, or ongoing turns.

## What changed

- Retired the automatic retrospective-review lookup, `review_log` insertion, and formatter from the whisper hot path.
- Removed the obsolete private review selector and its selector-only tests; replacement regressions seed historical withheld events and review history, then verify they neither appear in whisper output nor change the stored review rows.
- Preserved ordinary selection, preference applicability, exploration, budgets, maintenance signaling, and onboarding. Selected context plus `maintenance_due` still works; maintenance-only output remains bare.
- Preserved historical `review_log`, `whisper_log`, affinity, and signal schemas/records. `submit_feedback` continues to accept exact historical `whisper_log_id` attribution, and feedback on a held-back event remains relevance evidence rather than confirmed lifecycle use.

## Validation

- `tests/test_engine/test_review_mechanism.py tests/test_api/test_review_silence.py` — 14 passed.
- Focused feedback compatibility (exact attribution), held-back lifecycle, onboarding, and feedback-schema coverage — 3 + 1 + 5 + 22 passed.
- `/root/.local/bin/uv run make lint` and `git diff --check` — passed.
- The focused removal regression fails at the original PR head `98ee602` in the three first-turn shapes that appended a review alongside selected context, and passes after this change.
- An isolated `make test` run was interrupted at 10% after unrelated background failures. The new API regression passed in that run. A representative `test_llm_classifies_supports` failure is identical on unchanged `98ee602`: `A LIMIT or 'k = ?' constraint is required on vec0 knn queries.`

## Scope

Refs #132. Follow-up #300 tracks a dedicated review workflow; this PR does not implement it or resolve the broader issue automatically.
