### PR TITLE
fix(whisper): silence acknowledgement continuations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ That is what makes Ormah feel like memory instead of search. Search waits to be 
 
 Silence is better than noise. Ormah should whisper, not shout.
 
+Brief, self-contained acknowledgements such as "Thanks, that helps" are kept
+silent, even in an active session. They do not re-run recall using the prior
+question; a thank-you that includes a new command or question still does.
+
 ## Install
 
 ### Desktop App

--- a/src/ormah/engine/context_builder.py
+++ b/src/ormah/engine/context_builder.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 import numpy as np
 
 from ormah.engine.maintenance_signal import MAINTENANCE_DUE_SIGNAL
+from ormah.engine.prompt_classifier import PromptIntent, is_clear_acknowledgement
 from ormah.index.graph import GraphIndex
 from ormah.text.tokens import distinctive_tokens
 
@@ -383,6 +384,28 @@ class ContextBuilder:
             self._log_decision(
                 session_id=session_id, space=space, prompt=prompt,
                 intent=None, outcome="silent_short",
+            )
+            if _return_debug:
+                return "", _injected_ids
+            return ""
+
+        # This control must run before classifier/enrichment: an embedding
+        # classifier can mistake a clear acknowledgement for a continuation,
+        # which would attach the prior substantive prompt to this turn and
+        # re-inject already served context. The same small predicate also
+        # keeps silence correct if the classifier/model is unavailable.
+        if is_clear_acknowledgement(prompt):
+            intent = PromptIntent(categories=["acknowledgement"])
+            logger.info(
+                "Whisper diagnostics: prompt=%r acknowledgement_intent -> skip",
+                prompt_snippet,
+            )
+            self._log_decision(
+                session_id=session_id,
+                space=space,
+                prompt=prompt,
+                intent=intent,
+                outcome="silent_acknowledgement",
             )
             if _return_debug:
                 return "", _injected_ids

--- a/src/ormah/engine/prompt_classifier.py
+++ b/src/ormah/engine/prompt_classifier.py
@@ -113,6 +113,39 @@ _DANGLING_PREP_RE = re.compile(
     r"\b(?:in|during|from|over|for)\s+(?:the\s+)?(?=\s*$|\s*,)", re.IGNORECASE
 )
 
+# Acknowledgements are distinct from conversational turns: when they follow a
+# useful answer, embedding similarity can otherwise label them as a
+# continuation and cause the prior question to be searched again. Keep this
+# grammar deliberately small and anchored so a new request that contains a
+# thank-you ("Thanks, now explain the cache") keeps its substantive intent.
+_ACKNOWLEDGEMENT_RE = re.compile(
+    r"""
+    ^\s*
+    (?:
+        (?:thanks|thank\s+you)
+        (?:\s*,?\s*(?:that|this|it)\s+(?:helps?|was\s+helpful))?
+        | (?:that|this|it)\s+(?:helps?|was\s+helpful)
+        | got\s+it
+        | makes\s+sense
+        | all\s+set
+        | that(?:'s|\s+is)\s+all
+        | done
+    )
+    [\s.!?…]*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def is_clear_acknowledgement(prompt: str) -> bool:
+    """Return whether *prompt* is a self-contained acknowledgement or closure.
+
+    This intentionally recognizes only complete acknowledgement phrases. It is
+    not a general sentiment detector: commands and questions containing words
+    such as "thanks" or "done" must still be eligible for useful recall.
+    """
+    return bool(_ACKNOWLEDGEMENT_RE.match(prompt))
+
 
 def has_temporal_phrases(prompt: str) -> bool:
     """Return True if *prompt* contains explicit temporal phrases.
@@ -267,6 +300,12 @@ class PromptClassifier:
 
     def classify(self, prompt: str) -> PromptIntent:
         """Classify *prompt* and return an intent with search-param overrides."""
+        # Recognise explicit acknowledgement/closure before embedding matching.
+        # Their semantic proximity to continuation examples is not a retrieval
+        # request, and must not cause a buffered prior prompt to be re-used.
+        if is_clear_acknowledgement(prompt):
+            return PromptIntent(categories=["acknowledgement"])
+
         self._ensure_archetypes()
         assert self._archetype_vecs is not None
 

--- a/tests/test_engine/test_prompt_classifier.py
+++ b/tests/test_engine/test_prompt_classifier.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 from ormah.engine.prompt_classifier import (
     PromptClassifier,
@@ -282,6 +283,43 @@ class TestClassificationLogic:
         intent = classifier.classify("what did you learn about me recently")
         assert "temporal" in intent.categories
         assert "identity" in intent.categories
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "Thanks, that helps.",
+            "THANK YOU!",
+            "that helps...",
+            "Got it.",
+            "DONE",
+        ],
+    )
+    def test_clear_acknowledgements_have_a_distinct_intent(self, prompt):
+        """Clear acknowledgements bypass embedding continuation matching."""
+        encoder = MagicMock()
+        classifier = PromptClassifier(encoder)
+
+        intent = classifier.classify(prompt)
+
+        assert intent.categories == ["acknowledgement"]
+        encoder.encode.assert_not_called()
+        encoder.encode_batch.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "Thanks, now explain the cache.",
+            "Done with that; start the deployment.",
+            "and the second one?",
+            "and how often does that run?",
+            "continue where we left off",
+        ],
+    )
+    def test_substantive_and_follow_up_controls_are_not_acknowledgements(self, prompt):
+        """Only a self-contained acknowledgement should be suppressed."""
+        from ormah.engine.prompt_classifier import is_clear_acknowledgement
+
+        assert not is_clear_acknowledgement(prompt)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine/test_whisper_context.py
+++ b/tests/test_engine/test_whisper_context.py
@@ -535,6 +535,57 @@ class TestWhisperIntentAware:
         # Should not even attempt a search
         mock_engine.recall_search_structured.assert_not_called()
 
