### PR TITLE
fix(eval): reset whisper diagnostic state between cases

### DIFF
--- a/eval/whisper/corpus/README.md
+++ b/eval/whisper/corpus/README.md
@@ -38,6 +38,13 @@ Prompt expectations: `should_inject` (a.k.a. `must_include`), `may_include`,
 (a.k.a. `must_be_silent`). Prompts may carry `session_id` and
 `recent_prompts` for session-context probes.
 
+## Isolation between cases
+
+The runner reuses one isolated eval database, but each case resets the prior
+fixture's nodes plus its retrieval, decision, and feedback diagnostics. This
+keeps per-case evidence attributable to the current fixture while preserving
+intentional startup metadata and the case's `preserve_self` behavior.
+
 ## Case-design rules
 
 1. **Labels are set from ground-truth judgment BEFORE the first eval run of a

--- a/eval/whisper/seeder.py
+++ b/eval/whisper/seeder.py
@@ -6,6 +6,23 @@ from datetime import datetime, timedelta, timezone
 from ormah.models.node import Connection, EdgeType, MemoryNode, NodeType, Tier
 
 
+# ``IndexBuilder.full_rebuild`` owns node/index cleanup. These are the
+# case-scoped diagnostics, feedback, and session records it does not own.
+# Keep the dependency order explicit: feedback/lifecycle children go before
+# whisper_log, which must go before its retrieval_events parent (RESTRICT).
+_CASE_STATE_RESET_TABLES = (
+    "confirmed_use_claims",
+    "signals",
+    "affinity",
+    "whisper_log",
+    "retrieval_events",
+    "whisper_decisions",
+    "review_log",
+    "audit_log",
+    "auto_link_checked",
+)
+
+
 def _parse_dt(val: str) -> datetime:
     """Parse an ISO/RFC3339 datetime string into a timezone-aware UTC datetime.
 
@@ -110,20 +127,12 @@ def clear_eval_db(engine, *, preserve_self: bool = False) -> None:
     engine.file_store._cache_built = False
     engine.builder.full_rebuild()
     with engine.db.transaction() as conn:
-        # full_rebuild clears nodes/edges/fts; we also clear tables that can
-        # leak state across runs and affect scoring (affinity boost, logs, etc).
-        for table in (
-            "node_vectors",
-            "whisper_log",
-            "affinity",
-            "review_log",
-            "audit_log",
-            "auto_link_checked",
-        ):
-            try:
-                conn.execute(f"DELETE FROM {table}")
-            except Exception:
-                pass
+        # Keep startup metadata (including onboarding state) intact. The
+        # builder already clears node_vectors when it is available; these
+        # explicit tables are all created by the current SQLite schema, so a
+        # failure here must surface instead of silently producing a tainted eval.
+        for table in _CASE_STATE_RESET_TABLES:
+            conn.execute(f"DELETE FROM {table}")
 
     if preserve_self:
         # Recreate self node (engine.startup() does this normally).

--- a/tests/test_eval_whisper/test_seeder.py
+++ b/tests/test_eval_whisper/test_seeder.py
@@ -6,10 +6,17 @@ import pytest
 
 
 @pytest.fixture
-def tmp_engine(tmp_path):
+def tmp_engine(tmp_path, monkeypatch):
     from eval.whisper.cli import _EVAL_SETTINGS_OVERRIDES
     from ormah.config import Settings
     from ormah.engine.memory_engine import MemoryEngine
+
+    # Seeder coverage exercises SQLite/file reset behavior, not embedding or
+    # reranking. Keep these tests independent of model downloads while using
+    # the real MemoryEngine schema and its foreign-key constraints.
+    monkeypatch.setattr(MemoryEngine, "_index_embedding", lambda self, node: None)
+    monkeypatch.setattr(MemoryEngine, "_warmup_embedder", lambda self: None)
+    monkeypatch.setattr(MemoryEngine, "_warmup_reranker", lambda self: None)
 
     (tmp_path / "nodes").mkdir()
     settings = Settings(memory_dir=tmp_path, **_EVAL_SETTINGS_OVERRIDES)
@@ -40,6 +47,118 @@ _CASE = {
         },
     ],
 }
+
+
+_REUSED_ID_CASE = {
+    "id": "t-002",
+    "memories": [
+        {
+            "node_id": "aaa-portfact",
+            "title": "Replacement fact",
+            "content": "The replacement fixture has different content.",
+            "type": "fact",
+            "tier": "working",
+            "space": "ormah",
+        },
+    ],
+}
+
+
+_CASE_SCOPED_DIAGNOSTIC_TABLES = (
+    "retrieval_events",
+    "whisper_log",
+    "affinity",
+    "signals",
+    "confirmed_use_claims",
+    "whisper_decisions",
+)
+
+
+def _insert_case_diagnostics(engine, node_id: str) -> None:
+    """Record linked feedback/diagnostics using the production SQLite schema."""
+    with engine.db.transaction() as conn:
+        event = conn.execute(
+            "INSERT INTO retrieval_events "
+            "(surface, session_id, space, prompt_hash, prompt_text, prompt_vec, logged_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("whisper", "case-a", "ormah", "case-a-hash", "case A prompt", b"1234", "2026-01-01T00:00:00Z"),
+        )
+        whisper_log = conn.execute(
+            "INSERT INTO whisper_log "
+            "(session_id, space, prompt_hash, prompt_text, prompt_vec, node_id, score, "
+            "was_injected, logged_at, retrieval_event_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "case-a",
+                "ormah",
+                "case-a-hash",
+                None,
+                b"",
+                node_id,
+                0.8,
+                1,
+                "2026-01-01T00:00:00Z",
+                event.lastrowid,
+            ),
+        )
+        whisper_log_id = whisper_log.lastrowid
+        conn.execute(
+            "INSERT INTO affinity "
+            "(prompt_vec, prompt_text, node_id, signal, source, confirmed_at, space, session_id, whisper_log_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                b"1234",
+                "case A prompt",
+                node_id,
+                1,
+                "implicit",
+                "2026-01-01T00:00:00Z",
+                "ormah",
+                "case-a",
+                whisper_log_id,
+            ),
+        )
+        conn.execute(
+            "INSERT INTO signals "
+            "(whisper_log_id, node_id, signal_type, polarity, strength, source, session_id, "
+            "surface, space, prompt_hash, evidence, created) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                whisper_log_id,
+                node_id,
+                "implicit_confirmation",
+                1,
+                1.0,
+                "agent",
+                "case-a",
+                "whisper",
+                "ormah",
+                "case-a-hash",
+                "case A evidence",
+                "2026-01-01T00:00:00Z",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO confirmed_use_claims (whisper_log_id, node_id, claimed_at) "
+            "VALUES (?, ?, ?)",
+            (whisper_log_id, node_id, "2026-01-01T00:00:00Z"),
+        )
+        conn.execute(
+            "INSERT INTO whisper_decisions "
+            "(session_id, space, prompt_hash, intent, outcome, candidate_count, injected_count, "
+            "max_gate_score, logged_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "case-a",
+                "ormah",
+                "case-a-hash",
+                "factual",
+                "injected",
+                1,
+                1,
+                0.8,
+                "2026-01-01T00:00:00Z",
+            ),
+        )
 
 
 class TestSeedCase:
@@ -185,6 +304,85 @@ class TestSeedCase:
         for table in ("whisper_log", "affinity", "review_log", "audit_log", "auto_link_checked"):
             row = tmp_engine.db.conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()
             assert row["n"] == 0
+
+    def test_seed_case_clears_linked_diagnostics_before_same_id_fixture_reuse(self, tmp_engine):
+        """A later fixture must not retain evidence tied to the old fixture's node ID."""
+        from eval.whisper.seeder import seed_case
+
+        seed_case(tmp_engine, _CASE)
+        _insert_case_diagnostics(tmp_engine, "aaa-portfact")
+
+        for table in _CASE_SCOPED_DIAGNOSTIC_TABLES:
+            row = tmp_engine.db.conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()
+            assert row["n"] == 1
+
+        # Case B intentionally reuses A's node ID. A stale row would look valid
+        # after the reset, so checking only for orphaned node IDs would miss it.
+        seed_case(tmp_engine, _REUSED_ID_CASE)
+
+        for table in _CASE_SCOPED_DIAGNOSTIC_TABLES:
+            row = tmp_engine.db.conn.execute(f"SELECT COUNT(*) AS n FROM {table}").fetchone()
+            assert row["n"] == 0
+
+        node = tmp_engine.file_store.load("aaa-portfact")
+        assert node is not None
+        assert node.content == "The replacement fixture has different content."
+        assert tmp_engine.db.conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    @pytest.mark.parametrize("preserve_self", [False, True])
+    def test_clear_eval_db_is_idempotent_without_diagnostics_and_preserves_metadata(
+        self, tmp_engine, preserve_self
+    ):
+        from eval.whisper.seeder import clear_eval_db
+
+        with tmp_engine.db.transaction() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO meta (key, value) VALUES ('onboarding_prompted', '1')"
+            )
+
+        # The second invocation starts with no case nodes or diagnostics.
+        clear_eval_db(tmp_engine, preserve_self=preserve_self)
+        clear_eval_db(tmp_engine, preserve_self=preserve_self)
+
+        row = tmp_engine.db.conn.execute(
+            "SELECT value FROM meta WHERE key = 'onboarding_prompted'"
+        ).fetchone()
+        assert row is not None
+        assert row["value"] == "1"
+        assert tmp_engine.db.conn.execute("SELECT COUNT(*) FROM nodes").fetchone()[0] == (
+            1 if preserve_self else 0
+        )
+        for table in _CASE_SCOPED_DIAGNOSTIC_TABLES:
+            assert tmp_engine.db.conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
+        assert tmp_engine.db.conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+    def test_runner_results_are_unchanged_by_prior_diagnostics(self, tmp_engine, monkeypatch):
+        from eval.whisper.runner import run_whisper_eval
+
+        case = {
+            **_REUSED_ID_CASE,
+            "prompts": [
+                {
+                    "text": "What does this fixture contain?",
+                    "category": "factual",
+                    "expected": {"should_inject": ["aaa-portfact"]},
+                }
+            ],
+        }
+        monkeypatch.setattr(tmp_engine.context_builder, "_get_classifier", lambda: None)
+        monkeypatch.setattr(
+            tmp_engine,
+            "get_whisper_context",
+            lambda **kwargs: ("fixture context", ["aaa-portfact"]),
+        )
+
+        baseline = run_whisper_eval([case], tmp_engine)
+        _insert_case_diagnostics(tmp_engine, "aaa-portfact")
+        after_prior_diagnostics = run_whisper_eval([case], tmp_engine)
+
+        assert after_prior_diagnostics == baseline
+        for table in _CASE_SCOPED_DIAGNOSTIC_TABLES:
+            assert tmp_engine.db.conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0] == 0
 
     def test_clear_eval_db_can_preserve_self_node(self, tmp_engine):
         from eval.whisper.seeder import clear_eval_db, seed_case


