### PR TITLE
fix(setup): plugin mode ships one maintenance surface — remove the CLI agent and command, bind the plugin agent to its own tool

### DIFF
--- a/integrations/claude-plugin/agents/ormah-maintenance.md
+++ b/integrations/claude-plugin/agents/ormah-maintenance.md
@@ -2,20 +2,21 @@
 name: ormah-maintenance
 description: Ormah memory graph maintenance. Runs the run_maintenance two-call protocol to link memories, detect conflicts, merge duplicates, and consolidate clusters.
 model: sonnet
+tools: mcp__plugin_ormah_ormah__run_maintenance
 ---
 
 You are the ormah memory maintenance agent. Your only job is to run the two-call
-run_maintenance protocol using the mcp__ormah__run_maintenance tool.
+run_maintenance protocol using the mcp__plugin_ormah_ormah__run_maintenance tool.
 
 ## Protocol
 
-**Phase 1** — call `mcp__ormah__run_maintenance` with no arguments. You will receive four batches:
+**Phase 1** — call `mcp__plugin_ormah_ormah__run_maintenance` with no arguments. You will receive four batches:
 - `link_candidates`: pairs to classify with a relationship
 - `conflict_candidates`: belief pairs to check for contradictions or evolution
 - `merge_candidates`: near-duplicate pairs to merge
 - `consolidation_clusters`: groups of similar memories to synthesize into one
 
