### PR TITLE
fix(store): a Node reference resolves only when the node's Full id confirms it

### DIFF
--- a/src/ormah/store/file_store.py
+++ b/src/ormah/store/file_store.py
@@ -31,16 +31,18 @@ def _serialized_store_operation(method):
 class FileStore:
     """Manages memory node files on disk.
 
-    Maintains an in-memory ``id → Path`` cache so that lookups are O(1)
+    Maintains an in-memory ``Full id → Path`` cache so that lookups are O(1)
     after the first scan, instead of falling back to an O(N) grep over
-    every markdown file.
+    every markdown file. Only a Full id is ever a key, and only once the file
+    at that path has confirmed it: a Short id lookup re-resolves on each call,
+    and a miss caches nothing.
     """
 
     def __init__(self, nodes_dir: Path, operation_lock=None) -> None:
         self.nodes_dir = nodes_dir
         self._operation_lock = operation_lock or threading.RLock()
         self.nodes_dir.mkdir(parents=True, exist_ok=True)
-        # id -> Path cache, populated lazily on first miss
+        # Full id -> Path cache, populated lazily on first miss
         self._id_cache: dict[str, Path] = {}
         self._cache_built = False
 
@@ -90,8 +92,8 @@ class FileStore:
         path = self._find_file(node_id)
         if path is None:
             return False
+        self._forget(path)  # while the file is still there to name its Full id
         path.unlink()
-        self._id_cache.pop(node_id, None)
         return True
 
     @_serialized_store_operation
@@ -116,8 +118,8 @@ class FileStore:
         deleted_dir = self.nodes_dir.parent / "deleted"
         deleted_dir.mkdir(parents=True, exist_ok=True)
         dest = deleted_dir / path.name
+        self._forget(path)  # while the file is still there to name its Full id
         path.rename(dest)
-        self._id_cache.pop(node_id, None)
         return True
 
     @_serialized_store_operation
@@ -161,13 +163,39 @@ class FileStore:
         filename = f"{node.type.value}_{slug}_{node.short_id}.md"
         return self.nodes_dir / filename
 
+    def _forget(self, path: Path) -> None:
+        """Drop the cache entry for the node stored at ``path``.
+
+        The cache is keyed by Full id, but a caller may have addressed the node by
+        its Short id, so the key cannot be read off the reference — only off the
+        file. Call this while the file is still on disk. A file that will not parse
+        leaves nothing behind that the next lookup's existence check will not clear.
+        """
+        try:
+            self._id_cache.pop(self._load_path(path).id, None)
+        except Exception:
+            pass
+
     def _find_file(self, node_id: str) -> Path | None:
-        """Find the file for a given node ID.
+        """Find the file for a Node reference — a Full id, or the 8-character Short id
+        the Whisper showed the agent.
 
         Lookup order:
-        1. In-memory cache (O(1))
-        2. Glob on short_id suffix (fast for single file)
+        1. In-memory cache, keyed by Full id (O(1)), validated by file existence
+        2. Glob on the Short id suffix, accepting a candidate only once the Full id
+           in its own frontmatter confirms the reference
         3. Full cache rebuild from disk (one-time O(N), then O(1) forever)