+    @pytest.mark.parametrize("prompt", ["Thanks, that helps.", "THAT HELPS!"])
+    def test_acknowledgement_returns_empty_before_classifier_or_search(self, mock_graph, prompt):
+        """Acknowledgements stay silent even without a session continuation."""
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+        builder._classifier = MagicMock()
+
+        result = builder.build_whisper_context(prompt=prompt, min_score=0.1)
+
+        assert result == ""
+        builder._classifier.classify.assert_not_called()
+        mock_engine.recall_search_structured.assert_not_called()
+
+    def test_acknowledgement_is_silent_when_classifier_is_unavailable(self, mock_graph):
+        """The guard must not depend on local embedding-model availability."""
+        mock_engine = MagicMock()
+        mock_engine._get_hybrid_search.return_value = None
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+
+        result = builder.build_whisper_context(prompt="Thanks, that helps.", min_score=0.1)
+
+        assert result == ""
+        mock_engine.recall_search_structured.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("prompt", "title"),
+        [
+            ("Thanks, now explain the cache.", "Cache invalidation"),
+            ("Done with that; start the deployment.", "Deployment checklist"),
+        ],
+    )
+    def test_substantive_prompt_with_acknowledgement_words_still_searches(
+        self, mock_graph, prompt, title,
+    ):
+        """Acknowledgement words must not swallow a new useful request."""
+        from ormah.engine.prompt_classifier import PromptIntent
+
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+        builder._classifier = MagicMock()
+        builder._classifier.classify.return_value = PromptIntent(categories=["general"])
+        node = _make_node_dict("substantive-1", title)
+        mock_engine.recall_search_structured.return_value = [
+            {"node": node, "score": 0.8, "source": "hybrid"},
+        ]
+
+        result = builder.build_whisper_context(prompt=prompt, min_score=0.1)
+
+        assert title in result
+        mock_engine.recall_search_structured.assert_called_once()
+
     def test_general_intent_searches_normally(self, mock_graph):
         """General intent should use normal search behavior."""
         mock_engine = MagicMock()
@@ -1387,6 +1438,33 @@ class TestWhisperContextBuffer:
         assert "eval results" in query
         assert "what about the metrics side?" in query
 