### PR DESCRIPTION
Closes #216

## Trigger

The whisper eval runner reuses one isolated SQLite database for every corpus case. `clear_eval_db` removed legacy logs but left `retrieval_events` and `whisper_decisions`; it also left `signals` with a null `whisper_log_id` after the parent candidate rows were deleted. This made later case diagnostics and feedback/lifecycle evidence carry data from prior fixtures.

## Before / after

Before, reseeding a fixture left prior retrieval events, whisper decisions, and detached signals visible.

After, an explicit dependency-ordered reset clears confirmed-use claims, signals, affinity, candidate logs, retrieval events, decisions, and existing case-scoped review/audit/auto-link evidence. It preserves metadata, onboarding state, and `preserve_self` semantics. Ranking and feedback policy behavior are unchanged.

## Validation

- Added a real-schema/FK regression: seed case A, write a retrieval event, candidate, affinity, signal, confirmed-use claim, and decision, then seed case B with the same node ID. All prior case evidence is removed, case B remains correct, and `PRAGMA foreign_key_check` is clean.
- Added idempotent empty-reset coverage for both `preserve_self` modes and a runner-result invariance check.
- `uv run pytest tests/test_eval_whisper -q` — 90 passed, 1 deselected.
- `uv run make lint` — passed.
- `git diff --check` — passed.
- `uv run make test` was run in an isolated temporary cache. It has 27 failures in background/setup/vector paths outside this change. The same failures reproduce on unchanged `e1b65b6` with the same isolated environment (including vec0 requiring a LIMIT/k constraint), so they are baseline/environmental rather than introduced here.

## Remaining limitation

The private golden whisper corpus is unavailable on this host, so no corpus-score claim is made.

## Review guidance

Review the explicit FK-safe reset order in `eval/whisper/seeder.py`, especially the deliberate deletion of signals and confirmed-use claims before `whisper_log`, and the same-ID reuse regression.