+
+        The glob narrows; it never decides. A filename carries the Short id, which is
+        not unique, so the first match may be a stranger's memory — the file has to
+        state its Full id before the store hands it back (ADR-0007). An ambiguous
+        Short id resolves to nothing, with a warning: the load contract is nullable
+        and the background jobs branch only on "is it None", so raising would trade
+        silent corruption for a crashed sleep cycle.
+
+        A cache hit stays validated by file existence alone. Re-parsing on every hit
+        would destroy the O(1) the cache exists for. A file replaced behind the
+        store's back is the watcher's territory, and is accepted here.
         """
         # 1. Cache hit
         cached = self._id_cache.get(node_id)
@@ -177,12 +205,36 @@ class FileStore:
             # Stale entry — remove and fall through
             del self._id_cache[node_id]
 
-        # 2. Glob on short_id
+        # 2. Glob on the Short id, then confirm each candidate against its own Full id.
+        #    Width stays at 8: filenames end in the 8-character Short id, so any other
+        #    width would force a full directory scan to serve a caller that does not exist.
         short_id = node_id.split("-")[0]
-        matches = list(self.nodes_dir.glob(f"*_{short_id}.md"))
-        if matches:
-            self._id_cache[node_id] = matches[0]
-            return matches[0]
+        if len(short_id) == 8:
+            confirmed: list[tuple[str, Path]] = []
+            for path in sorted(self.nodes_dir.glob(f"*_{short_id}.md")):
+                try:
+                    candidate = self._load_path(path)
+                except Exception:
+                    continue  # a file that will not parse confirms nothing
+                # A bare Short id has no dashes, so the split above is a no-op and
+                # it equals itself — that is what tells the two lookups apart.
+                if candidate.id == node_id or (
+                    node_id == short_id and candidate.short_id == short_id
+                ):
+                    confirmed.append((candidate.id, path))
+            if len(confirmed) == 1:
+                full_id, found = confirmed[0]
+                # Keyed by Full id, and written only after the file confirmed it.
+                self._id_cache[full_id] = found
+                return found
+            if len(confirmed) > 1:
+                logger.warning(
+                    "Node reference %s is an ambiguous Short id: %d nodes share it. "
+                    "Resolving to nothing rather than to an arbitrary one of them.",
+                    node_id,
+                    len(confirmed),
+                )
+                return None
 
         # 3. Build full cache once if not already done
         if not self._cache_built:

--- a/src/ormah/store/file_store.py
+++ b/src/ormah/store/file_store.py
@@ -92,7 +92,7 @@ class FileStore:
         path = self._find_file(node_id)
         if path is None:
             return False
-        self._forget(path)  # while the file is still there to name its Full id
+        self._forget(path)  # by path: eviction must not depend on reading the file
         path.unlink()
         return True
 
@@ -118,7 +118,7 @@ class FileStore:
         deleted_dir = self.nodes_dir.parent / "deleted"
         deleted_dir.mkdir(parents=True, exist_ok=True)
         dest = deleted_dir / path.name
-        self._forget(path)  # while the file is still there to name its Full id
+        self._forget(path)  # by path: eviction must not depend on reading the file
         path.rename(dest)
         return True
 
@@ -164,17 +164,18 @@ class FileStore:
         return self.nodes_dir / filename
 
     def _forget(self, path: Path) -> None:
-        """Drop the cache entry for the node stored at ``path``.
+        """Drop every cache entry naming ``path``.
 
         The cache is keyed by Full id, but a caller may have addressed the node by
-        its Short id, so the key cannot be read off the reference — only off the
-        file. Call this while the file is still on disk. A file that will not parse
-        leaves nothing behind that the next lookup's existence check will not clear.
+        its Short id, so the key cannot be read off the reference. Reading it off
+        the file instead would make eviction depend on that read succeeding: a
+        transient OSError leaves the entry pointing at a path the caller is about
+        to unlink, and `_path_for` is deterministic, so the next node with the same
+        type, title and Short id lands on exactly that path and inherits the entry
+        through the existence-only cache hit. Comparing paths needs no file at all.
         """
-        try:
-            self._id_cache.pop(self._load_path(path).id, None)
-        except Exception:
-            pass
+        for key in [k for k, v in self._id_cache.items() if v == path]:
+            del self._id_cache[key]
 
     def _find_file(self, node_id: str) -> Path | None:
         """Find the file for a Node reference — a Full id, or the 8-character Short id

--- a/src/ormah/store/file_store.py
+++ b/src/ormah/store/file_store.py
@@ -194,6 +194,11 @@ class FileStore:
         and the background jobs branch only on "is it None", so raising would trade
         silent corruption for a crashed sleep cycle.
 
+        None therefore means *confirmed absent*, never *could not tell*. A file that
+        will not parse confirms nothing and is skipped, matching `list_all` and
+        `_build_cache`; an OSError propagates instead, because a caller that reads it
+        as absence goes on to mutate state the file still contradicts.
+
         A cache hit stays validated by file existence alone. Re-parsing on every hit
         would destroy the O(1) the cache exists for. A file replaced behind the
         store's back is the watcher's territory, and is accepted here.
@@ -215,6 +220,13 @@ class FileStore:
             for path in sorted(self.nodes_dir.glob(f"*_{short_id}.md")):
                 try:
                     candidate = self._load_path(path)
+                except OSError:
+                    # Not knowing is not absence. Swallowing this would resolve an
+                    # existing node to None, and `MemoryEngine.delete_node` reads
+                    # None as absence: it drops the index row and reports success
+                    # while the file survives to be reindexed. Before this lookup
+                    # opened candidates at all, the error surfaced from `load`.
+                    raise
                 except Exception:
                     continue  # a file that will not parse confirms nothing
                 # A bare Short id has no dashes, so the split above is a no-op and

--- a/tests/test_engine/test_reversible_promotion.py
+++ b/tests/test_engine/test_reversible_promotion.py
@@ -110,12 +110,13 @@ def test_a_live_superseded_by_still_blocks_promotion(engine):
 def test_a_prefix_collision_is_not_mistaken_for_a_live_replacement(engine):
     """`load(marker) is not None` is not the same question as "the replacement exists".
 