+    @pytest.mark.parametrize(
+        "prompt",
+        [
+            "and the second one?",
+            "and how often does that run?",
+            "continue where we left off",
+        ],
+    )
+    def test_prelabelled_continuations_still_enrich_search_query(self, mock_graph, prompt):
+        """Acknowledgement handling must not regress useful short follow-ups."""
+        from ormah.engine.prompt_classifier import PromptIntent
+
+        mock_engine = MagicMock()
+        builder = ContextBuilder(mock_graph, engine=mock_engine)
+        builder._classifier = MagicMock()
+        builder._classifier.classify.return_value = PromptIntent(categories=["continuation"])
+        mock_engine.recall_search_structured.return_value = []
+
+        builder.build_whisper_context(
+            prompt=prompt,
+            min_score=0.1,
+            recent_prompts=["how does the scheduler work?"],
+        )
+
+        query = mock_engine.recall_search_structured.call_args.kwargs["query"]
+        assert query == f"how does the scheduler work? {prompt}"
+
     def test_reranker_judges_context_enhanced_followup_query(self, mock_graph):
         """The reranker must score the same context-enhanced query that search
         ran on, not the bare prompt. Its ce_absolute drives the injection gate,
@@ -1560,6 +1638,139 @@ class TestSessionBufferRoute:
         assert [p for p, _ in _session_buffers["session-2"]] == ["session2 prompt"]
 
         _session_buffers.clear()
+
+    def test_acknowledgement_does_not_reinject_served_context(self, tmp_path):
+        """The real route must not enrich an acknowledgement with its prior turn.
+
+        The deterministic classifier deliberately labels the acknowledgement as
+        ``continuation`` to reproduce the old failure.  The first route call
+        writes an injected whisper_log event for the seeded Markdown decision;
+        the second call uses the same session buffer and must remain silent.
+        """
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ormah.api.routes_agent import _session_buffers, router
+        from ormah.engine.prompt_classifier import PromptIntent
+        from ormah.index.db import Database
+
+        _session_buffers.clear()
+        db = Database(tmp_path / "index.db")
+        db.init_schema()
+        graph = GraphIndex(db.conn)
+        node = _make_node_dict("markdown-choice", "Markdown source of truth", space="nova")
+        node["content"] = (
+            "Nova stores memories as Markdown because people can read, edit, version and "
+            "move them between tools. SQLite is a derived search index that can be rebuilt."
+        )
+        _insert_node(db.conn, node)
+        db.conn.commit()
+
+        prompt_vec = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        engine = MagicMock()
+        engine.settings = _make_settings_mock()
+        engine.db = db
+        encoder = MagicMock()
+        encoder.encode.return_value = prompt_vec
+        encoder.encode_query.return_value = prompt_vec
+        hybrid_search = MagicMock()
+        hybrid_search.encoder = encoder
+        engine._get_hybrid_search.return_value = hybrid_search
+        engine.recall_search_structured.return_value = [
+            {"node": node, "score": 0.9, "source": "hybrid", "raw_cosine": 0.9},
+        ]
+        builder = ContextBuilder(graph, engine=engine)
+        builder._classifier = MagicMock()
+        builder._classifier.classify.side_effect = [
+            PromptIntent(categories=["general"]),
+            PromptIntent(categories=["continuation"]),
+        ]
+
+        def get_whisper_context(**kwargs):
+            return builder.build_whisper_context(
+                **kwargs,
+                min_score=0.1,
+                injection_gate=0.55,
+                topic_shift_enabled=True,
+                topic_shift_threshold=0.75,
+            )
+
+        engine.get_whisper_context.side_effect = get_whisper_context
+        app = FastAPI()
+        app.include_router(router)
+        app.state.engine = engine
+
+        try:
+            with TestClient(app) as client:
+                first = client.post(
+                    "/agent/whisper",
+                    json={
+                        "prompt": "Why did we choose Markdown as the source of truth?",
+                        "space": "nova",
+                        "session_id": "ack-later",
+                    },
+                )
+                assert first.status_code == 200
+                assert "Markdown source of truth" in first.json()["text"]
+                served = db.conn.execute(
+                    "SELECT was_injected FROM whisper_log WHERE session_id = ? AND node_id = ?",
+                    ("ack-later", "markdown-choice"),
+                ).fetchone()
+                assert served is not None and served["was_injected"] == 1
+
+                acknowledgement = client.post(
+                    "/agent/whisper",
+                    json={
+                        "prompt": "Thanks, that helps.",
+                        "space": "nova",
+                        "session_id": "ack-later",
+                    },
+                )
+
+            assert acknowledgement.status_code == 200
+            assert acknowledgement.json()["text"] == ""
+            assert engine.recall_search_structured.call_count == 1
+            whisper_log_count = db.conn.execute(
+                "SELECT COUNT(*) FROM whisper_log WHERE session_id = ?",
+                ("ack-later",),
+            ).fetchone()[0]
+            assert whisper_log_count == 1
+        finally:
+            _session_buffers.clear()
+            db.close()
+
+    def test_session_gap_drops_acknowledgement_history(self):
+        """A stale buffer cannot make an acknowledgement a follow-up query."""
+        from collections import deque
+        import time
+
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from ormah.api.routes_agent import _session_buffers, router
+        from ormah.config import settings as global_settings
+
+        _session_buffers.clear()
+        gap_seconds = global_settings.whisper_session_gap_minutes * 60
+        _session_buffers["expired-ack"] = deque(
+            [("Why did we choose Markdown?", time.time() - gap_seconds - 1)],
+            maxlen=global_settings.whisper_context_buffer_size,
+        )
+        engine = MagicMock()
+        engine.get_whisper_context.return_value = ""
+        app = FastAPI()
+        app.include_router(router)
+        app.state.engine = engine
+
+        try:
+            with TestClient(app) as client:
+                response = client.post(
+                    "/agent/whisper",
+                    json={"prompt": "Thanks, that helps.", "session_id": "expired-ack"},
+                )
+
+            assert response.status_code == 200
+            assert engine.get_whisper_context.call_args.kwargs["recent_prompts"] is None
+        finally:
+            _session_buffers.clear()
 
 
 class TestWhisperTopicShift:


### PR DESCRIPTION
Closes #295

## Trigger

After a useful whisper in an active session, a clear acknowledgement could be classified as `continuation`. The continuation path enriched the acknowledgement with the prior substantive question, then re-injected the already-served ordinary memory.

## Change

- Add a deliberately small, anchored acknowledgement/closure intent before embedding classification and continuation enrichment.
- Skip ordinary whisper retrieval for self-contained acknowledgements, including when the classifier/model is unavailable.
- Preserve substantive prompts containing `thanks` or `done`, and preserve pre-labelled underspecified continuation retrieval.
- Add a real `/agent/whisper` session-buffer regression with a seeded synthetic Markdown decision and a recorded prior served event. It verifies the acknowledgement returns no context, does not search again, and creates no second `whisper_log` attribution.
- Document the behavior in the README.

## Validation

- Failing regression before the fix: the route re-injected the Markdown decision on `Thanks, that helps.`.
- Focused isolated suite: `70 passed` (two existing TestClient deprecation warnings).
- Stock offline BGE probe from a copied model cache, with the new guard disabled, reproduced `Thanks, that helps.` as `continuation`; `and the second one?` remained `continuation` and `Thanks, now explain the cache.` was `general`.
- `uv run make lint` passed; `git diff --check` passed.
- `uv run make test` ran in an isolated store/cache: `2037 passed, 27 failed, 1 deselected`. The 27 failures are outside this patch (background LLM/vector maintenance, DB concurrency, and setup configuration tests). The exact 27 test nodes reproduced on unchanged `f76cdbf` with the same isolated environment.

## Limitations / review

This intentionally recognizes only clear English self-contained acknowledgements and closures; it does not attempt to solve all contextual ambiguity, other languages, or general repeated-topic behavior. It does not alter lifecycle, feedback signal strengths, candidate selection, archival behavior, supersession, or review-block code. The independent review-only issue remains owned by #132 and needs its separate PR.

Please review the anchored phrase grammar for desired conservatism and the API/session-buffer regression for the intended no-repeat contract.