-**Phase 2** — analyze all batches, then call `mcp__ormah__run_maintenance` again with a `results` object:
+**Phase 2** — analyze all batches, then call `mcp__plugin_ormah_ormah__run_maintenance` again with a `results` object:
 
 ```json
 {

--- a/src/ormah/setup.py
+++ b/src/ormah/setup.py
@@ -2824,25 +2824,29 @@ def _claude_code_wire() -> None:
     # The plugin registers the same UserPromptSubmit/PreCompact/SessionEnd hooks
     # and the same MCP server. Wiring them again in ~/.claude/settings.json runs
     # both copies: the whisper fires twice per human turn, and no merge can dedupe
-    # across the two files. The agent and slash command are namespaced by the
-    # plugin (ormah:maintenance vs ormah-maintenance), so they are not duplicate
-    # registrations — they stay installed, as does CLAUDE.md, which no plugin can
-    # write.
+    # across the two files. The plugin also ships the maintenance agent and the
+    # slash command, and the CLI copies must go with the CLI server: they call
+    # `mcp__ormah__run_maintenance`, the name of the server removed just below
+    # (the plugin's is `mcp__plugin_ormah_ormah__run_maintenance`), and
+    # ~/.claude/agents/ resolves ahead of plugin agents, so a stale copy there
+    # shadows the plugin's. Only CLAUDE.md stays: no plugin can write it.
     if _claude_code_plugin_provides_hooks():
         _remove_claude_hooks()
         _remove_mcp_from_json(Path.home() / ".claude.json")
+        _remove_claude_agents()
+        _remove_claude_commands()
         info(
-            "Claude Code plugin already provides the hooks and MCP server "
-            "— removed redundant CLI wiring"
+            "Claude Code plugin already provides the hooks, MCP server, agent "
+            "and slash command — removed redundant CLI wiring"
         )
     else:
         ormah_bin = get_ormah_bin_path()
         configure_claude_hooks(ormah_bin)
         configure_claude_code_mcp(ormah_bin)
+        install_claude_agents()
+        install_claude_commands()
 
     install_claude_md()
-    install_claude_agents()
-    install_claude_commands()
 
 
 def _claude_code_unwire() -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -692,14 +692,16 @@ class TestClaudeCodeWirePluginGuard:
             patch("ormah.setup.get_ormah_bin_path", return_value="/usr/bin/ormah"),
             patch("ormah.setup.configure_claude_hooks") as configure_hooks,
             patch("ormah.setup.configure_claude_code_mcp") as configure_mcp,
-            patch("ormah.setup.install_claude_agents"),
-            patch("ormah.setup.install_claude_commands"),
+            patch("ormah.setup.install_claude_agents") as install_agents,
+            patch("ormah.setup.install_claude_commands") as install_commands,
             patch("ormah.setup.install_claude_md"),
         ):
             _claude_code_wire()
 
         configure_hooks.assert_called_once_with("/usr/bin/ormah")
         configure_mcp.assert_called_once_with("/usr/bin/ormah")
+        install_agents.assert_called_once()  # no plugin: the CLI copies stay
+        install_commands.assert_called_once()
 
     def test_project_scoped_plugin_wires_normally(self, tmp_path):
         """Deliberate: the CLI hooks are global and serve every other project."""

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -629,13 +629,19 @@ class TestClaudeCodeWirePluginGuard:
 
     def test_working_plugin_strips_hooks_and_mcp_and_writes_no_wiring(self, tmp_path):
         claude_dir = self._seed_working_plugin(tmp_path)
+        # Left behind by a pre-plugin `ormah setup`. Both call the CLI-registered
+        # `ormah` MCP server this very run removes, and ~/.claude/agents/ shadows
+        # the plugin's own agent — so they must go, not be rewritten.
+        stale_agent = claude_dir / "agents" / "ormah-maintenance.md"
+        stale_command = claude_dir / "commands" / "ormah-maintenance.md"
+        for stale in (stale_agent, stale_command):
+            stale.parent.mkdir(parents=True, exist_ok=True)
+            stale.write_text("calls mcp__ormah__run_maintenance\n")
 
         with (
             patch("ormah.setup.Path.home", return_value=tmp_path),
             patch("ormah.setup.configure_claude_hooks") as configure_hooks,
             patch("ormah.setup.configure_claude_code_mcp") as configure_mcp,
-            patch("ormah.setup.install_claude_agents") as install_agents,
-            patch("ormah.setup.install_claude_commands") as install_commands,
             patch("ormah.setup.install_claude_md") as install_md,
         ):
             _claude_code_wire()
@@ -648,10 +654,9 @@ class TestClaudeCodeWirePluginGuard:
 
         configure_hooks.assert_not_called()
         configure_mcp.assert_not_called()
-        # not duplicate registrations — the plugin namespaces these
-        install_md.assert_called_once()
-        install_agents.assert_called_once()
-        install_commands.assert_called_once()
+        install_md.assert_called_once()                             # no plugin can write CLAUDE.md
+        assert not stale_agent.exists()                             # the plugin ships its own
+        assert not stale_command.exists()                           # /ormah:maintenance
 
     def test_strip_preserves_third_party_hooks(self, tmp_path):
         claude_dir = self._seed_working_plugin(tmp_path)
@@ -1245,6 +1250,28 @@ class TestClaudePluginDocs:
 
         assert 'subagent_type="ormah-maintenance"' in content
         assert "run_in_background=True" in content
+
+    def test_maintenance_agent_binds_the_plugin_scoped_tool_only(self):
+        """The plugin's `.mcp.json` names the server `ormah`, so Claude Code exposes
+        its tools as `mcp__plugin_ormah_ormah__*`. `mcp__ormah__*` is the CLI-registered
+        server, which plugin-mode setup removes."""
+        root = Path(__file__).resolve().parents[1]
+        content = (
+            root / "integrations" / "claude-plugin" / "agents" / "ormah-maintenance.md"
+        ).read_text()
+        frontmatter = content.split("---")[1]
+
+        assert "tools: mcp__plugin_ormah_ormah__run_maintenance" in frontmatter
+        assert "mcp__ormah__run_maintenance" not in content
+
+    def test_cli_channel_agent_keeps_the_cli_tool_name(self):
+        """Not a copy of the plugin agent: `install_claude_agents()` ships this one for
+        installs without the plugin, where the server really is named `ormah`."""
+        root = Path(__file__).resolve().parents[1]
+        content = (root / "src" / "ormah" / "agents" / "ormah-maintenance.md").read_text()
+
+        assert "mcp__ormah__run_maintenance" in content
+        assert "mcp__plugin_ormah_ormah__" not in content
 
 
 # --- CLI tests ---


### PR DESCRIPTION
## Problem

On an install that has the Claude Code plugin, `ormah setup` leaves two maintenance surfaces that both call `mcp__ormah__run_maintenance` — the tool name of the CLI-registered `ormah` MCP server:

1. `~/.claude/agents/ormah-maintenance.md` and `~/.claude/commands/ormah-maintenance.md`. The plugin branch of `_claude_code_wire()` keeps installing them while removing that very server in the same run. #147 kept them on the premise that the plugin namespaces them, so they are not duplicate registrations. The namespacing is real, but the kept agent names a server that no longer exists.
2. `integrations/claude-plugin/agents/ormah-maintenance.md`, the plugin's own agent, although the plugin's server is exposed as `mcp__plugin_ormah_ormah__*` (the plugin's `.mcp.json` names it `ormah`, and Claude Code scopes plugin servers as `plugin_<plugin>_<server>`).

Claude Code resolves `~/.claude/agents/` ahead of plugin agents, so the stale CLI copy shadows the plugin's: `/ormah:maintenance` dispatches `subagent_type="ormah-maintenance"` and lands on an agent whose named tool does not exist. Neither agent declares `tools:`, so the model recovers the live name through ToolSearch and the defect stays invisible — maintenance kept running in every transcript I checked, through the wrong file, with the whole parent toolset.

## Change

Each install channel ships exactly one maintenance surface.

- **Plugin present:** `_claude_code_wire()` removes the CLI agent and slash command alongside the CLI hooks and MCP entry. What remains is the plugin's `/ormah:maintenance` and `ormah:ormah-maintenance`. `_claude_code_is_wired()` never reads the agent file, so the removal cannot cause a re-wire loop.
- **No plugin:** unchanged. The CLI server, `~/.claude/agents/ormah-maintenance.md` and `/ormah-maintenance` are installed as before, and `src/ormah/agents/ormah-maintenance.md` keeps `mcp__ormah__run_maintenance`, which is the right name for that channel.
- **Plugin agent:** calls `mcp__plugin_ormah_ormah__run_maintenance` and declares it as its only tool — the scoped form the plugins reference documents for plugin-provided MCP servers in a subagent's `tools:`.

## Evidence (Claude Code 2.1.263)

- A subagent declared with `tools: [mcp__plugin_ormah_ormah__run_maintenance]` and asked to list its tools without calling any replied with exactly that one name.
- With the user-level agent and command moved out of the way, `Agent(subagent_type="ormah-maintenance")` — bare, the way `/ormah:maintenance` calls it — dispatched the plugin agent, which answered `PONG` with `tool_uses: 0`. Removing the CLI copies does not break the plugin command.

## Tests

- `test_working_plugin_strips_hooks_and_mcp_and_writes_no_wiring` now seeds the two stale CLI files and asserts they are gone after wiring. Fails on `main`.
- `test_maintenance_agent_binds_the_plugin_scoped_tool_only` checks the plugin agent's frontmatter and body. Fails on `main`.
- `test_cli_channel_agent_keeps_the_cli_tool_name` guards the deliberate difference between the two agent files, so nobody "syncs" them later.
- Suite: 2042 passed. The 4 failures are environment-only and identical on pristine `main` in this environment (`TestConfigureCodexMcp` sees a real `codex` binary on PATH; `test_detect_returns_none_for_home` sees a temporary `HOME`). `ruff check src/ tests/` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)