-    FileStore._find_file resolves an id through the 8-character prefix in the
-    filename and returns the first match without checking the id it loaded (#280),
-    so a deleted replacement whose prefix collides with an unrelated node comes
-    back as that node.  The marker then reads as live, the block never lifts, and
-    the memory is buried forever — the failure the dangling-marker branch exists
-    to prevent.  The liveness check has to confirm the complete id."""
+    FileStore._find_file resolves a Node reference by Full id, not by the
+    8-character Short id in the filename alone (#280): an absent Full id whose
+    Short id collides with an unrelated node's filename must resolve to None, not
+    to that unrelated node.  If it resolved to the collider instead, a dangling
+    `superseded_by` marker would read as live, the block would never lift, and the
+    memory would be buried forever — the failure the dangling-marker branch exists
+    to prevent."""
     collider = MemoryNode(
         id="deadbeef-0000-0000-0000-00000000000b",
         type=NodeType.fact,
@@ -124,10 +125,9 @@ def test_a_prefix_collision_is_not_mistaken_for_a_live_replacement(engine):
     engine.builder.index_single(engine.file_store.save(collider))
 
     gone = "deadbeef-0000-0000-0000-00000000000a"
-    collision = engine.file_store.load(gone)
-    assert collision is not None and collision.id != gone, (
-        "precondition: this test needs load() to resolve the prefix to the collider; "
-        "drop this assertion once #280 makes the lookup exact"
+    assert engine.file_store.load(gone) is None, (
+        "a dangling Full id whose Short id collides with a live node's filename "
+        "must not resolve to that unrelated node"
     )
 
     marked = _archive(engine, "superseded by a node that no longer exists", superseded_by=gone)

--- a/tests/test_engine/test_short_id_reference.py
+++ b/tests/test_engine/test_short_id_reference.py
@@ -1,0 +1,21 @@
+"""An update addressed by a Short id still resolves end to end (#280)."""
+
+from __future__ import annotations
+
+from ormah.models.node import CreateNodeRequest, NodeType, UpdateNodeRequest
+
+
+def test_update_node_by_short_id_reaches_the_right_node(engine):
+    """update_node forwards node_id straight to FileStore.load — this seam breaks
+    if the engine ever normalises or pre-validates the reference before the store
+    sees it. A Short id that matches exactly one node must resolve to that node."""
+    node_id, _ = engine.remember(
+        CreateNodeRequest(content="original content", type=NodeType.fact, title="Short id target")
+    )
+    short_id = engine.file_store.load(node_id).short_id
+
+    result = engine.update_node(short_id, UpdateNodeRequest(content="updated content"))
+
+    assert result is not None
+    node = engine.file_store.load(node_id)
+    assert node.content == "updated content"

--- a/tests/test_store/test_prefix_resolution.py
+++ b/tests/test_store/test_prefix_resolution.py
@@ -20,6 +20,8 @@ reader for tombstones, so the soft-delete case reads the `deleted/` file itself.
 from __future__ import annotations
 
 import logging
+
+import pytest
 from pathlib import Path
 
 import frontmatter
@@ -256,3 +258,61 @@ def test_cache_hit_stays_validated_by_existence_only_watcher_hole_is_accepted(fi
 
     assert served is not None
     assert served.id == replacement.id
+
+
+def test_a_read_failure_on_a_cold_cache_is_not_reported_as_an_absent_node(
+    file_store, monkeypatch
+):
+    """An unreadable file must not resolve to None: absence and failure are not the same.
+
+    The Short-id glob confirms every candidate by parsing it, so a `continue` on any
+    exception turns "I could not read this file" into "this node does not exist".
+    `MemoryEngine.delete_node` reads that None as absence, falls back to the index,
+    removes the row and its edges, ignores `soft_delete()` returning False, and
+    reports success — while the file is still in nodes/ and the next reindex brings
+    the node back.
+
+    The sibling read-failure test warms the cache before failing the read, so it
+    exercises the cache-hit path and never reaches the glob. This one starts cold.
+
+    An unparseable file keeps confirming nothing — that is the store-wide rule
+    `list_all` and `_build_cache` already follow. Only an OSError is different: it
+    says nothing about what the file contains.
+    """
+    node = _collider("a", "Cold node", "a node whose file will not read")
+    path = file_store.save(node)
+    file_store._id_cache.clear()  # cold: the glob must confirm by parsing
+    file_store._cache_built = False
+
+    real_read_text = Path.read_text
+
+    def read_text_denied(self, *args, **kwargs):
+        if self.name == path.name:
+            raise PermissionError("unreadable")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text_denied)
+
+    assert path.exists()
+    with pytest.raises(OSError):
+        file_store.load(node.id)
+
+
+def test_an_unparseable_file_still_confirms_nothing_on_a_cold_cache(file_store):
+    """The other half of the same branch: a corrupt file is still treated as absent.
+
+    Distinguishing I/O failure from absence must not turn every malformed file into
+    a raise — that would let one corrupt file break lookups for every node sharing
+    its Short id.
+    """
+    live = _collider("a", "Live node", "the node actually being asked for")
+    file_store.save(live)
+    corrupt = file_store.nodes_dir / f"fact_corrupt_{COLLIDING_SHORT_ID}.md"
+    corrupt.write_text("this is not a node", encoding="utf-8")
+    file_store._id_cache.clear()
+    file_store._cache_built = False
+
+    loaded = file_store.load(live.id)
+
+    assert loaded is not None
+    assert loaded.id == live.id

--- a/tests/test_store/test_prefix_resolution.py
+++ b/tests/test_store/test_prefix_resolution.py
@@ -1,0 +1,186 @@
+"""Regression tests for issue #29: a Node reference must resolve only to the
+node it actually names, never to another node whose Short id happens to
+collide with it.
+
+FileStore._find_file resolves a Node reference (Full id or Short id) through
+a glob on the 8-char Short id suffix in the filename and accepts the first
+match without ever opening the file to confirm its Full id. Two nodes whose
+ids share the same first 8 hex characters (same "-" group) therefore collide:
+whichever file the glob happens to return wins, silently, and the wrong path
+gets cached under the requested id.
+
+Every assertion here goes through the FileStore public surface (save / load
+/ delete / soft_delete) except two declared exceptions: whether an absent id
+was left out of `_id_cache` is not externally observable, so that one case
+pokes `store._id_cache` directly — same pattern as
+test_file_cache.py::test_stale_cache_entry_recovers — and the store exposes no
+reader for tombstones, so the soft-delete case reads the `deleted/` file itself.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import frontmatter
+
+from ormah.models.node import MemoryNode, NodeType, Tier
+from ormah.store.markdown import serialize_node
+
+
+COLLIDING_SHORT_ID = "deadbeef"
+
+
+def _collider(suffix: str, title: str, content: str) -> MemoryNode:
+    """A node whose id is forced to start with the shared Short id prefix."""
+    return MemoryNode(
+        id=f"{COLLIDING_SHORT_ID}-0000-0000-0000-00000000000{suffix}",
+        type=NodeType.fact,
+        tier=Tier.working,
+        title=title,
+        content=content,
+        source="test",
+    )
+
+
+def test_deleting_one_of_a_colliding_pair_does_not_resurrect_it_as_the_other(file_store):
+    """Save two nodes that share a Short id, soft-delete the first, then ask for
+    it by its own Full id: it must come back None, not the survivor's node.
+
+    Before the fix, once the first node's file is moved out of nodes/, the
+    Short-id glob for its id has only the second node's file left to match
+    and returns that instead — the first node reads as still alive, as the
+    wrong node.
+    """
+    first = _collider("a", "Collision A", "first colliding node")
+    second = _collider("b", "Collision B", "second colliding node")
+    file_store.save(first)
+    file_store.save(second)
+
+    assert file_store.soft_delete(first.id) is True
+    file_store.save(second)  # second stays live and freshly written on disk
+
+    assert file_store.load(first.id) is None
+
+    deleted_dir = file_store.nodes_dir.parent / "deleted"
+    tombstones = sorted(deleted_dir.glob("*.md"))
+    assert len(tombstones) == 1
+    meta = frontmatter.loads(tombstones[0].read_text(encoding="utf-8")).metadata
+    assert meta["id"] == first.id
+    assert meta.get("deleted_at") is not None
+
+
+def test_absent_full_id_sharing_a_short_id_with_a_live_node_resolves_to_none(file_store):
+    """An id that was never saved must not resolve just because some other,
+    unrelated node's file happens to share its Short id — and the miss must
+    not be cached, so a second lookup is not silently served the wrong node
+    either."""
+    live = _collider("a", "Live node", "the only node actually on disk")
+    file_store.save(live)
+
+    absent_id = f"{COLLIDING_SHORT_ID}-ffff-ffff-ffff-ffffffffffff"
+
+    assert file_store.load(absent_id) is None
+    assert absent_id not in file_store._id_cache  # declared exception: not observable via load()
+
+    assert file_store.load(absent_id) is None
+
+
+def test_short_id_matching_exactly_one_node_resolves_via_load(file_store):
+    """The everyday path: a Short id with a single match still works."""
+    node = MemoryNode(
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Solo node",
+        content="the only node with this short id",
+        source="test",
+    )
+    file_store.save(node)
+
+    loaded = file_store.load(node.short_id)
+
+    assert loaded is not None
+    assert loaded.id == node.id
+
+
+def test_short_id_matching_two_nodes_resolves_to_none_and_warns(file_store, caplog):
+    """An ambiguous Short id resolves to nothing (ADR-0007), loudly."""
+    first = _collider("a", "Collision A", "first colliding node")
+    second = _collider("b", "Collision B", "second colliding node")
+    file_store.save(first)
+    file_store.save(second)
+
+    with caplog.at_level(logging.WARNING, logger="ormah.store.file_store"):
+        result = file_store.load(COLLIDING_SHORT_ID)
+
+    assert result is None
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(COLLIDING_SHORT_ID in r.getMessage() for r in warnings)
+
+
+def test_full_id_resolves_to_its_own_node_despite_a_short_id_collision(file_store):
+    """A Full id is unambiguous even when its Short id is not: load() must
+    return the exact node asked for, and delete()/soft_delete() must act on
+    that node's file only, leaving the collider untouched."""
+    target = _collider("a", "Target node", "the node actually being asked for")
+    collider = _collider("b", "Collider node", "an unrelated node sharing the short id")
+    file_store.save(target)
+    file_store.save(collider)
+
+    loaded = file_store.load(target.id)
+    assert loaded is not None
+    assert loaded.id == target.id
+    assert loaded.content == target.content
+
+    assert file_store.delete(target.id) is True
+    assert file_store.load(target.id) is None
+    survivor = file_store.load(collider.id)
+    assert survivor is not None
+    assert survivor.id == collider.id
+
+    # soft_delete must show the same discrimination, on a fresh colliding pair.
+    target2 = _collider("c", "Target node 2", "second node actually being asked for")
+    collider2 = _collider("d", "Collider node 2", "second unrelated collider")
+    file_store.save(target2)
+    file_store.save(collider2)
+
+    assert file_store.soft_delete(target2.id) is True
+    survivor2 = file_store.load(collider2.id)
+    assert survivor2 is not None
+    assert survivor2.id == collider2.id
+
+
+def test_cache_hit_stays_validated_by_existence_only_watcher_hole_is_accepted(file_store):
+    """ACCEPTED, documented behaviour — not a bug, not this ticket's territory.
+
+    Once a Full id is cached, a subsequent lookup trusts the cached path the
+    moment `Path.exists()` is true; it does not re-open and re-parse the
+    file to confirm the id still matches. If something outside FileStore
+    (the watcher) replaces the file behind its back, the cache keeps serving
+    the old path and load() returns whatever is now written there. Guarding
+    against that belongs to the watcher, not to `_find_file` — this test
+    pins the hole so nobody "fixes" it here by accident.
+    """
+    original = MemoryNode(
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Original node",
+        content="before the watcher clobbers it",
+        source="test",
+    )
+    path = file_store.save(original)
+    warmed = file_store.load(original.id)  # populates _id_cache[original.id] = path
+    assert warmed is not None and warmed.id == original.id
+
+    replacement = MemoryNode(
+        type=NodeType.fact,
+        tier=Tier.working,
+        title="Replacement node",
+        content="written straight to disk, bypassing the store",
+        source="test",
+    )
+    path.write_text(serialize_node(replacement), encoding="utf-8")
+
+    served = file_store.load(original.id)
+
+    assert served is not None
+    assert served.id == replacement.id

--- a/tests/test_store/test_prefix_resolution.py
+++ b/tests/test_store/test_prefix_resolution.py
@@ -20,6 +20,7 @@ reader for tombstones, so the soft-delete case reads the `deleted/` file itself.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import frontmatter
 
@@ -100,6 +101,77 @@ def test_short_id_matching_exactly_one_node_resolves_via_load(file_store):
 
     assert loaded is not None
     assert loaded.id == node.id
+
+
+def test_a_unique_short_id_stops_resolving_once_a_collider_is_born(file_store):
+    """A Short id is never a cache key, so a second node sharing it turns a
+    previously unique reference ambiguous on the very next call.
+
+    This is the transition the original bug lived in: `_find_file` used to cache
+    the *requested* key, so the first lookup's answer outlived the arrival of the
+    collider and kept naming the first node forever.
+    """
+    first = _collider("a", "First node", "the only node with this short id, at first")
+    file_store.save(first)
+
+    assert file_store.load(COLLIDING_SHORT_ID).id == first.id
+    assert COLLIDING_SHORT_ID not in file_store._id_cache  # declared exception, as above
+
+    file_store.save(_collider("b", "Second node", "the collider that arrives later"))
+
+    assert file_store.load(COLLIDING_SHORT_ID) is None
+
+
+def test_an_ambiguous_short_id_resolves_again_once_only_one_node_is_left(file_store):
+    """The inverse transition: ambiguity is recomputed, never remembered.
+
+    A negative cache would keep answering None after the pair became a single
+    node, losing a resolution that is valid again.
+    """
+    first = _collider("a", "Collision A", "first colliding node")
+    second = _collider("b", "Collision B", "second colliding node")
+    file_store.save(first)
+    file_store.save(second)
+
+    assert file_store.load(COLLIDING_SHORT_ID) is None
+
+    assert file_store.delete(first.id) is True
+
+    survivor = file_store.load(COLLIDING_SHORT_ID)
+    assert survivor is not None
+    assert survivor.id == second.id
+
+
+def test_a_read_failure_while_deleting_does_not_leave_the_id_resolvable(file_store, monkeypatch):
+    """`delete` must drop the cache entry even when the file will not read.
+
+    The cache is keyed by Full id, but the key cannot come from re-reading the
+    file: a transient OSError there used to be swallowed, leaving the entry
+    pointing at a path `delete` then unlinks. `_path_for` is deterministic, so
+    the next node with the same type, title and Short id lands on that exact
+    path — and the existence-only cache hit hands the deleted id the new node.
+    """
+    doomed = _collider("a", "Same title", "the node being deleted")
+    file_store.save(doomed)
+    file_store.load(doomed.id)  # warm the cache so the entry exists to go stale
+    assert file_store._id_cache[doomed.id].exists()
+
+    real_read_text = Path.read_text
+
+    def read_text_failing_once(self, *args, **kwargs):
+        if self.name == file_store._id_cache[doomed.id].name:
+            raise OSError("transient read failure")
+        return real_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text_failing_once)
+    assert file_store.delete(doomed.id) is True
+    monkeypatch.undo()
+
+    # Same type, same title, same Short id — so _path_for regenerates the freed path.
+    successor = _collider("b", "Same title", "an unrelated node reusing the filename")
+    file_store.save(successor)
+
+    assert file_store.load(doomed.id) is None
 
 
 def test_short_id_matching_two_nodes_resolves_to_none_and_warns(file_store, caplog):


### PR DESCRIPTION
## Problem

`FileStore._find_file` extracted the 8-character Short id from a reference, globbed `*_<short_id>.md` and returned `matches[0]` without opening the file to confirm that its frontmatter id equals the requested one. Two nodes sharing a 32-bit prefix therefore resolved to each other, and since load, save, delete, soft_delete and touch_access all go through that lookup, any of them could act on a stranger's node. The unverified path was also written into the id cache, so the wrong answer outlived the call and persisted until restart. Reported in #280.

## What changes

- `50ff0599` The glob narrows but never decides: each candidate is parsed and accepted only when its Full id confirms the reference (a Full id must match exactly; a bare Short id must equal the candidate's `short_id`). An ambiguous Short id, one prefix with two live nodes, resolves to `None` with a warning-level log. The id cache is keyed by Full id only, written only after that confirmation, and never on a miss. A cache hit stays validated by file existence alone.
- `dc663800` Cache eviction on delete and soft_delete goes by path (`_forget(path)`), so it no longer depends on reading the file about to be removed. Previously a swallowed read error left a stale entry pointing at a path that `_path_for` would deterministically hand to the next node with the same type, title and Short id.
- `e734ac5f` An `OSError` while confirming a candidate propagates instead of resolving as a confirmed absence: a caller that reads `None` as absence (for example `MemoryEngine.delete_node`) would go on to mutate index state the file still contradicts. An unparseable file still confirms nothing and is skipped, matching what `list_all` and `_build_cache` already do.

## Design decisions, open to review

- The accepted prefix width stays at 8. Filenames end with the 8-character Short id, so any other width would force a directory scan per lookup.
- Ambiguity returns "not found" plus a warning rather than raising. The load contract is nullable and the background jobs branch on `None`, so raising would trade silent corruption for a crashed sleep cycle.
- No public signature changes.

## Tests

- `tests/test_store/test_prefix_resolution.py` (11 tests): colliding pairs across load, save, delete, soft_delete and cache rebuild; a Short id that stops resolving once a collider is born and resolves again once only one node is left; the ambiguous-id warning; the accepted existence-only cache hit.
- `tests/test_engine/test_short_id_reference.py`: an update addressed by a Short id, end to end through the engine.
- One adjustment in `tests/test_engine/test_reversible_promotion.py`.
- Both halves of the third commit are pinned: reverting the `raise` fails the read-failure test; widening it to every exception fails the corrupt-file test.

## Scope against #280

Covers bullet 1 of the suggested fix (never return or cache a glob match until the parsed Full id matches) and regression tests for load, save, delete, soft_delete and cache rebuild.

Does not cover bullet 2 (`_path_for` reuse), bullets 3 and 4 (collision-safe filenames and deterministic behaviour for legacy files, both of which need a decision about existing vaults), or the reindex, restore and sync/import parts of bullet 5. Hence Refs rather than a closing keyword.

## Verification on this branch

Suite run from the branch's own venv: 2076 passed, 4 failed, 1 deselected. The 4 failures reproduce on pristine `main` (`9d8c48c3`) on macOS and are untouched by this PR:

- `tests/test_adapters/test_space_detect.py::test_detect_returns_none_for_home` (`/var` vs `/private/var` realpath under a temporary `HOME`)
- `tests/test_setup.py::TestConfigureCodexMcp` x3 (`_find_binary` finds a real `/opt/homebrew/bin/codex` despite the `shutil.which` patch)

`ruff check src/ tests/` clean.

Refs #280
Fork ticket: AndreLFSMartins/ormah#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
